### PR TITLE
🏗️ refactor [#10.3.8]: 1차 개선 - 통합 테스트 구조 개선 및 동시성 검증 추가

### DIFF
--- a/tests/integration/test_sync_map_manager.py
+++ b/tests/integration/test_sync_map_manager.py
@@ -1,0 +1,269 @@
+# tests/integration/test_sync_map_manager.py
+
+"""
+SyncMapManager Unit Tests
+
+매핑 CRUD 동작 및 Thread Safety를 검증합니다.
+"""
+
+import pytest
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, wait
+
+from backend.mcp.sync_map_manager import SyncMapManager
+from backend.models.external_sync import ExternalToolType
+
+
+# ==========================================
+# Fixtures
+# ==========================================
+
+
+@pytest.fixture
+def map_manager(tmp_path: Path) -> SyncMapManager:
+    """SyncMapManager 인스턴스 (임시 저장소)"""
+    return SyncMapManager(storage_dir=str(tmp_path / "mcp"))
+
+
+# ==========================================
+# Test: CRUD Operations
+# ==========================================
+
+
+def test_sync_map_manager_create_and_retrieve(map_manager: SyncMapManager):
+    """
+    [Unit] SyncMapManager: 매핑 생성 및 조회
+
+    검증:
+    - update_mapping으로 새 매핑 생성
+    - get_mapping_by_internal_id로 조회
+    - get_mapping_by_external_path로 조회 (O(1))
+    """
+    # Arrange & Act
+    mapping = map_manager.update_mapping(
+        internal_id="test_123",
+        external_path="/vault/test.md",
+        tool_type=ExternalToolType.OBSIDIAN,
+        current_hash="abc123",
+    )
+
+    # Assert
+    assert mapping.internal_file_id == "test_123"
+    assert mapping.external_path == "/vault/test.md"
+    assert mapping.last_synced_hash == "abc123"
+
+    # 조회 검증
+    retrieved_by_id = map_manager.get_mapping_by_internal_id("test_123")
+    assert retrieved_by_id is not None
+    assert retrieved_by_id.external_path == "/vault/test.md"
+
+    retrieved_by_path = map_manager.get_mapping_by_external_path("/vault/test.md")
+    assert retrieved_by_path is not None
+    assert retrieved_by_path.internal_file_id == "test_123"
+
+
+def test_sync_map_manager_update_existing(map_manager: SyncMapManager):
+    """
+    [Unit] SyncMapManager: 기존 매핑 업데이트
+
+    검증:
+    - 동일 internal_id로 update_mapping 재호출
+    - external_path 변경 반영
+    - 인덱스 업데이트 확인
+    """
+    # Arrange
+    map_manager.update_mapping(
+        internal_id="update_test",
+        external_path="/vault/old_path.md",
+        tool_type=ExternalToolType.OBSIDIAN,
+    )
+
+    # Act
+    updated = map_manager.update_mapping(
+        internal_id="update_test",
+        external_path="/vault/new_path.md",
+        tool_type=ExternalToolType.OBSIDIAN,
+        current_hash="new_hash",
+    )
+
+    # Assert
+    assert updated.external_path == "/vault/new_path.md"
+    assert updated.last_synced_hash == "new_hash"
+
+    # 이전 경로로 조회 시 None
+    old_path_result = map_manager.get_mapping_by_external_path("/vault/old_path.md")
+    assert old_path_result is None
+
+    # 새 경로로 조회 성공
+    new_path_result = map_manager.get_mapping_by_external_path("/vault/new_path.md")
+    assert new_path_result is not None
+    assert new_path_result.internal_file_id == "update_test"
+
+
+def test_sync_map_manager_remove(map_manager: SyncMapManager):
+    """
+    [Unit] SyncMapManager: 매핑 삭제
+
+    검증:
+    - remove_mapping으로 삭제
+    - 조회 시 None 반환
+    - 인덱스에서도 제거 확인
+    """
+    # Arrange
+    map_manager.update_mapping(
+        internal_id="remove_test",
+        external_path="/vault/remove.md",
+        tool_type=ExternalToolType.OBSIDIAN,
+    )
+
+    # Act
+    result = map_manager.remove_mapping("remove_test")
+
+    # Assert
+    assert result is True
+
+    # 조회 시 None
+    assert map_manager.get_mapping_by_internal_id("remove_test") is None
+    assert map_manager.get_mapping_by_external_path("/vault/remove.md") is None
+
+    # 존재하지 않는 ID 삭제 시 False
+    result_nonexistent = map_manager.remove_mapping("nonexistent")
+    assert result_nonexistent is False
+
+
+def test_sync_map_manager_get_total_count(map_manager: SyncMapManager):
+    """
+    [Unit] SyncMapManager: 전체 매핑 개수 조회
+
+    검증:
+    - get_total_count() 정확성
+    - 매핑 추가/삭제 시 개수 변화
+    """
+    # Arrange
+    assert map_manager.get_total_count() == 0
+
+    # Act: 매핑 추가
+    map_manager.update_mapping(
+        internal_id="count_test_1",
+        external_path="/vault/count1.md",
+        tool_type=ExternalToolType.OBSIDIAN,
+    )
+    map_manager.update_mapping(
+        internal_id="count_test_2",
+        external_path="/vault/count2.md",
+        tool_type=ExternalToolType.OBSIDIAN,
+    )
+
+    # Assert
+    assert map_manager.get_total_count() == 2
+
+    # Act: 매핑 삭제
+    map_manager.remove_mapping("count_test_1")
+
+    # Assert
+    assert map_manager.get_total_count() == 1
+
+
+# ==========================================
+# Test: Thread Safety (Concurrency)
+# ==========================================
+
+
+def test_sync_map_manager_thread_safe_concurrent_access(map_manager: SyncMapManager):
+    """
+    [Concurrency] SyncMapManager: 동시 업데이트 및 조회 시 스레드 세이프 동작
+
+    검증:
+    - 여러 스레드에서 동시에 update_mapping 호출
+    - 동시에 get_mapping_by_internal_id / get_mapping_by_external_path 호출
+    - 예외 없이 일관된 매핑 조회
+    - 레이스 컨디션 없음
+    """
+    num_workers = 8
+    iterations_per_worker = 50
+    internal_id_prefix = "concurrent-internal"
+    external_path_prefix = "/concurrent/external"
+
+    def worker(worker_idx: int) -> None:
+        for i in range(iterations_per_worker):
+            internal_id = f"{internal_id_prefix}-{worker_idx}-{i}"
+            external_path = f"{external_path_prefix}/{worker_idx}/{i}.md"
+
+            # 동시 업데이트
+            mapping = map_manager.update_mapping(
+                internal_id=internal_id,
+                external_path=external_path,
+                tool_type=ExternalToolType.OBSIDIAN,
+                current_hash=f"hash-{worker_idx}-{i}",
+            )
+
+            # 내부 ID 기준 조회
+            by_internal = map_manager.get_mapping_by_internal_id(internal_id)
+            assert by_internal is not None, f"매핑 조회 실패: {internal_id}"
+            assert by_internal.internal_file_id == mapping.internal_file_id
+            assert by_internal.external_path == mapping.external_path
+
+            # 외부 path 기준 조회 (O(1) 인덱스 사용)
+            by_external = map_manager.get_mapping_by_external_path(external_path)
+            assert by_external is not None, f"경로 조회 실패: {external_path}"
+            assert by_external.internal_file_id == mapping.internal_file_id
+            assert by_external.external_path == mapping.external_path
+
+    # Act: 멀티스레드 실행
+    with ThreadPoolExecutor(max_workers=num_workers) as executor:
+        futures = [executor.submit(worker, idx) for idx in range(num_workers)]
+        done, not_done = wait(futures)
+
+    # Assert: 모든 스레드가 예외 없이 완료
+    assert not not_done, "일부 worker future가 완료되지 않았습니다."
+    for f in done:
+        exc = f.exception()
+        assert exc is None, f"worker에서 예외 발생: {exc!r}"
+
+    # 최종 매핑 개수 검증
+    expected_count = num_workers * iterations_per_worker
+    assert (
+        map_manager.get_total_count() == expected_count
+    ), f"예상 매핑 개수: {expected_count}, 실제: {map_manager.get_total_count()}"
+
+
+def test_sync_map_manager_concurrent_update_same_id(map_manager: SyncMapManager):
+    """
+    [Concurrency] SyncMapManager: 동일 ID에 대한 동시 업데이트
+
+    검증:
+    - 여러 스레드가 동일 internal_id를 동시에 업데이트
+    - 레이스 컨디션 없이 최종 일관성 유지
+    - 인덱스 정합성 확인
+    """
+    num_workers = 10
+    shared_internal_id = "shared-id"
+
+    def worker(worker_idx: int) -> None:
+        external_path = f"/shared/path-{worker_idx}.md"
+        map_manager.update_mapping(
+            internal_id=shared_internal_id,
+            external_path=external_path,
+            tool_type=ExternalToolType.OBSIDIAN,
+            current_hash=f"hash-{worker_idx}",
+        )
+
+    # Act: 동일 ID에 대한 동시 업데이트
+    with ThreadPoolExecutor(max_workers=num_workers) as executor:
+        futures = [executor.submit(worker, idx) for idx in range(num_workers)]
+        done, not_done = wait(futures)
+
+    # Assert: 예외 없이 완료
+    assert not not_done
+    for f in done:
+        assert f.exception() is None
+
+    # 최종 상태 확인: 하나의 매핑만 존재해야 함
+    mapping = map_manager.get_mapping_by_internal_id(shared_internal_id)
+    assert mapping is not None
+    assert mapping.internal_file_id == shared_internal_id
+
+    # 인덱스 일관성: 최종 external_path로 조회 가능
+    by_path = map_manager.get_mapping_by_external_path(mapping.external_path)
+    assert by_path is not None
+    assert by_path.internal_file_id == shared_internal_id


### PR DESCRIPTION
🔍 변경 사항:
- **테스트 분리**:
  - 변경 전: `backend/mcp/sync_map_manager.py`의 [SyncMapManager] 테스트를 별도 파일로 이동 [test_sync_map_manager.py]
  - 변경 후: `tests/integration/test_sync_map_manager.py`
- **불필요한 async 제거**: 동기 함수에서 `@pytest.mark.asyncio` 제거.
- **테스트 이름 명확화**:
  - 변경 전:`test_file_creation_sync`
  - 변경 후: `tests/integration/test_obsidian_sync.py`의 [test_file_creation_no_conflict] (실제 검증 내용 반영).
- **Thread Safety 검증**: 2개의 동시성 테스트 추가 (일반 동시 접근, 동일 ID 동시 업데이트).
- **Assertion 강화**: 에러 메시지 문자열 대신 `backend/models/conflict.py`의 [ResolutionStatus] Enum으로 검증 (안정성 향상).

📁 파일:
- tests/integration/test_obsidian_sync.py (Modified)
- tests/integration/test_sync_map_manager.py (New)

📌 Related
- Issue [#76]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/131#issuecomment-3625268839)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

Obsidian 동기화 및 SyncMapManager 테스트를 개선하여, 단위 테스트와 통합 테스트의 책임을 분리하고 동시성 검증과 더 견고한 충돌 해결 단언을 추가했습니다.

Tests:
- Obsidian 동기화 통합 테스트의 이름을 변경하고 의미를 명확히 하며, 해시, 파일 워처, 충돌 모델 로직을 각각 집중된 단위 테스트로 분리합니다.
- SyncMapManager 테스트를 전용 모듈로 이동하고, CRUD 동작, 전체 개수(total count), 동일 ID 업데이트를 포함한 스레드 안전한 동시 접근 패턴을 포괄하도록 확장합니다.
- 충돌 해결 테스트를 강화하여, 취약한 오류 메시지 문자열 비교 대신 `ResolutionStatus` enum과 해결 메타데이터를 사용해 단언하도록 변경합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine Obsidian sync and SyncMapManager tests, separating concerns between unit and integration coverage while adding concurrency validation and more robust conflict resolution assertions.

Tests:
- Rename and clarify Obsidian sync integration tests, splitting hash, file watcher, and conflict model logic into focused unit tests.
- Move SyncMapManager tests into a dedicated module and expand them to cover CRUD behavior, total count, and thread-safe concurrent access patterns including same-ID updates.
- Strengthen conflict resolution tests to assert using ResolutionStatus enums and resolution metadata instead of brittle error-message string checks.

</details>