### PR TITLE
🏗️ refactor [#10.3.7]: Dependency Injection 패턴 개선 (lru_cache 이슈 해결)

### DIFF
--- a/backend/api/endpoints/sync.py
+++ b/backend/api/endpoints/sync.py
@@ -87,16 +87,17 @@ def get_map_manager() -> SyncMapManager:
     return SyncMapManager()
 
 
-def get_resolution_service() -> ConflictResolutionService:
+def get_resolution_service(
+    sync_service: SyncServiceBase = Depends(get_sync_service),
+    map_manager: SyncMapManager = Depends(get_map_manager),
+) -> ConflictResolutionService:
     """
     충돌 해결 서비스 팩토리 (FastAPI Dependency)
 
-    Note: @lru_cache 제거 (Depends와 함께 사용 시 캐시 키 이슈).
-    내부에서 이미 캐시된 서비스들을 직접 호출하여 인스턴스 생성.
+    Note: @lru_cache 제거 (FastAPI가 요청 단위 캐싱 자동 처리).
+    Depends()로 주입받아 DI 시맨틱 유지 (overrides, async 지원).
     """
-    return ConflictResolutionService(
-        sync_service=get_sync_service(), map_manager=get_map_manager()
-    )
+    return ConflictResolutionService(sync_service=sync_service, map_manager=map_manager)
 
 
 # ==========================================


### PR DESCRIPTION
🔍 변경 사항:
- **[get_resolution_service] 수정**
    - `backend/api/endpoints/sync.py`
    - `@lru_cache` 제거 (`Depends()`와 함께 사용 시 캐시 키 이슈).
    - 내부에서 이미 캐시된 서비스들을 직접 호출: [get_sync_service], [get_map_manager].
- **일관된 DI 패턴**: 모든 엔드포인트에서 FastAPI `Depends()`만 사용.

📁 파일:
- backend/api/endpoints/sync.py

📌 Related
- Issue [#77]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/129#pullrequestreview-3548619490)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

lru_cache 문제를 피하고, 충돌 해결 서비스에 대해 일관된 FastAPI Depends 사용을 보장하기 위해 sync 엔드포인트의 의존성 주입 패턴을 개선합니다.

개선 사항:
- 캐시된 의존성 기반의 ConflictResolutionService 제공자를, 내부적으로 이미 캐시된 서비스들을 사용하는 단순 팩토리로 교체합니다.
- sync 로깅 메시지 텍스트를 일관성을 위해 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the sync endpoint dependency injection pattern to avoid lru_cache issues and ensure consistent FastAPI Depends usage for conflict resolution services.

Enhancements:
- Replace the cached dependency-based ConflictResolutionService provider with a simple factory that internally uses already-cached services.
- Update sync logging message text for consistency.

</details>