### PR TITLE
🔒 security [#10.9.3]: 3차 개선 - 보안 및 타입 안전성 강화

### DIFF
--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -41,6 +41,12 @@ export const WS_READY_STATE = {
 } as const;
 
 /**
+ * WebSocket readyState 타입
+ * 유효한 readyState 값만 허용 (0-3)
+ */
+export type WebSocketReadyState = typeof WS_READY_STATE[keyof typeof WS_READY_STATE];
+
+/**
  * Native WebSocket readyState를 WebSocketStatus로 변환
  * 
  * @param readyState - WebSocket.readyState 값 (0-3)
@@ -51,7 +57,7 @@ export const WS_READY_STATE = {
  * const status = mapReadyStateToStatus(ws.readyState);
  * ```
  */
-export const mapReadyStateToStatus = (readyState: number): WebSocketStatus => {
+export const mapReadyStateToStatus = (readyState: WebSocketReadyState): WebSocketStatus => {
   switch (readyState) {
     case WS_READY_STATE.CONNECTING:
       return WebSocketStatus.CONNECTING;
@@ -60,7 +66,5 @@ export const mapReadyStateToStatus = (readyState: number): WebSocketStatus => {
     case WS_READY_STATE.CLOSING:
     case WS_READY_STATE.CLOSED:
       return WebSocketStatus.DISCONNECTED;
-    default:
-      return WebSocketStatus.ERROR;
   }
 };


### PR DESCRIPTION
🔧 변경 사항:
- **[Security]**: URL 검증 강화 및 프로덕션 WSS 강제
- **[Type Safety]**: WebSocketReadyState 타입 추가
- **[Validation]**: 호스트명 필수 검증

🛡️ 보안 개선:
1. **URL 검증 강화**:
   - 호스트명 필수 검증 (`ws://` 또는 `ws://?x=1` 차단)
   - `new URL()` 파싱으로 정확한 검증
   - 프로덕션 환경에서 `ws://` 차단 (WSS 강제)

2. **타입 안전성**:
   - `WebSocketReadyState = 0 | 1 | 2 | 3`
   - `mapReadyStateToStatus` 파라미터 타입 강화
   - Exhaustive switch (default 케이스 제거)

3. **보안 경고**:
   - 프로덕션에서 `ws://` 감지 시 경고 로그
   - 개발 환경에서는 `ws://` 허용

📝 개선 내용:
- Before: `/^wss?:///` 정규식만 체크
- After: URL 파싱 + 호스트명 검증 + 프로덕션 보안

🎯 목적:
- 잘못된 URL 형식 차단
- 프로덕션 보안 강화 (WSS 강제)
- 컴파일 타임 타입 안전성 확보

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/282#pullrequestreview-3643742105) - `URL Validation`, `Type Safety`, `Security`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

WebSocket URL 검증을 강화하고 WebSocket readyState에 대한 타입 안정성을 향상합니다.

New Features:
- 유효한 readyState 값으로만 제한되는 전용 `WebSocketReadyState` 타입을 도입합니다.

Bug Fixes:
- 호스트 이름이 반드시 존재하도록 강제하고, 프로덕션 환경에서 `ws://`를 거부하여 잘못되었거나 보안에 취약한 WebSocket URL을 방지합니다.

Enhancements:
- 단순한 정규식 기반 WebSocket URL 검사 방식을 URL 파싱 및 환경 인식 검증 로직으로 교체합니다.
- 앱 전반에서 재사용할 수 있도록 기존 WebSocket 상태 유틸리티와 함께 `WebSocketReadyState`를 export 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen WebSocket URL validation and type safety for WebSocket ready states.

New Features:
- Introduce a dedicated WebSocketReadyState type constrained to valid readyState values.

Bug Fixes:
- Prevent invalid or insecure WebSocket URLs by enforcing hostname presence and rejecting ws:// in production.

Enhancements:
- Replace simple regex-based WebSocket URL checks with URL parsing and environment-aware validation logic.
- Export WebSocketReadyState alongside existing WebSocket status utilities for reuse across the app.

</details>