### PR TITLE
🐛 refactor[#6.2.15]: Phase 2.3 - common.py 중복 제거

### DIFF
--- a/backend/models/common.py
+++ b/backend/models/common.py
@@ -64,6 +64,7 @@ class SuccessResponse(BaseModel):
         description="응답 시각"
     )
 
+
 class FileMetadata(BaseModel):
     """
     파일 메타데이터
@@ -161,8 +162,12 @@ class SearchRequest(BaseModel):
     filters: Optional[Dict[str, Any]] = Field(None, description="검색 필터")
 
 
-class ErrorResponse(BaseModel):
-    """에러 응답"""
-    error: str
-    detail: Optional[str] = None
-    timestamp: datetime = Field(default_factory=datetime.now)
+
+__all__ = [
+    "ErrorResponse",
+    "SuccessResponse",
+    "FileMetadata",
+    "MetadataResponse",
+    "SaveClassificationRequest",
+    "SearchRequest",
+]


### PR DESCRIPTION
📂 주요 변경사항:
- backend/models/common.py: 224-227줄 중복 ErrorResponse 제거

🎯 목적:
- common.py 끝에 있던 중복 정의 제거
- 파일 시작 부분의 완전한 정의만 유지

📌 Related: Issue #29 (Phase 2.3 완전 통합 & Conflict Models 정리)

💡 Status: Phase 2.3.1.

Co-authored-by: Perplexity AI, Claude-4.5-sonnet

## Sourcery 요약

common.py를 리팩토링하여 중복된 모델 정의를 없애고 중앙 집중식 내보내기 목록을 도입합니다.

개선 사항:
- common.py 파일 끝에 있는 중복된 ErrorResponse 모델 정의 제거
- common.py에 공개적으로 내보낼 항목을 명시적으로 정의하기 위한 `__all__` 목록 추가

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor common.py to eliminate duplicated model definitions and introduce a centralized export list.

Enhancements:
- Remove duplicated ErrorResponse model definition at the end of common.py
- Add __all__ list to explicitly define public exports in common.py

</details>