### PR TITLE
♻️ refactor [#10.7.6]: 2차 개선 - NavItem 보안 및 마크업 표준화

### DIFF
--- a/web_ui/src/components/layout/nav-item.tsx
+++ b/web_ui/src/components/layout/nav-item.tsx
@@ -2,6 +2,7 @@
 
 "use client";
 
+import type React from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Button } from "@/components/ui/button";
@@ -25,15 +26,18 @@ export function NavItem({ href, label, icon: Icon, external, onClick }: NavItemP
     </>
   );
 
+  // Use asChild=true for both cases to avoid <button> inside <button> nesting issues
+  // The Button component with asChild will render the child element (Link or a) directly
+  // while preserving the button styles.
   return (
     <Button
       variant={isActive ? "secondary" : "ghost"}
       className="w-full justify-start"
-      asChild={!external}
+      asChild
       onClick={onClick}
     >
       {external ? (
-        <a href={href} target="_blank" rel="noreferrer">
+        <a href={href} target="_blank" rel="noreferrer noopener">
           {content}
         </a>
       ) : (


### PR DESCRIPTION
🔧 변경 사항:
- **[Security]**: 외부 링크(`<a>`)에 `rel="noreferrer noopener"` 적용 (Tabnabbing 방지)
- **[A11y/Markup]**: `asChild`를 항상 true로 설정하여 불법 중첩(`<button> > <a>`) 방지 및 시맨틱 보장
- **[Type]**: `React` type import 명시 추가

🎯 목적:
- 코드 리뷰 피드백 반영을 통한 보안성 및 접근성 강화
- Reflected Code Review (Security, A11y)

📌 Related:
- Issue [#214]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/255#pullrequestreview-3615170628)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

외부 및 내부 내비게이션 링크에 대해 NavItem 보안과 마크업 시멘틱을 강화합니다.

버그 수정:
- 외부 내비게이션 링크에 `rel="noreferrer noopener"`를 추가하여 잠재적인 탭내빙(tabnabbing) 공격을 방지합니다.

개선 사항:
- `asChild`를 통해 항상 기본 링크 요소를 렌더링하여 잘못된 중첩 버튼 구조를 피하고 시멘틱을 보존함으로써 NavItem 마크업을 표준화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen NavItem security and markup semantics for external and internal navigation links.

Bug Fixes:
- Prevent potential tabnabbing attacks by adding `rel="noreferrer noopener"` to external navigation links.

Enhancements:
- Standardize NavItem markup by always rendering the underlying link element via `asChild` to avoid invalid nested button structures and preserve semantics.

</details>