### PR TITLE
🐛 fix [#10.5.8]: Critical - unlink 실패 시 원본 에러 가려짐 방지

### DIFF
--- a/backend/services/conflict_resolution_service.py
+++ b/backend/services/conflict_resolution_service.py
@@ -153,9 +153,15 @@ class ConflictResolutionService:
                 shutil.copy2(str(local_path), str(backup_path))
             except OSError as e:
                 # 부분 백업 파일 정리 (손상된 파일이 남지 않도록)
-                backup_path.unlink(missing_ok=True)
+                # NOTE: 정리 실패는 원본 에러를 가리지 않도록 무시 (best-effort cleanup)
+                try:
+                    backup_path.unlink(missing_ok=True)
+                except OSError:
+                    # 정리 실패는 무시 (권한 문제, 읽기 전용 파일 시스템 등)
+                    pass
+
                 logger.exception(
-                    "⚠️ Failed to create conflict backup '%s'. Partial file cleaned up.",
+                    "⚠️ Failed to create conflict backup '%s'. Partial file cleanup attempted.",
                     backup_path,
                 )
                 return False


### PR DESCRIPTION
🔧 변경 사항:
- **[Resolution]**: `backup_path.unlink()`를 try-except로 감싸기
  - 정리 실패(권한 문제, 읽기 전용 파일 시스템 등)가 원본 `copy2` 에러를 가리지 않도록 방어
  - Best-effort cleanup 구현: 정리 실패는 무시하되 원본 에러는 항상 로깅
  - 로그 메시지 수정: "cleaned up" → "cleanup attempted"

📌 Note:
- 리뷰어(@ai-bot-review) 지적 Critical 버그 해결
- 원본 에러 컨텍스트 보존 보장
- 모든 엣지 케이스 검증 완료

📌 Related:
- Issue [#212]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/235#pullrequestreview-3602481530)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

충돌 해결 중에 백업 파일 정리(cleanup) 실패로 인해 원래의 백업 생성 오류가 가려지지 않도록 합니다.

버그 수정:
- 백업 파일 `unlink` 오류를 무시하여, 원래의 `shutil.copy2` 오류가 그대로 유지되고 올바르게 로그에 기록되도록 합니다.

개선 사항:
- 충돌 백업 실패 로그 메시지를 수정하여, 정리가 보장된 것이 아니라 시도만 되었음을 명확히 표시합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure backup file cleanup failures do not mask original backup creation errors during conflict resolution.

Bug Fixes:
- Ignore backup file unlink errors so that the original shutil.copy2 error is preserved and logged correctly.

Enhancements:
- Clarify conflict backup failure log message to indicate that cleanup was only attempted, not guaranteed.

</details>