### PR TITLE
♻️ refactor [#10.9.5]: 1차 개선 - WebSocket 타입 안전성 및 명명 규칙

### DIFF
--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -139,9 +139,10 @@ export interface SyncStatus {
 }
 
 /**
- * 충돌 정보 데이터 타입
+ * 충돌 정보 데이터 타입 (WebSocket Payload)
+ * REST API의 Conflict 타입과 구분을 위해 WsConflict로 명명
  */
-export interface Conflict {
+export interface WsConflict {
   id: string;
   fileId: string;
   baseVersion: string;
@@ -184,5 +185,30 @@ export interface GraphData {
 export type WebSocketEvent = 
   | { type: 'file_classified'; data: FileClassification }
   | { type: 'sync_status_changed'; data: SyncStatus }
-  | { type: 'conflict_detected'; data: Conflict }
+  | { type: 'conflict_detected'; data: WsConflict }
   | { type: 'graph_updated'; data: GraphData };
+
+/**
+ * WebSocket 이벤트 타입 가드
+ * 런타임에 메시지가 유효한 WebSocketEvent 구조인지 검증합니다.
+ */
+export const isWebSocketEvent = (message: unknown): message is WebSocketEvent => {
+  if (!message || typeof message !== 'object') {
+    return false;
+  }
+
+  const candidate = message as { type?: unknown; data?: unknown };
+
+  if (typeof candidate.type !== 'string' || !('data' in candidate)) {
+    return false;
+  }
+
+  const validTypes = [
+    'file_classified',
+    'sync_status_changed',
+    'conflict_detected',
+    'graph_updated'
+  ];
+
+  return validTypes.includes(candidate.type);
+};


### PR DESCRIPTION
🔧 변경 사항:
- **[Type Safety]**: isWebSocketEvent 타입 가드 도입 (as 단언 제거)
- **[Rename]**: WebSocket Conflict 타입을 WsConflict로 변경 (REST API 타입과 구분)
- **[Robustness]**: SyncMonitor switch문에 default 케이스 추가

🎯 목적:
- 런타임 크래시 방지 및 타입 혼동 제거
- 코드 리뷰 피드백 반영 (안전성 강화)"

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/293#pullrequestreview-3647594519)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

대시보드 동기화 모니터와 공용 타입에서 WebSocket 이벤트 처리의 안전성을 강화하고 네이밍 일관성을 개선합니다.

새 기능:
- WebSocket 이벤트에 대한 런타임 타입 가드를 도입하여, 처리 전에 들어오는 메시지를 검증합니다.

개선 사항:
- WebSocket 충돌 페이로드 타입의 이름을 REST API의 `Conflict` 타입과 명확히 구분하기 위해 `WsConflict`로 변경합니다.
- SyncMonitor 컴포넌트에 인식되지 않는 WebSocket 이벤트에 대한 기본 핸들러를 추가하여 이벤트 처리의 견고성을 높입니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen WebSocket event handling safety and naming consistency in the dashboard sync monitor and shared types.

New Features:
- Introduce a runtime type guard for WebSocket events to validate incoming messages before handling them.

Enhancements:
- Rename the WebSocket conflict payload type to WsConflict to clearly distinguish it from the REST API Conflict type.
- Add a default handler for unrecognized WebSocket events in the SyncMonitor component to make event processing more robust.

</details>