### PR TITLE
♻️ refactor [#10.4.11]: 유지보수 태스크 2차 개선 - 파일 디스크립터 누수 방지

### DIFF
--- a/backend/celery_app/tasks/maintenance.py
+++ b/backend/celery_app/tasks/maintenance.py
@@ -7,6 +7,7 @@ Maintenance Tasks
 
 import json
 import logging
+import os
 import uuid
 import shutil
 import tempfile
@@ -98,6 +99,8 @@ def _cleanup_jsonl_file(
     temp_fd, temp_path = tempfile.mkstemp(
         dir=file_path.parent, prefix=f".{file_path.stem}_", suffix=".tmp"
     )
+    # 파일 디스크립터 즉시 닫기 (리소스 누수 방지)
+    os.close(temp_fd)
 
     total_count = 0
     kept_count = 0
@@ -105,7 +108,7 @@ def _cleanup_jsonl_file(
 
     try:
         with open(file_path, "r", encoding="utf-8") as infile, open(
-            temp_fd, "w", encoding="utf-8"
+            temp_path, "w", encoding="utf-8"
         ) as outfile:
 
             for line in infile:


### PR DESCRIPTION
🔧 변경 사항:
- **[Resource Leak Fix]**: mkstemp 반환 fd를 즉시 os.close()로 닫아 디스크립터 누수 방지
- **[Correct Usage]**: temp_path를 일반 파일 경로로 사용 (open(temp_fd, ...) 오류 수정)
- **[Long-running Stability]**: Celery 워커에서 장기 실행 시 디스크립터 고갈 방지

📌 Review Feedback Addressed:
- Close mkstemp file descriptor immediately to prevent leaks
- Use temp_path as regular file path instead of raw fd

📌 Related
- Issue [#78]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/187#pullrequestreview-3576913774)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

임시 파일을 올바르게 처리하여 유지 관리용 JSONL 정리 작업에서 파일 디스크립터 누수를 방지합니다.

버그 수정:
- 장시간 실행되는 Celery 워커에서 디스크립터 누수가 발생하지 않도록, `tempfile.mkstemp`가 반환하는 파일 디스크립터를 즉시 닫습니다.
- 출력 파일을 열 때, 원시 파일 디스크립터를 사용하는 대신 `mkstemp`에서 반환된 임시 파일 경로를 일반 파일 경로처럼 사용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent file descriptor leaks in the maintenance JSONL cleanup task by correctly handling temporary files.

Bug Fixes:
- Close the file descriptor returned by tempfile.mkstemp immediately to avoid leaking descriptors in long-running Celery workers.
- Use the temporary file path from mkstemp as a regular file path when opening the output file instead of using the raw file descriptor.

</details>