### PR TITLE
🔧 fix [#10.3.9]: 2차 개선 - API 문서 TypeScript 구문 적용 및 MVP 응답 명확화

### DIFF
--- a/docs/P/v4_phase3_mcp_integration/api_sync_conflict.md
+++ b/docs/P/v4_phase3_mcp_integration/api_sync_conflict.md
@@ -285,7 +285,9 @@ Content-Type: application/json
 | `AUTO_BY_CONTEXT` | 컨텍스트 기반 자동 해결 (MVP: Remote Wins) | ✅ 구현 |
 | `AUTO_BY_CONFIDENCE` | 신뢰도 기반 자동 해결 (MVP: Remote Wins) | ✅ 구현 |
 
-**Response** (200 OK)
+**Response (200 OK) - MVP 현재 상태**
+
+> **⚠️ 중요**: MVP에서는 File Service 미구현으로 **모든 요청이 HTTP 200 OK를 반환하지만, `success: false` 및 `status: "FAILED"`로 응답**합니다.
 
 ```json
 {
@@ -304,6 +306,37 @@ Content-Type: application/json
     "notes": "Not implemented: File Service required"
   },
   "success": false
+}
+```
+
+**MVP 응답 구분 방법**
+
+| 필드 | MVP 값 | 의미 |
+|------|--------|------|
+| HTTP Status | `200 OK` | 요청 처리 성공 (서버 정상) |
+| `success` | `false` | 해결 실패 (구현 제한) |
+| `resolution.status` | `"FAILED"` | 해결 상태 실패 |
+| `resolution.notes` | `"Not implemented: ..."` | 실패 원인 (File Service 미구현) |
+
+**Phase 4 예상 응답 (성공 시)**
+
+```json
+{
+  "resolution": {
+    "conflict_id": "uuid-1234",
+    "status": "RESOLVED",
+    "strategy": {
+      "method": "AUTO_BY_CONTEXT",
+      "recommended_value": null,
+      "confidence": 0.9,
+      "reasoning": "Remote wins strategy",
+      "conflict_id": "uuid-1234"
+    },
+    "resolved_by": "system",
+    "resolved_at": "2025-12-08T17:05:00Z",
+    "notes": "Successfully applied remote version"
+  },
+  "success": true
 }
 ```
 
@@ -365,18 +398,18 @@ else:
 
 ### SyncConflict
 
-```json
+```typescript
 {
-  "conflict_id": "string (UUID)",
-  "file_id": "string",
-  "external_path": "string",
-  "tool_type": "OBSIDIAN",
-  "conflict_type": "CONTENT_MISMATCH | DELETED_REMOTE | DELETED_LOCAL | METADATA_MISMATCH",
-  "local_hash": "string | null",
-  "remote_hash": "string | null",
-  "status": "PENDING | PENDING_REVIEW | RESOLVED | FAILED",
-  "detected_at": "string (ISO 8601)",
-  "metadata": "object | null"
+  conflict_id: string;        // UUID
+  file_id: string;
+  external_path: string;
+  tool_type: "OBSIDIAN";
+  conflict_type: "CONTENT_MISMATCH" | "DELETED_REMOTE" | "DELETED_LOCAL" | "METADATA_MISMATCH";
+  local_hash: string | null;
+  remote_hash: string | null;
+  status: "PENDING" | "PENDING_REVIEW" | "RESOLVED" | "FAILED";
+  detected_at: string;        // ISO 8601
+  metadata?: object | null;
 }
 ```
 
@@ -396,13 +429,13 @@ else:
 
 ### ResolutionStrategy
 
-```json
+```typescript
 {
-  "method": "MANUAL_OVERRIDE | AUTO_BY_CONTEXT | AUTO_BY_CONFIDENCE | VOTING | HYBRID",
-  "recommended_value": "string | null",
-  "confidence": "number (0.0 ~ 1.0)",
-  "reasoning": "string",
-  "conflict_id": "string (UUID)"
+  method: "MANUAL_OVERRIDE" | "AUTO_BY_CONTEXT" | "AUTO_BY_CONFIDENCE" | "VOTING" | "HYBRID";
+  recommended_value: string | null;
+  confidence: number;         // 0.0 ~ 1.0
+  reasoning: string;
+  conflict_id: string;        // UUID
 }
 ```
 
@@ -417,14 +450,14 @@ else:
 
 ### ConflictResolution
 
-```json
+```typescript
 {
-  "conflict_id": "string (UUID)",
-  "status": "RESOLVED | FAILED",
-  "strategy": "ResolutionStrategy",
-  "resolved_by": "string (user_id or 'system')",
-  "resolved_at": "string (ISO 8601)",
-  "notes": "string | null"
+  conflict_id: string;        // UUID
+  status: "RESOLVED" | "FAILED";
+  strategy: ResolutionStrategy;
+  resolved_by: string;        // user_id or 'system'
+  resolved_at: string;        // ISO 8601
+  notes: string | null;
 }
 ```
 


### PR DESCRIPTION
🔍 변경 사항:
- **TypeScript 구문 적용**: 데이터 모델 섹션
    - `json` → `typescript` (Union type 지원)
    - 정확한 타입 표현 (string | null, optional fields)
- **MVP FAILED 응답 명확화**:
    - HTTP 200 OK + success: false 명시
    - MVP vs Phase 4 응답 비교 테이블 추가
    - 응답 구분 방법 가이드 제공
- **개선 사항**:
    - 모든 필드에 주석 추가 (// UUID, // ISO 8601)
    - Phase 4 예상 응답 예제 추가

📁 파일:
- docs/P/v4_phase3_mcp_integration/api_sync_conflict.md (Modified)

📌 Related
- Issue [#76]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/143#pullrequestreview-3550828324)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

MVP 동기화 충돌 API 동작을 명확히 하고, TypeScript 기반 사용자를 위한 데이터 모델 문서를 업데이트합니다.

Bug Fixes:
- MVP 동기화 충돌 해결 요청이 항상 HTTP 200을 반환하며, 실패 여부는 `success: false` 및 `status: "FAILED"` 필드를 통해 표시된다는 점을 명확히 함.

Enhancements:
- 필드별 설명 테이블을 통해 MVP 실패 응답을 구분하는 방법을 문서화.
- 향후 Phase 4 구현을 위한 예상 성공 응답 형태의 예시를 추가.
- 더 정확한 타입 지정을 위해 union 타입, null 가능성, 선택적 필드를 사용한 TypeScript 문법으로 동기화 충돌 관련 데이터 모델 예시를 재작성.

Documentation:
- MVP와 Phase 4의 동작 차이 및 상세 응답 예시를 포함하여, 동기화 충돌 해결 응답에 대한 API 문서를 개선.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify MVP sync conflict API behavior and update data model documentation for TypeScript-based consumers.

Bug Fixes:
- Clarify that MVP sync conflict resolution requests always return HTTP 200 with failure indicated via `success: false` and `status: "FAILED"` fields.

Enhancements:
- Document how to distinguish MVP failure responses using a field-by-field explanation table.
- Add an example of the expected successful response shape for a future Phase 4 implementation.
- Rewrite sync conflict-related data model examples using TypeScript syntax with union types, nullability, and optional fields for more precise typing.

Documentation:
- Improve API docs for sync conflict resolution responses, including MVP vs Phase 4 behavior and detailed response examples.

</details>