### PR TITLE
✨ feat [#10.9.5]: WebSocket 이벤트 타입 정의 및 SyncMonitor 실시간 연동

### DIFF
--- a/web_ui/src/components/dashboard/sync-monitor.tsx
+++ b/web_ui/src/components/dashboard/sync-monitor.tsx
@@ -2,8 +2,10 @@
 
 "use client"
 
-import React, { useState } from 'react';
-import { useVisibilityPolling } from '@/hooks/use-visibility-polling';
+import React, { useState, useEffect } from 'react';
+import { useWebSocket } from '@/hooks/useWebSocket';
+import { getWebSocketUrl } from '@/config/websocket';
+import { WebSocketEvent } from '@/types/websocket';
 import { API_BASE, fetchAPI } from '@/lib/api';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -41,7 +43,7 @@ interface Conflict {
   remote_hash: string;
 }
 
-const POLLING_INTERVAL = 5000;
+
 
 export function SyncMonitor() {
   const [syncStatus, setSyncStatus] = useState<SyncStatus | null>(null);
@@ -80,8 +82,38 @@ export function SyncMonitor() {
     }
   };
 
-  // Optimized polling with visibility check
-  useVisibilityPolling(fetchData, POLLING_INTERVAL);
+  // WebSocket Integration
+  const { isConnected, lastMessage } = useWebSocket(getWebSocketUrl(), {
+    autoConnect: true,
+    reconnect: true,
+  });
+
+  // Initial fetch
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  // Handle WebSocket events
+  useEffect(() => {
+    if (!lastMessage) return;
+
+    // Type assertion to treat message as WebSocketEvent Discriminated Union
+    const event = lastMessage as unknown as WebSocketEvent;
+
+    switch (event.type) {
+      case 'sync_status_changed':
+        console.log('[SyncMonitor] Sync status changed, refreshing data...');
+        fetchData();
+        break;
+      case 'conflict_detected':
+        console.log('[SyncMonitor] Conflict detected, refreshing list...');
+        fetchData();
+        toast.warning('New conflict detected!', {
+          description: `Conflict ID: ${event.data.id}`
+        });
+        break;
+    }
+  }, [lastMessage]);
 
   const handleResolveClick = (conflict: Conflict) => {
     // In a real scenario, we would fetch the actual file content diff here.
@@ -126,7 +158,19 @@ export function SyncMonitor() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h2 className="text-3xl font-bold tracking-tight">Sync Monitor</h2>
+        <div className="flex items-center gap-4">
+          <h2 className="text-3xl font-bold tracking-tight">Sync Monitor</h2>
+          {isConnected ? (
+            <Badge variant="outline" className="text-green-600 border-green-200 bg-green-50">
+              <div className="w-2 h-2 rounded-full bg-green-500 mr-2 animate-pulse" />
+              Live
+            </Badge>
+          ) : (
+            <Badge variant="outline" className="text-gray-500">
+              Connecting...
+            </Badge>
+          )}
+        </div>
         <Button onClick={fetchData} variant="outline" size="sm">
           <RefreshCw className="mr-2 h-4 w-4" /> Refresh
         </Button>

--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -116,3 +116,73 @@ export const mapReadyStateToStatus = (readyState: number): WebSocketStatus => {
   // 런타임 안전성: 이 지점에 도달하는 것은 버그이므로 명시적으로 예외를 던진다
   throw new Error(`Unexpected WebSocket readyState: ${_exhaustiveCheck}`);
 };
+
+/**
+ * 파일 분류 결과 데이터 타입
+ */
+export interface FileClassification {
+  id: string;
+  fileName: string;
+  category: string;
+  confidence: number;
+  processedAt: string;
+}
+
+/**
+ * 동기화 상태 데이터 타입
+ */
+export interface SyncStatus {
+  isSyncing: boolean;
+  lastSyncedAt: string | null;
+  error: string | null;
+  pendingChanges: number;
+}
+
+/**
+ * 충돌 정보 데이터 타입
+ */
+export interface Conflict {
+  id: string;
+  fileId: string;
+  baseVersion: string;
+  remoteVersion: string;
+  localVersion: string;
+  timestamp: string;
+}
+
+/**
+ * 그래프 노드 데이터 타입
+ */
+export interface GraphNode {
+  id: string;
+  label: string;
+  type: 'project' | 'area' | 'resource' | 'archive' | 'note';
+  val: number; // 크기
+}
+
+/**
+ * 그래프 엣지 데이터 타입
+ */
+export interface GraphEdge {
+  source: string;
+  target: string;
+  value: number; // 가중치
+}
+
+/**
+ * 그래프 전체 데이터 타입
+ */
+export interface GraphData {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+/**
+ * WebSocket 이벤트 타입 정의 (Discriminated Union)
+ * 서버에서 전송되는 메시지의 구조를 정의합니다.
+ */
+export type WebSocketEvent = 
+  | { type: 'file_classified'; data: FileClassification }
+  | { type: 'sync_status_changed'; data: SyncStatus }
+  | { type: 'conflict_detected'; data: Conflict }
+  | { type: 'graph_updated'; data: GraphData };


### PR DESCRIPTION
✨ 기능 추가:
  - **[Type]**: WebSocketEvent 및 하위 인터페이스 정의 (FileClassification, SyncStatus, Conflict, GraphData)
  - **[UI]**: SyncMonitor에 WebSocket 연동 및 연결 상태(Live badge) 표시
  - **[Logic]**: 기존 Polling 방식을 제거하고 WebSocket 이벤트 기반 Revalidation 로직 적용

🔧 변경 사항:
  - `SyncMonitor`: useVisibilityPolling → useWebSocket 교체
  - `WebSocketEvent`: Discriminated Union 타입으로 타입 안전성 확보

🎯 목적:
  - 실시간 데이터 동기화 기반 마련 (Phase 1 목표 달성)
  - 사용자 경험 개선 (실시간 연결 상태 인지)

📌 Related:
  - Issue [#273]
  - WebSocket Integration

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

SyncMonitor의 폴링 기반 데이터 새로고침을 WebSocket 기반 업데이트로 대체하고, 동기화 관련 데이터에 대해 타입이 지정된 WebSocket 이벤트를 노출합니다.

새 기능:
- 파일 분류, 동기화 상태, 충돌, 그래프 데이터에 대해 강하게 타입이 지정된 `WebSocketEvent` 유니온과 관련 데이터 모델을 정의합니다.
- SyncMonitor에 WebSocket 연결을 통합하여 실시간 새로고침을 트리거하고, UI의 배지를 통해 실시간 연결 상태를 표시합니다.

개선 사항:
- WebSocket 메시지로 트리거되는 이벤트 기반 재검증을 사용하도록 SyncMonitor에서 가시성 기반 폴링을 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace SyncMonitor’s polling-based data refresh with WebSocket-driven updates and expose typed WebSocket events for sync-related data.

New Features:
- Define strongly typed WebSocketEvent union and related data models for file classification, sync status, conflicts, and graph data.
- Integrate WebSocket connectivity into SyncMonitor to trigger real-time refreshes and show live connection status with a badge in the UI.

Enhancements:
- Remove visibility-based polling from SyncMonitor in favor of event-driven revalidation triggered by WebSocket messages.

</details>