### PR TITLE
🛡️ security [#10.9.3]: 4차 개선 - 런타임 안전성 및 프로덕션 SSR 보안 강화

### DIFF
--- a/web_ui/src/config/websocket.ts
+++ b/web_ui/src/config/websocket.ts
@@ -51,9 +51,10 @@ const isValidWebSocketUrl = (url: string): boolean => {
  * 1. NEXT_PUBLIC_WS_URL 환경 변수 (유효성 검사 통과 시)
  * 2. window.location 기반 동적 URL (브라우저 환경)
  * 3. NEXT_PUBLIC_WS_FALLBACK_URL 환경 변수 (SSR 환경)
- * 4. ws://localhost:8000/ws (최종 폴백, 개발 환경만)
+ * 4. ws://localhost:8000/ws (개발 환경 SSR만)
  * 
  * @returns WebSocket 서버 URL
+ * @throws {Error} 프로덕션 SSR 환경에서 NEXT_PUBLIC_WS_FALLBACK_URL이 설정되지 않은 경우
  * 
  * @example
  * ```typescript
@@ -81,10 +82,25 @@ export const getWebSocketUrl = (): string => {
 
   // 2. SSR 환경 (window 없음)
   if (typeof window === 'undefined') {
-    // SSR 폴백 URL (환경 변수로 설정 가능)
-    const ssrFallback = process.env.NEXT_PUBLIC_WS_FALLBACK_URL || 'ws://localhost:8000/ws';
-    logger.debug('Using SSR fallback URL:', ssrFallback);
-    return ssrFallback;
+    const ssrFallback = process.env.NEXT_PUBLIC_WS_FALLBACK_URL;
+    
+    if (ssrFallback) {
+      logger.debug('Using SSR fallback URL:', ssrFallback);
+      return ssrFallback;
+    }
+    
+    // 개발 환경에서만 localhost 허용
+    if (process.env.NODE_ENV === 'development') {
+      // nosemgrep: javascript.lang.security.detect-insecure-websocket
+      // 개발 환경 전용: 로컬 개발 서버 연결
+      const devFallback = 'ws://localhost:8000/ws';
+      logger.debug('Using development SSR fallback URL:', devFallback);
+      return devFallback;
+    }
+    
+    // 프로덕션 SSR에서 폴백 URL이 없으면 오류
+    logger.error('NEXT_PUBLIC_WS_FALLBACK_URL not set in production SSR environment');
+    throw new Error('WebSocket URL configuration required for production SSR');
   }
 
   // 3. 브라우저 환경 - location 기반 동적 URL

--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -66,5 +66,11 @@ export const mapReadyStateToStatus = (readyState: WebSocketReadyState): WebSocke
     case WS_READY_STATE.CLOSING:
     case WS_READY_STATE.CLOSED:
       return WebSocketStatus.DISCONNECTED;
+    default:
+      // 런타임 안전성: 예상치 못한 값에 대한 방어적 처리
+      // TypeScript는 이 케이스에 도달할 수 없다고 판단하지만,
+      // 느슨한 타입 컨텍스트나 외부 라이브러리에서 호출될 수 있음
+      console.error(`[WebSocket] Unexpected readyState value: ${readyState}`);
+      return WebSocketStatus.ERROR;
   }
 };


### PR DESCRIPTION
🔧 변경 사항:
- **[Runtime Safety]**: mapReadyStateToStatus에 default 케이스 추가
- **[Production Security]**: SSR 환경에서 명시적 환경 체크 및 오류 발생
- **[Security Scanner]**: nosemgrep 주석으로 개발 환경 명시

🛡️ 보안 및 안전성:
1. **런타임 방어**:
   - `mapReadyStateToStatus`에 default 케이스 추가
   - 예상치 못한 readyState 값에 대한 에러 로깅
   - 타입 안전성과 런타임 안전성 모두 확보

2. **프로덕션 SSR 보안**:
   - 개발 환경에서만 localhost 허용 (명시적 체크)
   - 프로덕션 SSR에서 `NEXT_PUBLIC_WS_FALLBACK_URL` 필수
   - 설정 누락 시 명시적 에러 throw (조용한 실패 방지)

3. **보안 스캐너 대응**:
   - `nosemgrep` 주석으로 개발 환경 의도 명시
   - 보안 스캐너 오탐 방지

📝 개선 내용:
- Before: SSR에서 항상 localhost 폴백 가능
- After: 개발 환경만 localhost, 프로덕션은 오류 발생

🎯 목적:
- 느슨한 타입 컨텍스트에서도 안전
- 프로덕션 배포 시 설정 누락 조기 발견
- 보안 스캐너 오탐 제거

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/283#pullrequestreview-3643759902) - `Runtime Safety`, `Production Security`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

프로덕션 환경에서 WebSocket 런타임 안전성을 강화하고 SSR WebSocket URL 처리를 더 엄격하게 합니다.

버그 수정:
- 예기치 않은 WebSocket `readyState` 값에 대해 방어적으로 처리하고, 이를 오류 상태에 매핑합니다.

개선 사항:
- 프로덕션 SSR에서 WebSocket 연결 시 명시적인 `NEXT_PUBLIC_WS_FALLBACK_URL` 설정을 필수로 요구하며, 암묵적인 localhost 폴백을 허용하지 않습니다.
- localhost WebSocket 폴백을 개발 환경 SSR에서만 허용하며, 보안 스캐너의 오탐(false positive)을 방지하기 위한 주석을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen WebSocket runtime safety and tighten SSR WebSocket URL handling for production environments.

Bug Fixes:
- Add defensive handling for unexpected WebSocket readyState values by mapping them to an error status.

Enhancements:
- Require an explicit NEXT_PUBLIC_WS_FALLBACK_URL for WebSocket connections in production SSR, disallowing implicit localhost fallbacks.
- Restrict localhost WebSocket fallback to development SSR only and annotate it to avoid security scanner false positives.

</details>