### PR TITLE
♻️ refactor[#10.1.6]: Backend 서비스 레이어 KeywordClassifier 마이그레이션

### DIFF
--- a/backend/classifier/para_agent.py
+++ b/backend/classifier/para_agent.py
@@ -8,7 +8,7 @@ from backend.config import ModelConfig
 from backend.classifier.langchain_integration import (
     classify_with_langchain, 
 )
-from backend.classifier.keyword_classifier import KeywordClassifier
+from backend.classifier.keyword import KeywordClassifier
 from backend.classifier.conflict_resolver import (
     ConflictResolver,
     ClassificationResult

--- a/backend/services/classification_service.py
+++ b/backend/services/classification_service.py
@@ -1,3 +1,5 @@
+# backend/services/classification_service.py
+
 """
 분류 비즈니스 로직 서비스 (Skeleton)
 - PARA Agent + Keyword Classifier + Conflict Resolution 오케스트레이션
@@ -19,7 +21,7 @@ from backend.models import ClassifyResponse
 from backend.services.conflict_service import ConflictService
 from backend.data_manager import DataManager
 from backend.classifier.para_agent import run_para_agent
-from backend.classifier.keyword_classifier import KeywordClassifier
+from backend.classifier.keyword import KeywordClassifier
 
 # 추후 Step 3에서 실제 로직 구현 시 필요한 임포트들
 # from backend.classifier.para_agent import run_para_agent
@@ -160,7 +162,7 @@ class ClassificationService:
     async def _extract_keywords(self, text: str, user_context: dict) -> dict:
         """키워드 추출"""
         classifier = KeywordClassifier()  # 매번 새 인스턴스 (상태 없음)
-        result = await classifier.aclassify(text=text, user_context=user_context)
+        result = await classifier.classify(text=text, context=user_context)
 
         # 태그 안전 처리
         tags = result.get("tags", [])

--- a/backend/services/conflict_service.py
+++ b/backend/services/conflict_service.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 # 필요한 분류기 import
 try:
     from backend.classifier.para_agent import run_para_agent
-    from backend.classifier.keyword_classifier import KeywordClassifier
+    from backend.classifier.keyword import KeywordClassifier
     from backend.classifier.conflict_resolver import ClassificationResult, ConflictResolver
     from backend.classifier.snapshot_manager import SnapshotManager
 except ImportError:
@@ -28,7 +28,7 @@ except ImportError:
     PROJECT_ROOT = Path(__file__).parent.parent.parent
     sys.path.insert(0, str(PROJECT_ROOT))
     from backend.classifier.para_agent import run_para_agent
-    from backend.classifier.keyword_classifier import KeywordClassifier
+    from backend.classifier.keyword import KeywordClassifier
     from backend.classifier.conflict_resolver import ClassificationResult, ConflictResolver
     from backend.classifier.snapshot_manager import SnapshotManager
     
@@ -89,9 +89,9 @@ class ConflictService:
             # 2. Keyword 분류 
             if keyword_result is None:
                 logger.info("2. Keyword 분류 실행...")
-                # KeywordClassifier가 async 지원하면 aclassify 사용
-                if hasattr(self.keyword_classifier, 'aclassify'):
-                    keyword_result = await self.keyword_classifier.aclassify(
+                # KeywordClassifier가 async 지원하면 classify 사용
+                if hasattr(self.keyword_classifier, 'classify'):
+                    keyword_result = await self.keyword_classifier.classify(
                         text, user_context
                     )
                 else:


### PR DESCRIPTION
🔄 임포트 경로 변경:
- keyword_classifier → keyword 모듈로 변경
- 모든 서비스 및 분류기에서 새로운 경로 사용

📁 파일 변경 사항:
- backend/services/classification_service.py
  - 임포트: keyword_classifier → keyword
  - 메서드: aclassify() → classify()
  - 파라미터: user_context → context

- backend/services/conflict_service.py
  - 임포트: keyword_classifier → keyword (2곳)
  - 메서드: aclassify() → classify()
  - 주석 업데이트: "async 지원하면 classify 사용"

- backend/classifier/para_agent.py
  - 임포트: keyword_classifier → keyword

🔧 API 변경 사항:
- 메서드명: aclassify() → classify()
- 파라미터: user_context → context (일관성)
- 반환값 구조: {"tags": [...]} → {"category": "..."}

📌 호환성:
- 기존 Mock 테스트와 호환 유지
- 실제 분류 로직은 새로운 keyword.py 사용
- 에러 핸들링 및 Fallback 로직 유지

📌 Related: Issue [#75]

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

기존 분류 워크플로우는 그대로 유지하면서, 백엔드 서비스들이 업데이트된 `KeywordClassifier` 인터페이스와 모듈 경로를 사용하도록 마이그레이션합니다.

개선 사항:
- 충돌 및 분류 서비스를 업데이트하여 `KeywordClassifier`를 기존 경로 대신 새로운 `backend.classifier.keyword` 모듈에서 import 하도록 변경합니다.
- 서비스 호출에서 `aclassify(...)` 대신 `classify(...)`를 사용하여, 새로운 `KeywordClassifier`의 비동기(async) 인터페이스와 동작을 일치시킵니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate backend services to use the updated KeywordClassifier interface and module path while preserving existing classification workflows.

Enhancements:
- Update conflict and classification services to import KeywordClassifier from the new backend.classifier.keyword module.
- Align service calls with the new KeywordClassifier async interface by using classify(...) instead of aclassify(...).

</details>