### PR TITLE
♻️ refactor [#10.4.1]: 2차 개선 - 태스크 명시적 임포트 전환 및 pkgutil 제거

### DIFF
--- a/backend/celery_app/celery.py
+++ b/backend/celery_app/celery.py
@@ -12,8 +12,7 @@ app.config_from_object(CeleryConfig)
 
 # 태스크 자동 발견 (Auto-discover Tasks)
 # 'backend.celery_app' 앱 내의 tasks 모듈(패키지)을 자동으로 찾아 로드합니다.
-# backend/celery_app/tasks/__init__.py에서 하위 모듈들을 동적으로 임포트하므로,
-# 새로운 태스크 파일 추가 시 별도 설정 없이 자동 등록됩니다.
+# backend/celery_app/tasks/__init__.py에서 명시적으로 임포트된 태스크들이 등록됩니다.
 app.autodiscover_tasks(["backend.celery_app"])
 
 # Beat Schedule 정의

--- a/backend/celery_app/tasks/__init__.py
+++ b/backend/celery_app/tasks/__init__.py
@@ -1,18 +1,14 @@
 # backend/celery_app/tasks/__init__.py
 
-import pkgutil
-import importlib
-from pathlib import Path
+# 태스크 모듈 명시적 등록
+# autodiscover_tasks가 이 패키지(backend.celery_app.tasks)를 임포트할 때,
+# 아래의 서브 모듈들도 함께 임포트되어 태스크가 등록됩니다.
+# 새로운 태스크 파일을 생성하면 여기에 추가해 주세요.
 
-# 현재 패키지(tasks) 내의 모든 모듈을 동적으로 발견하여 임포트합니다.
-# 이를 통해 celery.py에서 별도로 include 리스트를 관리하거나 복잡한 로직을 넣을 필요 없이,
-# autodiscover_tasks가 이 패키지를 로드할 때 모든 태스크가 자동으로 등록됩니다.
-
-package_dir = Path(__file__).resolve().parent
-
-__all__ = []
-
-for _, module_name, _ in pkgutil.iter_modules([str(package_dir)]):
-    # 하위 모듈 임포트 (예: backend.celery_app.tasks.reclassification)
-    module = importlib.import_module(f"{__name__}.{module_name}")
-    __all__.append(module_name)
+from . import (
+    reclassification,
+    archiving,
+    reporting,
+    monitoring,
+    maintenance,
+)


### PR DESCRIPTION
🔧 변경 사항:
- **`backend/celery_app/tasks/__init__.py`**:
    - `pkgutil`을 이용한 동적 로직 제거
    - 태스크 모듈 명시적 임포트(`from . import ...`)로 변경하여 안정성 및 가독성 확보
- **`backend/celery_app/celery.py`**:
    - 변경된 동작 방식에 맞게 주석 업데이트
- **리뷰 반영**:
    - 불필요한 동적 레이어 제거 요구사항 반영
    - `__all__` 리스트 제거

📌 Related
- Issue [#78]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/150#pullrequestreview-3555010523)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

Celery 태스크 등록 방식을 리팩터링하여 `pkgutil`을 통한 동적 탐색을 제거하고, 명시적인 태스크 import 방식으로 변경하며 관련 문서를 업데이트합니다.

Enhancements:
- Celery 태스크 패키지에서 `pkgutil` 기반의 동적 태스크 import를 명시적인 import로 대체하여 안정성과 가독성을 개선합니다.
- Celery 설정 주석을 업데이트하여 새로운 명시적 태스크 import 동작을 반영하고, 동적 로딩에 대한 오래된 언급을 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor Celery task registration to remove dynamic discovery via pkgutil in favor of explicit task imports and update related documentation.

Enhancements:
- Replace dynamic pkgutil-based task imports with explicit imports in the Celery tasks package to improve stability and readability.
- Update Celery configuration comments to reflect the new explicit task import behavior and remove outdated references to dynamic loading.

</details>