### PR TITLE
🚑 fix [#10.3.1]-[#10.3.3]: AI 코드 리뷰 피드백 반영 (Type Safety & Code Quality)

### DIFF
--- a/backend/config/mcp_config.py
+++ b/backend/config/mcp_config.py
@@ -29,9 +29,7 @@ class ObsidianConfig(BaseModel):
         """Vault 경로 유효성 검사"""
         if not self.enabled:
             return True
-        if not self.vault_path:
-            return False
-        return Path(self.vault_path).exists()
+        return False if not self.vault_path else Path(self.vault_path).exists()
 
 
 class NotionConfig(BaseModel):

--- a/backend/models/conflict.py
+++ b/backend/models/conflict.py
@@ -1,4 +1,5 @@
 # backend/models/conflict.py
+from __future__ import annotations
 
 """
 충돌 감지 및 해결 관련 Pydantic 모델
@@ -314,9 +315,9 @@ __all__ = [
     "ResolveConflictRequest",
     "ConflictDetectResponse",
     "ConflictResolveResponse",
-    "ConflictResolveResponse",
     # Sync Conflict Models (Phase 3)
     "SyncConflict",
+    "SyncConflictType",
     "ConflictResolutionLog",
 ]
 
@@ -324,6 +325,17 @@ __all__ = [
 # ==========================================
 # Sync Conflict Models (Phase 3)
 # ==========================================
+
+
+class SyncConflictType(str, Enum):
+    """
+    동기화 충돌 유형
+    """
+
+    CONTENT_MISMATCH = "content_mismatch"
+    DELETED_REMOTE = "deleted_remote"
+    DELETED_LOCAL = "deleted_local"
+    METADATA_MISMATCH = "metadata_mismatch"
 
 
 class SyncConflict(BaseModel):
@@ -355,7 +367,7 @@ class SyncConflict(BaseModel):
     file_id: str = Field(..., description="내부 파일 ID")
     external_path: str = Field(..., description="외부 파일 경로")
     tool_type: ExternalToolType = Field(..., description="외부 도구 유형")
-    conflict_type: str = Field(..., description="충돌 유형 (content_mismatch 등)")
+    conflict_type: SyncConflictType = Field(..., description="충돌 유형 (Enum)")
     local_hash: Optional[str] = Field(None, description="로컬 파일 해시")
     remote_hash: Optional[str] = Field(None, description="원격 파일 해시")
     detected_at: datetime = Field(default_factory=datetime.now, description="감지 시각")

--- a/backend/services/sync_service.py
+++ b/backend/services/sync_service.py
@@ -63,7 +63,8 @@ class SyncServiceBase(ABC):
         if content is None:
             return ""
         # 정규화: 줄바꿈 문자 통일 (CRLF -> LF)
-        normalized = content.replace("\r\n", "\n").strip()
+        # 선행/후행 공백 및 마지막 개행도 해시에 포함해 경계 공백 변경도 감지한다.
+        normalized = content.replace("\r\n", "\n")
         return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
 
     def detect_conflict_by_hash(self, current_hash: str, last_synced_hash: str) -> bool:
@@ -77,9 +78,7 @@ class SyncServiceBase(ABC):
         Returns:
             bool: 변경됨(True) / 변경없음(False)
         """
-        if not last_synced_hash:
-            return True  # 첫 동기화면 무조건 변경으로 간주
-        return current_hash != last_synced_hash
+        return True if not last_synced_hash else current_hash != last_synced_hash
 
     async def _handle_conflict(self, conflict: SyncConflict) -> bool:
         """


### PR DESCRIPTION
🔍 변경 사항:
- Models: `__all__` 중복 제거, `SyncConflictType` Enum 도입으로 충돌 유형 타입 안전성 강화.
- Config: `mcp_config.py` 유효성 검사 로직 간결화 (Refactoring).
- Service: `SyncServiceBase` 해시 계산 시 `strip()` 제거 (공백 변경 감지), 충돌 감지 로직 개선.

📁 파일:
- backend/models/conflict.py
- backend/config/mcp_config.py
- backend/services/sync_service.py

📌 Related
- Issue [#77]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/119#pullrequestreview-3547941972)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

동기화 충돌 모델링과 해시 기반 변경 감지를 개선하면서 MCP 설정 검증을 단순화합니다.

New Features:
- 동기화 충돌 유형을 타입 세이프하게 표현하기 위해 `SyncConflictType` enum을 도입했습니다.

Bug Fixes:
- 파일 해시 계산 시 앞뒤 공백을 그대로 보존하여, 경계 공백의 변경도 감지되도록 했습니다.
- 해시 기반 충돌 감지에서 `last_synced_hash`가 없는 경우를 해시 변경으로 처리하도록 했습니다.
- `conflict.py`에서 내보내는 모델 목록에서 중복 항목을 제거하고 `SyncConflictType`을 추가하여 올바르게 수정했습니다.
- MCP vault 경로 검증 시, 존재 여부를 확인하기 전에 빈 경로를 올바르게 처리하도록 수정했습니다.

Enhancements:
- 동기화 충돌 모델이 기존의 원시 문자열 대신 새 `SyncConflictType` enum을 사용하도록 개선했습니다.
- 해시 기반 충돌 감지와 MCP 설정 검증의 조건 로직을 단순화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve sync conflict modeling and hash-based change detection while simplifying MCP configuration validation.

New Features:
- Introduce a SyncConflictType enum to represent sync conflict types in a type-safe way.

Bug Fixes:
- Ensure file hash calculation preserves leading and trailing whitespace so boundary whitespace changes are detected.
- Treat missing last_synced_hash as a change in hash-based conflict detection.
- Correct the exported models list in conflict.py by removing a duplicate entry and adding SyncConflictType.
- Fix MCP vault path validation to properly handle empty paths before existence checks.

Enhancements:
- Refine sync conflict models to use the new SyncConflictType enum instead of raw strings.
- Simplify conditional logic in hash-based conflict detection and MCP config validation.

</details>