### PR TITLE
✨ feat [#10.4.9]: 모니터링 태스크 check_sync_status 구현

### DIFF
--- a/backend/celery_app/tasks/monitoring.py
+++ b/backend/celery_app/tasks/monitoring.py
@@ -1,0 +1,146 @@
+# backend/celery_app/tasks/monitoring.py
+
+import asyncio
+import logging
+import uuid
+import json
+from datetime import datetime
+from typing import Dict, Any
+
+from backend.celery_app.celery import app
+from backend.config import PathConfig
+from backend.config.mcp_config import mcp_config
+from backend.mcp.obsidian_server import ObsidianSyncService
+from backend.models.automation import (
+    AutomationLog,
+    AutomationTaskType,
+    AutomationStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+# 로그 디렉토리 및 파일 설정 (Reporting과 동일 구조 사용)
+LOG_DIR = PathConfig.DATA_DIR / "automation_logs"
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+AUTO_LOG_FILE = LOG_DIR / "automation.jsonl"
+
+
+def _save_monitoring_log(log: AutomationLog):
+    """AutomationLog 저장 (Monitoring 전용)"""
+    try:
+        with open(AUTO_LOG_FILE, "a", encoding="utf-8") as f:
+            f.write(log.model_dump_json() + "\n")
+    except Exception as exc:
+        logger.error(
+            "Failed to save monitoring log",
+            exc_info=False,
+            extra={"error_type": type(exc).__name__}
+        )
+
+
+def _run_async_check(service: ObsidianSyncService) -> bool:
+    """Run async connection check synchronously."""
+    try:
+        # Create a new event loop for this thread/process if needed
+        # Celery worker might prevent getting existing loop cleanly
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        
+        # Run connect()
+        result = loop.run_until_complete(service.connect())
+        
+        loop.close()
+        return result
+    except Exception as exc:
+        logger.error(
+            "Async connection check failed",
+            exc_info=False,
+            extra={"error_type": type(exc).__name__}
+        )
+        return False
+
+
+@app.task(bind=True)
+def check_sync_status(self):
+    """
+    [동기화 상태 모니터링]
+    - 매 10분마다 실행 (스케줄러 설정 필요)
+    - 외부 도구(Obsidian) 연결 상태 확인
+    - 에러 발생 시 로그 생성
+    """
+    task_name = "check_sync_status"
+    start_time = datetime.now()
+    log_id = str(uuid.uuid4())
+    
+    # 설정 확인
+    if not mcp_config.obsidian.enabled:
+        return "Obsidian Sync Disabled"
+    
+    service = ObsidianSyncService(mcp_config.obsidian)
+    is_connected = False
+    
+    try:
+        is_connected = _run_async_check(service)
+        
+        if not is_connected:
+            # 연결 실패 시에만 AutomationLog에 ERROR로 기록
+            log = AutomationLog(
+                log_id=log_id,
+                task_type=AutomationTaskType.MONITORING,
+                task_name=task_name,
+                celery_task_id=self.request.id,
+                status=AutomationStatus.FAILED,
+                started_at=start_time,
+                completed_at=datetime.now(),
+                duration_seconds=(datetime.now() - start_time).total_seconds(),
+                details={
+                    "error": "Obsidian Connection Failed",
+                    "vault_path": mcp_config.obsidian.vault_path
+                },
+                errors_count=1
+            )
+            _save_monitoring_log(log)
+            
+            logger.error(
+                "❌ External Tool Connection Failed",
+                exc_info=False,
+                extra={
+                    "tool": "Obsidian",
+                    "vault_path": mcp_config.obsidian.vault_path,
+                    "task_name": task_name,
+                    "error_type": "ConnectionError"
+                }
+            )
+            return "Connection Failed"
+
+        # 성공 시에는 로그를 남기지 않거나, INFO 레벨만 기록 (Log flooding 방지)
+        logger.info(f"✅ Sync Status Check Passed: {mcp_config.obsidian.vault_path}")
+        return "Healthy"
+
+    except Exception as exc:
+        error_type = type(exc).__name__
+        logger.error(
+            f"{task_name} unexpected error",
+            exc_info=False,
+            extra={
+                "task_name": task_name,
+                "error_type": error_type,
+                "unhandled": True
+            }
+        )
+        # 예기치 못한 에러도 로그에 남김
+        log = AutomationLog(
+            log_id=log_id,
+            task_type=AutomationTaskType.MONITORING,
+            task_name=task_name,
+            celery_task_id=self.request.id,
+            status=AutomationStatus.FAILED,
+            started_at=start_time,
+            completed_at=datetime.now(),
+            duration_seconds=(datetime.now() - start_time).total_seconds(),
+            details={"error_type": error_type},
+            errors_count=1
+        )
+        _save_monitoring_log(log)
+        
+        raise


### PR DESCRIPTION
🔧 변경 사항:
- **[Monitoring]**: Obsidian 연결 상태를 주기적으로 확인하는 [check_sync_status] `backend/celery_app/tasks/monitoring.py` Celery 태스크 추가
- **[Async Support]**: Celery 동기 태스크 내에서 비동기 Service 메서드([connect] `backend/services/sync_service.py` ) 실행을 위한 헬퍼([_run_async_check] `backend/celery_app/tasks/monitoring.py`) 구현
- **[Quality Check]**: AI 리뷰 체크리스트 준수 (보안 로깅, 명시적 예외 처리, 타입 힌팅)

📌 Check:
- [x] Secure Logging (No raw tracebacks)
- [x] Async Handling
- [x] Configuration Validation

📌 Related
- Issue [#78]
- 모니터링 작업 1/2

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

주기적인 모니터링 작업을 추가하여 외부 Obsidian 동기화 서비스의 상태를 확인하고, 실패 시 자동화 로그 저장소에 기록합니다.

새 기능:
- Obsidian 동기화 연결을 주기적으로 검증하고 단순한 상태 문자열을 반환하는 Celery 모니터링 작업 `check_sync_status` 를 도입합니다.

개선 사항:
- Celery 워커 내에서 비동기 Obsidian 동기화 `connect` 메서드를 실행하기 위한 동기 헬퍼를 구현하고, 예외 처리가 보호된(error-guarded) 형태로 이루어지도록 구조화된 로깅과 함께 제공합니다.
- 모니터링 실패를 전용 자동화 JSONL 로그 파일에 `AutomationLog` 항목으로 저장하여 동기화 문제에 대한 관측 가능성을 확보합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a periodic monitoring task to check the external Obsidian sync service health and log failures to the automation log store.

New Features:
- Introduce a Celery monitoring task `check_sync_status` that periodically validates the Obsidian sync connection and returns a simple health status string.

Enhancements:
- Implement a synchronous helper to run the async Obsidian sync `connect` method within Celery workers, with guarded error handling and structured logging.
- Persist monitoring failures as `AutomationLog` entries in a dedicated automation JSONL log file for observability of sync issues.

</details>