### PR TITLE
✨ feat[#10.2.3]: RuleEngine 구현 (규칙 기반 분류기)

### DIFF
--- a/backend/services/rule_engine.py
+++ b/backend/services/rule_engine.py
@@ -1,0 +1,125 @@
+# backend/services/rule_engine.py
+
+"""
+RuleEngine - 규칙 기반 분류 엔진
+"""
+import logging
+import re
+from typing import Dict, Any, List, Optional, Literal, TypedDict
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+ParaCategory = Literal["Projects", "Areas", "Resources", "Archives"]
+
+
+@dataclass
+class RuleResult:
+    """규칙 평가 결과"""
+    category: ParaCategory
+    confidence: float
+    matched_rule: str
+    details: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Rule:
+    """분류 규칙 정의"""
+    name: str
+    pattern: str  # 정규식 패턴 문자열
+    category: ParaCategory
+    confidence: float
+    description: str
+    _compiled_pattern: Optional[re.Pattern] = None
+
+    @property
+    def compiled_pattern(self) -> re.Pattern:
+        """지연 컴파일된 정규식 패턴 반환"""
+        if self._compiled_pattern is None:
+            self._compiled_pattern = re.compile(self.pattern, re.IGNORECASE)
+        return self._compiled_pattern
+
+
+class RuleEngine:
+    """
+    정규식 패턴 및 메타데이터 규칙을 기반으로 문서를 분류합니다.
+    """
+
+    # 기본 PARA 규칙 정의 (15개 이상)
+    _DEFAULT_RULES_DATA = [
+        # Projects (목표, 마감일, 계획)
+        {"name": "project_keyword", "pattern": r"\b(project|plan|roadmap|milestone)\b", "category": "Projects", "confidence": 0.7, "description": "Explicit project keywords"},
+        {"name": "deadline_pattern", "pattern": r"(deadline|due date|target date):?\s*\d{4}-\d{2}-\d{2}", "category": "Projects", "confidence": 0.8, "description": "Deadline format"},
+        {"name": "todo_list", "pattern": r"(-|\*)\s*\[\s*\]", "category": "Projects", "confidence": 0.6, "description": "Unchecked todo items"},
+        {"name": "urgent_tag", "pattern": r"#urgent|#priority", "category": "Projects", "confidence": 0.75, "description": "Urgency tags"},
+        {"name": "sprint_pattern", "pattern": r"\bsprint\s*\d+", "category": "Projects", "confidence": 0.7, "description": "Sprint numbering"},
+
+        # Areas (지속적인 관리, 책임)
+        {"name": "area_finance", "pattern": r"\b(finance|budget|invoice|tax|expense)\b", "category": "Areas", "confidence": 0.7, "description": "Finance related terms"},
+        {"name": "area_health", "pattern": r"\b(health|workout|diet|medical|checkup)\b", "category": "Areas", "confidence": 0.7, "description": "Health related terms"},
+        {"name": "area_study", "pattern": r"\b(study|learn|course|lecture|exam)\b", "category": "Areas", "confidence": 0.65, "description": "Study related terms"},
+        {"name": "area_home", "pattern": r"\b(home|house|chore|maintenance|repair)\b", "category": "Areas", "confidence": 0.65, "description": "Home maintenance"},
+        {"name": "routine_keyword", "pattern": r"\b(routine|daily|weekly|monthly|habit)\b", "category": "Areas", "confidence": 0.6, "description": "Routine activities"},
+
+        # Resources (참고 자료, 정보)
+        {"name": "resource_keyword", "pattern": r"\b(reference|guide|manual|tutorial|handbook)\b", "category": "Resources", "confidence": 0.7, "description": "Explicit resource keywords"},
+        {"name": "note_keyword", "pattern": r"\b(note|memo|idea|thought|draft)\b", "category": "Resources", "confidence": 0.6, "description": "General notes"},
+        {"name": "link_collection", "pattern": r"(https?://[^\s]+)", "category": "Resources", "confidence": 0.5, "description": "Contains URLs"},
+        {"name": "code_snippet", "pattern": r"```[\s\S]*?```", "category": "Resources", "confidence": 0.6, "description": "Code blocks"},
+        {"name": "book_ref", "pattern": r"\b(book|article|paper|citation)\b", "category": "Resources", "confidence": 0.65, "description": "Literature references"},
+
+        # Archives (완료됨, 보관)
+        {"name": "archive_keyword", "pattern": r"\b(archive|deprecated|obsolete|legacy)\b", "category": "Archives", "confidence": 0.8, "description": "Explicit archive keywords"},
+        {"name": "completed_status", "pattern": r"\b(completed|done|finished|closed)\b", "category": "Archives", "confidence": 0.6, "description": "Completion status"},
+        {"name": "old_year", "pattern": r"\b(20[0-1][0-9]|202[0-3])\b", "category": "Archives", "confidence": 0.5, "description": "Past years (context dependent)"},
+    ]
+
+    def __init__(self):
+        """RuleEngine 초기화 및 규칙 로드"""
+        self.rules: List[Rule] = []
+        self._load_default_rules()
+
+    def _load_default_rules(self):
+        """기본 규칙 데이터를 Rule 객체로 변환하여 로드"""
+        for rule_data in self._DEFAULT_RULES_DATA:
+            try:
+                self.rules.append(Rule(**rule_data))
+            except TypeError as e:
+                logger.error(f"Failed to load rule {rule_data.get('name')}: {e}")
+
+    def evaluate(
+        self, 
+        text: str, 
+        metadata: Optional[Dict[str, Any]] = None
+    ) -> Optional[RuleResult]:
+        """
+        텍스트와 메타데이터를 기반으로 규칙을 평가합니다.
+        
+        가장 높은 신뢰도를 가진 매칭 결과를 반환합니다.
+        매칭되는 규칙이 없으면 None을 반환합니다.
+
+        Args:
+            text: 분석할 파일 내용
+            metadata: 파일 메타데이터 (선택 사항)
+
+        Returns:
+            Optional[RuleResult]: 최고의 매칭 결과 또는 None
+        """
+        if not text:
+            return None
+
+        best_match: Optional[RuleResult] = None
+        
+        # 모든 규칙 순회
+        for rule in self.rules:
+            if rule.compiled_pattern.search(text):
+                # 매칭 성공
+                if best_match is None or rule.confidence > best_match.confidence:
+                    best_match = RuleResult(
+                        category=rule.category,
+                        confidence=rule.confidence,
+                        matched_rule=rule.name,
+                        details={"description": rule.description}
+                    )
+        
+        return best_match

--- a/docs/P/v4_phase2_hybrid_classifier/rule_engine_test_report.md
+++ b/docs/P/v4_phase2_hybrid_classifier/rule_engine_test_report.md
@@ -1,0 +1,33 @@
+# RuleEngine 단위 테스트 결과 보고서
+
+> **테스트 실행일**: 2025-12-05 
+> 
+> **대상 모듈**: `backend/services/rule_engine.py` 
+>
+> **테스트 파일**: `tests/unit/services/test_rule_engine.py` 
+
+## 📊 요약
+- **총 테스트 케이스**: 7개
+- **통과**: 7개 (100%)
+- **실패**: 0개
+- **커버리지**: 96% (45줄 중 43줄 실행)
+
+## ✅ 테스트 상세 결과
+
+| 테스트 케이스 | 설명 | 결과 | 비고 |
+| :--- | :--- | :---: | :--- |
+| `test_match_projects` | Projects 카테고리 매칭 (키워드, 마감일, 체크리스트) | ✅ Pass | `project`, `deadline`, `[ ]` 패턴 인식 확인 |
+| `test_match_areas` | Areas 카테고리 매칭 (재무, 건강, 루틴) | ✅ Pass | `finance`, `workout` 등 패턴 인식 확인 |
+| `test_match_resources` | Resources 카테고리 매칭 (참고, 노트, 코드) | ✅ Pass | `reference`, `note`, `code block` 인식 확인 |
+| `test_match_archives` | Archives 카테고리 매칭 (보관, 완료) | ✅ Pass | `archive`, `completed` 패턴 인식 확인 |
+| `test_priority_highest_confidence` | 다중 규칙 매칭 시 신뢰도 우선순위 검증 | ✅ Pass | 낮은 신뢰도(`note`, 0.6)보다 높은 신뢰도(`project`, 0.7) 선택 확인 |
+| `test_no_match` | 매칭되는 규칙이 없는 경우 | ✅ Pass | `None` 반환 확인 |
+| `test_empty_input` | 빈 입력 또는 None 처리 | ✅ Pass | `None` 반환 확인 |
+
+## 📝 커버리지 분석
+- **실행되지 않은 라인**: 87-88 (`except TypeError` 블록)
+- **분석**: 기본 규칙 데이터(`_DEFAULT_RULES_DATA`)가 코드 내에 하드코딩되어 있어 `TypeError`가 발생할 가능성이 없으므로, 해당 예외 처리 블록은 정상적인 테스트 실행으로는 도달하지 않음. *이는 예상된 동작임.*
+
+## 💡 결론
+- `RuleEngine`은 PARA 방법론에 기반한 4가지 카테고리에 대해 정의된 정규식 규칙을 정확하게 매칭하며, 여러 규칙이 경합할 경우 신뢰도가 가장 높은 규칙을 올바르게 선택함
+- 또한 빈 입력이나 매칭 실패와 같은 엣지 케이스도 적절히 처리하고 있어 프로덕션 환경에서 사용할 준비 완료

--- a/tests/unit/services/test_rule_engine.py
+++ b/tests/unit/services/test_rule_engine.py
@@ -1,0 +1,98 @@
+# tests/unit/services/test_rule_engine.py
+
+import pytest
+from backend.services.rule_engine import RuleEngine
+
+@pytest.fixture
+def engine():
+    return RuleEngine()
+
+def test_match_projects(engine):
+    """Projects 카테고리 매칭 테스트"""
+    # 1. Explicit keyword
+    res1 = engine.evaluate("This is a new project roadmap.")
+    assert res1 is not None
+    assert res1.category == "Projects"
+    assert res1.matched_rule == "project_keyword"
+    
+    # 2. Deadline
+    res2 = engine.evaluate("Task due date: 2025-12-31")
+    assert res2 is not None
+    assert res2.category == "Projects"
+    assert res2.matched_rule == "deadline_pattern"
+    
+    # 3. Todo list
+    res3 = engine.evaluate("- [ ] Task 1\n- [ ] Task 2")
+    assert res3 is not None
+    assert res3.category == "Projects"
+    assert res3.matched_rule == "todo_list"
+
+def test_match_areas(engine):
+    """Areas 카테고리 매칭 테스트"""
+    # 1. Finance
+    res1 = engine.evaluate("Monthly finance report and budget.")
+    assert res1 is not None
+    assert res1.category == "Areas"
+    assert res1.matched_rule == "area_finance"
+    
+    # 2. Health
+    res2 = engine.evaluate("Daily workout routine.")
+    assert res2 is not None
+    assert res2.category == "Areas"
+    assert res2.matched_rule == "area_health" # or routine_keyword depending on priority
+
+def test_match_resources(engine):
+    """Resources 카테고리 매칭 테스트"""
+    # 1. Explicit keyword
+    res1 = engine.evaluate("Python reference guide.")
+    assert res1 is not None
+    assert res1.category == "Resources"
+    assert res1.matched_rule == "resource_keyword"
+    
+    # 2. Note
+    res2 = engine.evaluate("Just a quick note about ideas.")
+    assert res2 is not None
+    assert res2.category == "Resources"
+    assert res2.matched_rule == "note_keyword"
+    
+    # 3. Code snippet
+    res3 = engine.evaluate("```python\nprint('hello')\n```")
+    assert res3 is not None
+    assert res3.category == "Resources"
+    assert res3.matched_rule == "code_snippet"
+
+def test_match_archives(engine):
+    """Archives 카테고리 매칭 테스트"""
+    # 1. Explicit keyword
+    res1 = engine.evaluate("This project is deprecated and archived.")
+    assert res1 is not None
+    assert res1.category == "Archives"
+    assert res1.matched_rule == "archive_keyword"
+    
+    # 2. Completed
+    res2 = engine.evaluate("Status: completed.")
+    assert res2 is not None
+    assert res2.category == "Archives"
+    assert res2.matched_rule == "completed_status"
+
+def test_priority_highest_confidence(engine):
+    """여러 규칙 매칭 시 가장 높은 신뢰도 선택"""
+    # "note"(Resources, 0.6) vs "project"(Projects, 0.7)
+    text = "This is a project note."
+    result = engine.evaluate(text)
+    
+    assert result is not None
+    assert result.category == "Projects"
+    assert result.confidence == 0.7
+    assert result.matched_rule == "project_keyword"
+
+def test_no_match(engine):
+    """매칭되는 규칙이 없는 경우"""
+    text = "Just some random text with no specific keywords."
+    result = engine.evaluate(text)
+    assert result is None
+
+def test_empty_input(engine):
+    """빈 입력 처리"""
+    assert engine.evaluate("") is None
+    assert engine.evaluate(None) is None


### PR DESCRIPTION
📏 주요 기능:
- 정규식 기반 패턴 매칭 엔진
- PARA 방법론에 따른 4대 카테고리 규칙 정의 (총 15+개)
  - Projects: 'project', 'plan', 'deadline' 등
  - Areas: 'health', 'finance', 'study' 등
  - Resources: 'note', 'reference', 'guide' 등
  - Archives: 'done', 'completed', 'deprecated' 등
- 매칭된 규칙 중 최고 신뢰도 결과 반환

🛠️ Implementation Details:
- 정규식 컴파일 최적화 (re.compile)
- Rule 데이터 클래스 활용으로 구조화된 관리
- 확장 가능한 규칙 등록 구조

✅ Testing:
- 단위 테스트 작성 (tests/unit/services/test_rule_engine.py)
- 테스트 결과 문서화 (docs/P/v4_phase2_hybrid_classifier/rule_engine_test_report.md)

📁 파일:
- backend/services/rule_engine.py
- tests/unit/services/test_rule_engine.py
- docs/P/v4_phase2_hybrid_classifier/rule_engine_test_report.md

📌 Related: Issue [#76] (Step 2/5)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

PARA 카테고리를 사용하는 규칙 기반 텍스트 분류 엔진을 도입하고, 유닛 테스트와 문서를 통해 이를 검증합니다.

New Features:
- 정규식 규칙을 기반으로 텍스트를 PARA 카테고리로 분류하고, 가장 높은 신뢰도의 매치를 반환하는 `RuleEngine` 서비스를 추가합니다.

Documentation:
- `RuleEngine` 유닛 테스트 케이스, 통과 여부, 커버리지 메트릭을 문서화한 테스트 리포트를 추가합니다.

Tests:
- PARA 카테고리 매칭, 신뢰도 기반 우선순위 결정, 매치 없음 또는 빈 입력과 같은 엣지 케이스를 포함하여 `RuleEngine`에 대한 유닛 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a rule-based text classification engine using PARA categories and validate it with unit tests and documentation.

New Features:
- Add a RuleEngine service that classifies text into PARA categories based on regex rules and returns the highest-confidence match.

Documentation:
- Add a test report documenting RuleEngine unit test cases, pass status, and coverage metrics.

Tests:
- Add unit tests covering PARA category matching, confidence-based prioritization, and edge cases like no matches or empty input for the RuleEngine.

</details>