### PR TITLE
🐛 fix[#8.9]: Use hash-based file_id in CLI for security

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -37,6 +37,14 @@ class FlowNoteCLI:
             with open(file_path, "r", encoding="utf-8") as f:
                 text = f.read()
 
+            # 보안: 절대 경로 노출 방지를 위해 해시값 사용
+            import hashlib
+
+            file_hash = hashlib.md5(
+                f"{path_obj.name}_{text[:100]}".encode()
+            ).hexdigest()[:8]
+            safe_file_id = f"{path_obj.name}_{file_hash}"
+
             # 사용자 컨텍스트 가져오기
             user_context = {}
             if user_id:
@@ -57,7 +65,7 @@ class FlowNoteCLI:
             result = await self.classification_service.classify(
                 text=text,
                 user_id=user_id,
-                file_id=str(path_obj.resolve()),
+                file_id=safe_file_id,
                 occupation=user_context.get("occupation"),
                 areas=user_context.get("areas"),
             )

--- a/docs/P/refactoring/phase4/temp_test_security.txt
+++ b/docs/P/refactoring/phase4/temp_test_security.txt
@@ -1,0 +1,1 @@
+Test security fix


### PR DESCRIPTION
🛠️ 수정 내용:
- backend/cli.py: file_id를 '파일명_해시(MD5)' 형식으로 변경

🤔 이유:
- 절대 경로 사용 시 로컬 파일 시스템 구조 노출 위험 방지 (Security)
- 파일 내용 기반 해시를 추가하여 동명 파일 충돌 방지 (Uniqueness)

🔗 출처:
- PR [#48] Code Review (sourcery-ai bot feedback 반영)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

CLI 분류 플로우에서 해시 기반의 비경로(file path 비포함) 파일 식별자를 사용하여 보안을 강화하고 파일 이름 충돌을 방지합니다.

Bug Fixes:
- CLI에서 경로 기반 파일 식별자를 해시 기반 ID로 교체하여 절대 파일 경로가 노출되는 것을 방지합니다.

Enhancements:
- 동일한 이름의 파일들 사이에서 발생할 수 있는 충돌을 줄이기 위해, 파일 이름과 콘텐츠 일부를 결합한 짧은 콘텐츠 기반 해시 파일 식별자를 생성합니다.

Documentation:
- 보안 테스트와 관련된 문서를 refactoring/phase4 아래에 플레이스홀더 아티팩트로 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use a hash-based, non-path file identifier in the CLI classification flow to improve security and avoid filename collisions.

Bug Fixes:
- Prevent exposure of absolute file paths by replacing path-based file identifiers with hash-based IDs in the CLI.

Enhancements:
- Generate short, content-based hashed file identifiers combining filename and content snippet to reduce collisions between same-named files.

Documentation:
- Add a placeholder documentation artifact under refactoring/phase4 related to security testing.

</details>