### PR TITLE
✨ feat [#10.4.14]: 3차 개선 – 스트리밍 ID 조회 & 최신‑우선 로그 정렬

### DIFF
--- a/backend/services/automation_manager.py
+++ b/backend/services/automation_manager.py
@@ -291,10 +291,12 @@ class AutomationManager:
                 extra={"error_type": type(exc).__name__},
             )
 
-        # 최신 로그가 먼저 오도록 역순 및 limit 적용
+        # 최신 로그가 먼저 오도록 정렬 후 limit 적용
+        # logs는 파일 순서(오래된 → 최신)로 수집되므로 역순으로 최신 → 오래된 리스트를 만든다
+        logs = list(reversed(logs))
         if limit is not None:
-            return list(reversed(logs[-limit:]))
-        return list(reversed(logs))
+            return logs[:limit]
+        return logs
 
 
 # 싱글톤 인스턴스


### PR DESCRIPTION
🔧 주요 변경:
- `AutomationManager.get_automation_log_by_id` → 스트리밍 검색, 메모리 절감
- [_read_jsonl_logs] `backend/services/automation_manager.py` → 최신‑우선 정렬 + limit 적용 로직 수정
- API 파라미터에 [AutomationTaskType] `backend/models/automation.py` / [AutomationStatus]`backend/models/automation.py` enum 적용
- `PUT /rules/{rule_id}` 파라미터 순서 수정 (필수 바디)
- 규칙 관리 엔드포인트를 서비스 레이어에 위임 (현재 Stub)
- 불필요한 마크업 제거, docstring/주석 최신화

📌 Related:
- Issue [#78]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/190#pullrequestreview-3576996141)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

버그 수정:
- JSONL 자동화 로그를 읽을 때, 제한을 적용하기 전에 로그를 최신순(가장 최근 것이 먼저)으로 뒤집어 제한된 결과가 올바른 순서로 정렬되도록 수정했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix JSONL automation log reading so that logs are reversed to newest-first before applying the limit, ensuring the limited result is properly ordered.

</details>

새로운 기능:
- 메모리 사용량을 줄이기 위해 스트리밍 기반 자동화 로그 조회를 지원합니다.

버그 수정:
- 최신 로그가 먼저 오도록 순서를 뒤집은 이후에 제한이 적용되도록, 로그 제한 로직을 수정했습니다.

개선 사항:
- JSONL 형식의 자동화 로그를 읽을 때, 제한을 적용하기 전에 로그를 최신순으로 정렬하도록 조정했습니다.
- 더 강력한 타입 지정을 위해 관련 API 파라미터에 `AutomationTaskType` 및 `AutomationStatus` enum을 적용했습니다.
- 관심사의 분리를 명확히 하기 위해 규칙 관리 엔드포인트를 서비스 레이어 스텁으로 위임했습니다.
- `PUT /rules/{rule_id}` 파라미터 순서를 변경하여 요청 본문이 필수로 필요하도록 했습니다.
- 더는 사용되지 않는 마크업을 제거하고, 현재 동작을 반영하도록 docstring과 주석을 갱신했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

버그 수정:
- JSONL 자동화 로그를 읽을 때, 제한을 적용하기 전에 로그를 최신순(가장 최근 것이 먼저)으로 뒤집어 제한된 결과가 올바른 순서로 정렬되도록 수정했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix JSONL automation log reading so that logs are reversed to newest-first before applying the limit, ensuring the limited result is properly ordered.

</details>

</details>