### PR TITLE
♻️ refactor [#10.8.10]: 3차 개선 - UI 텍스트 상수화 및 중앙 관리 (Centralized UI Messages)

### DIFF
--- a/web_ui/src/app/loading.tsx
+++ b/web_ui/src/app/loading.tsx
@@ -1,6 +1,7 @@
 // web_ui/src/app/loading.tsx 
 
 import { Skeleton } from "@/components/ui/skeleton";
+import { UI_MESSAGES } from "@/config/messages";
 
 export default function Loading() {
   return (
@@ -9,7 +10,7 @@ export default function Loading() {
       role="status" 
       aria-busy="true" 
       aria-live="polite"
-      aria-label="콘텐츠를 불러오는 중입니다..."
+      aria-label={UI_MESSAGES.common.loading}
     >
       <div className="space-y-2">
         <Skeleton className="h-8 w-[200px]" />

--- a/web_ui/src/config/messages.ts
+++ b/web_ui/src/config/messages.ts
@@ -1,0 +1,7 @@
+// web_ui/src/config/messages.ts
+
+export const UI_MESSAGES = {
+  common: {
+    loading: "콘텐츠를 불러오는 중입니다...",
+  },
+} as const;


### PR DESCRIPTION
🔧 변경 사항:
- **[Refactor]**: 하드코딩된 로딩 메시지를 `config/messages.ts`로 추출
- **[Maintainability]**: UI 텍스트 중앙 관리를 통해 향후 i18n 도입 기반 마련

🎯 목적:
- 매직 스트링 제거 및 유지보수성 향상

📌 Related:
- Issue [#214]
- ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/267#pullrequestreview-3623033348)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

향후 유지 보수와 i18n 지원을 용이하게 하기 위해 로딩 UI 텍스트를 공용 설정으로 중앙 집중화했습니다.

개선 사항:
- 로딩 화면에서 하드코딩된 로딩 aria-label을 공용 UI 메시지 상수 참조로 교체했습니다.
- 공통 UI 텍스트 문자열을 중앙에서 관리하기 위한 UI 메시지 설정 모듈을 도입했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize the loading UI text into a shared configuration for easier maintenance and future i18n support.

Enhancements:
- Replace hardcoded loading aria-label in the loading screen with a reference to a shared UI message constant.
- Introduce a UI messages configuration module to centralize common UI text strings.

</details>