### PR TITLE
♻️ refactor [#10.6.16]: normalizeStatus → getStatusClassName 변경 (Code Review 반영)

### DIFF
--- a/web_ui/src/components/AutomationDashboard.js
+++ b/web_ui/src/components/AutomationDashboard.js
@@ -1,7 +1,7 @@
 // web_ui/src/components/AutomationDashboard.js
 
 import React, { useState, useEffect } from 'react';
-import { API_BASE, fetchAPI, validateResponse, normalizeStatus } from '../utils/api';
+import { API_BASE, fetchAPI, validateResponse, getStatusClassName } from '../utils/api';
 import LoadingSpinner from './common/LoadingSpinner';
 import ErrorMessage from './common/ErrorMessage';
 import './AutomationDashboard.css';
@@ -82,7 +82,7 @@ const AutomationDashboard = () => {
               <div key={log.log_id} className="log-item">
                 <div className="log-header">
                   <span className="log-id">{log.log_id}</span>
-                  <span className={`log-status status-${normalizeStatus(log.status)}`}>
+                  <span className={`log-status ${getStatusClassName(log.status)}`}>
                     {log.status}
                   </span>
                 </div>
@@ -128,7 +128,7 @@ const AutomationDashboard = () => {
                   <p className="event-message">
                     <strong>[Obsidian]</strong> File {event.event_type}: "{event.file_path}" → {event.action}
                   </p>
-                  <span className={`event-status status-${normalizeStatus(event.status)}`}>
+                  <span className={`event-status ${getStatusClassName(event.status)}`}>
                     {event.status}
                   </span>
                 </div>

--- a/web_ui/src/components/GeneralDashboard.js
+++ b/web_ui/src/components/GeneralDashboard.js
@@ -1,7 +1,7 @@
 // web_ui/src/components/GeneralDashboard.js
 
 import React, { useState, useEffect } from 'react';
-import { API_BASE, fetchAPI, normalizeStatus } from '../utils/api';
+import { API_BASE, fetchAPI, getStatusClassName } from '../utils/api';
 import LoadingSpinner from './common/LoadingSpinner';
 import ErrorMessage from './common/ErrorMessage';
 import './GeneralDashboard.css';
@@ -100,7 +100,7 @@ const GeneralDashboard = () => {
         <div className="status-info">
           <div className="status-item">
             <span className="label">Status:</span>
-            <span className={`value status-${normalizeStatus(summary?.sync_status)}`}>
+            <span className={`value ${getStatusClassName(summary?.sync_status)}`}>
               {summary?.sync_status || 'Unknown'}
             </span>
           </div>

--- a/web_ui/src/components/SyncMonitor.js
+++ b/web_ui/src/components/SyncMonitor.js
@@ -1,7 +1,7 @@
 // web_ui/src/components/SyncMonitor.js
 
 import React, { useState, useEffect } from 'react';
-import { API_BASE, fetchAPI, normalizeStatus } from '../utils/api';
+import { API_BASE, fetchAPI, getStatusClassName } from '../utils/api';
 import LoadingSpinner from './common/LoadingSpinner';
 import ErrorMessage from './common/ErrorMessage';
 import './SyncMonitor.css';
@@ -168,7 +168,7 @@ const SyncMonitor = () => {
               <div key={conflict.conflict_id} className="conflict-item">
                 <div className="conflict-header">
                   <span className="conflict-id">{conflict.conflict_id}</span>
-                  <span className={`conflict-status status-${normalizeStatus(conflict.status)}`}>
+                  <span className={`conflict-status ${getStatusClassName(conflict.status)}`}>
                     {conflict.status}
                   </span>
                 </div>

--- a/web_ui/src/utils/api.js
+++ b/web_ui/src/utils/api.js
@@ -39,29 +39,27 @@ export const STATUS_MAP = {
 };
 
 /**
- * 상태 값을 CSS 클래스명으로 정규화
+ * 상태 값에 해당하는 CSS 클래스명 반환
  * 
- * @param {any} status - 원본 상태 값 (문자열이 아니어도 문자열로 변환하여 처리)
- * @returns {string} 정규화된 CSS 클래스명
+ * 원본 상태 값을 매핑된 안전한 CSS 클래스명('status-{key}')으로 변환합니다.
+ * 매핑되지 않은 값은 'status-unknown'을 반환합니다.
  * 
- * @example
- * normalizeStatus('Connected') // 'connected'
- * normalizeStatus('RUNNING')   // 'running'
- * normalizeStatus(null)        // 'unknown'
- * normalizeStatus(123)         // 'unknown' (숫자는 매핑되지 않음)
+ * @param {any} status - 원본 상태 값
+ * @returns {string} CSS 클래스명 (예: 'status-running', 'status-unknown')
  */
-export const normalizeStatus = (status) => {
+export const getStatusClassName = (status) => {
   // null, undefined 체크
-  if (status == null) return STATUS_MAP.unknown;
+  if (status == null) return `status-${STATUS_MAP.unknown}`;
   
   // 문자열로 변환 후 정규화
   const normalized = String(status).toLowerCase().trim();
 
   // 빈 문자열 체크
-  if (!normalized) return STATUS_MAP.unknown;
+  if (!normalized) return `status-${STATUS_MAP.unknown}`;
   
-  // STATUS_MAP에서 찾거나, 없으면 unknown 반환 (안전한 CSS 클래스 생성 위함)
-  return STATUS_MAP[normalized] || STATUS_MAP.unknown;
+  // STATUS_MAP에서 찾거나, 없으면 unknown 반환
+  const key = STATUS_MAP[normalized] || STATUS_MAP.unknown;
+  return `status-${key}`;
 };
 
 /**


### PR DESCRIPTION
🔧 변경 사항:
- **[utils/api.js]**: 함수명 변경 및 역할 구체화
  - `normalizeStatus` → `getStatusClassName`
  - 반환값: 접미사(`running`)가 아닌 전체 클래스명(`status-running`) 반환
  - 목적: 데이터 정제가 아닌 CSS 클래스 생성 전용 헬퍼임을 명시

- **[Components]**: 호출부 단순화
  - `status-${normalizeStatus(...)}` → `${getStatusClassName(...)}`
  - 템플릿 리터럴 복잡도 감소 및 실수 방지

🎯 해결된 이슈:
- Comment #1: Pass-through 값 오용 방지 (함수명으로 목적 명시)
- Comment #2: CSS 클래스 생성 로직 캡슐화 (Helper Wrapper 적용)

📌 Related:
- Issue [#213]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/246#pullrequestreview-3612140228)
- Comment (#1, #2)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

상태(helper)의 이름을 변경하고 전체 CSS 클래스 이름을 반환하도록 조정했으며, 이에 따라 모든 컴포넌트 사용처를 업데이트했습니다.

향상 사항:
- CSS를 더 안전하게 사용하기 위해, 상태 매핑 helper가 접미사 대신 전체 `'status-{key}'` 클래스 이름을 반환하도록 개선했습니다.
- 대시보드와 모니터 컴포넌트 전반에서 상태 관련 `className` 생성 로직을 helper에 위임하여, `className` 구성 방식을 단순화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename and adjust the status helper to return full CSS class names and update all component usages accordingly.

Enhancements:
- Refine the status mapping helper to return full 'status-{key}' class names instead of suffixes for safer CSS usage.
- Simplify status-related className construction across dashboard and monitor components by delegating class name generation to the helper.

</details>