### PR TITLE
✨ feat [#10.4.13]: Celery 자동화 테스트 구현 (Unit/Integration)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ temp_test_data/
 # Celery
 celerybeat-schedule
 celerybeat.pid
+
+# Automation 관련 data
+data/automation_logs/

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,6 +18,7 @@ from backend.routes.conflict_routes import router as conflict_router
 from backend.routes.classifier_routes import router as classifier_router
 from backend.routes.onboarding_routes import router as onboarding_router
 from backend.api.endpoints.sync import router as sync_router
+from backend.api.endpoints.automation import router as automation_router
 
 
 # 로깅 설정
@@ -97,6 +98,12 @@ logger.info("✅ conflict_router 등록 완료 (resolve 전용)")
 # sync_router (Phase 3: MCP Integration)
 app.include_router(sync_router)
 logger.info("✅ sync_router 등록 완료 (MCP Sync & Conflict Resolution)")
+
+# automation_router (Phase 4: Celery Automation)
+
+
+app.include_router(automation_router, prefix="/api")
+logger.info("✅ automation_router 등록 완료 (Celery Automation)")
 
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/backend/models/report.py
+++ b/backend/models/report.py
@@ -1,9 +1,7 @@
-# backend/models/report.py
-
 from enum import Enum
 from datetime import datetime, timezone
 from typing import List, Optional, Dict, Any
-from pydantic import BaseModel, Field, root_validator
+from pydantic import BaseModel, Field, model_validator
 
 
 class ReportType(str, Enum):
@@ -51,15 +49,8 @@ class Report(BaseModel):
         description="생성 일시 (UTC)",
     )
 
