### PR TITLE
🚑 fix-2 [#10.3.06]: Phase 3 핵심 서비스 안정화 (All Review Feedback)

### DIFF
--- a/backend/mcp/sync_map_manager.py
+++ b/backend/mcp/sync_map_manager.py
@@ -27,14 +27,11 @@ class SyncMapManager:
     """
 
     def __init__(self, storage_dir: str = "mcp", filename: str = "file_mappings.json"):
-        # PathConfig를 활용하여 데이터 경로 설정
         self.storage_path = PathConfig.DATA_DIR / storage_dir / filename
 
         # In-memory storage
-        self._mappings: Dict[str, ExternalFileMapping] = {}  # Key: internal_file_id
-        self._path_index: Dict[str, str] = (
-            {}
-        )  # Key: external_path -> Value: internal_file_id
+        self._mappings: Dict[str, ExternalFileMapping] = {}
+        self._path_index: Dict[str, str] = {}
 
         # Thread Lock
         self._lock = threading.Lock()
@@ -46,7 +43,7 @@ class SyncMapManager:
         self._load_mappings()
 
     def _load_mappings(self):
-        """JSON 파일에서 매핑 데이터 로드 (초기화 시 1회 수행)"""
+        """JSON 파일에서 매핑 데이터 로드"""
         if not self.storage_path.exists():
             logger.info("ℹ️ No mapping file found, initializing empty.")
             return
@@ -57,10 +54,8 @@ class SyncMapManager:
                 count = 0
                 for item in data:
                     try:
-                        # Pydantic 모델로 변환
                         mapping = ExternalFileMapping(**item)
                         self._mappings[mapping.internal_file_id] = mapping
-                        # Indexing
                         self._path_index[mapping.external_path] = (
                             mapping.internal_file_id
                         )
@@ -75,18 +70,10 @@ class SyncMapManager:
             logger.error(f"❌ Failed to load mappings: {e}")
 
     def _save_mappings(self, snapshot: List[ExternalFileMapping]):
-        """
-        메모리 상의 매핑 데이터를 JSON 파일로 저장
-
-        NOTE:
-        - I/O 작업을 수행하므로 반드시 Lock 밖에서 호출해야 함.
-        - 인자로 전달받은 snapshot 데이터를 저장함.
-        """
+        """메모리 상의 매핑 데이터를 JSON 파일로 저장 (Lock 밖에서 호출)"""
         try:
-            # model_dump 사용 (Pydantic V2)
             data = [m.model_dump(mode="json") for m in snapshot]
 
-            # Atomic Write를 위해 임시 파일 사용이 좋지만, MVP에서는 직접 쓰기
             with open(self.storage_path, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2, ensure_ascii=False)
             logger.debug(f"Saved {len(data)} mappings to disk.")
@@ -103,7 +90,7 @@ class SyncMapManager:
     def get_mapping_by_external_path(
         self, external_path: str
     ) -> Optional[ExternalFileMapping]:
-        """외부 경로로 매핑 조회 (Thread-safe, O(1) Lookup)"""
+        """외부 경로로 매핑 조회 (Thread-safe, O(1))"""
         with self._lock:
             if internal_id := self._path_index.get(external_path):
                 return self._mappings.get(internal_id)
@@ -116,48 +103,71 @@ class SyncMapManager:
         tool_type: ExternalToolType,
         current_hash: Optional[str] = None,
     ) -> ExternalFileMapping:
-        """
-        매핑 정보 생성 또는 갱신 (Thread-safe)
-        """
+        """매핑 정보 생성 또는 갱신 (Thread-safe)"""
         with self._lock:
             mapping = self._mappings.get(internal_id)
 
             if mapping:
-                # Update existing
-                old_path = mapping.external_path
-                # Update Index (Remove old path)
-                if old_path in self._path_index:
-                    del self._path_index[old_path]
-
-                mapping.external_path = external_path
-                mapping.tool_type = tool_type
-                mapping.last_synced_at = datetime.now()
-                logger.info(f"Updated mapping for {internal_id}")
+                mapping = self._update_existing_mapping(
+                    mapping, external_path, tool_type, current_hash
+                )
             else:
-                # Create new
-                mapping = ExternalFileMapping(
-                    internal_file_id=internal_id,
-                    external_path=external_path,
-                    tool_type=tool_type,
-                    last_synced_at=datetime.now(),
-                )
-                self._mappings[internal_id] = mapping
-                logger.info(
-                    f"Created new mapping for {internal_id} <-> {external_path}"
+                mapping = self._create_new_mapping(
+                    internal_id, external_path, tool_type, current_hash
                 )
 
-            # Common updates (Hoist)
-            if current_hash:
-                mapping.last_synced_hash = current_hash
-
-            # Update Index (Add new path)
+            # Update Index
             self._path_index[external_path] = internal_id
 
-            # Create Snapshot inside lock
+            # Create Snapshot
             snapshot = list(self._mappings.values())
 
         # Save outside lock
         self._save_mappings(snapshot)
+        return mapping
+
+    def _update_existing_mapping(
+        self,
+        mapping: ExternalFileMapping,
+        external_path: str,
+        tool_type: ExternalToolType,
+        current_hash: Optional[str],
+    ) -> ExternalFileMapping:
+        """기존 매핑 업데이트 (Lock 안에서 호출)"""
+        old_path = mapping.external_path
+
+        # Remove old path from index
+        if old_path in self._path_index:
+            del self._path_index[old_path]
+
+        # Update fields
+        mapping.external_path = external_path
+        mapping.tool_type = tool_type
+        mapping.last_synced_at = datetime.now()
+
+        if current_hash:
+            mapping.last_synced_hash = current_hash
+
+        logger.info(f"Updated mapping for {mapping.internal_file_id}")
+        return mapping
+
+    def _create_new_mapping(
+        self,
+        internal_id: str,
+        external_path: str,
+        tool_type: ExternalToolType,
+        current_hash: Optional[str],
+    ) -> ExternalFileMapping:
+        """새 매핑 생성 (Lock 안에서 호출)"""
+        mapping = ExternalFileMapping(
+            internal_file_id=internal_id,
+            external_path=external_path,
+            tool_type=tool_type,
+            last_synced_hash=current_hash,
+            last_synced_at=datetime.now(),
+        )
+        self._mappings[internal_id] = mapping
+        logger.info(f"Created new mapping for {internal_id} <-> {external_path}")
         return mapping
 
     def remove_mapping(self, internal_id: str) -> bool:
@@ -167,14 +177,15 @@ class SyncMapManager:
         with self._lock:
             if internal_id in self._mappings:
                 mapping = self._mappings[internal_id]
-                # Remove Index
+
+                # Remove from index
                 if mapping.external_path in self._path_index:
                     del self._path_index[mapping.external_path]
 
-                # Remove Mapping
+                # Remove from mappings
                 del self._mappings[internal_id]
 
-                # Create Snapshot
+                # Create snapshot
                 snapshot = list(self._mappings.values())
                 logger.info(f"Removed mapping for {internal_id}")
 


### PR DESCRIPTION
🔍 변경 사항:
- **ConflictResolutionService**:
    - `NotImplementedError` 우아한 처리로 호출자 크래시 방지.
    - 중복 전략 병합 (`tests/unit/services/test_rule_engine.py`의 [in]의 연산자 사용).
- **ObsidianSyncService**:
    - Move 이벤트 처리 개선 (`dest_path` 체크).
    - `backend/mcp/obsidian_server.py`의 [_on_file_change]에서 `run_coroutine_threadsafe` 연결로 실제 동기화 작업 스케줄링.
    - `backend/mcp/obsidian_server.py`의 [sync_all] 최적화 (불필요한 변수 제거).
- **SyncMapManager**:
    - Extract Method 패턴 적용으로 `backend/mcp/sync_map_manager.py`의 [update_mapping] 복잡도 감소.

📁 파일:
- backend/services/conflict_resolution_service.py
- backend/mcp/obsidian_server.py
- backend/mcp/sync_map_manager.py

📌 Related
- Issue [#77]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/126#pullrequestreview-3548061861)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

Obsidian 통합 및 매핑 관리 전반의 동기화와 충돌 해결 동작을 정교하게 다듬어, 안정성을 향상시키고 향후 파일 서비스 통합을 대비합니다.

버그 수정:
- 충돌 해결 과정에서 발생하는 `NotImplementedError`를 우아하게 처리하여 호출 측 크래시를 방지합니다.
- Obsidian 이동 이벤트가 마크다운 대상 경로에 대해서만 동기화를 트리거하도록 하고, 가능한 경우 이벤트 루프에서 처리 작업이 예약되도록 보장합니다.

개선 사항:
- `SyncMapManager`의 업데이트 로직을 매핑 생성 및 업데이트 전용 헬퍼로 리팩터링하여 인덱싱과 해시 처리 방식을 단순화했습니다.
- 전체 동기화 의미 체계 구현에 앞서 Obsidian vault의 `sync_all` 및 파일 워처 로직을 간소화했습니다.
- 여러 자동(auto) 방식을 MVP 단계에서는 통합된 “remote-wins(원격 우선)” 동작으로 취급해, 충돌 해결 전략을 단순화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine sync and conflict resolution behavior across Obsidian integration and mapping management to improve robustness and prepare for future file service integration.

Bug Fixes:
- Gracefully handle NotImplementedError in conflict resolution to avoid caller crashes.
- Ensure Obsidian move events only trigger sync for markdown destination paths and schedule processing on the event loop when available.

Enhancements:
- Refactor SyncMapManager update logic into dedicated helpers for creating and updating mappings, simplifying indexing and hash handling.
- Simplify Obsidian vault sync_all and file watcher logic ahead of implementing full sync semantics.
- Streamline conflict resolution strategies by treating multiple auto methods as a unified remote-wins behavior for the MVP.

</details>