### PR TITLE
🏗️ refactor [#10.3.7]: Sync API FastAPI Best Practice 적용 (DI, Excepton Chaining)

### DIFF
--- a/backend/api/endpoints/sync.py
+++ b/backend/api/endpoints/sync.py
@@ -2,13 +2,15 @@
 
 """
 Sync API Endpoints
-외부 도구(Obsidian 등)와의 동기화 및 충돌 해결 API
+외부 도구(Obsidian)와의 동기화 및 충돌 해결 API
+
+Note: MVP에서는 Obsidian만 지원합니다.
 """
 
 import logging
-import threading
+from functools import lru_cache
 from typing import List, Optional
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, status, Depends
 from pydantic import BaseModel, Field
 
 from backend.models.external_sync import ExternalToolType
@@ -32,15 +34,6 @@ router = APIRouter(prefix="/sync", tags=["Synchronization"])
 # ==========================================
 # Request/Response Models
 # ==========================================
-
-
-class SyncTriggerRequest(BaseModel):
-    """동기화 트리거 요청"""
-
-    tool_type: ExternalToolType = Field(..., description="동기화할 외부 도구")
-    file_id: Optional[str] = Field(
-        None, description="특정 파일 ID (None이면 전체 동기화)"
-    )
 
 
 class SyncStatusResponse(BaseModel):
@@ -74,46 +67,33 @@ class ConflictResolveResponse(BaseModel):
 
 
 # ==========================================
-# Dependency Injection (Thread-safe Singleton)
+# Dependency Injection (FastAPI Best Practice)
 # ==========================================
 
-_sync_service: Optional[SyncServiceBase] = None
-_map_manager: Optional[SyncMapManager] = None
-_resolution_service: Optional[ConflictResolutionService] = None
-_lock = threading.Lock()
 
-
+@lru_cache
 def get_sync_service() -> SyncServiceBase:
-    """동기화 서비스 싱글톤 (Thread-safe)"""
-    global _sync_service
-    if _sync_service is None:
-        with _lock:
-            # Double-checked locking
-            if _sync_service is None:
-                _sync_service = ObsidianSyncService(mcp_config.obsidian)
-    return _sync_service
+    """
+    동기화 서비스 싱글톤 (FastAPI Dependency)
+
+    Note: MVP에서는 Obsidian만 지원
+    """
+    return ObsidianSyncService(mcp_config.obsidian)
 
 
+@lru_cache
 def get_map_manager() -> SyncMapManager:
-    """매핑 매니저 싱글톤 (Thread-safe)"""
-    global _map_manager
-    if _map_manager is None:
-        with _lock:
-            if _map_manager is None:
-                _map_manager = SyncMapManager()
-    return _map_manager
+    """매핑 매니저 싱글톤 (FastAPI Dependency)"""
+    return SyncMapManager()
 
 
-def get_resolution_service() -> ConflictResolutionService:
-    """충돌 해결 서비스 싱글톤 (Thread-safe)"""
-    global _resolution_service
-    if _resolution_service is None:
-        with _lock:
-            if _resolution_service is None:
-                _resolution_service = ConflictResolutionService(
-                    sync_service=get_sync_service(), map_manager=get_map_manager()
-                )
-    return _resolution_service
+@lru_cache
+def get_resolution_service(
+    sync_service: SyncServiceBase = Depends(get_sync_service),
+    map_manager: SyncMapManager = Depends(get_map_manager),
+) -> ConflictResolutionService:
+    """충돌 해결 서비스 싱글톤 (FastAPI Dependency)"""
+    return ConflictResolutionService(sync_service=sync_service, map_manager=map_manager)
 
 
 # ==========================================
@@ -122,25 +102,22 @@ def get_resolution_service() -> ConflictResolutionService:
 
 
 @router.post("/trigger", status_code=status.HTTP_202_ACCEPTED)
-async def trigger_sync(request: SyncTriggerRequest) -> dict:
+async def trigger_sync(
+    sync_service: SyncServiceBase = Depends(get_sync_service),
+) -> dict:
     """
-    수동 동기화 트리거
+    수동 동기화 트리거 (전체 파일)
 
-    - **tool_type**: 동기화할 외부 도구 (obsidian, notion 등)
-    - **file_id**: 특정 파일만 동기화 (None이면 전체)
+    Note: MVP에서는 Obsidian 전체 동기화만 지원합니다.
     """
-    logger.info(
-        f"Sync trigger requested for {request.tool_type}, file_id={request.file_id}"
-    )
+    logger.info("Sync trigger requested for Obsidian (全체)")
 
     try:
-        sync_service = get_sync_service()
-
         # 연결 확인
         if not await sync_service.connect():
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail=f"Failed to connect to {request.tool_type}",
+                detail="Failed to connect to Obsidian vault",
             )
 
         # 동기화 수행
