### PR TITLE
🔧 fix [#10.3.9]: 3차 개선 - TypeScript Interface 적용 및 중복 필드 제거

### DIFF
--- a/docs/P/v4_phase3_mcp_integration/api_sync_conflict.md
+++ b/docs/P/v4_phase3_mcp_integration/api_sync_conflict.md
@@ -271,8 +271,7 @@ Content-Type: application/json
     "method": "AUTO_BY_CONTEXT",
     "recommended_value": null,
     "confidence": 0.9,
-    "reasoning": "Remote wins strategy",
-    "conflict_id": "uuid-1234"
+    "reasoning": "Remote wins strategy"
   }
 }
 ```
@@ -298,8 +297,7 @@ Content-Type: application/json
       "method": "AUTO_BY_CONTEXT",
       "recommended_value": null,
       "confidence": 0.9,
-      "reasoning": "Remote wins strategy",
-      "conflict_id": "uuid-1234"
+      "reasoning": "Remote wins strategy"
     },
     "resolved_by": "system",
     "resolved_at": "2025-12-08T17:05:00Z",
@@ -329,8 +327,7 @@ Content-Type: application/json
       "method": "AUTO_BY_CONTEXT",
       "recommended_value": null,
       "confidence": 0.9,
-      "reasoning": "Remote wins strategy",
-      "conflict_id": "uuid-1234"
+      "reasoning": "Remote wins strategy"
     },
     "resolved_by": "system",
     "resolved_at": "2025-12-08T17:05:00Z",
@@ -350,8 +347,7 @@ curl -X POST http://localhost:8000/api/sync/conflicts/uuid-1234/resolve \
       "method": "AUTO_BY_CONTEXT",
       "recommended_value": null,
       "confidence": 0.9,
-      "reasoning": "Remote wins strategy",
-      "conflict_id": "uuid-1234"
+      "reasoning": "Remote wins strategy"
     }
   }'
 ```
@@ -367,8 +363,7 @@ payload = {
         "method": "AUTO_BY_CONTEXT",
         "recommended_value": None,
         "confidence": 0.9,
-        "reasoning": "Remote wins strategy",
-        "conflict_id": conflict_id
+        "reasoning": "Remote wins strategy"
     }
 }
 
@@ -399,7 +394,7 @@ else:
 ### SyncConflict
 
 ```typescript
-{
+interface SyncConflict {
   conflict_id: string;        // UUID
   file_id: string;
   external_path: string;
@@ -430,12 +425,12 @@ else:
 ### ResolutionStrategy
 
 ```typescript
-{
+interface ResolutionStrategy {
   method: "MANUAL_OVERRIDE" | "AUTO_BY_CONTEXT" | "AUTO_BY_CONFIDENCE" | "VOTING" | "HYBRID";
   recommended_value: string | null;
   confidence: number;         // 0.0 ~ 1.0
   reasoning: string;
-  conflict_id: string;        // UUID
+  // Note: conflict_id는 API 요청 시 포함하지만, 응답에서는 resolution.conflict_id 사용
 }
 ```
 
@@ -451,8 +446,8 @@ else:
 ### ConflictResolution
 
 ```typescript
-{
-  conflict_id: string;        // UUID
+interface ConflictResolution {
+  conflict_id: string;        // UUID (충돌 식별자)
   status: "RESOLVED" | "FAILED";
   strategy: ResolutionStrategy;
   resolved_by: string;        // user_id or 'system'
@@ -493,8 +488,7 @@ for conflict in conflicts['conflicts']:
             "method": "AUTO_BY_CONTEXT",
             "recommended_value": None,
             "confidence": 0.9,
-            "reasoning": "Auto resolution",
-            "conflict_id": conflict_id
+            "reasoning": "Auto resolution"
         }
     }
     


### PR DESCRIPTION
🔍 변경 사항:
- **TypeScript Interface 적용**:
    - `interface SyncConflict { ... }`
    - `interface ResolutionStrategy { ... }`
    - `interface ConflictResolution { ... }`
    - 타입 참조 명확화 (ResolutionStrategy 타입 사용)
- **중복 필드 제거**: `strategy.conflict_id` 제거
    - `resolution.conflict_id`에 이미 존재
    - 모든 예제에서 일관되게 제거 (Request Body, Response, cURL, Python)
    - ResolutionStrategy에 주석 추가 (API 요청 시 사용 방법 명시)
- **문서 정확성 향상**:
    - 데이터 구조 명확화
    - 필드 중복 제거로 혼란 방지

📁 파일:
- docs/P/v4_phase3_mcp_integration/api_sync_conflict.md (Modified)

📌 Related
- Issue [#76]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/144#pullrequestreview-3550869860)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

TypeScript 스타일의 타입 정의를 더 엄격하게 하고 예제에서 중복 필드를 제거하여 동기화 충돌 해결 API 문서를 명확히 합니다.

Documentation:
- 동기화 충돌 API에 대해 `SyncConflict`, `ResolutionStrategy`, `ConflictResolution`을 명시적인 TypeScript 인터페이스로 문서화합니다.
- 모든 요청/응답, cURL, Python 예제에서 중복되는 `strategy.conflict_id` 필드를 제거하고 대신 `resolution.conflict_id`에 의존하도록 업데이트하며, 예상되는 API 사용 방식에 대한 설명을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the sync conflict resolution API documentation by tightening TypeScript-style type definitions and removing redundant fields from examples.

Documentation:
- Document SyncConflict, ResolutionStrategy, and ConflictResolution as explicit TypeScript interfaces for the sync conflict API.
- Update all request/response, cURL, and Python examples to remove the redundant strategy.conflict_id field and rely on resolution.conflict_id instead, with notes on expected API usage.

</details>