### PR TITLE
♻️ refactor [#10.5.11]: 1차 개선 - Test Quality & Documentation

### DIFF
--- a/docs/P/v5_phase1_mcp_server/v5.0_phase5_testing.md
+++ b/docs/P/v5_phase1_mcp_server/v5.0_phase5_testing.md
@@ -47,18 +47,27 @@ python -m pytest tests/integration/test_phase5_sync_flow.py --cov=backend/servic
 
 The `claude_desktop_config.json` file enables Claude Desktop to connect to the FlowNote MCP server.
 
-**Location:** `/Users/jay/ICT-projects/flownote-mvp/claude_desktop_config.json`
+**Setup Instructions:**
 
-**Configuration:**
+1. Copy the example configuration:
+   ```bash
+   cp claude_desktop_config.example.json claude_desktop_config.json
+   ```
+
+2. Edit `claude_desktop_config.json` with your actual paths:
+   - Replace `/path/to/your/flownote-mvp` with your project directory
+   - Replace `/path/to/your/ObsidianVault` with your Obsidian Vault path
+
+**Example Configuration** (see `claude_desktop_config.example.json`):
 ```json
 {
   "mcpServers": {
     "flownote": {
       "command": "python",
       "args": ["-m", "backend.mcp.server"],
-      "cwd": "/Users/jay/ICT-projects/flownote-mvp",
+      "cwd": "/path/to/your/flownote-mvp",
       "env": {
-        "OBSIDIAN_VAULT_PATH": "/Users/jay/Documents/ObsidianVault",
+        "OBSIDIAN_VAULT_PATH": "/path/to/your/ObsidianVault",
         "OBSIDIAN_SYNC_ENABLED": "true",
         "OBSIDIAN_SYNC_INTERVAL": "300"
       }
@@ -69,9 +78,9 @@ The `claude_desktop_config.json` file enables Claude Desktop to connect to the F
 
 ### **Testing with Claude Desktop**
 
-1. **Copy Configuration:**
+1. **Copy Configuration to Claude Desktop:**
    ```bash
-   # macOS
+   # macOS - Update paths in claude_desktop_config.json first!
    cp claude_desktop_config.json ~/Library/Application\ Support/Claude/claude_desktop_config.json
    ```
 


### PR DESCRIPTION
🔧 변경 사항:
- **[Tests]**: Conflict resolution 테스트 assertion 추가
  - resolution.status 및 conflict_id 검증
  - 백업 파일 생성 확인 (개수, 이름 형식, 확장자)
  - 백업 파일 내용 검증 (로컬 내용 보존)
  - 원본 파일 내용 검증 (원격 내용 적용)
  - 로컬/원격 파일 분리로 테스트 정확성 향상
- **[Tests]**: MCP Tools 통합 테스트 추가
  - `test_mcp_tools_integration` 구현
  - classify_content 도구 동작 검증
  - PARA 카테고리 및 신뢰도 검증
- **[Docs]**: 문서 경로 플레이스홀더 처리
  - 하드코딩된 경로 제거
  - `claude_desktop_config.example.json` 참조 추가
  - 환경 간 재사용성 향상

📊 테스트 결과:
- 5개 테스트 모두 통과 ✅
- 실행 시간: 3.90s
- Coverage 향상: conflict_service (31% → 58%), classification_service (26% → 72%)

📌 Note:
- 리뷰어(@ai-bot-review) 지적 사항 4건 전수 반영 완료
- Silent regression 방지 (실제 assertion 검증)
- 문서 재사용성 향상 (플레이스홀더 사용)
- MCP 통합 경로 검증 추가

📌 Related:
- Issue [#212] -@ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/239#pullrequestreview-3607318203)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

충돌 해결 범위를 개선하고 MCP 도구 통합을 검증하며, Claude Desktop MCP 구성 문서를 여러 환경에서 재사용할 수 있도록 개선합니다.

Enhancements:
- 로컬 파일과 원격 파일을 분리하여 사용해 백업 생성, 콘텐츠 보존, 최종 파일 상태를 검증함으로써 충돌 해결 테스트를 강화합니다.
- 분류 서비스에 대한 통합 수준 테스트를 추가하여 PARA 카테고리 출력, 신뢰도 범위, 그리고 추론 과정을 검증합니다.

Documentation:
- MCP 테스트 문서를 업데이트하여 플레이스홀더 경로를 사용하고, 예시 Claude 설정을 참조하도록 하며, Claude Desktop 설정 및 복사 단계에 대한 설명을 명확히 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve conflict resolution coverage and validate MCP tool integration while making Claude Desktop MCP configuration docs reusable across environments.

Enhancements:
- Strengthen conflict resolution tests to verify backup creation, content preservation, and final file state using separate local and remote files.
- Add an integration-level test for the classification service to validate PARA category output, confidence range, and reasoning.

Documentation:
- Update MCP testing documentation to use placeholder paths, reference the example Claude config, and clarify setup and copy steps for Claude Desktop.

</details>