@@ -148,7 +125,7 @@ async def trigger_sync(request: SyncTriggerRequest) -> dict:
 
         return {
             "message": "Sync triggered successfully",
-            "tool_type": request.tool_type,
+            "tool_type": ExternalToolType.OBSIDIAN,
             "conflicts_detected": len(conflicts),
             "conflicts": [c.model_dump() for c in conflicts],
         }
@@ -157,28 +134,26 @@ async def trigger_sync(request: SyncTriggerRequest) -> dict:
         raise HTTPException(
             status_code=status.HTTP_501_NOT_IMPLEMENTED,
             detail=f"Sync operation not fully implemented: {str(e)}",
-        )
+        ) from e
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Sync trigger failed: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Sync failed: {str(e)}",
-        )
+        ) from e
 
 
 @router.get("/status", response_model=SyncStatusResponse)
 async def get_sync_status(
-    tool_type: ExternalToolType = ExternalToolType.OBSIDIAN,
+    sync_service: SyncServiceBase = Depends(get_sync_service),
+    map_manager: SyncMapManager = Depends(get_map_manager),
 ) -> SyncStatusResponse:
     """
-    동기화 상태 조회
-
-    - **tool_type**: 조회할 외부 도구
+    동기화 상태 조회 (Obsidian)
     """
     try:
-        sync_service = get_sync_service()
-        map_manager = get_map_manager()
-
         is_connected = await sync_service.connect()
 
         # Obsidian specific status
@@ -187,11 +162,11 @@ async def get_sync_status(
             is_watching = sync_service.is_watching
 
         return SyncStatusResponse(
-            tool_type=tool_type,
+            tool_type=ExternalToolType.OBSIDIAN,
             is_connected=is_connected,
             is_watching=is_watching,
             last_sync_at=None,  # TODO: Track last sync timestamp
-            total_mappings=map_manager.get_total_count(),  # Use public method
+            total_mappings=map_manager.get_total_count(),
         )
 
     except Exception as e:
@@ -199,18 +174,20 @@ async def get_sync_status(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Status check failed: {str(e)}",
-        )
+        ) from e
 
 
 @router.get("/conflicts", response_model=ConflictListResponse)
-async def get_conflicts() -> ConflictListResponse:
+async def get_conflicts(
+    sync_service: SyncServiceBase = Depends(get_sync_service),
+) -> ConflictListResponse:
     """
     현재 감지된 충돌 목록 조회
 
-    Note: MVP에서는 DB 저장 없이 실시간 스캔 결과만 반환
+    Note: MVP에서는 DB 저장 없이 실시간 스캔 결과만 반환.
+    TODO: 충돌 캐싱으로 반복 스캔 비용 절감 필요.
     """
     try:
-        sync_service = get_sync_service()
         conflicts = await sync_service.sync_all()
 
         return ConflictListResponse(conflicts=conflicts, total_count=len(conflicts))
