### PR TITLE
🔧 refactor [#10.9.3]: 7차 개선 - 동기화 보장 및 타입 안전성 강화

### DIFF
--- a/web_ui/src/config/websocket.ts
+++ b/web_ui/src/config/websocket.ts
@@ -50,7 +50,7 @@ const isValidWebSocketUrl = (url: string): boolean => {
  * @param env - 환경 변수 (기본값: process.env.NODE_ENV)
  * @returns 개발 또는 테스트 환경인 경우 true
  */
-export const isNonProductionEnv = (env: string = process.env.NODE_ENV || 'production'): boolean => {
+export const isNonProductionEnv = (env: string | undefined = process.env.NODE_ENV): boolean => {
   return env === 'development' || env === 'test';
 };
 
@@ -100,19 +100,20 @@ export const getWebSocketUrl = (): string => {
     }
     
     // 개발/테스트 환경에서만 localhost 허용
-    const currentEnv = process.env.NODE_ENV || 'production';
+    const currentEnv = process.env.NODE_ENV;
     if (isNonProductionEnv(currentEnv)) {
       // nosemgrep: javascript.lang.security.detect-insecure-websocket
       // 개발/테스트 환경 전용: 로컬 개발 서버 연결
       const devFallback = 'ws://localhost:8000/ws';
-      logger.debug(`Using ${currentEnv} SSR fallback URL:`, devFallback);
+      logger.debug(`Using ${currentEnv || 'unknown'} SSR fallback URL:`, devFallback);
       return devFallback;
     }
     
     // 프로덕션/스테이징 SSR에서 폴백 URL이 없으면 오류
-    logger.error(`NEXT_PUBLIC_WS_FALLBACK_URL not set in ${currentEnv} SSR environment`);
+    const envName = currentEnv || 'unknown';
+    logger.error(`NEXT_PUBLIC_WS_FALLBACK_URL not set in ${envName} SSR environment`);
     throw new Error(
-      `WebSocket URL configuration required for ${currentEnv} SSR. ` +
+      `WebSocket URL configuration required for ${envName} SSR. ` +
       'Please set NEXT_PUBLIC_WS_FALLBACK_URL environment variable.'
     );
   }


### PR DESCRIPTION
🔧 변경 사항:
- **[Sync]**: WS_READY_STATE에서 유효 값 파생
- **[Type Safety]**: 외부 타입 엄격화, 내부 캐스팅
- **[Error Handling]**: Exhaustiveness check 실패 시 예외 throw
- **[Config]**: NODE_ENV 누락 감지 개선
- **[Type Fix]**: VALID_READY_STATES를 Set<number>로 명시

🎯 동기화 보장:
1. **VALID_READY_STATES Set**:
   - `Object.values(WS_READY_STATE)`에서 파생
   - 하드코딩 제거 (0 | 1 | 2 | 3)
   - 새로운 상태 추가 시 자동 반영

2. **단일 진실 공급원**:
   - `WS_READY_STATE`만 수정하면 모든 곳에 반영
   - 유지보수성 향상

🛡️ 타입 안전성:
1. **외부 타입 엄격화**:
   - Before: `WebSocketReadyState | number`
   - After: `WebSocketReadyState`
   - 호출부의 타입 안전성 유지

2. **내부 런타임 검증**:
   - `readyState as number`로 캐스팅
   - `isValidReadyState` 타입 가드
   - 느슨한 타입 컨텍스트에서도 안전

🚨 오류 처리 개선:
1. **Exhaustiveness check**:
   - Before: `return _exhaustiveCheck` (타입 불일치)
   - After: `throw new Error(...)` (명시적 오류)
   - 버그 조기 발견

2. **NODE_ENV 누락 감지**:
   - Before: `'production'` 기본값 (누락 숨김)
   - After: `undefined` 기본값 (누락 명시)
   - 로그에 'unknown' 표시

🎯 목적:
- 동기화 자동 보장
- 타입 안전성 최대화
- 설정 오류 조기 발견
- 코드 품질 향상
- 런타임 동작 변경 없음

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/286#pullrequestreview-3643834236) - `Sync`, `Type Safety`, `Error Handling`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

더 나은 동기화, 타입 안정성, 그리고 에러 가시성을 위해 WebSocket `readyState` 처리와 환경 기반 WebSocket 설정을 개선합니다.

버그 수정:
- 잘못된 WebSocket `readyState` 매핑이 더 이상 조용히 빠져나가지 않고, 명시적인 런타임 에러로 드러나도록 보장합니다.
- `NODE_ENV` 값이 누락된 경우 조용히 production으로 기본값을 사용하는 대신, 로그와 에러 메시지에 명확히 드러나도록 합니다.

개선 사항:
- 런타임 체크가 자동으로 동기화되도록 유효한 WebSocket `readyState` 값을 `WS_READY_STATE`에서 파생합니다.
- 내부 타입 가드를 통한 런타임 검증은 유지하면서, `mapReadyStateToStatus`의 파라미터 타입을 `WebSocketReadyState`로 더 엄격하게 지정합니다.
- 알 수 없는 환경에 대해서는 명시적으로 라벨링하여 SSR WebSocket 폴백 URL 해석 관련 로깅을 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine WebSocket readyState handling and environment-based WebSocket configuration for better sync, type safety, and error visibility.

Bug Fixes:
- Ensure invalid WebSocket readyState mappings now surface as explicit runtime errors instead of silent exhaustiveness fallthrough.
- Make missing NODE_ENV values visible in logs and error messages instead of defaulting silently to production.

Enhancements:
- Derive valid WebSocket readyState values from WS_READY_STATE to keep runtime checks automatically in sync.
- Tighten mapReadyStateToStatus parameter typing to WebSocketReadyState while preserving runtime validation via an internal type guard.
- Improve logging around SSR WebSocket fallback URL resolution by explicitly labeling unknown environments.

</details>