### PR TITLE
✨ feat [#10.7.7]: Graph View 노드 인터랙션 추가 (Click to Inspect)

### DIFF
--- a/web_ui/src/components/para/GraphView.tsx
+++ b/web_ui/src/components/para/GraphView.tsx
@@ -11,6 +11,7 @@ import ReactFlow, {
   Node,
 } from 'reactflow';
 import 'reactflow/dist/style.css';
+import { toast } from "sonner";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
 
@@ -36,6 +37,7 @@ export default function GraphView() {
       setEdges(data.edges);
     } catch (error) {
       console.error('Error fetching graph data:', error);
+      toast.error("Failed to load graph data");
     } finally {
       setLoading(false);
     }
@@ -44,6 +46,12 @@ export default function GraphView() {
   useEffect(() => {
     fetchData();
   }, [fetchData]);
+
+  const onNodeClick = useCallback((event: React.MouseEvent, node: Node) => {
+    toast(`Selected: ${node.data.label}`, {
+      description: `Type: ${node.type === 'input' ? 'Category' : 'File'}`,
+    });
+  }, []);
 
   if (loading) {
     return <div className="flex h-full w-full items-center justify-center p-10">Loading Graph...</div>;
@@ -56,6 +64,7 @@ export default function GraphView() {
         edges={edges}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
+        onNodeClick={onNodeClick}
         fitView
         attributionPosition="bottom-right"
       >


### PR DESCRIPTION
🔧 변경 사항:
- **[Interaction]**: `onNodeClick` 이벤트 핸들러 구현
- **[UX]**: 노드 클릭 시 `Sonner` Toast를 통해 파일/카테고리 정보 표시

🎯 목적:
- 정적인 그래프 뷰를 넘어 사용자와의 상호작용성(Interactivity) 강화

📌 Related: Issue [#214]

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

그래프 뷰에 상호작용 가능한 노드 클릭 처리 기능을 추가하여 사용자에게 컨텍스트 정보를 보여줍니다.

새 기능:
- 그래프 노드를 클릭했을 때 노드 레이블과 타입을 토스트 알림으로 표시합니다.

개선 사항:
- 그래프 데이터 로드에 실패했을 때 토스트 오류 메시지를 표시하여 오류 가시성을 향상합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add interactive node click handling to the graph view to show contextual information to users.

New Features:
- Display a toast notification with node label and type when a graph node is clicked.

Enhancements:
- Show a toast error message when graph data fails to load to improve error visibility.

</details>