### PR TITLE
♻️ refactor [#10.9.3]: 6차 개선 - 런타임 타입 가드 및 테스트 가능성 개선

### DIFF
--- a/web_ui/src/config/websocket.ts
+++ b/web_ui/src/config/websocket.ts
@@ -47,10 +47,10 @@ const isValidWebSocketUrl = (url: string): boolean => {
 /**
  * 개발/테스트 환경 여부 확인
  * 
+ * @param env - 환경 변수 (기본값: process.env.NODE_ENV)
  * @returns 개발 또는 테스트 환경인 경우 true
  */
-const isNonProductionEnv = (): boolean => {
-  const env = process.env.NODE_ENV;
+export const isNonProductionEnv = (env: string = process.env.NODE_ENV || 'production'): boolean => {
   return env === 'development' || env === 'test';
 };
 
@@ -100,19 +100,19 @@ export const getWebSocketUrl = (): string => {
     }
     
     // 개발/테스트 환경에서만 localhost 허용
-    if (isNonProductionEnv()) {
+    const currentEnv = process.env.NODE_ENV || 'production';
+    if (isNonProductionEnv(currentEnv)) {
       // nosemgrep: javascript.lang.security.detect-insecure-websocket
       // 개발/테스트 환경 전용: 로컬 개발 서버 연결
       const devFallback = 'ws://localhost:8000/ws';
-      logger.debug(`Using ${process.env.NODE_ENV} SSR fallback URL:`, devFallback);
+      logger.debug(`Using ${currentEnv} SSR fallback URL:`, devFallback);
       return devFallback;
     }
     
     // 프로덕션/스테이징 SSR에서 폴백 URL이 없으면 오류
-    const env = process.env.NODE_ENV || 'unknown';
-    logger.error(`NEXT_PUBLIC_WS_FALLBACK_URL not set in ${env} SSR environment`);
+    logger.error(`NEXT_PUBLIC_WS_FALLBACK_URL not set in ${currentEnv} SSR environment`);
     throw new Error(
-      `WebSocket URL configuration required for ${env} SSR. ` +
+      `WebSocket URL configuration required for ${currentEnv} SSR. ` +
       'Please set NEXT_PUBLIC_WS_FALLBACK_URL environment variable.'
     );
   }


### PR DESCRIPTION
🔧 변경 사항:
- **[Type Guard]**: isValidReadyState 타입 가드 추가
- **[Testability]**: isNonProductionEnv 파라미터화
- **[Type Safety]**: Exhaustiveness check 유지 + 런타임 안전성 강화

🎯 타입 안전성 개선:
1. **런타임 타입 가드**:
   - [isValidReadyState(value: number): value is WebSocketReadyState](web_ui/src/types/websocket.ts)
   - 잘못된 readyState 값 사전 차단
   - 타입 narrowing 제공

2. **Exhaustiveness Check 유지**:
   - switch 밖의 `never` 체크가 정확한 위치
   - switch 안에 default를 넣으면 exhaustiveness 무력화됨
   - 현재 구현이 TypeScript 모범 사례

3. **유연한 타입**:
   - `WebSocketReadyState | number` 유니온 타입
   - 느슨한 타입 컨텍스트에서도 안전

📝 테스트 가능성 개선:
1. **isNonProductionEnv 파라미터화**:
   - Before: `process.env.NODE_ENV` 직접 참조
   - After: 파라미터로 env 받음 (기본값 유지)
   - 유닛 테스트 작성 가능

2. **export 추가**:
   - 테스트에서 직접 호출 가능
   - 전역 상태 의존성 감소

🛡️ 안전성:
- 컴파일 타임: Exhaustiveness check
- 런타임: Type guard + validation
- 테스트: 파라미터화된 함수

🎯 목적:
- 타입 안전성 최대화
- 테스트 가능성 향상
- 코드 품질 개선

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/285#pullrequestreview-3643803863) - `Type Guard`, `Testability`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

런타임 안정성과 테스트 용이성을 높이기 위해 WebSocket `readyState` 처리 및 WebSocket URL 설정 동작을 개선했습니다.

New Features:
- WebSocket `readyState` 값을 내부 상태로 매핑하기 전에 검증하기 위한 런타임 타입 가드를 추가했습니다.

Enhancements:
- `mapReadyStateToStatus` 입력 타입을 완전성(exhaustiveness) 검사를 유지하면서 `WebSocketReadyState`와 숫자(raw numeric) 값을 모두 허용하도록 완화했습니다.
- 동작과 로깅을 더 명확히 하기 위해 현재 `NODE_ENV` 값을 헬퍼 유틸리티 전반에 명시적으로 전달하는 방식으로 WebSocket URL 환경값 처리 로직을 다듬었습니다.

Tests:
- WebSocket 설정을 위한 환경 체크 헬퍼를 내보낼(exportable) 수 있고, 파라미터를 받을 수 있도록 만들어 직관적인 단위 테스트가 가능하게 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve WebSocket readyState handling and WebSocket URL configuration behavior for better runtime safety and testability.

New Features:
- Add a runtime type guard to validate WebSocket readyState values before mapping them to internal status.

Enhancements:
- Relax the mapReadyStateToStatus input type to accept both WebSocketReadyState and raw numeric values while preserving exhaustiveness checks.
- Refine WebSocket URL environment handling by threading the current NODE_ENV value explicitly through helper utilities for clearer behavior and logging.

Tests:
- Make the environment-checking helper for WebSocket configuration exportable and parameterized to enable straightforward unit testing.

</details>