### PR TITLE
✨ feat [#10.5.2]: MCP 서버 기본 구축 및 Tools/Resources 구현

### DIFF
--- a/backend/mcp/server.py
+++ b/backend/mcp/server.py
@@ -1,0 +1,97 @@
+# backend/mcp/server.py
+
+"""
+FlowNote MCP Server
+External AI agents can use FlowNote capabilities as Tools and access Resources.
+"""
+
+import json
+from typing import Dict, Any, List, Optional
+from mcp.server.fastmcp import FastMCP
+
+# FlowNote Internal Services
+from backend.classifier.hybrid_classifier import HybridClassifier
+from backend.faiss_search import FAISSRetriever
+from backend.dashboard.dashboard_core import MetadataAggregator
+
+# Initialize FastMCP
+mcp = FastMCP("FlowNote MCP Server")
+
+# Global instances (lazy loaded)
+_classifier: Optional[HybridClassifier] = None
+_retriever: Optional[FAISSRetriever] = None
+_aggregator: Optional[MetadataAggregator] = None
+
+def get_classifier() -> HybridClassifier:
+    global _classifier
+    if _classifier is None:
+        _classifier = HybridClassifier()
+    return _classifier
+
+def get_retriever() -> FAISSRetriever:
+    global _retriever
+    if _retriever is None:
+        _retriever = FAISSRetriever()
+        # Note: In a real implementation, we would load existing embeddings here.
+        # Currently, FAISSRetriever starts empty in memory.
+    return _retriever
+
+def get_aggregator() -> MetadataAggregator:
+    global _aggregator
+    if _aggregator is None:
+        _aggregator = MetadataAggregator()
+    return _aggregator
+
+# 1. Tools (기능 노출)
+
+@mcp.tool()
+async def classify_content(text: str) -> Dict[str, Any]:
+    """
+    Classify text into PARA categories (Projects, Areas, Resources, Archive) using Hybrid Classifier.
+    
+    Args:
+        text: The text content to classify.
+    """
+    classifier = get_classifier()
+    # classify method is async in HybridClassifier
+    return await classifier.classify(text)
+
+@mcp.tool()
+async def search_notes(query: str) -> List[Dict[str, Any]]:
+    """
+    Search for notes using vector similarity search.
+    
+    Args:
+        query: The search query.
+    """
+    retriever = get_retriever()
+    # Sync method in FAISSRetriever
+    results = retriever.search(query, k=5)
+    return results
+
+@mcp.tool()
+async def get_automation_stats() -> Dict[str, Any]:
+    """
+    Get recent automation statistics (files, searches, categories).
+    """
+    aggregator = get_aggregator()
+    return aggregator.get_file_statistics()
+
+# 2. Resources (데이터 노출)
+
+@mcp.resource("flownote://para/projects")
+def get_projects() -> str:
+    """Get list of projects/categories breakdown as JSON string"""
+    aggregator = get_aggregator()
+    stats = aggregator.get_para_breakdown()
+    return json.dumps(stats, ensure_ascii=False, indent=2)
+
+@mcp.resource("flownote://dashboard/summary")
+def get_dashboard_summary() -> str:
+    """Get dashboard summary as JSON string"""
+    aggregator = get_aggregator()
+    stats = aggregator.get_file_statistics()
+    return json.dumps(stats, ensure_ascii=False, indent=2)
+
+if __name__ == "__main__":
+    mcp.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -114,3 +114,4 @@ zstandard==0.25.0
 
 celery[redis]==5.3.4
 flower==2.0.1
+mcp==1.24.0


### PR DESCRIPTION
🔧 변경 사항:
- **[Feat]**: [backend/mcp/server.py] `backend/mcp/server.py` 생성 (MCP Server 진입점)
  - `FastMCP`를 사용하여 서버 인스턴스 초기화
  - **Tools (기능)**:
    - [classify_content] `backend/mcp/server.py`: HybridClassifier를 통한 PARA 분류
    - [search_notes] `backend/mcp/server.py`: FAISSRetriever를 통한 벡터 검색
    - [get_automation_stats] `backend/mcp/server.py`: MetadataAggregator를 통한 통계 조회
  - **Resources (데이터)**:
    - `flownote://para/projects`: 프로젝트별 분류 현황
    - `flownote://dashboard/summary`: 전체 대시보드 요약
- **[Dep]**: [requirements.txt] `requirements.txt`에 `mcp==1.24.0` 의존성 추가

📌 Note:
- Phase 5 Step 1 - 기본 서버 및 주요 인터페이스 구현
- 외부 에이전트(Claude 등)와 연동하기 위한 기반 마련

📌 Related:
- Issue [#212]
- v5.0 - Phase 1

## Summary by Sourcery

외부 AI 에이전트가 도구와 리소스로 활용할 수 있도록 핵심 FlowNote 기능을 노출하는 MCP 서버 엔트리포인트를 도입합니다.

New Features:
- FlowNote 분류, 검색, 대시보드 통계를 MCP 도구로 제공하는 FastMCP 기반 서버를 추가합니다.
- PARA 프로젝트 분해 및 대시보드 요약을 `flownote://` URI를 통해 접근 가능한 MCP 리소스로 노출합니다.

Build:
- MCP 서버를 실행하기 위해 `mcp==1.24.0` 의존성을 requirements에 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an MCP server entrypoint exposing core FlowNote capabilities to external AI agents as tools and resources.

New Features:
- Add a FastMCP-based server that exposes FlowNote classification, search, and dashboard statistics as MCP tools.
- Expose PARA project breakdown and dashboard summary as MCP resources accessible via flownote:// URIs.

Build:
- Add mcp==1.24.0 dependency to requirements for running the MCP server.

</details>