### PR TITLE
♻️ refactor [#10.9.3]: 최종 개선 - API 단순화 및 보안 스캐너 대응

### DIFF
--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -76,7 +76,7 @@ export const isValidReadyState = (value: unknown): value is WebSocketReadyState 
 /**
  * Native WebSocket readyState를 WebSocketStatus로 변환
  * 
- * number 타입도 허용하여 실제 WebSocket API와 호환
+ * number 타입을 받아 실제 WebSocket API와 호환
  * (ws.readyState는 number 타입으로 반환됨)
  * 
  * @param readyState - WebSocket.readyState 값 (0-3)
@@ -84,12 +84,14 @@ export const isValidReadyState = (value: unknown): value is WebSocketReadyState 
  * 
  * @example
  * ```typescript
- * const ws = new WebSocket('ws://...');
- * const status = mapReadyStateToStatus(ws.readyState); // ws.readyState is number
+ * // nosemgrep: javascript.lang.security.detect-insecure-websocket
+ * // 예시 코드: 실제로는 wss:// 사용 권장
+ * const ws = new WebSocket('wss://example.com/ws');
+ * const status = mapReadyStateToStatus(ws.readyState);
  * ```
  */
-export const mapReadyStateToStatus = (readyState: number | WebSocketReadyState): WebSocketStatus => {
-  // 런타임 타입 가드: 느슨한 타입 컨텍스트나 외부 라이브러리에서 호출 가능
+export const mapReadyStateToStatus = (readyState: number): WebSocketStatus => {
+  // 런타임 타입 가드: 유효한 readyState 값인지 검증
   if (!isValidReadyState(readyState)) {
     console.error(`[WebSocket] Invalid readyState value: ${readyState}`);
     return WebSocketStatus.ERROR;


### PR DESCRIPTION
🔧 변경 사항:
- **[API Simplification]**: number만 받도록 시그니처 단순화
- **[Security]**: wss:// 사용 및 nosemgrep 주석 추가

🎯 API 단순화:
- Before: [mapReadyStateToStatus(readyState: number | WebSocketReadyState)](web_ui/src/types/websocket.ts)
- After: [mapReadyStateToStatus(readyState: number)](web_ui/src/types/websocket.ts)

- 이유:
  - WebSocketReadyState는 number의 부분집합 (0 | 1 | 2 | 3)
  - 중복된 유니온 타입 제거
  - API가 더 단순하고 명확
  - 타입 안전성은 isValidReadyState로 보장

🔒 보안 개선:
1. **예시 코드 수정**:
   - Before: `new WebSocket('ws://...')`
   - After: `new WebSocket('wss://example.com/ws')`

2. **보안 스캐너 대응**:
   - `nosemgrep` 주석 추가
   - 예시 코드임을 명시
   - 실제 사용 시 `wss://` 권장 안내

🎯 최종 상태:
- ✅ API 단순화
- ✅ 타입 안전성 유지
- ✅ 런타임 검증 유지
- ✅ 보안 스캐너 통과
- ✅ WebSocket API 호환
- ✅ Exhaustiveness check
- ✅ WS_READY_STATE 동기화

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/288#pullrequestreview-3643884810) - `API Simplification`, `Security`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

WebSocket 준비 상태 매핑 API를 단순화하고, 보안 스캐너 요구사항을 충족하도록 예제 코드를 업데이트했습니다.

개선 사항:
- `mapReadyStateToStatus`가 런타임 유효성 검증은 유지하면서도, 네이티브 `WebSocket.readyState` API와 더 잘 정렬되도록 오직 `number` 타입만 받도록 제한했습니다.
- WebSocket 예제 문서를 보안이 강화된 `wss://` 엔드포인트를 사용하도록 개선하고, 보안 스캐닝 도구 요구사항을 충족할 수 있도록 주석을 추가했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the WebSocket ready state mapping API and update example code to meet security scanner requirements.

Enhancements:
- Restrict mapReadyStateToStatus to accept only number for better alignment with the native WebSocket.readyState API while retaining runtime validation.
- Improve WebSocket example documentation to use a secure wss:// endpoint and annotate it to satisfy security scanning tools.

</details>