### PR TITLE
✨ feat[#10.1.5]: KeywordClassifier Async 버전 추가

### DIFF
--- a/backend/classifier/keyword.py
+++ b/backend/classifier/keyword.py
@@ -1,0 +1,94 @@
+# backend/classifier/keyword.py
+
+"""
+KeywordClassifier - Async 지원
+"""
+import asyncio
+import logging
+from typing import Dict, Any
+from classifier.base_classifier import BaseClassifier
+
+logger = logging.getLogger(__name__)
+
+
+class KeywordClassifier(BaseClassifier):
+    """키워드 기반 분류기"""
+
+    def __init__(self):
+        super().__init__()
+        self.keyword_rules = {
+            "Projects": ["urgent", "deadline", "task", "project", "todo"],
+            "Areas": ["ongoing", "maintain", "update", "improve"],
+            "Resources": ["reference", "guide", "tutorial", "template"],
+            "Archives": ["done", "completed", "finished", "archived"]
+        }
+
+    async def classify(
+        self, text: str, context: dict[str, Any] | None = None
+    ) -> Dict[str, Any]:
+        """키워드 기반 분류"""
+        try:
+            # 오래 걸리는 작업은 thread pool에서 실행
+            result = await asyncio.to_thread(
+                self._classify_sync, text, context
+            )
+            
+            # 검증
+            is_valid, error_msg = self.validate_result(result)
+            if not is_valid:
+                logger.warning(f"Validation failed: {error_msg}")
+                return self._default_result()
+            
+            return result
+
+        except Exception as e:
+            logger.error(f"Keyword classification failed: {str(e)}")
+            self.last_error = str(e)
+            return self._default_result()
+
+    def _classify_sync(
+        self, text: str, context: dict[str, Any] | None = None
+    ) -> Dict[str, Any]:
+        """동기식 분류 로직"""
+        scores = {cat: 0 for cat in self.keyword_rules.keys()}
+        matched_keywords = {cat: [] for cat in self.keyword_rules.keys()}
+        
+        text_lower = text.lower()
+        
+        # 키워드 매칭
+        for category, keywords in self.keyword_rules.items():
+            for keyword in keywords:
+                if keyword.lower() in text_lower:
+                    scores[category] += 1
+                    matched_keywords[category].append(keyword)
+        
+        # 최고 점수 카테고리 선택
+        max_score = max(scores.values())
+        if max_score == 0:
+            best_category = "Inbox"
+            confidence = 0.0
+        else:
+            best_category = max(scores, key=scores.get)
+            total_keywords = sum(len(kw) for kw in self.keyword_rules.values())
+            confidence = min(1.0, max_score / total_keywords)
+        
+        return {
+            "category": best_category,
+            "confidence": confidence,
+            "reasoning": f"Matched {scores[best_category]} keywords: {', '.join(matched_keywords[best_category])}",
+            "method": "keyword",
+            "metadata": {
+                "matched_keywords": matched_keywords[best_category],
+                "scores": scores
+            }
+        }
+
+    def _default_result(self) -> Dict[str, Any]:
+        """기본 결과"""
+        return {
+            "category": "Inbox",
+            "confidence": 0.0,
+            "reasoning": "Keyword classification error",
+            "method": "keyword",
+            "metadata": {}
+        }


### PR DESCRIPTION
🔄 마이그레이션:
- BaseClassifier를 상속받는 새로운 KeywordClassifier 구현
- LLM 의존성 제거, 간단한 키워드 매칭 방식으로 전환
- 완전한 비동기(Async/Await) 지원

📁 파일 변경 사항:
- backend/classifier/keyword.py: 새로운 키워드 분류기 추가 (~100줄)

🔧 주요 기능:
- async classify() 메서드: 비동기 분류 수행
- _classify_sync(): 동기식 키워드 매칭 로직
- PARA 카테고리 기반 분류 (Projects, Areas, Resources, Archives)
- 신뢰도 계산 (confidence scoring)
- 에러 핸들링 및 기본값 반환

🎯 분류 규칙:
- Projects: urgent, deadline, task, project, todo
- Areas: ongoing, maintain, update, improve
- Resources: reference, guide, tutorial, template
- Archives: done, completed, finished, archived

📌 배경:
- 기존 LLM 기반 keyword_classifier.py (1354줄)를 대체
- Phase 1 목표: Service Layer 정리 및 BaseClassifier 통합
- 백업: backups/keyword_classifier_v3_20251203.py

📌 Related: Issue [#75]

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

LLM에 의존하던 분류 방식을 대체하기 위해, 비동기 키워드 기반의 가벼운 PARA 스타일 키워드 매처를 도입합니다.

New Features:
- 비동기 `classify`를 지원하는 `BaseClassifier` 확장 구현체인 `KeywordClassifier`를 추가합니다.
- 키워드 기반 PARA 카테고리 분류를 제공하고, 매칭된 키워드에 대한 메타데이터 및 신뢰도 점수(confidence score)를 함께 반환합니다.
- 잘못된 입력이나 분류 실패 시, 로깅 및 에러 트래킹과 함께 표준화된 기본(default) 결과를 반환합니다.

Enhancements:
- 비동기 워크플로와의 통합을 개선하기 위해, 동기식 키워드 매칭 로직을 비동기 인터페이스 뒤에서 활용하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an async keyword-based classifier to replace LLM-dependent classification with a lightweight PARA-style keyword matcher.

New Features:
- Add KeywordClassifier implementation extending BaseClassifier with async classify support.
- Provide keyword-based PARA category classification with confidence scoring and metadata about matched keywords.
- Return a standardized default result for invalid or failed classifications with logging and error tracking.

Enhancements:
- Leverage synchronous keyword matching logic behind an async interface for improved integration with async workflows.

</details>