### PR TITLE
⚡️ test [#10.2.10]: 통합 테스트 검증 강화 (Rule Miss Flow Assertion)

### DIFF
--- a/docs/P/v4_phase2_hybrid_classifier/integration_test_result.txt
+++ b/docs/P/v4_phase2_hybrid_classifier/integration_test_result.txt
@@ -70,7 +70,7 @@ backend/routes/conflict_routes.py                     20      8    60%   42-49, 
 backend/routes/onboarding_routes.py                   36     16    56%   63-64, 89-100, 122-126, 148-154, 174-179
 backend/search_history.py                             93     93     0%   9-353
 backend/services/__init__.py                           1      0   100%
-backend/services/classification_service.py            93     16    83%   115-117, 138-140, 169-171, 189, 192, 194, 255, 290-292
+backend/services/classification_service.py            93     35    62%   115-117, 138-140, 169-171, 189, 192, 194, 227-292
 backend/services/confidence_calculator.py             84     84     0%   6-240
 backend/services/conflict_service.py                  74     31    58%   25-35, 84-86, 91-103, 140-143, 174, 191, 201-204, 217, 221, 225, 229-230
 backend/services/feature_extractor.py                 90     90     0%   6-233
@@ -82,5 +82,5 @@ backend/services/rule_engine.py                       45     13    71%   38-40, 
 backend/utils.py                                      42     42     0%   9-110
 backend/validators.py                                 88     88     0%   16-252
 --------------------------------------------------------------------------------
-TOTAL                                               3273   2427    26%
-============================== 2 passed in 0.43s ===============================
+TOTAL                                               3273   2446    25%
+============================== 2 passed in 0.46s ===============================

--- a/tests/integration/test_hybrid_flow.py
+++ b/tests/integration/test_hybrid_flow.py
@@ -62,9 +62,10 @@ async def test_hybrid_flow_end_to_end_ai_fallback():
     service = ClassificationService()
 
     # Patch RuleEngine (Miss) and _save_results (No I/O)
+    # Capture mock_rule_eval to verify it was attempted
     with patch(
         "backend.services.rule_engine.RuleEngine.evaluate", return_value=None
-    ), patch.object(service, "_save_results") as mock_save:
+    ) as mock_rule_eval, patch.object(service, "_save_results") as mock_save:
 
         mock_save.return_value = {"csv_saved": True, "json_saved": True}
 
@@ -88,5 +89,6 @@ async def test_hybrid_flow_end_to_end_ai_fallback():
         assert response.category == "Areas"
 
         # Verify wiring
+        mock_rule_eval.assert_called_once()  # Verify Rule Engine was attempted first
         service.hybrid_classifier.ai_classifier.classify.assert_called_once()
         mock_save.assert_called_once()


### PR DESCRIPTION
🔍 개선 사항:
- `tests/integration/test_hybrid_flow.py`
- [test_hybrid_flow_end_to_end_ai_fallback]: AI Fallback 시나리오에서 단순히 AI 결과만 확인하는 것이 아니라, `RuleEngine.evaluate`가 실제로 호출되었음(그리고 실패했음)을 명시적으로 검증(`assert_called_once`)하여, "Rule Miss -> AI" 파이프라인 흐름을 더 확실하게 입증하도록 개선.
- 테스트 내용 수정 -> 리포트 결과 업데이트

📁 파일:
- tests/integration/test_hybrid_flow.py
- docs/P/v4_phase2_hybrid_classifier/integration_test_result.txt

📌 Related
- Issue [#76] (Step 5/5 - Code)
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/114#pullrequestreview-3546970215)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

하이브리드 플로우 AI 폴백 통합 테스트를 강화하여 규칙 엔진이 호출되는지를 명시적으로 검증하고, 이에 대응하는 통합 테스트 리포트 아티팩트를 업데이트합니다.

Documentation:
- 수정된 AI 폴백 테스트 동작을 반영하도록 기록된 하이브리드 분류기 통합 테스트 결과를 업데이트합니다.

Tests:
- Rule Miss → AI 플로우를 더 잘 검증하기 위해, AI 폴백 엔드투엔드 통합 테스트에서 규칙 엔진의 `evaluate` 메서드가 한 번 호출되는지 명시적으로 단언을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen the hybrid flow AI fallback integration test to explicitly assert the rule engine is invoked and update the corresponding integration test report artifact.

Documentation:
- Update the recorded hybrid classifier integration test results to reflect the revised AI fallback test behavior.

Tests:
- Add explicit assertion that the rule engine evaluate method is called once in the AI fallback end-to-end integration test to better validate the Rule Miss → AI flow.

</details>