### PR TITLE
✨ feat [#10.4.15]: 8차 개선 - limit 검증 강화 (음수·bool 방지)

### DIFF
--- a/backend/services/automation_manager.py
+++ b/backend/services/automation_manager.py
@@ -292,10 +292,11 @@ class AutomationManager:
                 extra={"error_type": type(exc).__name__},
             )
 
-        # limit 검증: None 또는 0 이상의 정수만 허용
+        # limit 검증: None 또는 0 이상의 정수만 허용 (bool 제외)
         if limit is not None:
-            if not isinstance(limit, int):
-                raise TypeError("limit must be an int or None")
+            # type 체크 (bool 은 int 서브클래스이므로 별도 검사)
+            if type(limit) is not int:
+                raise TypeError("limit must be an int (bool not allowed) or None")
             if limit < 0:
                 raise ValueError("limit must be non-negative")
         # 최신 로그가 먼저 오도록 역순 iterator 사용


### PR DESCRIPTION
🔧 주요 변경:
- [_read_jsonl_logs] `backend/services/automation_manager.py` 에 limit 검증을 단일 블록으로 통합
- `type(limit) is int` 로 bool 제외
- 음수 값에 대해 ValueError 재도입
- 주석·docstring 업데이트 (정수·양수·bool 제외 명시)

📌 Related:
- Issue [#78]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/195#pullrequestreview-3577079566)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

JSONL 로그를 읽을 때 `limit` 파라미터에 대해 정수형이 아닌 값과 불리언 값을 명시적으로 거부하고, 동시에 0 이상의 값만 허용하도록 검증을 강화합니다.

버그 수정:
- JSONL 로그를 읽을 때 불리언 값이 유효한 `limit` 입력으로 받아들여지는 문제를 방지합니다.

개선 사항:
- JSONL 로그 읽기에서 `limit` 검증 로직과 관련 주석/도크스트링을 정리하고 더 명확하게 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen validation of the limit parameter in JSONL log reading to explicitly reject non-int and boolean values while ensuring it remains non-negative.

Bug Fixes:
- Prevent boolean values from being accepted as valid limit inputs when reading JSONL logs.

Enhancements:
- Consolidate and clarify limit validation logic and related comments/docstrings for JSONL log reading.

</details>