### PR TITLE
🏗️ refactor [#10.2.6]: HybridClassifier 테스트 8차 개선

### DIFF
--- a/tests/unit/classifier/test_hybrid_classifier.py
+++ b/tests/unit/classifier/test_hybrid_classifier.py
@@ -50,7 +50,7 @@ def test_init_threshold_validation(mock_rule_engine, mock_ai_classifier):
     [
         # --- Standard Cases (Rule Matches) ---
         (0.8, True, 0.9, "rule"),  # Conf > Threshold -> Rule
-        (0.8, True, 0.8, "rule"),  # Conf == Threshold -> Rule (Boundary Inclusive)
+        (0.8, True, 0.8, "rule"),  # Conf == Threshold -> Rule
         (0.8, True, 0.79, "ai"),  # Conf < Threshold -> AI
         # --- Low Threshold Cases (Rule Matches) ---
         (0.5, True, 0.6, "rule"),  # Conf > Threshold -> Rule
@@ -58,7 +58,6 @@ def test_init_threshold_validation(mock_rule_engine, mock_ai_classifier):
         # --- Edge Case: Threshold 0.0 (Accept Match) ---
         (0.0, True, 0.0, "rule"),  # Zero Conf Rule -> Rule
         # --- Edge Case: Rule Miss (ALWAYS AI Fallback) ---
-        # Rule 매칭 실패 시 임계값과 상관없이 무조건 AI로 가야 함
         (0.0, False, 0.0, "ai"),  # No Match at 0.0 -> AI
         (0.5, False, 0.0, "ai"),  # No Match at 0.5 -> AI
         (1.0, False, 0.0, "ai"),  # No Match at 1.0 -> AI
@@ -107,20 +106,21 @@ async def test_classify_threshold_logic(
     # 5. Verify Method
     assert result["method"] == expected_method
 
-    # 6. Verify Wiring (Rule Engine MUST be called exactly once)
-    # metadata may be None or empty dict depending on implementation detail, but text must be correct.
-    # evaluate signature: (text, metadata=None)
-    mock_rule_engine.evaluate.assert_called_once_with(test_text, metadata=None)
+    # 6. Verify Wiring (Rule Engine)
+    # metadata may occur as None or {}, so check flexible
+    mock_rule_engine.evaluate.assert_called_once()
+    # Check only position arg 0 (test_text) to be robust against metadata default changes
+    args, _ = mock_rule_engine.evaluate.call_args
+    assert args[0] == test_text
 
-    # 7. Verify Routing
+    # 7. Verify Routing & AI Wiring
     if expected_method == "rule":
         assert result["category"] == "Projects"
         mock_ai_classifier.classify.assert_not_called()
     else:
         assert result["category"] == "AI-Category"
-        # AI Classifier must be awaited call
-        mock_ai_classifier.classify.assert_awaited_once()  # Simple check
-        # Checking arguments if possible (AsyncMock call args are tricky but this is good enough)
+        # AI Classifier must be awaited call with exact args (text, context=None)
+        mock_ai_classifier.classify.assert_awaited_once_with(test_text, None)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
✅ test
- HybridClassifier 테스트 8차 개선
- Robust Wiring & Args Check

🔍 검증 로직 개선:
- Robust RuleEngine Wiring: `backend/services/gpt_helper.py`의 `metadata` 인자의 구현 변화에 유연하게 대응하면서도 [text] 인자의 정확성과 호출 여부를 확실히 검증 (`assert_called_once()` + `call_args`).
- Strict AIClassifier Args: `backend/services/gpt_helper.py`의 AI Fallback 시 `AIClassifier.classify`가 정확한 인자([text], `context=None`)로 호출되는지 엄격하게 검증 (`assert_awaited_once_with`).

✅ Testing Status:
- 총 14개 테스트 케이스 100% 통과 (pytest)
- Init, Parametrized Logic (11 scenarios), Error Resilience, Empty Input

📁 파일:
- tests/unit/classifier/test_hybrid_classifier.py

📌 Related
- Issue [#76] (Step 4/5) - Hybrid Logic
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/109#pullrequestreview-3544401143)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

HybridClassifier 테스트를 강화하여 RuleEngine 및 AI 분류기의 연결 방식과 인자 처리 방식을 보다 견고하게 검증하되, 내부 메타데이터 기본값에 의존하지 않도록 합니다.

Tests:
- RuleEngine 평가에 대한 단언을 강화하여 메타데이터 파라미터 동작이 변경되더라도 안정적으로 동작하면서, 입력 텍스트가 올바르게 전달되는지를 검증합니다.
- AI 폴백 시나리오에서 `AIClassifier.classify`가 예상된 텍스트와 컨텍스트 인자를 사용해 정확히 한 번만 `await`되는지를 엄격히 검증합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen HybridClassifier tests to more robustly verify RuleEngine and AI classifier wiring and argument handling without depending on internal metadata defaults.

Tests:
- Tighten RuleEngine evaluation assertions to validate the input text while remaining resilient to changes in the metadata parameter behavior.
- Enforce strict verification that AIClassifier.classify is awaited exactly once with the expected text and context arguments in AI fallback scenarios.

</details>