### PR TITLE
🏗️ refactor [#10.2.2]: ConfidenceCalculator PR 피드백 반영 및 개선

### DIFF
--- a/tests/unit/services/test_confidence_calculator.py
+++ b/tests/unit/services/test_confidence_calculator.py
@@ -34,10 +34,6 @@ def test_calculate_weighted_average(calculator):
     # 가중 합: 0.45
     # 예상 기본 점수: 0.45 / 0.65 ≈ 0.692
     
-    # Agreement 조건: 1.0과 0.5는 차이가 0.5로 큼 -> Disagreement Penalty?
-    # 하지만 0.5는 threshold(0.6) 미만이므로 valid_scores에 포함되지 않음
-    # 따라서 Agreement/Disagreement 로직 타지 않음
-    
     result = calculator.calculate(scores)
     expected_base = round(0.45 / 0.65, 3)
     assert result.details["base_score"] == expected_base
@@ -52,26 +48,35 @@ def test_agreement_boost(calculator):
     
     result = calculator.calculate(scores)
     
-    # "Agreement Boost"가 이유에 포함되어야 함
-    assert any("Agreement Boost" in r for r in result.reasons)
+    # 구조화된 adjustments 확인
+    assert any(adj["type"] == "boost" and adj["reason"] == "Agreement Boost" 
+               for adj in result.details["adjustments"])
     assert result.score > result.details["base_score"]
 
 def test_disagreement_penalty(calculator):
     """분류기 간 불일치 시 페널티 적용"""
+    # Negative case: one score below threshold -> no disagreement penalty
     scores = {
         "ai": 0.9,
         "rule": 0.4  # 0.4는 threshold 미만이므로 무시됨 -> Disagreement 발생 안 함
     }
-    # Disagreement를 유발하려면 둘 다 threshold(0.6) 이상이어야 함
+    result_no_disagreement = calculator.calculate(scores)
+    base_score_no_disagreement = result_no_disagreement.details["base_score"]
+
+    # "Disagreement Penalty"가 이유에 포함되지 않아야 하고, 최종 점수는 base_score와 같아야 함
+    assert all("Disagreement Penalty" not in r for r in result_no_disagreement.reasons)
+    assert result_no_disagreement.score == base_score_no_disagreement
+
+    # Positive case: both scores above threshold and sufficiently different -> disagreement penalty
     scores_valid = {
         "ai": 0.95,
         "rule": 0.60
     }
     # 차이 0.35 > 0.3 (0.15 * 2) -> Disagreement Penalty (-0.20)
-    
     result = calculator.calculate(scores_valid)
     
-    assert any("Disagreement Penalty" in r for r in result.reasons)
+    assert any(adj["type"] == "penalty" and adj["reason"] == "Disagreement Penalty" 
+               for adj in result.details["adjustments"])
     assert result.score < result.details["base_score"]
 
 def test_feature_adjustments(calculator):
@@ -87,21 +92,22 @@ def test_feature_adjustments(calculator):
     
     # Base 0.7 + 0.10 + 0.05 = 0.85
     assert result.score == pytest.approx(0.85)
-    assert any("High Frequency Boost" in r for r in result.reasons)
-    assert any("Recent Edit Boost" in r for r in result.reasons)
+    assert any(adj["reason"] == "High Frequency Boost" for adj in result.details["adjustments"])
+    assert any(adj["reason"] == "Recent Edit Boost" for adj in result.details["adjustments"])
 
 def test_low_info_penalty(calculator):
     """정보 부족(짧은 텍스트) 페널티"""
     scores = {"ai": 0.7}
-    features = {
-        "text_length": 10  # Low info penalty (-0.10)
-    }
     
-    result = calculator.calculate(scores, features)
+    # Case 1: text_length < 50
+    features_short = {"text_length": 10}
+    result_short = calculator.calculate(scores, features_short)
+    assert any(adj["reason"] == "Low Info Penalty" for adj in result_short.details["adjustments"])
     
-    # Base 0.7 - 0.10 = 0.60
-    assert result.score == pytest.approx(0.60)
-    assert any("Low Info Penalty" in r for r in result.reasons)
+    # Case 2: text_length == 0 (Empty)
+    features_empty = {"text_length": 0}
+    result_empty = calculator.calculate(scores, features_empty)
+    assert any(adj["reason"] == "Low Info Penalty" for adj in result_empty.details["adjustments"])
 
 def test_score_clamping(calculator):
     """점수가 0.0 ~ 1.0 범위를 벗어나지 않도록 클램핑"""
@@ -110,24 +116,34 @@ def test_score_clamping(calculator):
     result_high = calculator.calculate(scores_high)
     assert result_high.score == 1.0
     
-    # 0.0 미만 케이스 (이론상 어렵지만 페널티 누적 시)
+    # 0.0 미만 케이스
     scores_low = {"ai": 0.0} # Base 0.0
     features_bad = {"text_length": 10} # Penalty -0.10 -> -0.10 -> 0.0
     result_low = calculator.calculate(scores_low, features_bad)
     assert result_low.score == 0.0
 
 def test_recommend_action(calculator):
-    """점수 구간별 액션 권고"""
+    """점수 구간별 액션 권고 (경계값 포함)"""
     # Auto Apply (> 0.85)
-    res1 = calculator.calculate({"ai": 0.9}) # Base 0.9 -> Auto Apply
+    res1 = calculator.calculate({"ai": 0.9})  # Base 0.9 -> Auto Apply
     assert res1.action == "auto_apply"
-    
+
+    # Boundary: Auto Apply (== 0.85)
+    # Base 0.85 -> Auto Apply
+    res_boundary_auto = calculator.calculate({"ai": 0.85})
+    assert res_boundary_auto.action == "auto_apply"
+
     # Suggest (0.60 ~ 0.85)
-    res2 = calculator.calculate({"ai": 0.7}) # Base 0.7 -> Suggest
+    res2 = calculator.calculate({"ai": 0.7})  # Base 0.7 -> Suggest
     assert res2.action == "suggest"
-    
+
+    # Boundary: Suggest (== 0.60)
+    # Base 0.60 -> Suggest
+    res_boundary_suggest = calculator.calculate({"ai": 0.60})
+    assert res_boundary_suggest.action == "suggest"
+
     # Manual Review (< 0.60)
-    res3 = calculator.calculate({"ai": 0.4}) # Base 0.4 -> Manual Review
+    res3 = calculator.calculate({"ai": 0.4})  # Base 0.4 -> Manual Review
     assert res3.action == "manual_review"
 
 def test_empty_scores(calculator):
@@ -136,3 +152,50 @@ def test_empty_scores(calculator):
     assert result.score == 0.0
     assert result.action == "manual_review"
     assert "No valid scores provided" in result.reasons
+    
+    # Details 검증
+    assert result.details["base_score"] == 0.0
+    assert result.details["input_scores"] == {}
+    assert result.details["adjustments"] == []
+
+def test_complex_scenario_multiple_adjustments(calculator):
+    """복합 시나리오: 여러 조정이 동시에 적용되는 경우"""
+    scores = {
+        "ai": 0.75,
+        "rule": 0.70,
+        "keyword": 0.72
+    }
+    # Agreement: 모두 0.6 이상이고 차이 0.05 (< 0.15) -> Boost +0.15
+    
+    features = {
+        "access_frequency": 0.6,   # High freq boost +0.10
+        "days_since_edit": 5,      # Recent edit boost +0.05
+        "text_length": 30          # Low info penalty -0.10
+    }
+    
+    result = calculator.calculate(scores, features)
+    
+    # Base score 계산 (가중 평균)
+    # ai(0.75*0.4) + rule(0.70*0.25) + keyword(0.72*0.2) = 0.3 + 0.175 + 0.144 = 0.619
+    # 총 가중치: 0.85
+    # Base: 0.619 / 0.85 ≈ 0.728
+    expected_base = round((0.75*0.4 + 0.70*0.25 + 0.72*0.2) / 0.85, 3)
+    assert result.details["base_score"] == expected_base
+    
+    # 조정 확인: Agreement(+0.15) + High Freq(+0.10) + Recent(+0.05) + Low Info(-0.10)
+    # = +0.20
+    adjustments = result.details["adjustments"]
+    assert len(adjustments) == 4
+    
+    # 각 조정 타입 확인
+    adjustment_types = {adj["reason"]: adj["amount"] for adj in adjustments}
+    assert adjustment_types["Agreement Boost"] == 0.15
+    assert adjustment_types["High Frequency Boost"] == 0.10
+    assert adjustment_types["Recent Edit Boost"] == 0.05
+    assert adjustment_types["Low Info Penalty"] == -0.10
+    
+    # 최종 점수: base + 조정 = 0.728 + 0.20 = 0.928
+    expected_final = round(expected_base + 0.20, 3)
+    assert result.score == expected_final
+    assert result.action == "auto_apply"
+


### PR DESCRIPTION
🔧 PR Feedback 반영:
- 구조화된 adjustments 리스트 (문자열 파싱 의존성 제거)
  - TypedDict 기반 AdjustmentDetail 타입 정의
  - 각 조정 내역을 {"type", "reason", "amount"} 구조로 저장
- Docstring 개선 (하드코딩된 값 대신 상수 참조)
  - _AGREEMENT_THRESHOLD, _AGREEMENT_DIFF_LIMIT 등 상수명 명시
- Low Info Penalty 로직 수정
  - features에 text_length 키가 명시적으로 존재할 때만 적용
  - 정보 미제공 시 페널티 부과 방지

✅ 테스트 보강:
- 경계값 테스트 추가 (0.60, 0.85 임계값)
- Disagreement 음수 케이스 검증
  - threshold 미만 점수 시 페널티 미적용 확인
- Empty Scores 상세 검증
  - details 필드까지 포괄적 검증
- 복합 시나리오 테스트 추가
  - 여러 조정이 동시 적용되는 경우 검증

🎯 추가 개선:
- __init__ 메서드 추가 및 가중치 합 검증
  - 초기화 시 _WEIGHTS 합계가 1.0인지 확인
  - 오차 범위 벗어날 시 warning 로그
- 포괄적인 사용 예시 추가
  - Docstring에 Example 섹션 포함
  - 실제 사용 패턴 및 출력 예시 제공

📊 코드 품질:
- 테스트 커버리지: 99% (84줄 중 83줄)
- 테스트 케이스: 10개 (모두 통과)
- 모든 매직 넘버 상수화 완료

📁 파일:
- backend/services/confidence_calculator.py
- tests/unit/services/test_confidence_calculator.py

📌 Related
- Issue [#76] (Step 1/5)
- @sourcery-ai review (https://github.com/jjaayy2222/flownote-mvp/pull/95#pullrequestreview-3538188290)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

구조화된 조정 메타데이터를 사용하도록 신뢰도(Confidence) 점수 로직을 개선하고, 찬성/반대(agreement/disagreement) 규칙을 명확히 하며, 가중치와 저정보(low‑information) 패널티에 대한 검증을 강화하는 동시에, 엣지 케이스와 복잡한 시나리오에 대한 테스트 커버리지를 확장합니다.

New Features:
- 신뢰도 계산 결과에 구조화된 조정 메타데이터를 추가하여, 각 부스트/패널티에 대해 타입(type), 이유(reason), 양(amount)을 노출합니다.
- 초기화 시점에 분류기 가중치가 대략 1.0이 되도록 합산되는지 검증하고, 그렇지 않은 경우 경고를 출력하는 기능을 도입합니다.
- 전형적인 입력과 출력 예시를 포함한 신뢰도 계산기 사용 예제를 전체 흐름으로 문서화합니다.

Bug Fixes:
- 명시적인 `text_length` 피처가 제공되지 않은 경우 저정보 패널티가 적용되지 않도록 방지합니다.
- 고려 대상 점수들이 모두 유효성 임계값을 충족할 때에만 반대(disagreement) 패널티가 적용되도록 보장합니다.

Enhancements:
- 사람에게 읽기 쉬운 이유와 머신이 읽을 수 있는 조정 세부정보를 모두 기록하는 헬퍼로 조정 처리 로직을 리팩터링합니다.
- 명명된 임계값(named thresholds)과 문서화된 경계 조건(boundary conditions)을 사용하도록 찬성/반대(agreement/disagreement) 체크를 명확히 하고, 이를 도크스트링에 기술합니다.

Tests:
- 찬성/반대 케이스의 긍정/부정 상황, 짧은 텍스트 및 빈 텍스트에 대한 저정보 동작, 0.0 및 1.0에서의 점수 클램핑, 액션 추천 경계값, 빈 점수에 대한 상세 정보, 그리고 여러 조정이 동시에 발생하는 복합 시나리오를 포괄하도록 단위 테스트를 확장합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the confidence scoring logic to use structured adjustment metadata, clarify agreement/disagreement rules, and strengthen validation around weights and low‑information penalties while expanding test coverage for edge and complex scenarios.

New Features:
- Add structured adjustment metadata to confidence calculation results, exposing type, reason, and amount for each boost or penalty.
- Introduce initialization‑time validation that classifier weights approximately sum to 1.0 and emit a warning when they do not.
- Document a full usage example of the confidence calculator, including typical inputs and outputs.

Bug Fixes:
- Prevent low‑information penalties from being applied when no explicit text_length feature is provided.
- Ensure disagreement penalties only apply when all considered scores meet the validity threshold.

Enhancements:
- Refactor adjustment handling into a helper that records both human‑readable reasons and machine‑readable adjustment details.
- Clarify agreement and disagreement checks to use named thresholds and documented boundary conditions in docstrings.

Tests:
- Extend unit tests to cover agreement/disagreement negative and positive cases, low‑information behavior for short and empty text, score clamping at 0.0 and 1.0, action recommendation boundary values, empty‑scores details, and a complex scenario with multiple simultaneous adjustments.

</details>