### PR TITLE
✨ feat[#9.1.10]: pytest.ini에 기본 옵션 -vv, --tb=short 추가

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 asyncio_default_fixture_loop_scope = function
 norecursedirs = temp backups .git streamlit
 python_files = test_*.py
+addopts = -vv --tb=short


### PR DESCRIPTION
📂 주요 변경사항:
- `[pytest]` 섹션에 `addopts = -vv --tb=short` 를 삽입
- 테스트 실행 시 상세 로그와 짧은 traceback 제공

🧪 검증:
- `pytest -q` 로 실행해도 동일 결과, `-vv` 로 상세 출력 확인

📌 Related
- Issue [#18]
- Merged [#52]
- [sourcery-ai bot left a comment](https://github.com/jjaayy2222/flownote-mvp/pull/52#pullrequestreview-3503202380)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

Chores:
- `pytest.ini` 파일에 올바른 종료 개행(newline)이 포함되도록 정리합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Tidy pytest.ini by ensuring it has a proper terminating newline.

</details>