### PR TITLE
✨ feat [#10.4.15]: 6차 개선 – limit 타입·값 검증 강화

### DIFF
--- a/backend/services/automation_manager.py
+++ b/backend/services/automation_manager.py
@@ -295,6 +295,12 @@ class AutomationManager:
         # limit 검증: None 또는 0 이상의 정수만 허용
         if limit is not None and limit < 0:
             raise ValueError("limit must be non-negative or None")
+        # limit 검증: None 또는 0 이상의 정수만 허용
+        if limit is not None:
+            if not isinstance(limit, int):
+                raise TypeError("limit must be an int or None")
+            if limit < 0:
+                raise ValueError("limit must be non-negative")
         # 최신 로그가 먼저 오도록 역순 iterator 사용
         reversed_logs = reversed(logs)
         if limit is not None:


### PR DESCRIPTION
🔧 주요 변경:
- [_read_jsonl_logs] `backend/services/automation_manager.py` 에 limit 검증 추가:
  - None 또는 int 타입만 허용
  - 음수 값은 ValueError
  - 비정수는 TypeError
- 주석·docstring 업데이트 (정수·양수 제한 명시)
- 기존 iterator + islice 로직 유지 (메모리 절감)

📌 Related:
- Issue [#78]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/193#pullrequestreview-3577048402)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

JSONL 로그를 읽을 때 `limit` 매개변수에 대해 정수 타입과 음수가 아님을 강제하도록 검증을 강화했습니다.

버그 수정:
- JSONL 로그를 읽을 때 정수가 아닌 `limit` 값에 대해 `TypeError`를 발생시키도록 했습니다.
- 음수 `limit` 값에 대해 더 명확하고 전용인 검증 경로를 통해 `ValueError`를 발생시키도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen validation of the limit parameter in JSONL log reading to enforce integer type and non-negative values.

Bug Fixes:
- Reject non-integer limit values with a TypeError when reading JSONL logs.
- Raise ValueError for negative limit values with a clearer, dedicated validation path.

</details>