### PR TITLE
✨ feat [#10.4.15]: 9차 개선 - limit 검증을 int 서브클래스 허용 + bool 배제

### DIFF
--- a/backend/services/automation_manager.py
+++ b/backend/services/automation_manager.py
@@ -294,9 +294,9 @@ class AutomationManager:
 
         # limit 검증: None 또는 0 이상의 정수만 허용 (bool 제외)
         if limit is not None:
-            # type 체크 (bool 은 int 서브클래스이므로 별도 검사)
-            if type(limit) is not int:
-                raise TypeError("limit must be an int (bool not allowed) or None")
+            # int 서브클래스 허용, bool 제외
+            if not (isinstance(limit, int) and not isinstance(limit, bool)):
+                raise TypeError("limit must be a non-boolean int or None")
             if limit < 0:
                 raise ValueError("limit must be non-negative")
         # 최신 로그가 먼저 오도록 역순 iterator 사용


### PR DESCRIPTION
🔧 주요 변경:
- [_read_jsonl_logs] `backend/services/automation_manager.py`å 에 limit 검증을 `isinstance(limit, int) and not isinstance(limit, bool)` 로 교체
- 에러 메시지를 “non‑boolean int” 로 명확히 업데이트
- 주석·docstring 수정 (int 서브클래스 허용, bool 제외)
- 기존 음수 검증 유지

📌 Related:
- Issue [#78]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/196#pullrequestreview-3577126594)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

개선 사항:
- `limit` 매개변수 타입 검증을 업데이트하여 `bool` 값은 계속 제외하면서, 정수(`int`)의 서브클래스를 허용하고 음수가 아님을 확인하는 검사를 유지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update limit parameter type validation to accept int subclasses while still excluding bool values and preserving non-negative checks.

</details>