### PR TITLE
🏗️ refactor [#10.3.8]: 테스트 구조 2차 개선 - Unit/Integration 분리, 동시성 안전성 강화

### DIFF
--- a/tests/integration/test_obsidian_sync.py
+++ b/tests/integration/test_obsidian_sync.py
@@ -3,13 +3,13 @@
 """
 Obsidian 동기화 통합 테스트
 
-파일 생성/수정/삭제 시나리오 및 충돌 해결 전략을 검증합니다.
+End-to-End 시나리오 및 서비스 간 상호작용을 검증합니다.
 """
 
 import pytest
 from pathlib import Path
 
-from backend.mcp.obsidian_server import ObsidianSyncService, ObsidianFileWatcher
+from backend.mcp.obsidian_server import ObsidianSyncService
 from backend.mcp.sync_map_manager import SyncMapManager
 from backend.services.conflict_resolution_service import ConflictResolutionService
 from backend.config.mcp_config import ObsidianConfig
@@ -55,7 +55,7 @@ def map_manager(tmp_path: Path) -> SyncMapManager:
 
 
 # ==========================================
-# Test: 파일 동기화 기본 시나리오
+# Test: End-to-End 동기화 시나리오
 # ==========================================
 
 
@@ -90,149 +90,27 @@ async def test_file_creation_no_conflict(
     assert len(conflicts) == 0, "새 파일 생성 시 sync_all()은 충돌을 반환하지 않아야 함"
 
 
-def test_file_hash_calculation_consistency(sync_service: ObsidianSyncService):
-    """
-    [Unit] 파일 해시 계산 일관성 검증
-
-    시나리오:
-    1. 동일 내용에 대해 해시 계산
-    2. 해시 값 일관성 확인
-    3. 내용 변경 시 해시 변경 확인
-    """
-    # Arrange
-    original_content = "# Original\n\nOriginal content."
-    modified_content = "# Modified\n\nModified content."
-
-    # Act
-    hash1 = sync_service.calculate_file_hash(original_content)
-    hash2 = sync_service.calculate_file_hash(original_content)  # 동일 내용
-    hash3 = sync_service.calculate_file_hash(modified_content)
-
-    # Assert
-    assert hash1 == hash2, "동일 내용은 동일 해시를 생성해야 함"
-    assert hash1 != hash3, "내용 변경 시 해시가 달라야 함"
-
-
-def test_conflict_detection_by_hash(sync_service: ObsidianSyncService):
-    """
-    [Unit] 해시 기반 충돌 감지 로직 검증
-
-    시나리오:
-    1. 해시 불일치 시 변경 감지
-    2. 해시 일치 시 변경 없음
-    3. last_synced_hash가 None인 경우 처리
-    """
-    # Arrange
-    current_hash = "abc123"
-    last_synced_hash = "def456"
-
-    # Act & Assert
-    assert (
-        sync_service.detect_conflict_by_hash(current_hash, last_synced_hash) is True
-    ), "해시 불일치 시 변경 감지되어야 함"
-
-    assert (
-        sync_service.detect_conflict_by_hash(current_hash, current_hash) is False
-    ), "해시 일치 시 변경 없음"
-
-    assert (
-        sync_service.detect_conflict_by_hash(current_hash, None) is True
-    ), "last_synced_hash가 None이면 변경으로 간주"
-
-
-def test_file_watcher_event_handling(mock_vault: Path):
-    """
-    [Unit] FileWatcher 이벤트 핸들링 검증
-
-    시나리오:
-    1. 각 이벤트 타입별 콜백 호출 확인
-    2. .md 파일만 필터링 확인
-    3. 디렉토리 이벤트 무시 확인
-    """
-    # Arrange
-    events_captured = []
-
-    def mock_callback(file_path: str, event_type: str):
-        events_captured.append((file_path, event_type))
-
-    watcher = ObsidianFileWatcher(mock_callback)
-
-    # Mock events
-    class MockEvent:
-        def __init__(
-            self, src_path: str, is_directory: bool = False, dest_path: str = None
-        ):
-            self.src_path = src_path
-            self.is_directory = is_directory
-            self.dest_path = dest_path
-
-    # Act: 다양한 이벤트 시뮬레이션
-    watcher.on_created(MockEvent(str(mock_vault / "created.md")))
-    watcher.on_modified(MockEvent(str(mock_vault / "modified.md")))
-    watcher.on_deleted(MockEvent(str(mock_vault / "deleted.md")))
-    watcher.on_moved(
-        MockEvent(str(mock_vault / "old.md"), dest_path=str(mock_vault / "new.md"))
-    )
-
-    # 무시되어야 하는 이벤트
-    watcher.on_created(MockEvent(str(mock_vault / "ignored.txt")))  # .md 아님
-    watcher.on_created(
-        MockEvent(str(mock_vault / "dir"), is_directory=True)
-    )  # 디렉토리
-
-    # Assert
-    assert len(events_captured) == 4, "4개의 .md 파일 이벤트만 캡처되어야 함"
-    assert events_captured[0][1] == "created"
-    assert events_captured[1][1] == "modified"
-    assert events_captured[2][1] == "deleted"
-    assert events_captured[3][1] == "moved"
-
-
 # ==========================================
-# Test: 충돌 시나리오
+# Test: 충돌 해결 통합 시나리오
 # ==========================================
-
-
-def test_conflict_model_creation():
-    """
-    [Unit] SyncConflict 모델 생성 및 속성 검증
-
-    시나리오:
-    1. Content Mismatch 충돌 생성
-    2. 필수 속성 확인
-    3. 기본 상태 확인
-    """
-    # Arrange & Act
-    conflict = SyncConflict(
-        file_id="test_file_123",
-        external_path="/vault/test.md",
-        tool_type=ExternalToolType.OBSIDIAN,
-        conflict_type=SyncConflictType.CONTENT_MISMATCH,
-        local_hash="abc123",
-        remote_hash="def456",
-    )
-
-    # Assert
-    assert conflict.conflict_type == SyncConflictType.CONTENT_MISMATCH
-    assert conflict.local_hash != conflict.remote_hash
-    assert conflict.status == ResolutionStatus.PENDING
 
 
 @pytest.mark.asyncio
-async def test_conflict_resolution_remote_wins_status(
+async def test_conflict_resolution_remote_wins_integration(
     sync_service: ObsidianSyncService, map_manager: SyncMapManager, mock_vault: Path
 ):
     """
-    [Integration] 충돌 해결: Remote Wins 전략 (상태 검증)
+    [Integration] 충돌 해결: Remote Wins 전략 (End-to-End)
 
     시나리오:
-    1. Content Mismatch 충돌 생성
-    2. AUTO_BY_CONTEXT 전략 적용
-    3. ResolutionStatus.FAILED 확인 (MVP: File Service 미구현)
+    1. Vault에 파일 생성
+    2. Content Mismatch 충돌 생성
+    3. ConflictResolutionService를 통한 해결 시도
+    4. ResolutionStatus.FAILED 확인 (MVP: File Service 미구현)
 
-    Note: 에러 메시지 문자열 대신 상태 Enum으로 검증하여 안정성 확보
+    Note: 서비스 간 상호작용 및 전체 플로우 검증
     """
-    # Arrange
+    # Arrange: Vault에 파일 생성
     test_file = mock_vault / "conflict_test.md"
     remote_content = "# Remote Version\n\nRemote content wins."
     test_file.write_text(remote_content, encoding="utf-8")
@@ -256,30 +134,31 @@ async def test_conflict_resolution_remote_wins_status(
 
     resolution_service = ConflictResolutionService(sync_service, map_manager)
 
-    # Act
+    # Act: 충돌 해결 시도
     resolution = await resolution_service.resolve_conflict(conflict, strategy)
 
-    # Assert: 상태 Enum으로 검증 (문자열 대신)
+    # Assert: 상태 Enum으로 검증
     assert (
         resolution.status == ResolutionStatus.FAILED
     ), "MVP에서는 File Service 미구현으로 FAILED 상태여야 함"
     assert resolution.conflict_id == conflict.conflict_id
     assert resolution.resolved_by == "system"
+    assert resolution.resolved_at is not None
 
 
 @pytest.mark.asyncio
-async def test_conflict_resolution_manual_not_implemented_status(
+async def test_conflict_resolution_manual_not_implemented_integration(
     sync_service: ObsidianSyncService, map_manager: SyncMapManager
 ):
     """
-    [Integration] 충돌 해결: MANUAL_OVERRIDE 미구현 처리 (상태 검증)
+    [Integration] 충돌 해결: MANUAL_OVERRIDE 미구현 처리 (End-to-End)
 
     시나리오:
-    1. MANUAL_OVERRIDE 전략 호출
-    2. ResolutionStatus.FAILED 확인
-    3. NotImplementedError 처리 확인
+    1. MANUAL_OVERRIDE 전략으로 충돌 해결 시도
+    2. ConflictResolutionService가 NotImplementedError 처리
+    3. ResolutionStatus.FAILED 및 적절한 메시지 확인
 
-    Note: 상태 Enum으로 검증하여 에러 메시지 변경에 강건함
+    Note: 예외 처리 및 서비스 응답 검증
     """
     # Arrange
     conflict = SyncConflict(
@@ -308,4 +187,5 @@ async def test_conflict_resolution_manual_not_implemented_status(
     assert resolution.status == ResolutionStatus.FAILED
     assert (
         "not implemented" in resolution.notes.lower()
-    ), "NotImplementedError 관련 메시지 포함 (보조 검증)"
+    ), "NotImplementedError 관련 메시지 포함"
+    assert resolution.resolved_at is not None

--- a/tests/unit/test_obsidian_sync_unit.py
+++ b/tests/unit/test_obsidian_sync_unit.py
@@ -1,0 +1,184 @@
+# tests/unit/test_obsidian_sync_unit.py
+
+"""
+Obsidian 동기화 Unit Tests
+
+개별 컴포넌트의 독립적인 동작을 검증합니다.
+"""
+
+import pytest
+from pathlib import Path
+
+from backend.mcp.obsidian_server import ObsidianSyncService, ObsidianFileWatcher
+from backend.config.mcp_config import ObsidianConfig
+from backend.models.conflict import (
+    SyncConflict,
+    SyncConflictType,
+    ResolutionStatus,
+)
+from backend.models.external_sync import ExternalToolType
+
+
+# ==========================================
+# Fixtures
+# ==========================================
+
+
+@pytest.fixture
+def mock_vault(tmp_path: Path) -> Path:
+    """임시 Obsidian Vault 디렉토리 생성"""
+    vault = tmp_path / "test_vault"
+    vault.mkdir()
+    return vault
+
+
+@pytest.fixture
+def obsidian_config(mock_vault: Path) -> ObsidianConfig:
+    """테스트용 Obsidian 설정"""
+    return ObsidianConfig(vault_path=str(mock_vault), sync_interval=300, enabled=True)
+
+
+@pytest.fixture
+def sync_service(obsidian_config: ObsidianConfig) -> ObsidianSyncService:
+    """ObsidianSyncService 인스턴스"""
+    return ObsidianSyncService(obsidian_config)
+
+
+# ==========================================
+# Test: 해시 계산 및 충돌 감지
+# ==========================================
+
+
+def test_file_hash_calculation_consistency(sync_service: ObsidianSyncService):
+    """
+    [Unit] 파일 해시 계산 일관성 검증
+
+    시나리오:
+    1. 동일 내용에 대해 해시 계산
+    2. 해시 값 일관성 확인
+    3. 내용 변경 시 해시 변경 확인
+    """
+    # Arrange
+    original_content = "# Original\n\nOriginal content."
+    modified_content = "# Modified\n\nModified content."
+
+    # Act
+    hash1 = sync_service.calculate_file_hash(original_content)
+    hash2 = sync_service.calculate_file_hash(original_content)  # 동일 내용
+    hash3 = sync_service.calculate_file_hash(modified_content)
+
+    # Assert
+    assert hash1 == hash2, "동일 내용은 동일 해시를 생성해야 함"
+    assert hash1 != hash3, "내용 변경 시 해시가 달라야 함"
+
+
+def test_conflict_detection_by_hash(sync_service: ObsidianSyncService):
+    """
+    [Unit] 해시 기반 충돌 감지 로직 검증
+
+    시나리오:
+    1. 해시 불일치 시 변경 감지
+    2. 해시 일치 시 변경 없음
+    3. last_synced_hash가 None인 경우 처리
+    """
+    # Arrange
+    current_hash = "abc123"
+    last_synced_hash = "def456"
+
+    # Act & Assert
+    assert (
+        sync_service.detect_conflict_by_hash(current_hash, last_synced_hash) is True
+    ), "해시 불일치 시 변경 감지되어야 함"
+
+    assert (
+        sync_service.detect_conflict_by_hash(current_hash, current_hash) is False
+    ), "해시 일치 시 변경 없음"
+
+    assert (
+        sync_service.detect_conflict_by_hash(current_hash, None) is True
+    ), "last_synced_hash가 None이면 변경으로 간주"
+
+
+# ==========================================
+# Test: FileWatcher 이벤트 핸들링
+# ==========================================
+
+
+def test_file_watcher_event_handling(mock_vault: Path):
+    """
+    [Unit] FileWatcher 이벤트 핸들링 검증
+
+    시나리오:
+    1. 각 이벤트 타입별 콜백 호출 확인
+    2. .md 파일만 필터링 확인
+    3. 디렉토리 이벤트 무시 확인
+    """
+    # Arrange
+    events_captured = []
+
+    def mock_callback(file_path: str, event_type: str):
+        events_captured.append((file_path, event_type))
+
+    watcher = ObsidianFileWatcher(mock_callback)
+
+    # Mock events
+    class MockEvent:
+        def __init__(
+            self, src_path: str, is_directory: bool = False, dest_path: str = None
+        ):
+            self.src_path = src_path
+            self.is_directory = is_directory
+            self.dest_path = dest_path
+
+    # Act: 다양한 이벤트 시뮬레이션
+    watcher.on_created(MockEvent(str(mock_vault / "created.md")))
+    watcher.on_modified(MockEvent(str(mock_vault / "modified.md")))
+    watcher.on_deleted(MockEvent(str(mock_vault / "deleted.md")))
+    watcher.on_moved(
+        MockEvent(str(mock_vault / "old.md"), dest_path=str(mock_vault / "new.md"))
+    )
+
+    # 무시되어야 하는 이벤트
+    watcher.on_created(MockEvent(str(mock_vault / "ignored.txt")))  # .md 아님
+    watcher.on_created(
+        MockEvent(str(mock_vault / "dir"), is_directory=True)
+    )  # 디렉토리
+
+    # Assert
+    assert len(events_captured) == 4, "4개의 .md 파일 이벤트만 캡처되어야 함"
+    assert events_captured[0][1] == "created"
+    assert events_captured[1][1] == "modified"
+    assert events_captured[2][1] == "deleted"
+    assert events_captured[3][1] == "moved"
+
+
+# ==========================================
+# Test: SyncConflict 모델
+# ==========================================
+
+
+def test_conflict_model_creation():
+    """
+    [Unit] SyncConflict 모델 생성 및 속성 검증
+
+    시나리오:
+    1. Content Mismatch 충돌 생성
+    2. 필수 속성 확인
+    3. 기본 상태 확인
+    """
+    # Arrange & Act
+    conflict = SyncConflict(
+        file_id="test_file_123",
+        external_path="/vault/test.md",
+        tool_type=ExternalToolType.OBSIDIAN,
+        conflict_type=SyncConflictType.CONTENT_MISMATCH,
+        local_hash="abc123",
+        remote_hash="def456",
+    )
+
+    # Assert
+    assert conflict.conflict_type == SyncConflictType.CONTENT_MISMATCH
+    assert conflict.local_hash != conflict.remote_hash
+    assert conflict.status == ResolutionStatus.PENDING
+    assert conflict.file_id == "test_file_123"
+    assert conflict.tool_type == ExternalToolType.OBSIDIAN


### PR DESCRIPTION
🔍 변경 사항:
- **테스트 디렉토리 재구성**:
    - [tests/unit/test_sync_map_manager.py]: SyncMapManager CRUD + Concurrency (New)
    - [tests/unit/test_obsidian_sync_unit.py]: 해시, FileWatcher, 모델 검증 (New)
    - [tests/integration/test_obsidian_sync.py]: End-to-End 시나리오만 유지 (Modified)
    - [tests/integration/test_sync_map_manager.py]: 삭제 (백업 완료)
- **동시성 테스트 안전성 강화**:
    - `timeout=10` 추가 (교착 상태 방지)
    - `return_when=FIRST_EXCEPTION` 추가 (첫 예외 즉시 감지)
- **Assertion 명확화**: 미완료 개수 표시, 예외 메시지 포맷 개선

📁 파일:
- tests/unit/test_sync_map_manager.py (New)
- tests/unit/test_obsidian_sync_unit.py (New)
- tests/integration/test_obsidian_sync.py (Modified)
- tests/integration/test_sync_map_manager.py (Deleted)

📌 Related
- Issue [#76]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/132#pullrequestreview-3550386194)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

Obsidian 동기화 테스트를 명확한 단위 테스트와 통합 테스트 모음으로 분리하고, 동시성 및 충돌 해결 커버리지를 강화합니다.

Tests:
- ObsidianSyncService의 해싱, 충돌 감지, FileWatcher, SyncConflict 모델 검증을 통합 테스트에서 분리하여 전용 단위 테스트 모듈로 이동합니다.
- SyncMapManager 테스트를 단위 테스트로 전환하고, 타임아웃, FIRST_EXCEPTION 처리, 더 명확한 단언을 통해 동시 접근/업데이트 시나리오를 강화합니다.
- 통합 테스트 범위를 실제 end-to-end Obsidian 동기화 및 충돌 해결 플로우로 한정하고, 단언을 (해결 타임스탬프 및 실패 기대치 포함) 더 엄격하게 만들며 이름을 정제합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Separate Obsidian sync tests into clear unit and integration suites while hardening concurrency and conflict-resolution coverage.

Tests:
- Move ObsidianSyncService hashing, conflict detection, FileWatcher, and SyncConflict model checks from integration tests into a dedicated unit test module.
- Convert SyncMapManager tests into unit tests and strengthen concurrent access/update scenarios with timeouts, FIRST_EXCEPTION handling, and clearer assertions.
- Narrow integration tests to true end-to-end Obsidian sync and conflict-resolution flows, renaming and tightening assertions (including resolution timestamps and failure expectations).

</details>