### PR TITLE
✨ feat [#10.9.3]: WebSocket 설정 모듈 구현

### DIFF
--- a/web_ui/.env.example
+++ b/web_ui/.env.example
@@ -1,1 +1,8 @@
+# web_ui/.env.example
+
 NEXT_PUBLIC_API_BASE=http://localhost:8000
+
+# WebSocket 서버 URL
+# 개발 환경: ws://localhost:8000/ws
+# 프로덕션 환경: wss://your-domain.com/ws
+NEXT_PUBLIC_WS_URL=ws://localhost:8000/ws

--- a/web_ui/src/config/websocket.ts
+++ b/web_ui/src/config/websocket.ts
@@ -1,0 +1,57 @@
+//web_ui/src/config/websocket.ts
+
+/**
+ * WebSocket 설정 모듈
+ * 
+ * 환경 변수를 통해 WebSocket URL을 중앙 집중 관리합니다.
+ * 개발/프로덕션 환경에 따라 다른 URL을 사용할 수 있습니다.
+ */
+
+/**
+ * WebSocket URL 가져오기
+ * 
+ * @returns WebSocket 서버 URL
+ * 
+ * @example
+ * ```typescript
+ * import { getWebSocketUrl } from '@/config/websocket';
+ * 
+ * const wsUrl = getWebSocketUrl();
+ * const ws = new WebSocket(wsUrl);
+ * ```
+ */
+export const getWebSocketUrl = (): string => {
+  const url = process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:8000/ws';
+  
+  // 개발 환경에서 로그 출력
+  if (process.env.NODE_ENV === 'development') {
+    console.log('[WebSocket Config] Using URL:', url);
+  }
+  
+  return url;
+};
+
+/**
+ * WebSocket 재연결 설정
+ */
+export const WEBSOCKET_CONFIG = {
+  /** 초기 재연결 지연 시간 (ms) */
+  INITIAL_RECONNECT_DELAY: 1000,
+  
+  /** 최대 재연결 지연 시간 (ms) */
+  MAX_RECONNECT_DELAY: 30000,
+  
+  /** 재연결 시도 횟수 (-1: 무제한) */
+  MAX_RECONNECT_ATTEMPTS: -1,
+} as const;
+
+/**
+ * WebSocket 연결 상태
+ */
+export enum WebSocketStatus {
+  CONNECTING = 'CONNECTING',
+  CONNECTED = 'CONNECTED',
+  DISCONNECTED = 'DISCONNECTED',
+  RECONNECTING = 'RECONNECTING',
+  ERROR = 'ERROR',
+}


### PR DESCRIPTION
🔧 변경 사항:
- **[Config]**: 중앙 집중화된 WebSocket 설정 모듈 생성
- **[Env]**: .env.example에 WebSocket URL 설정 추가

📁 새로운 파일:
- web_ui/src/config/websocket.ts

📝 업데이트된 파일:
- web_ui/.env.example

🎯 주요 기능:
- [getWebSocketUrl()](web_ui/src/config/websocket.ts): 환경 변수 기반 URL 반환
- `WEBSOCKET_CONFIG`: 재연결 설정 상수
- `WebSocketStatus`: 연결 상태 Enum

💡 사용 예시:
```typescript
import { getWebSocketUrl } from '@/config/websocket';
const ws = new WebSocket(getWebSocketUrl());
```

📌 Related: Issue [#273] (v6.0 Phase 1)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

웹 UI를 위한 중앙화된 WebSocket 구성 모듈과 환경 기반 URL 설정을 도입합니다.

New Features:
- 웹 UI에서 사용할 환경 기반 URL 헬퍼, 재연결 설정, 연결 상태 enum을 제공하는 공용 WebSocket 구성 모듈을 추가합니다.

Build:
- 프론트엔드에서 사용할 공개 WebSocket URL 변수를 포함하도록 예시 환경 설정을 확장합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a centralized WebSocket configuration module and environment-based URL setup for the web UI.

New Features:
- Add a shared WebSocket configuration module exposing an environment-driven URL helper, reconnection settings, and a connection status enum for the web UI.

Build:
- Extend the example environment configuration to include a public WebSocket URL variable for frontend use.

</details>