@@ -220,18 +197,24 @@ async def get_conflicts() -> ConflictListResponse:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Conflict retrieval failed: {str(e)}",
-        )
+        ) from e
 
 
 @router.post("/conflicts/{conflict_id}/resolve", response_model=ConflictResolveResponse)
 async def resolve_conflict(
-    conflict_id: str, request: ConflictResolveRequest
+    conflict_id: str,
+    request: ConflictResolveRequest,
+    sync_service: SyncServiceBase = Depends(get_sync_service),
+    resolution_service: ConflictResolutionService = Depends(get_resolution_service),
 ) -> ConflictResolveResponse:
     """
     충돌 해결
 
     - **conflict_id**: 해결할 충돌 ID
     - **strategy**: 해결 전략 (MANUAL_OVERRIDE, AUTO_BY_CONTEXT 등)
+
+    Note: MVP에서는 실시간 스캔으로 충돌을 찾습니다.
+    TODO: 충돌 DB 저장 후 ID로 직접 조회하도록 개선 필요.
     """
     logger.info(
         f"Resolving conflict {conflict_id} with strategy {request.strategy.method}"
@@ -239,7 +222,6 @@ async def resolve_conflict(
 
     try:
         # 1. 충돌 조회 (MVP: 실시간 스캔에서 찾기)
-        sync_service = get_sync_service()
         conflicts = await sync_service.sync_all()
 
         conflict = next((c for c in conflicts if c.conflict_id == conflict_id), None)
@@ -250,7 +232,6 @@ async def resolve_conflict(
             )
 
         # 2. 해결 수행
-        resolution_service = get_resolution_service()
         resolution = await resolution_service.resolve_conflict(
             conflict, request.strategy
         )
@@ -266,10 +247,10 @@ async def resolve_conflict(
         raise HTTPException(
             status_code=status.HTTP_501_NOT_IMPLEMENTED,
             detail=f"Resolution strategy not implemented: {str(e)}",
-        )
+        ) from e
     except Exception as e:
         logger.error(f"Conflict resolution failed: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Resolution failed: {str(e)}",
-        )
+        ) from e


### PR DESCRIPTION
🔍 변경 사항:
- **API 단순화**: MVP 현실 반영 (Obsidian 전용 명시, 미사용 파라미터 제거).
    - `SyncTriggerRequest` 제거 (`tool_type`, `file_id` 불필요).
    - 모든 엔드포인트에서 Obsidian 전용임을 문서화.
- **FastAPI Best Practice**:
    - Global Singleton → `@lru_cache` + `Depends()` 패턴으로 전환.
    - 모든 서비스를 Dependency Injection으로 주입.
    - Thread-safe 보장 (FastAPI 기본 동작).
- **Exception Chaining**: 모든 `raise HTTPException`에 `from e` 추가 (디버깅 개선).
- **TODO 명시**: 충돌 캐싱 필요성 주석 추가.

📁 파일:
- backend/api/endpoints/sync.py

📌 Related
- Issue [#77]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/128#pullrequestreview-3548596631)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

동기화 API 엔드포인트를 FastAPI 의존성 주입 모범 사례에 맞게 리팩터링하고, 현재 Obsidian 전용 MVP 사용 사례에 맞추어 단순화했습니다.

개선 사항:
- 커스텀 스레드-안전 싱글톤을 `@lru_cache`와 `Depends()`를 사용하는 FastAPI 스타일 의존성으로 대체하여 동기화 관련 서비스를 관리.
- 사용되지 않는 요청 파라미터와 도구 선택 기능을 제거하고, 동기화 트리거 및 상태 엔드포인트가 Obsidian 에서만 명시적으로 동작하도록 단순화.
- 테스트 용이성과 구조 개선을 위해 동기화, 매핑, 충돌 해결 서비스를 의존성 주입 방식으로 엔드포인트에 주입.
- 디버깅 및 관측 가능성을 높이기 위해, 하위 예외들을 `HTTPException`에 체이닝하여 에러 처리 개선.
- 현재 MVP의 제한 사항을 문서화하고, 충돌 캐싱 및 향후 충돌 영속성 구현을 위한 TODO 메모 추가.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the sync API endpoints to align with FastAPI dependency injection best practices and simplify them around the current Obsidian-only MVP use case.

Enhancements:
- Replace custom thread-safe singletons with FastAPI-style dependencies using @lru_cache and Depends() for sync-related services.
- Simplify sync trigger and status endpoints to operate explicitly on Obsidian only, removing unused request parameters and tool selection.
- Inject sync, mapping, and conflict resolution services into endpoints via dependency injection to improve testability and structure.
- Improve error handling by chaining underlying exceptions into HTTPException for better debugging and observability.
- Document current MVP limitations and add TODO notes for conflict caching and future conflict persistence.

</details>