### PR TITLE
🐛 fix [#10.4.15]: 문서 내용 오류 수정 (EntryPoint & TestResults)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ flownote-mvp/
 ├── .gitignore
 │
 ├── backend/                            # FastAPI 백엔드
-│   ├── main.py                         # FastAPI 메인 앱
+│   ├── main.py                         # FastAPI 메인 앱 (Entrypoint)
 │   ├── celery_app/                     # Celery 설정 ✨
 │   │   ├── celery.py                   # Celery 인스턴스
 │   │   ├── config.py                   # Celery 설정
@@ -257,7 +257,7 @@ FlowNote의 모든 기능을 사용하려면 **4개의 터미널**이 필요합�
 **1. FastAPI Backend 실행 (Terminal 1)**
 ```bash
 cd backend
-python app.py
+python main.py
 # → http://127.0.0.1:8000
 ```
 


### PR DESCRIPTION
🔧 변경 사항:
- **[Docs]**: README.md의 Backend 실행 명령어 수정
  - `python app.py` (오류) -> `python main.py` (실제 EntryPoint)
  - 프로젝트 구조 및 실제 코드와 일치하도록 가이드 정정
- **[Docs]**: Test Results 파일 내용 복구/확인
  - `test_results_phase4.txt` 내용 재확인 및 저장

📌 Note:
- 사용자 혼란 방지를 위한 긴급 수정

📌 Related:
- Issue [#78]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/210#pullrequestreview-3581049417)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

올바른 FastAPI 백엔드 엔트리포인트를 반영하도록 문서를 업데이트합니다.

문서:
- 프로젝트 구조 개요에서 `backend/main.py`가 FastAPI 애플리케이션 엔트리포인트임을 명확히 합니다.
- README에서 잘못된 `python app.py` 대신 올바른 백엔드 시작 명령인 `python main.py`를 사용하도록 수정합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update documentation to reflect the correct FastAPI backend entrypoint.

Documentation:
- Clarify that backend/main.py is the FastAPI application entrypoint in the project structure overview.
- Fix the backend startup command in the README to use python main.py instead of the incorrect python app.py.

</details>