### PR TITLE
📝 docs [#10.4.1]: 3차 개선 - 태스크 등록 가이드 및 플레이스홀더 추가

### DIFF
--- a/backend/celery_app/tasks/__init__.py
+++ b/backend/celery_app/tasks/__init__.py
@@ -1,9 +1,7 @@
-# backend/celery_app/tasks/__init__.py
-
-# 태스크 모듈 명시적 등록
-# autodiscover_tasks가 이 패키지(backend.celery_app.tasks)를 임포트할 때,
-# 아래의 서브 모듈들도 함께 임포트되어 태스크가 등록됩니다.
-# 새로운 태스크 파일을 생성하면 여기에 추가해 주세요.
+# [NOTICE] 태스크 모듈 등록 가이드
+# 새로운 태스크 파일(모듈)을 생성했다면, 반드시 아래 리스트에 추가해야 합니다.
+# Celery의 autodiscover_tasks는 이 파일을 최초 진입점으로 사용하므로,
+# 여기에 명시적으로 임포트되지 않은 모듈의 태스크는 실행되지 않습니다. (Silent Failure 방지)
 
 from . import (
     reclassification,
@@ -11,4 +9,5 @@ from . import (
     reporting,
     monitoring,
     maintenance,
+    # 여기에 새로운 태스크 모듈을 추가하세요. (e.g., my_new_task)
 )


### PR DESCRIPTION
🔧 변경 사항:
- **[backend/celery_app/tasks/__init__.py]**:
    - 개발자가 새 태스크 추가 시 등록을 잊지 않도록 `[NOTICE]` 경고 주석 추가
    - `import` 튜플 내부에 명시적인 플레이스홀더 주석 추가
    - Silent Failure 방지를 위한 가이드 강화

📌 Review Feedback Addressed:
- Add explicit reminder/placeholder for future contributors

📌 Related
- Issue [#78]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/151#pullrequestreview-3555036516)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

향상 사항:
- 새로운 태스크 모듈을 등록해야 하는 위치를 기여자들에게 상기시키기 위해 Celery 태스크 모듈 목록에 인라인 주석을 추가했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Add an inline comment in the Celery task module list reminding contributors where to register new task modules.

</details>