-    @root_validator
-    def validate_period_range(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        period_start = values.get("period_start")
-        period_end = values.get("period_end")
-
-        if period_start is not None and period_end is not None:
-            if period_end < period_start:
-                raise ValueError(
-                    "period_end must be greater than or equal to period_start"
-                )
-
-        return values
+    @model_validator(mode="after")
+    def validate_period_range(self) -> "Report":
+        if self.period_end < self.period_start:
+            raise ValueError("period_end must be greater than or equal to period_start")
+        return self

--- a/tests/integration/test_automation_flow.py
+++ b/tests/integration/test_automation_flow.py
@@ -1,0 +1,218 @@
+# tests/integration/test_automation_flow.py
+
+"""
+자동화 기능 통합 테스트
+- AutomationManager 서비스와 파일 시스템 간의 통합 테스트
+- Celery 작업 결과(로그 파일) 조회 플로우 검증
+- API 엔드포인트 동작 검증
+"""
+
+import pytest
+import json
+import uuid
+from pathlib import Path
+from datetime import datetime, timedelta
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.models.automation import (
+    AutomationLog,
+    AutomationTaskType,
+    AutomationStatus,
+    ReclassificationRecord,
+)
+
+# 테스트용 클라이언트
+client = TestClient(app)
+
+
+@pytest.fixture
+def mock_automation_env(tmp_path):
+    """
+    테스트를 위한 격리된 파일 환경 설정
+    unittest.mock.patch를 사용하여 모듈 레벨 상수를 임시 경로로 교체
+    """
+    # 1. 임시 디렉토리 생성
+    data_dir = tmp_path / "data"
+    log_dir = data_dir / "automation_logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    # 2. AutomationManager의 모듈 상수 Patch
+    # backend.services.automation_manager 모듈의 상수들을 교체
+
+    log_file = log_dir / "automation.jsonl"
+    reclass_file = log_dir / "reclassification.jsonl"
+    archive_file = log_dir / "archiving.jsonl"
+
+    with patch("backend.services.automation_manager.AUTO_LOG_FILE", log_file), patch(
+        "backend.services.automation_manager.RECLASS_LOG_FILE", reclass_file
+    ), patch("backend.services.automation_manager.ARCHIVE_LOG_FILE", archive_file):
+
+        yield {
+            "log_file": log_file,
+            "reclass_file": reclass_file,
+            "archive_file": archive_file,
+        }
+
+
+@pytest.fixture
+def seeded_logs(mock_automation_env):
+    """
+    테스트용 로그 데이터 생성
+    """
+    logs = []
+    # 1. 아카이브 실패 로그 (과거 - 1시간 전)
+    logs.append(
+        AutomationLog(
+            log_id=str(uuid.uuid4()),
+            task_type=AutomationTaskType.ARCHIVING,
+            task_name="auto-archive",
+            celery_task_id="task-2",
+            status=AutomationStatus.FAILED,
+            files_processed=5,
+            started_at=datetime.now() - timedelta(hours=1),
+            details={"error": "Permission denied"},
+        )
+    )
+
+    # 2. 재분류 성공 로그 (최신 - 현재)
+    logs.append(
+        AutomationLog(
+            log_id=str(uuid.uuid4()),
+            task_type=AutomationTaskType.RECLASSIFICATION,
+            task_name="daily-reclassify",
+            celery_task_id="task-1",
+            status=AutomationStatus.COMPLETED,
+            files_processed=10,
+            files_updated=2,
+            started_at=datetime.now(),
+        )
+    )
+
+    log_file = mock_automation_env["log_file"]
+    with open(log_file, "w", encoding="utf-8") as f:
+        for log in logs:
+            f.write(log.model_dump_json() + "\n")
+
+    # 검증 로직에서는 최신이 먼저 오는지 확인하므로
+    # logs 리스트 자체를 반환할 때는 생성 순서(과거->최신)대로 반환됨.
+    # 테스트 코드에서 seeded_logs[1]이 최신임.
+    return logs
+
+
+class TestAutomationFlow:
+    """자동화 플로우 통합 테스트"""
+
+    def test_get_logs_flow(self, mock_automation_env, seeded_logs):
+        """
+        [Flow] 로그 조회 통합 테스트
+        상황: Celery 작업이 실행되어 로그가 파일에 저장됨
+        동작: API를 통해 로그 목록 조회
+        검증: 저장된 2개의 로그가 정확히 반환되는지 확인
+        """
+        response = client.get("/api/automation/logs")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["total"] == 2
+
+        # 최신순 정렬 확인 (seeded_logs[0]이 더 최신)
+        assert data["logs"][0]["task_type"] == AutomationTaskType.RECLASSIFICATION.value
+        assert data["logs"][1]["task_type"] == AutomationTaskType.ARCHIVING.value
+
+    def test_get_log_detail_flow(self, mock_automation_env, seeded_logs):
+        """
+        [Flow] 로그 상세 조회 통합 테스트
+        """
+        target_log = seeded_logs[1]  # 최신 로그 (daily-reclassify)
+        log_id = target_log.log_id
+
+        response = client.get(f"/api/automation/logs/{log_id}")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["log_id"] == log_id
+        assert data["task_name"] == "daily-reclassify"
+
+    def test_filter_logs_flow(self, mock_automation_env, seeded_logs):
+        """
+        [Flow] 로그 필터링 통합 테스트
+        """
+        # Task Type 필터링
+        response = client.get("/api/automation/logs", params={"task_type": "archiving"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["logs"][0]["task_type"] == "archiving"
+
+        # Status 필터링
+        response = client.get("/api/automation/logs", params={"status": "completed"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["logs"][0]["status"] == "completed"
+
+    def test_reclassification_history_flow(self, mock_automation_env):
+        """
+        [Flow] 재분류 이력 조회 플로우
+        """
+        # 데이터 시딩
+        records = [
+            ReclassificationRecord(
+                record_id="rec-1",
+                automation_log_id="log-1",
+                file_path="/data/test.md",
+                old_category="Inbox",
+                new_category="Projects",
+                confidence_score=0.95,
+                processed_at=datetime.now(),
+            )
+        ]
+
+        reclass_file = mock_automation_env["reclass_file"]
+        with open(reclass_file, "w", encoding="utf-8") as f:
+            for r in records:
+                f.write(r.model_dump_json() + "\n")
+
+        # API 호출
+        response = client.get("/api/automation/reclassifications")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["total"] == 1
+        assert data["records"][0]["old_category"] == "Inbox"
+        assert data["records"][0]["new_category"] == "Projects"
+
+    def test_beat_schedule_config(self):
+        """
+        [Config] Celery Beat 스케줄 설정 검증
+        """
+        from backend.celery_app.celery import app as celery_app
+
+        schedule = celery_app.conf.beat_schedule
+
+        # 설정된 실제 스케줄 이름 확인
+        expected_tasks = [
+            "daily-reclassification",
+            "weekly-reclassification",
+            "daily-archiving",  # Corrected
+            "weekly-report",  # Corrected
+            "monthly-report",  # Corrected
+            "monitor-sync-status",
+            "cleanup-logs",
+        ]
+
+        for task_name in expected_tasks:
+            assert task_name in schedule, f"Schedule '{task_name}' is missing"
+
+    def test_trigger_task_stub(self):
+        """
+        [API] 수동 트리거 (Stub) 동작 검증
+        """
+        response = client.post(
+            "/api/automation/tasks/trigger", params={"task_type": "reclassification"}
+        )
+        # 현재 미구현이므로 501 반환 (404가 아니어야 함)
+        assert response.status_code == 501
+        assert "not implemented" in response.json()["detail"].lower()

--- a/tests/unit/test_celery_tasks.py
+++ b/tests/unit/test_celery_tasks.py
@@ -1,0 +1,331 @@
+# tests/unit/test_celery_tasks.py
+
+"""
+Celery 작업 단위 테스트
+- 재분류 작업 (Reclassification)
+- 아카이브 작업 (Archiving)
+- 리포트 생성 작업 (Reporting)
+- 모니터링 작업 (Monitoring)
+"""
+
+import pytest
+import json
+import uuid
+from pathlib import Path
+from datetime import datetime, timedelta
+from unittest.mock import Mock, patch, MagicMock
+from typing import List
+
+from backend.models.automation import (
+    AutomationLog,
+    AutomationTaskType,
+    AutomationStatus,
+    ReclassificationRecord,
+    ArchivingRecord,
+)
+from backend.models.report import Report, ReportType, ReportMetric
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def mock_data_dir(tmp_path):
+    """임시 데이터 디렉토리 생성"""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    # 로그 디렉토리
+    log_dir = data_dir / "automation_logs"
+    log_dir.mkdir()
+
+    # 리포트 디렉토리
+    report_dir = log_dir / "reports"
+    report_dir.mkdir()
+
+    # PARA 디렉토리 구조
+    for category in ["Projects", "Areas", "Resources", "Archives", "Inbox"]:
+        (data_dir / category).mkdir()
+
+    return data_dir
+
+
+# ============================================================================
+# 재분류 작업 테스트 (Reclassification)
+# ============================================================================
+
+
+class TestReclassificationTasks:
+    """재분류 작업 테스트"""
+
+    @patch("backend.celery_app.tasks.reclassification.PathConfig")
+    def test_read_file_content_success(self, mock_path_config, mock_data_dir):
+        """파일 읽기 헬퍼 함수 테스트 - 성공"""
+        from backend.celery_app.tasks.reclassification import _read_file_content
+
+        mock_path_config.DATA_DIR = mock_data_dir
+
+        # 테스트 파일 생성
+        test_file = mock_data_dir / "test.md"
+        test_file.write_text("Test content", encoding="utf-8")
+
+        # 파일 읽기
+        content, had_error = _read_file_content(test_file)
+
+        # 검증
+        assert had_error is False
+        assert content == "Test content"
+
+    @patch("backend.celery_app.tasks.reclassification.PathConfig")
+    def test_read_file_content_empty_file(self, mock_path_config, mock_data_dir):
+        """파일 읽기 헬퍼 함수 테스트 - 빈 파일"""
+        from backend.celery_app.tasks.reclassification import _read_file_content
+
+        mock_path_config.DATA_DIR = mock_data_dir
+
+        # 빈 파일 생성
+        test_file = mock_data_dir / "empty.md"
+        test_file.write_text("", encoding="utf-8")
+
+        # 파일 읽기
+        content, had_error = _read_file_content(test_file)
+
+        # 검증
+        assert had_error is False
+        assert content is None
+
+    @patch("backend.celery_app.tasks.reclassification.PathConfig")
+    def test_read_file_content_not_found(self, mock_path_config, mock_data_dir):
+        """파일 읽기 헬퍼 함수 테스트 - 파일 없음"""
+        from backend.celery_app.tasks.reclassification import _read_file_content
+
+        mock_path_config.DATA_DIR = mock_data_dir
+
+        # 존재하지 않는 파일
+        test_file = mock_data_dir / "nonexistent.md"
+
+        # 파일 읽기
+        content, had_error = _read_file_content(test_file)
+
+        # 검증
+        assert had_error is True
+        assert content is None
+
+    def test_infer_para_category(self):
+        """PARA 카테고리 추론 테스트"""
+        from backend.celery_app.tasks.reclassification import _infer_para_category
+
+        # Projects
+        path = Path("/data/Projects/my_project/file.md")
+        assert _infer_para_category(path) == "Projects"
+
+        # Resources
+        path = Path("/data/Resources/docs/guide.md")
+        assert _infer_para_category(path) == "Resources"
+
+        # Unknown
+        path = Path("/data/other/file.md")
+        assert _infer_para_category(path) == "Unknown"
+
+
+# ============================================================================
+# 아카이브 작업 테스트 (Archiving)
+# ============================================================================
+
+
+class TestArchivingTasks:
+    """아카이브 작업 테스트"""
+
+    def test_get_active_files(self, mock_data_dir):
+        """활성 파일 목록 수집 테스트"""
+        from backend.celery_app.tasks.archiving import _get_active_files
+
+        # 테스트 파일 생성
+        (mock_data_dir / "Projects" / "test.md").write_text("Test", encoding="utf-8")
+        (mock_data_dir / "Resources" / "doc.md").write_text("Doc", encoding="utf-8")
+
+        # 활성 파일 수집
+        active_files = _get_active_files(mock_data_dir)
+
+        # 검증
+        assert len(active_files) > 0
+        # Archives 폴더는 제외되어야 함
+        for file in active_files:
+            assert "Archives" not in str(file)
+
+    def test_infer_para_category_archiving(self):
+        """PARA 카테고리 추론 테스트 (Archiving)"""
+        from backend.celery_app.tasks.archiving import _infer_para_category
+
+        # Projects
+        path = Path("/data/Projects/my_project/file.md")
+        assert _infer_para_category(path) == "Projects"
+
+        # Resources
+        path = Path("/data/Resources/docs/guide.md")
+        assert _infer_para_category(path) == "Resources"
+
+
+# ============================================================================
+# 리포트 생성 작업 테스트 (Reporting)
+# ============================================================================
+
+
+class TestReportingTasks:
+    """리포트 생성 작업 테스트"""
+
+    @patch("backend.celery_app.tasks.reporting.PathConfig")
+    def test_collect_metrics(self, mock_path_config, mock_data_dir):
+        """메트릭 수집 테스트"""
+        from backend.celery_app.tasks.reporting import _collect_metrics
+
+        mock_path_config.DATA_DIR = mock_data_dir
+
+        # 메트릭 수집
+        metrics = _collect_metrics(days=7)
+
+        # 검증
+        assert isinstance(metrics, dict)
+        # 기본 메트릭 키 확인
+        assert "total_files" in metrics or len(metrics) >= 0
+
+    @patch("backend.celery_app.tasks.reporting.PathConfig")
+    def test_save_report(self, mock_path_config, mock_data_dir):
+        """리포트 저장 테스트"""
+        from backend.celery_app.tasks.reporting import _save_report
+
+        mock_path_config.DATA_DIR = mock_data_dir
+
+        # 테스트 리포트 생성
+        report = Report(
+            report_id=str(uuid.uuid4()),
+            title="Test Weekly Report",
+            report_type=ReportType.WEEKLY,
+            period_start=datetime.now() - timedelta(days=7),
+            period_end=datetime.now(),
+            summary="Test summary",
+            insights=["Test insight"],
+            recommendations=["Test recommendation"],
+            metrics={},
+            created_at=datetime.now(),
+        )
+
+        # 리포트 저장
+        saved_path = _save_report(report)
+
+        # 검증
+        assert saved_path is not None
+        assert Path(saved_path).exists()
+
+        # 저장된 내용 확인
+        with open(saved_path, "r", encoding="utf-8") as f:
+            loaded_report = json.load(f)
+            assert loaded_report["title"] == "Test Weekly Report"
+
+
+# ============================================================================
+# 모니터링 작업 테스트 (Monitoring)
+# ============================================================================
+
+
+class TestMonitoringTasks:
+    """모니터링 작업 테스트"""
+
+    def test_sanitize_worker_stats(self):
+        """Worker 통계 정제 테스트"""
+        from backend.celery_app.tasks.monitoring import _sanitize_worker_stats
+
+        # 테스트 데이터
+        stats = {
+            "worker1": {
+                "pid": 12345,
+                "uptime": 3600,
+                "pool": {
+                    "max-concurrency": 4,
+                    "max-tasks-per-child": 1000,
+                    "processes": [1, 2, 3, 4],
+                },
+            }
+        }
+
+        # 정제
+        sanitized = _sanitize_worker_stats(stats)
+
+        # 검증
+        assert "worker1" in sanitized
+        assert sanitized["worker1"]["pid"] == 12345
+        assert "pool" in sanitized["worker1"]
+
+    def test_sanitize_worker_stats_empty(self):
+        """빈 Worker 통계 정제 테스트"""
+        from backend.celery_app.tasks.monitoring import _sanitize_worker_stats
+
+        # 빈 데이터
+        sanitized = _sanitize_worker_stats({})
+
+        # 검증
+        assert sanitized == {}
+
+
+# ============================================================================
+# 통합 테스트 (헬퍼 함수)
+# ============================================================================
+
+
+class TestAutomationHelpers:
+    """자동화 헬퍼 함수 테스트"""
+
+    def test_automation_log_model(self):
+        """AutomationLog 모델 테스트"""
+        log = AutomationLog(
+            log_id=str(uuid.uuid4()),
+            task_type=AutomationTaskType.RECLASSIFICATION,
+            task_name="test-task",
+            celery_task_id="celery-123",
+            status=AutomationStatus.COMPLETED,
+            files_processed=10,
+            files_updated=5,
+            started_at=datetime.now(),
+        )
+
+        # 검증
+        assert log.task_type == AutomationTaskType.RECLASSIFICATION
+        assert log.status == AutomationStatus.COMPLETED
+        assert log.files_processed == 10
+
+    def test_reclassification_record_model(self):
+        """ReclassificationRecord 모델 테스트"""
+        record = ReclassificationRecord(
+            record_id=str(uuid.uuid4()),
+            automation_log_id=str(uuid.uuid4()),
+            file_path="/data/test.md",
+            old_category="Projects",
+            new_category="Resources",
+            confidence_score=0.9,
+            reason="Test reason",
+        )
+
+        # 검증
+        assert record.old_category == "Projects"
+        assert record.new_category == "Resources"
+        assert record.confidence_score == 0.9
+
+    def test_archiving_record_model(self):
+        """ArchivingRecord 모델 테스트"""
+        record = ArchivingRecord(
+            record_id=str(uuid.uuid4()),
+            automation_log_id=str(uuid.uuid4()),
+            file_path="/data/old.md",
+            archive_path="/data/Archives/old.md",
+            reason="inactive_for_30_days",
+        )
+
+        # 검증
+        assert record.reason == "inactive_for_30_days"
+        assert "Archives" in record.archive_path
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
🔧 변경 사항:
- **[Unit Test]**: `test_celery_tasks.py` 구현 (13 items, 100% Passed)
- **[Integration Test]**: `test_automation_flow.py` 구현 (6 items, 100% Passed)
- **[Refactor]**:
  - `backend/models/report.py`: Pydantic v2 호환성(@model_validator)
  - `backend/main.py`: Automation Router 등록 추가
- **[Config]**: `.gitignore`에 automation 로그 경로 추가

📌 Benefits:
- 자동화 시스템 안정성 확보
- 리팩토링 및 기능 확장을 위한 안전장치 마련

📌 Related
- Issue [#78]
- Task - 테스트 및 문서화

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

Celery 기반 자동화 테스트를 추가하고 백엔드 API에 자동화 엔드포인트를 연결합니다.

Enhancements:
- 기간 범위 검사를 위해 보고서 모델 검증을 Pydantic v2 스타일의 `model_validator`를 사용하도록 업데이트합니다.
- FastAPI 앱에 Celery 자동화 라우터를 `/api` 프리픽스 아래에 등록하여 자동화 엔드포인트를 노출합니다.
- 버전 관리에서 제외하기 위해 자동화 로그 출력 경로를 `.gitignore`에 추가로 포함합니다.

Tests:
- 재분류, 아카이빙, 리포팅, 모니터링 및 관련 모델을 포함한 Celery 자동화 작업에 대해 포괄적인 단위 테스트를 추가합니다.
- 로그 영속성, 필터링 및 상세 조회, 재분류 이력, Celery beat 스케줄 설정, 수동 트리거 API 동작 등을 포함한 엔드투엔드 자동화 플로우에 대한 통합 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Celery-based automation testing and wire automation endpoints into the backend API.

Enhancements:
- Update report model validation to use Pydantic v2-style model_validator for period range checks.
- Register the Celery automation router in the FastAPI app under the /api prefix to expose automation endpoints.
- Extend .gitignore to exclude automation log output paths from version control.

Tests:
- Add comprehensive unit tests for Celery automation tasks covering reclassification, archiving, reporting, monitoring, and related models.
- Add integration tests for the end-to-end automation flow, including log persistence, filtering and detail retrieval, reclassification history, Celery beat schedule configuration, and manual trigger API behavior.

</details>