### PR TITLE
♻️ refactor [#10.7.6]: 1차 개선 - 코드 개선 반영

### DIFF
--- a/web_ui/src/components/layout/mobile-nav.tsx
+++ b/web_ui/src/components/layout/mobile-nav.tsx
@@ -3,9 +3,7 @@
 'use client';
 
 import * as React from "react";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { Menu, LayoutDashboard, Network, BarChart3, Settings, Github } from "lucide-react";
+import { Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -14,10 +12,11 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
+import { NavItem } from "./nav-item";
+import { mainNavItems, settingsItems } from "@/config/navigation";
 
 export function MobileNav() {
   const [open, setOpen] = React.useState(false);
-  const pathname = usePathname();
 
   return (
     <div className="md:hidden flex items-center p-4 border-b bg-white sticky top-0 z-50">
@@ -35,24 +34,9 @@ export function MobileNav() {
           <div className="space-y-4 py-4">
              <div className="px-3 py-2">
               <div className="space-y-1">
-                <Button variant={pathname === "/" ? "secondary" : "ghost"} className="w-full justify-start" onClick={() => setOpen(false)} asChild>
-                  <Link href="/">
-                    <LayoutDashboard className="mr-2 h-4 w-4" />
-                    Dashboard
-                  </Link>
-                </Button>
-                <Button variant={pathname === "/graph" ? "secondary" : "ghost"} className="w-full justify-start" onClick={() => setOpen(false)} asChild>
-                  <Link href="/graph">
-                    <Network className="mr-2 h-4 w-4" />
-                    Graph View
-                  </Link>
-                </Button>
-                <Button variant={pathname === "/stats" ? "secondary" : "ghost"} className="w-full justify-start" onClick={() => setOpen(false)} asChild>
-                  <Link href="/stats">
-                     <BarChart3 className="mr-2 h-4 w-4" />
-                    Statistics
-                  </Link>
-                </Button>
+                {mainNavItems.map(item => (
+                  <NavItem key={item.href} {...item} onClick={() => setOpen(false)} />
+                ))}
               </div>
             </div>
              <div className="px-3 py-2">
@@ -60,14 +44,9 @@ export function MobileNav() {
                 Settings
               </h2>
               <div className="space-y-1">
-                <Button variant="ghost" className="w-full justify-start">
-                  <Settings className="mr-2 h-4 w-4" />
-                  Preferences
-                </Button>
-                <Button variant="ghost" className="w-full justify-start">
-                  <Github className="mr-2 h-4 w-4" />
-                  GitHub
-                </Button>
+                {settingsItems.map(item => (
+                  <NavItem key={item.href} {...item} onClick={() => setOpen(false)} />
+                ))}
               </div>
             </div>
           </div>

--- a/web_ui/src/components/layout/nav-item.tsx
+++ b/web_ui/src/components/layout/nav-item.tsx
@@ -1,0 +1,44 @@
+// web_ui/src/components/layout/nav-item.tsx
+
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Button } from "@/components/ui/button";
+
+interface NavItemProps {
+  href: string;
+  label: string;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  external?: boolean;
+  onClick?: () => void;
+}
+
+export function NavItem({ href, label, icon: Icon, external, onClick }: NavItemProps) {
+  const pathname = usePathname();
+  const isActive = !external && pathname === href;
+
+  const content = (
+    <>
+      <Icon className="mr-2 h-4 w-4" />
+      {label}
+    </>
+  );
+
+  return (
+    <Button
+      variant={isActive ? "secondary" : "ghost"}
+      className="w-full justify-start"
+      asChild={!external}
+      onClick={onClick}
+    >
+      {external ? (
+        <a href={href} target="_blank" rel="noreferrer">
+          {content}
+        </a>
+      ) : (
+        <Link href={href}>{content}</Link>
+      )}
+    </Button>
+  );
+}

--- a/web_ui/src/components/layout/sidebar.tsx
+++ b/web_ui/src/components/layout/sidebar.tsx
@@ -1,62 +1,28 @@
 // web_ui/src/components/layout/sidebar.tsx
 
-'use client';
-
-import Link from "next/link";
-import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { LayoutDashboard, Network, BarChart3, Settings, Github } from "lucide-react";
+import { NavItem } from "./nav-item";
+import { mainNavItems, settingsItems } from "@/config/navigation";
 
-// interface SidebarProps extends React.HTMLAttributes<HTMLDivElement> {
-//   // Add specific props if needed, currently empty is fine for extension
-// }
-
-export function Sidebar({ className }: React.HTMLAttributes<HTMLDivElement>) {
-  const pathname = usePathname();
-
+export function Sidebar({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return (
-    <div className={cn("hidden md:block w-64 fixed left-0 top-0 h-screen border-r bg-slate-50/50", className)}>
+    <div {...props} className={cn("hidden md:block w-64 fixed left-0 top-0 h-screen border-r bg-slate-50/50", className)}>
       <ScrollArea className="h-full py-4">
         <div className="px-3 py-2">
-          <h2 className="mb-2 px-4 text-lg font-semibold tracking-tight">
-            FlowNote
-          </h2>
+          <h2 className="mb-2 px-4 text-lg font-semibold tracking-tight">FlowNote</h2>
           <div className="space-y-1">
-            <Button variant={pathname === "/" ? "secondary" : "ghost"} className="w-full justify-start" asChild>
-              <Link href="/">
-                <LayoutDashboard className="mr-2 h-4 w-4" />
-                Dashboard
-              </Link>
-            </Button>
-            <Button variant={pathname === "/graph" ? "secondary" : "ghost"} className="w-full justify-start" asChild>
-              <Link href="/graph">
-                <Network className="mr-2 h-4 w-4" />
-                Graph View
-              </Link>
-            </Button>
-            <Button variant={pathname === "/stats" ? "secondary" : "ghost"} className="w-full justify-start" asChild>
-              <Link href="/stats">
-                <BarChart3 className="mr-2 h-4 w-4" />
-                Statistics
-              </Link>
-            </Button>
+            {mainNavItems.map(item => (
+              <NavItem key={item.href} {...item} />
+            ))}
           </div>
         </div>
         <div className="px-3 py-2">
-          <h2 className="mb-2 px-4 text-lg font-semibold tracking-tight">
-            Settings
-          </h2>
+          <h2 className="mb-2 px-4 text-lg font-semibold tracking-tight">Settings</h2>
           <div className="space-y-1">
-            <Button variant="ghost" className="w-full justify-start">
-              <Settings className="mr-2 h-4 w-4" />
-              Preferences
-            </Button>
-            <Button variant="ghost" className="w-full justify-start">
-              <Github className="mr-2 h-4 w-4" />
-              GitHub
-            </Button>
+            {settingsItems.map(item => (
+              <NavItem key={item.href} {...item} />
+            ))}
           </div>
         </div>
       </ScrollArea>

--- a/web_ui/src/components/ui/sheet.tsx
+++ b/web_ui/src/components/ui/sheet.tsx
@@ -1,3 +1,5 @@
+// web_ui/src/components/ui/sheet.tsx 
+
 "use client"
 
 import * as React from "react"
@@ -64,15 +66,15 @@ function SheetContent({
           side === "left" &&
             "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
           side === "top" &&
-            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto max-h-screen overflow-y-auto border-b",
           side === "bottom" &&
-            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto max-h-screen overflow-y-auto border-t",
           className
         )}
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:pointer-events-none">
           <XIcon className="size-4" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>

--- a/web_ui/src/config/navigation.ts
+++ b/web_ui/src/config/navigation.ts
@@ -1,0 +1,14 @@
+// web_ui/src/config/navigation.ts
+
+import { LayoutDashboard, Network, BarChart3, Settings, Github } from "lucide-react";
+
+export const mainNavItems = [
+  { href: "/", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/graph", label: "Graph View", icon: Network },
+  { href: "/stats", label: "Statistics", icon: BarChart3 },
+];
+
+export const settingsItems = [
+  { href: "/preferences", label: "Preferences", icon: Settings, external: false },
+  { href: "https://github.com/jjaayy2222/flownote-mvp", label: "GitHub", icon: Github, external: true },
+];


### PR DESCRIPTION
🔧 변경 사항:
- **[UI]**: Shadcn UI `Sheet` 컴포넌트 추가 및 스타일 표준화 (rounded-sm, outline-none)
- **[Navigation]**:
  - `Sidebar` 및 `MobileNav` 구현
  - **Refactor**: 네비게이션 설정을 `config/navigation.ts`로 추출하여 단일 소스 관리 (DRY 원칙 적용)
  - **Component**: 재사용 가능한 `NavItem` 컴포넌트 구현
- **[UX]**: 모바일 Drawer(`Sheet`)의 Overflow 처리 추가 (max-h-screen)
- **[Props]**: `Sidebar`가 표준 HTML Attributes를 올바르게 전달하도록 수정

🎯 목적:
- 데스크탑과 모바일 환경 모두에서 최적화된 탐색 경험(UX) 제공 및 유지보수성 확보
- Reflected Code Review (Tailwind fix, Nav Config Extraction)

📌 Related:
- Issue [#214]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/254#pullrequestreview-3615161230)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

공유 구성과 재사용 가능한 NavItem 컴포넌트를 사용하도록 내비게이션을 리팩터링하고, 시트 동작과 사이드바 props 처리 방식을 개선합니다.

New Features:
- 데스크톱 사이드바와 모바일 내비게이션 모두에서 사용할 수 있는 재사용 가능한 NavItem 컴포넌트를 도입합니다.
- 메인 및 설정 링크를 위한 중앙 집중식 내비게이션 구성을 `config/navigation.ts`에 추가합니다.

Enhancements:
- 사이드바와 MobileNav가 하드코딩된 링크 대신 공유 내비게이션 구성을 사용하도록 업데이트합니다.
- Sidebar가 표준 HTML div 속성을 루트 요소로 전달하도록 보장합니다.
- 상단 및 하단 변형의 시트 콘텐츠를 조정하여 스크롤 가능하고 화면에 한정된 드로어를 지원하고, 닫기 버튼 스타일을 표준화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor navigation to use shared configuration and a reusable NavItem component while improving sheet behavior and sidebar props handling.

New Features:
- Introduce a reusable NavItem component for both desktop sidebar and mobile navigation.
- Add centralized navigation configuration in config/navigation.ts for main and settings links.

Enhancements:
- Update Sidebar and MobileNav to consume shared navigation config instead of hardcoded links.
- Ensure Sidebar forwards standard HTML div attributes to its root element.
- Adjust sheet content for top and bottom variants to support scrollable, screen-bounded drawers and standardize close button styles.

</details>