### PR TITLE
✅ test[#10.1.10]: Route 단위 테스트 추가

### DIFF
--- a/docs/P/v4_phase1_service_layer/test_results_routes.txt
+++ b/docs/P/v4_phase1_service_layer/test_results_routes.txt
@@ -1,0 +1,86 @@
+============================= test session starts ==============================
+platform darwin -- Python 3.11.10, pytest-8.3.0, pluggy-1.6.0 -- /Users/jay/.pyenv/versions/3.11.10/envs/myenv/bin/python
+cachedir: .pytest_cache
+rootdir: /Users/jay/ICT-projects/flownote-mvp
+configfile: pytest.ini
+plugins: anyio-4.11.0, langsmith-0.4.37, asyncio-1.3.0, cov-7.0.0
+asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
+collecting ... collected 8 items
+
+tests/unit/routes/test_classifier_routes.py::test_classify_text_success PASSED [ 12%]
+tests/unit/routes/test_classifier_routes.py::test_classify_text_error PASSED [ 25%]
+tests/unit/routes/test_classifier_routes.py::test_classify_file_success PASSED [ 37%]
+tests/unit/routes/test_onboarding_routes.py::test_step1_create_user PASSED [ 50%]
+tests/unit/routes/test_onboarding_routes.py::test_suggest_areas PASSED   [ 62%]
+tests/unit/routes/test_onboarding_routes.py::test_save_context PASSED    [ 75%]
+tests/unit/routes/test_onboarding_routes.py::test_get_status_success PASSED [ 87%]
+tests/unit/routes/test_onboarding_routes.py::test_get_status_not_found PASSED [100%]
+
+================================ tests coverage ================================
+______________ coverage: platform darwin, python 3.11.10-final-0 _______________
+
+Name                                               Stmts   Miss  Cover   Missing
+--------------------------------------------------------------------------------
+backend/__init__.py                                    1      0   100%
+backend/api/__init__.py                                3      3     0%   8-41
+backend/api/endpoints/__init__.py                      4      4     0%   5-9
+backend/api/endpoints/classify.py                      5      5     0%   5-12
+backend/api/endpoints/conflict_resolver.py            71     71     0%   3-197
+backend/api/endpoints/conflict_resolver_agent.py     165    165     0%   9-430
+backend/api/endpoints/dashboard.py                    31     31     0%   5-56
+backend/api/endpoints/metadata.py                      5      5     0%   5-12
+backend/api/endpoints/search.py                        5      5     0%   5-12
+backend/api/models.py                                  4      4     0%   7-21
+backend/api/models/__init__.py                         3      3     0%   11-37
+backend/api/routes.py                                  6      6     0%   5-13
+backend/chunking.py                                   35     35     0%   10-124
+backend/classifier/__init__.py                         2      0   100%
+backend/classifier/base_classifier.py                 31     19    39%   41, 47-66, 70
+backend/classifier/conflict_resolver.py               38     21    45%   40-42, 68-111, 119, 128-136, 140-150
+backend/classifier/context_injector.py               109    109     0%   7-243
+backend/classifier/keyword.py                         40     28    30%   30-47, 53-75, 88
+backend/classifier/langchain_integration.py          208    171    18%   47-58, 75-109, 115-133, 147-171, 186-203, 235-272, 281-299, 304-320, 348-374, 400-460, 466-555
+backend/classifier/metadata_classifier.py             37     37     0%   7-91
+backend/classifier/para_agent.py                      77     49    36%   32-41, 49-54, 62-86, 94-104, 112-124, 132-149, 154-170, 175, 181-194
+backend/classifier/para_agent_wrapper.py              21     21     0%   5-111
+backend/classifier/para_classifier.py                 83     83     0%   9-277
+backend/classifier/snapshot_manager.py                38     15    61%   27, 50-65, 69, 73-76, 80-86, 97
+backend/cli.py                                        89     89     0%   6-165
+backend/config.py                                    118     53    55%   29-37, 89, 93-95, 98-100, 107, 111, 113, 128-142, 147-176, 223, 238-245
+backend/dashboard/__init__.py                          0      0   100%
+backend/dashboard/dashboard_core.py                   13     13     0%   3-42
+backend/data_manager.py                              167    132    21%   44-46, 50-51, 55-57, 73-114, 120-129, 135-158, 168-182, 188-195, 201-204, 215-227, 240-254, 260-270, 291-331
+backend/database/__init__.py                           2      2     0%   3-5
+backend/database/connection.py                        96     96     0%   3-202
+backend/database/metadata_schema.py                   52     52     0%   3-144
+backend/embedding.py                                  33     33     0%   10-118
+backend/exceptions.py                                 12     12     0%   10-43
+backend/export.py                                     28     28     0%   7-68
+backend/faiss_search.py                               78     78     0%   9-248
+backend/main.py                                       33      7    79%   110, 125, 143-149
+backend/metadata.py                                   95     95     0%   9-329
+backend/models/__init__.py                             5      0   100%
+backend/models/classification.py                      78      0   100%
+backend/models/common.py                              43      0   100%
+backend/models/conflict.py                            81      0   100%
+backend/models/user.py                                32      0   100%
+backend/modules/__init__.py                            3      3     0%   7-10
+backend/modules/pdf_helper.py                         26     26     0%   9-62
+backend/modules/vision_helper.py                      59     59     0%   11-296
+backend/routes/__init__.py                             0      0   100%
+backend/routes/api_models.py                          24     24     0%   17-112
+backend/routes/classifier_routes.py                   42     13    69%   150-154, 158-162, 179-181
+backend/routes/conflict_routes.py                     20      8    60%   42-49, 55
+backend/routes/onboarding_routes.py                   36      1    97%   64
+backend/search_history.py                             93     93     0%   9-353
+backend/services/__init__.py                           1      0   100%
+backend/services/classification_service.py            81     58    28%   74-132, 137, 150-156, 164-176, 182-189, 201-266
+backend/services/conflict_service.py                  71     48    32%   25-35, 78-143, 161-199, 212, 216, 220, 224-225
+backend/services/gpt_helper.py                       130     89    32%   25-29, 57-60, 74-103, 119-128, 146-196, 209-222, 244-274, 296-327, 357-392
+backend/services/onboarding_service.py                53     39    26%   38-60, 78-98, 113-140, 158-182
+backend/services/parallel_processor.py                23     23     0%   8-72
+backend/utils.py                                      42     42     0%   9-110
+backend/validators.py                                 88     88     0%   16-252
+--------------------------------------------------------------------------------
+TOTAL                                               2869   2194    24%
+============================== 8 passed in 0.41s ===============================

--- a/tests/unit/routes/test_classifier_routes.py
+++ b/tests/unit/routes/test_classifier_routes.py
@@ -1,0 +1,83 @@
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, patch
+from backend.main import app
+from backend.models import ClassifyResponse
+
+client = TestClient(app)
+
+@pytest.fixture
+def mock_classification_service():
+    with patch("backend.routes.classifier_routes.classification_service") as mock:
+        yield mock
+
+def test_classify_text_success(mock_classification_service):
+    """POST /classifier/classify 성공 테스트"""
+    # Mock 설정
+    mock_response = ClassifyResponse(
+        category="Projects",
+        confidence=0.9,
+        snapshot_id="snap_123",
+        keyword_tags=["test"],
+        reasoning="Test reasoning",
+        user_context_matched=True,
+        context_injected=False
+    )
+    mock_classification_service.classify = AsyncMock(return_value=mock_response)
+
+    # 요청
+    payload = {
+        "text": "프로젝트 마감일 확인",
+        "user_id": "user_001"
+    }
+    response = client.post("/classifier/classify", json=payload)
+
+    # 검증
+    assert response.status_code == 200
+    data = response.json()
+    assert data["category"] == "Projects"
+    assert data["confidence"] == 0.9
+    
+    # Service 호출 확인
+    mock_classification_service.classify.assert_called_once()
+
+def test_classify_text_error(mock_classification_service):
+    """POST /classifier/classify 에러 처리 테스트"""
+    # Mock 설정 (예외 발생)
+    mock_classification_service.classify = AsyncMock(side_effect=Exception("Service Error"))
+
+    # 요청
+    payload = {"text": "Error case"}
+    response = client.post("/classifier/classify", json=payload)
+
+    # 검증
+    assert response.status_code == 500
+    assert "분류 실패" in response.json()["detail"]
+
+def test_classify_file_success(mock_classification_service):
+    """POST /classifier/file 성공 테스트"""
+    # Mock 설정
+    mock_response = ClassifyResponse(
+        category="Resources",
+        confidence=0.8,
+        snapshot_id="snap_file_123",
+        keyword_tags=["file"],
+        reasoning="File reasoning",
+        user_context_matched=False,
+        context_injected=False
+    )
+    mock_classification_service.classify = AsyncMock(return_value=mock_response)
+
+    # 파일 업로드 요청
+    files = {"file": ("test.txt", b"File content", "text/plain")}
+    data = {"user_id": "user_001", "occupation": "Developer"}
+    
+    response = client.post("/classifier/file", files=files, data=data)
+
+    # 검증
+    assert response.status_code == 200
+    data = response.json()
+    assert data["category"] == "Resources"
+    
+    # Service 호출 확인
+    mock_classification_service.classify.assert_called_once()

--- a/tests/unit/routes/test_onboarding_routes.py
+++ b/tests/unit/routes/test_onboarding_routes.py
@@ -1,0 +1,96 @@
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock, patch
+from backend.main import app
+
+client = TestClient(app)
+
+@pytest.fixture
+def mock_onboarding_service():
+    with patch("backend.routes.onboarding_routes.onboarding_service") as mock:
+        yield mock
+
+def test_step1_create_user(mock_onboarding_service):
+    """POST /onboarding/step1 테스트"""
+    # Mock 설정
+    mock_result = {
+        "status": "success",
+        "user_id": "user_123",
+        "occupation": "Developer",
+        "name": "Test User"
+    }
+    mock_onboarding_service.create_user.return_value = mock_result
+
+    # 요청
+    payload = {"name": "Test User", "occupation": "Developer"}
+    response = client.post("/onboarding/step1", json=payload)
+
+    # 검증
+    assert response.status_code == 200
+    data = response.json()
+    assert data["user_id"] == "user_123"
+    assert "next_step" in data
+    
+    mock_onboarding_service.create_user.assert_called_once_with(
+        occupation="Developer", name="Test User"
+    )
+
+def test_suggest_areas(mock_onboarding_service):
+    """GET /onboarding/suggest-areas 테스트"""
+    # Mock 설정
+    mock_result = {
+        "status": "success",
+        "suggested_areas": ["Area1", "Area2"]
+    }
+    mock_onboarding_service.suggest_areas.return_value = mock_result
+
+    # 요청
+    params = {"user_id": "user_123", "occupation": "Developer"}
+    response = client.get("/onboarding/suggest-areas", params=params)
+
+    # 검증
+    assert response.status_code == 200
+    assert response.json()["suggested_areas"] == ["Area1", "Area2"]
+
+def test_save_context(mock_onboarding_service):
+    """POST /onboarding/save-context 테스트"""
+    # Mock 설정
+    mock_result = {
+        "status": "success",
+        "message": "Saved"
+    }
+    mock_onboarding_service.save_user_context.return_value = mock_result
+
+    # 요청
+    payload = {"user_id": "user_123", "selected_areas": ["Area1"]}
+    response = client.post("/onboarding/save-context", json=payload)
+
+    # 검증
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+
+def test_get_status_success(mock_onboarding_service):
+    """GET /onboarding/status/{user_id} 성공 테스트"""
+    mock_result = {
+        "status": "success",
+        "is_completed": True
+    }
+    mock_onboarding_service.get_user_status.return_value = mock_result
+
+    response = client.get("/onboarding/status/user_123")
+    
+    assert response.status_code == 200
+    assert response.json()["is_completed"] is True
+
+def test_get_status_not_found(mock_onboarding_service):
+    """GET /onboarding/status/{user_id} 실패 테스트"""
+    mock_result = {
+        "status": "error",
+        "message": "User not found"
+    }
+    mock_onboarding_service.get_user_status.return_value = mock_result
+
+    response = client.get("/onboarding/status/unknown_user")
+    
+    assert response.status_code == 404
+    assert response.json()["detail"] == "User not found"


### PR DESCRIPTION
🧪 테스트 파일 추가:
- `tests/unit/routes/test_classifier_routes.py`
  - 텍스트 분류 (성공/실패)
  - 파일 분류 (성공)
- `tests/unit/routes/test_onboarding_routes.py`
  - 사용자 생성, 영역 추천, 컨텍스트 저장, 상태 확인

🔧 테스트 내용:
- Service Layer Mocking을 통한 격리 테스트
- 엔드포인트 정상 동작 및 에러 핸들링 검증
- 8개 테스트 케이스 모두 통과

📝 결과 기록:
- `docs/P/v4_phase1_service_layer/test_results_routes.txt`
- phase 1 - `step 3/5` 완료

📌 Related: Issue [#75]

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

모의 서비스 레이어를 사용하여 온보딩 및 분류기 HTTP 라우트에 대한 단위 테스트를 추가하고, 해당 결과를 1단계 서비스 레이어 문서에 기록합니다.

Documentation:
- `test_results_routes` 문서 파일에 1단계 서비스 레이어의 라우트 테스트 실행 결과를 기록합니다.

Tests:
- 사용자 생성, 영역 추천, 컨텍스트 저장, 상태 조회(존재하지 않는 경우 처리 포함)를 다루는 온보딩 라우트 테스트를 추가합니다.
- 텍스트 및 파일 분류의 성공 사례와 텍스트 분류 실패에 대한 오류 처리를 다루는 분류기 라우트 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add unit tests for onboarding and classifier HTTP routes using mocked service layers and record their results in phase 1 service layer documentation.

Documentation:
- Record route test execution results for phase 1 service layer in the test_results_routes documentation file.

Tests:
- Add onboarding route tests covering user creation, area suggestions, context saving, and status retrieval including not-found handling.
- Add classifier route tests covering successful text and file classification and error handling for text classification failures.

</details>