### PR TITLE
🏗️ refactor [#10.3.8]: 테스트 3차 개선 - Fixture 중앙화, ALL_COMPLETED 패턴

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,3 +58,40 @@ def sample_user():
 @pytest.fixture
 def sample_text():
     return "오늘 프로젝트 회의가 있습니다. 마감일은 다음주입니다."
+
+
+# ==========================================
+# Obsidian Sync Fixtures (Phase 3)
+# ==========================================
+
+
+@pytest.fixture
+def mock_vault(tmp_path: Path) -> Path:
+    """임시 Obsidian Vault 디렉토리 생성"""
+    vault = tmp_path / "test_vault"
+    vault.mkdir()
+    return vault
+
+
+@pytest.fixture
+def obsidian_config(mock_vault: Path):
+    """테스트용 Obsidian 설정"""
+    from backend.config.mcp_config import ObsidianConfig
+
+    return ObsidianConfig(vault_path=str(mock_vault), sync_interval=300, enabled=True)
+
+
+@pytest.fixture
+def sync_service(obsidian_config):
+    """ObsidianSyncService 인스턴스"""
+    from backend.mcp.obsidian_server import ObsidianSyncService
+
+    return ObsidianSyncService(obsidian_config)
+
+
+@pytest.fixture
+def map_manager(tmp_path: Path):
+    """SyncMapManager 인스턴스 (임시 저장소)"""
+    from backend.mcp.sync_map_manager import SyncMapManager
+
+    return SyncMapManager(storage_dir=str(tmp_path / "mcp"))

--- a/tests/integration/test_obsidian_sync.py
+++ b/tests/integration/test_obsidian_sync.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from backend.mcp.obsidian_server import ObsidianSyncService
 from backend.mcp.sync_map_manager import SyncMapManager
 from backend.services.conflict_resolution_service import ConflictResolutionService
-from backend.config.mcp_config import ObsidianConfig
 from backend.models.external_sync import ExternalToolType
 from backend.models.conflict import (
     SyncConflict,
@@ -23,35 +22,7 @@ from backend.models.conflict import (
 )
 
 
-# ==========================================
-# Fixtures
-# ==========================================
-
-
-@pytest.fixture
-def mock_vault(tmp_path: Path) -> Path:
-    """임시 Obsidian Vault 디렉토리 생성"""
-    vault = tmp_path / "test_vault"
-    vault.mkdir()
-    return vault
-
-
-@pytest.fixture
-def obsidian_config(mock_vault: Path) -> ObsidianConfig:
-    """테스트용 Obsidian 설정"""
-    return ObsidianConfig(vault_path=str(mock_vault), sync_interval=300, enabled=True)
-
-
-@pytest.fixture
-def sync_service(obsidian_config: ObsidianConfig) -> ObsidianSyncService:
-    """ObsidianSyncService 인스턴스"""
-    return ObsidianSyncService(obsidian_config)
-
-
-@pytest.fixture
-def map_manager(tmp_path: Path) -> SyncMapManager:
-    """SyncMapManager 인스턴스 (임시 저장소)"""
-    return SyncMapManager(storage_dir=str(tmp_path / "mcp"))
+# Note: Fixtures는 tests/conftest.py에서 제공됩니다.
 
 
 # ==========================================

--- a/tests/unit/test_obsidian_sync_unit.py
+++ b/tests/unit/test_obsidian_sync_unit.py
@@ -10,7 +10,6 @@ import pytest
 from pathlib import Path
 
 from backend.mcp.obsidian_server import ObsidianSyncService, ObsidianFileWatcher
-from backend.config.mcp_config import ObsidianConfig
 from backend.models.conflict import (
     SyncConflict,
     SyncConflictType,
@@ -19,29 +18,7 @@ from backend.models.conflict import (
 from backend.models.external_sync import ExternalToolType
 
 
-# ==========================================
-# Fixtures
-# ==========================================
-
-
-@pytest.fixture
-def mock_vault(tmp_path: Path) -> Path:
-    """임시 Obsidian Vault 디렉토리 생성"""
-    vault = tmp_path / "test_vault"
-    vault.mkdir()
-    return vault
-
-
-@pytest.fixture
-def obsidian_config(mock_vault: Path) -> ObsidianConfig:
-    """테스트용 Obsidian 설정"""
-    return ObsidianConfig(vault_path=str(mock_vault), sync_interval=300, enabled=True)
-
-
-@pytest.fixture
-def sync_service(obsidian_config: ObsidianConfig) -> ObsidianSyncService:
-    """ObsidianSyncService 인스턴스"""
-    return ObsidianSyncService(obsidian_config)
+# Note: Fixtures는 tests/conftest.py에서 제공됩니다.
 
 
 # ==========================================

--- a/tests/unit/test_sync_map_manager.py
+++ b/tests/unit/test_sync_map_manager.py
@@ -7,22 +7,13 @@ SyncMapManager Unit Tests
 """
 
 import pytest
-from pathlib import Path
-from concurrent.futures import ThreadPoolExecutor, wait, FIRST_EXCEPTION
+from concurrent.futures import ThreadPoolExecutor, wait, ALL_COMPLETED
 
 from backend.mcp.sync_map_manager import SyncMapManager
 from backend.models.external_sync import ExternalToolType
 
 
-# ==========================================
-# Fixtures
-# ==========================================
-
-
-@pytest.fixture
-def map_manager(tmp_path: Path) -> SyncMapManager:
-    """SyncMapManager 인스턴스 (임시 저장소)"""
-    return SyncMapManager(storage_dir=str(tmp_path / "mcp"))
+# Note: Fixtures는 tests/conftest.py에서 제공됩니다.
 
 
 # ==========================================
@@ -210,24 +201,24 @@ def test_sync_map_manager_thread_safe_concurrent_access(map_manager: SyncMapMana
             assert by_external.internal_file_id == mapping.internal_file_id
             assert by_external.external_path == mapping.external_path
 
-    # Act: 멀티스레드 실행 (Timeout 및 FIRST_EXCEPTION 추가)
+    # Act: 멀티스레드 실행 (ALL_COMPLETED로 모든 worker 완료 대기)
     with ThreadPoolExecutor(max_workers=num_workers) as executor:
         futures = [executor.submit(worker, idx) for idx in range(num_workers)]
         done, not_done = wait(
             futures,
             timeout=10,  # 10초 timeout (교착 상태 방지)
-            return_when=FIRST_EXCEPTION,  # 첫 예외 발생 시 즉시 반환
+            return_when=ALL_COMPLETED,  # 모든 worker 완료 대기
         )
 
-    # Assert: Timeout 내에 모든 스레드 완료
+    # Assert: 모든 worker가 완료되었는지 확인
     assert (
-        not not_done
-    ), f"일부 worker future가 타임아웃 내에 완료되지 않았습니다. 미완료: {len(not_done)}"
+        len(done) == num_workers
+    ), f"모든 worker가 완료되어야 함. 완료: {len(done)}, 미완료: {len(not_done)}"
 
-    # Assert: 모든 스레드가 예외 없이 완료
-    for f in done:
+    # Assert: 예외 없이 완료
+    for idx, f in enumerate(done):
         exc = f.exception()
-        assert exc is None, f"worker에서 예외 발생: {exc!r}"
+        assert exc is None, f"worker {idx}에서 예외 발생: {exc!r}"
 
     # 최종 매핑 개수 검증
     expected_count = num_workers * iterations_per_worker
@@ -258,24 +249,24 @@ def test_sync_map_manager_concurrent_update_same_id(map_manager: SyncMapManager)
             current_hash=f"hash-{worker_idx}",
         )
 
-    # Act: 동일 ID에 대한 동시 업데이트 (Timeout 추가)
+    # Act: 동일 ID에 대한 동시 업데이트 (ALL_COMPLETED)
     with ThreadPoolExecutor(max_workers=num_workers) as executor:
         futures = [executor.submit(worker, idx) for idx in range(num_workers)]
         done, not_done = wait(
             futures,
             timeout=10,
-            return_when=FIRST_EXCEPTION,
+            return_when=ALL_COMPLETED,
         )
 
-    # Assert: Timeout 내에 완료
+    # Assert: 모든 worker 완료
     assert (
-        not not_done
-    ), f"일부 worker future가 타임아웃 내에 완료되지 않았습니다. 미완료: {len(not_done)}"
+        len(done) == num_workers
+    ), f"모든 worker가 완료되어야 함. 완료: {len(done)}, 미완료: {len(not_done)}"
 
     # Assert: 예외 없이 완료
-    for f in done:
+    for idx, f in enumerate(done):
         exc = f.exception()
-        assert exc is None, f"worker에서 예외 발생: {exc!r}"
+        assert exc is None, f"worker {idx}에서 예외 발생: {exc!r}"
 
     # 최종 상태 확인: 하나의 매핑만 존재해야 함
     mapping = map_manager.get_mapping_by_internal_id(shared_internal_id)


### PR DESCRIPTION
🔍 변경 사항:
- **Fixture 중앙화**: `tests/conftest.py`의 [conftest.py]에 Obsidian sync 관련 fixture 추가
  - 모든 테스트 파일에서 중복 제거
  - [mock_vault], [obsidian_config], [sync_service], [map_manager]
- **동시성 테스트 개선**:
    - `return_when=ALL_COMPLETED` 사용 (FIRST_EXCEPTION 제거)
    - `len(done) == num_workers` 검증으로 명확한 완료 확인
    - Timeout과 예외 케이스 구분 명확화
- **코드 품질**: Import 정리, Docstring 개선, 주석 추가

📁 파일:
- tests/conftest.py (Modified)
- tests/unit/test_sync_map_manager.py (Modified)
- tests/unit/test_obsidian_sync_unit.py (Modified)
- tests/integration/test_obsidian_sync.py (Modified)

📌 Related
- Issue [#76]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/133#issuecomment-3625327007)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

공유 테스트 설정에서 Obsidian 동기화 픽스처를 중앙화하고, 모든 워커가 성공적으로 완료되어야만 통과하도록 동시성 테스트 동작을 강화합니다.

Tests:
- 단위 및 통합 테스트 전반에서 재사용할 수 있도록 Obsidian 동기화 및 `SyncMapManager` 픽스처를 `tests/conftest.py`로 이동합니다.
- 멀티스레드 `SyncMapManager` 테스트를 `ALL_COMPLETED`를 기다리도록 수정하고, 모든 워커가 예외 없이 종료되는지를 명시적으로 검증합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize Obsidian sync fixtures in the shared test configuration and tighten concurrency test behavior to require all workers to complete successfully.

Tests:
- Move Obsidian sync and SyncMapManager fixtures into tests/conftest.py for reuse across unit and integration tests.
- Update multithreaded SyncMapManager tests to wait for ALL_COMPLETED and explicitly verify all workers finish without exceptions.

</details>