### PR TITLE
♻️ refactor [#10.9.3]: 5차 개선 - Exhaustiveness checking 복원 및 test 환경 지원

### DIFF
--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -66,11 +66,14 @@ export const mapReadyStateToStatus = (readyState: WebSocketReadyState): WebSocke
     case WS_READY_STATE.CLOSING:
     case WS_READY_STATE.CLOSED:
       return WebSocketStatus.DISCONNECTED;
-    default:
-      // 런타임 안전성: 예상치 못한 값에 대한 방어적 처리
-      // TypeScript는 이 케이스에 도달할 수 없다고 판단하지만,
-      // 느슨한 타입 컨텍스트나 외부 라이브러리에서 호출될 수 있음
-      console.error(`[WebSocket] Unexpected readyState value: ${readyState}`);
-      return WebSocketStatus.ERROR;
   }
+  
+  // Exhaustiveness check: TypeScript가 모든 케이스를 처리했는지 확인
+  // 새로운 WS_READY_STATE 값이 추가되면 컴파일 오류 발생
+  const _exhaustiveCheck: never = readyState;
+  
+  // 런타임 안전성: 예상치 못한 값에 대한 방어적 처리
+  // 느슨한 타입 컨텍스트나 외부 라이브러리에서 호출될 수 있음
+  console.error(`[WebSocket] Unexpected readyState value: ${_exhaustiveCheck}`);
+  return WebSocketStatus.ERROR;
 };


### PR DESCRIPTION
🔧 변경 사항:
- **[Type Safety]**: never 타입으로 exhaustiveness check 복원
- **[Test Support]**: test 환경 지원 추가
- **[Error Messages]**: 구체적인 설정 가이드 제공

🎯 타입 안전성 개선:
1. **Exhaustiveness Checking**:
   - `default` 케이스 제거 → switch 밖으로 이동
   - `const _exhaustiveCheck: never = readyState`
   - 새로운 WS_READY_STATE 추가 시 컴파일 오류 발생
   - 런타임 안전성도 유지

2. **컴파일 타임 vs 런타임**:
   - 컴파일 타임: exhaustiveness check로 모든 케이스 처리 강제
   - 런타임: 예상치 못한 값에 대한 방어적 처리

📝 환경 지원 개선:
1. **test 환경 지원**:
   - [isNonProductionEnv()](web_ui/src/config/websocket.ts): development || test
   - test 환경에서도 localhost 허용

2. **명확한 에러 메시지**:
   - 현재 환경 표시 (`${env} SSR`)
   - 설정 방법 가이드 포함

🛡️ 안전성:
- Before: default 케이스로 exhaustiveness 무력화
- After: never 타입으로 컴파일 타임 체크 + 런타임 방어

🎯 목적:
- 타입 안전성 최대화
- test/staging 환경 지원
- 개발자 경험 개선 (명확한 에러 메시지)

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/284#pullrequestreview-3643778643) - `Exhaustiveness Checking`, `Test Support`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

WebSocket 설정의 안전성과 환경 처리 방식을 개선하고, WebSocket ready-state 매핑에 대한 엄격한 완전성(exhaustiveness) 검사 기능을 복원합니다.

버그 수정:
- 개발 환경에서만 허용되던 localhost WebSocket 폴백(fallback)을 개발 및 테스트 SSR 환경 모두에서 허용하도록 변경했습니다.

개선 사항:
- never 타입 가드를 사용하여 WebSocket ready-state 상태 매핑에 대해 컴파일 타임 완전성(exhaustiveness) 검사를 복원했습니다.
- SSR WebSocket URL 해석 방식을 개선하여 프로덕션이 아닌 환경들을 구분하고, 각 환경에 맞는 더 명확한 로깅 및 오류 메시지를 제공하도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve WebSocket configuration safety and environment handling while restoring strict exhaustiveness checks for WebSocket ready-state mapping.

Bug Fixes:
- Allow localhost WebSocket fallback in both development and test SSR environments instead of development only.

Enhancements:
- Restore compile-time exhaustiveness checking for WebSocket ready-state status mapping using a never-type guard.
- Refine SSR WebSocket URL resolution to distinguish non-production environments and provide clearer, environment-specific logging and error messages.

</details>