### PR TITLE
🏗️ refactor [#10.2.6]: HybridClassifier 2차 개선 - Threshold 설정 및 에러 처리 강화

### DIFF
--- a/backend/classifier/hybrid_classifier.py
+++ b/backend/classifier/hybrid_classifier.py
@@ -34,9 +34,17 @@ class HybridClassifier(BaseClassifier):
             rule_threshold: 룰 매칭으로 인정할 최소 신뢰도 (기본값 0.8)
         """
         super().__init__()
+
+        if not (0.0 <= rule_threshold <= 1.0):
+            raise ValueError(
+                f"rule_threshold must be between 0.0 and 1.0, got {rule_threshold}"
+            )
+
         self.rule_engine = rule_engine or RuleEngine()
         self.ai_classifier = ai_classifier or AIClassifier()
         self.rule_threshold = rule_threshold
+        # BaseClassifier에 있지만 명시적으로 초기화
+        self.last_error: Optional[str] = None
 
     async def classify(
         self, text: str, context: Optional[Dict[str, Any]] = None
@@ -70,9 +78,9 @@ class HybridClassifier(BaseClassifier):
                 }
         except Exception as e:
             # Rule Engine 실패는 치명적이지 않으므로 경고만 남기고 AI로 진행
-            # 단, 디버깅을 위해 last_error에 기록은 해둠
+            # 단, 디버깅을 위해 last_error에 기록하고 traceback은 로그로 남김
             error_msg = f"RuleEngine warning: {e}"
-            logger.warning(f"{error_msg}, proceeding to AI")
+            logger.warning(f"{error_msg}, proceeding to AI", exc_info=True)
             self.last_error = error_msg
 
         # 2. AI-based Classification (Asynchronous)


### PR DESCRIPTION
🔄 주요 변경:
- Configurable Rule Threshold: 생성자에서 threshold 설정 가능 및 범위 검증(0.0~1.0)
- Enhanced Error Handling: RuleEngine 실패 시 Full Traceback 로깅 및 last_error 명시적 초기화
- Validation Error 구분: 빈 입력 시 method=validation_error 반환

✅ Testing:
- Threshold 설정에 따른 동작 검증 테스트 추가
- Threshold 유효성 검사 테스트 추가
- 기존 로직 회귀 테스트 완료

📁 파일:
- backend/classifier/hybrid_classifier.py
- tests/unit/classifier/test_hybrid_classifier.py

📌 Related
- Issue [#76] (Step 4/5) - Hybrid Logic
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/104#pullrequestreview-3544243114)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

하이브리드 분류기(HybridClassifier)의 rule threshold 설정을 검증하고, AI 폴백(fallback) 이전의 규칙 기반 분류에 대해 에러 처리와 관측 가능성을 개선합니다.

New Features:
- 인스턴스별로 `HybridClassifier`의 `rule_threshold`를 0.0–1.0 범위 내에서 검증된 값으로 설정할 수 있도록 허용합니다.

Enhancements:
- `RuleEngine` 평가가 실패했을 때에도 AI 분류로 폴백하면서 전체 traceback을 로깅합니다.
- `HybridClassifier` 인스턴스에서 `last_error`를 명시적으로 초기화하여 에러 상태 처리가 명확해지도록 합니다.

Tests:
- 유효하지 않은 `rule_threshold` 값과, 서로 다른 threshold 설정에 따라 달라지는 동작을 검증하는 단위 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate HybridClassifier rule threshold configuration and improve error handling and observability for rule-based classification before AI fallback.

New Features:
- Allow configuring HybridClassifier rule_threshold per instance within a validated 0.0–1.0 range.

Enhancements:
- Log full traceback when RuleEngine evaluation fails while still falling back to AI classification.
- Explicitly initialize last_error to ensure clear error state handling in HybridClassifier instances.

Tests:
- Add unit tests covering invalid rule_threshold values and behavior changes based on different configured thresholds.

</details>