### PR TITLE
♻️ refactor [#10.9.5]: 2차 개선 - WebSocket 타입 시스템 및 핸들링 강화

### DIFF
--- a/web_ui/src/components/dashboard/sync-monitor.tsx
+++ b/web_ui/src/components/dashboard/sync-monitor.tsx
@@ -118,9 +118,14 @@ export function SyncMonitor() {
           description: `Conflict ID: ${event.data.id}`
         });
         break;
+      case 'file_classified':
+      case 'graph_updated':
+        // 이 컴포넌트에서는 모니터링하지 않는 이벤트
+        break;
       default:
-        // 미래에 추가될 수 있는 이벤트 타입에 대한 방어 로직
-        console.debug('[SyncMonitor] Unhandled WebSocket event:', event.type);
+        // Exhaustiveness Check: 모든 케이스가 처리되지 않으면 여기서 컴파일 에러 발생
+        const _exhaustiveCheck: never = event;
+        console.debug('[SyncMonitor] Unhandled WebSocket event:', JSON.stringify(_exhaustiveCheck));
         break;
     }
   }, [lastMessage]);

--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -179,6 +179,23 @@ export interface GraphData {
 }
 
 /**
+ * 유효한 WebSocket 이벤트 타입 목록
+ * 타입 가드 등에서 런타임 검증에 사용됩니다.
+ * 새로운 이벤트 타입을 추가할 때는 이 리스트에도 반드시 추가해야 합니다.
+ */
+export const WEBSOCKET_EVENT_TYPES = [
+  'file_classified',
+  'sync_status_changed',
+  'conflict_detected',
+  'graph_updated',
+] as const;
+
+/**
+ * WebSocket 이벤트 타입 문자열
+ */
+export type WebSocketEventType = typeof WEBSOCKET_EVENT_TYPES[number];
+
+/**
  * WebSocket 이벤트 타입 정의 (Discriminated Union)
  * 서버에서 전송되는 메시지의 구조를 정의합니다.
  */
@@ -203,12 +220,12 @@ export const isWebSocketEvent = (message: unknown): message is WebSocketEvent =>
     return false;
   }
 
-  const validTypes = [
-    'file_classified',
-    'sync_status_changed',
-    'conflict_detected',
-    'graph_updated'
-  ];
+  if (typeof candidate.type !== 'string' || !('data' in candidate)) {
+    return false;
+  }
 
-  return validTypes.includes(candidate.type);
+  // WEBSOCKET_EVENT_TYPES에 포함된 타입인지 확인
+  // 주의: data 필드의 구체적인 내부 구조(속성 존재 여부 등)까지는 검증하지 않습니다.
+  // 단순히 type이 유효하고 data 속성이 존재하는지만 확인합니다.
+  return WEBSOCKET_EVENT_TYPES.includes(candidate.type as WebSocketEventType);
 };


### PR DESCRIPTION
🔧 변경 사항:
- **[Typed Constant]**: WEBSOCKET_EVENT_TYPES 상수 정의로 Single Source of Truth 확보
- **[Safety]**: SyncMonitor switch문에 Exhaustiveness Check(never type) 적용하여 누락된 이벤트 방지
- **[Validation]**: isWebSocketEvent에서 상수를 참조하도록 수정 및 데이터 검증 한계 주석 추가

🎯 목적:
- 이벤트 타입 추가 시 컴파일 타임에 누락된 핸들러 감지
- 하드코딩 제거 및 유지보수성 향상
- 코드 리뷰 코멘트 완벽 반영

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/294#pullrequestreview-3647596357)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

대시보드 동기화 모니터링을 위해 WebSocket 타입 시스템과 이벤트 처리 로직을 강화합니다.

새로운 기능:
- 유효한 WebSocket 이벤트 타입에 대한 단일 진실 공급원(single source of truth)으로서 중앙 `WEBSOCKET_EVENT_TYPES` 상수와 `WebSocketEventType` 타입 별칭을 도입합니다.

개선 사항:
- `isWebSocketEvent` 타입 가드를 공용 이벤트 타입 상수를 사용하도록 업데이트하고, 더 엄격한 런타임 검증을 수행하며, 해당 검증의 한계를 문서화합니다.
- `SyncMonitor`에서 WebSocket 이벤트를 빠짐없이(exhaustive) 처리하도록 강제하고, 관련 없는 이벤트는 명시적으로 무시하며, 향후 이벤트가 추가될 경우를 대비해 컴파일 타임 exhaustiveness 체크를 사용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen the WebSocket type system and event handling for dashboard sync monitoring.

New Features:
- Introduce a central WEBSOCKET_EVENT_TYPES constant and WebSocketEventType type alias as the single source of truth for valid WebSocket event types.

Enhancements:
- Update the isWebSocketEvent type guard to use the shared event type constant, perform stricter runtime validation, and document its validation limits.
- Enforce exhaustive handling of WebSocket events in SyncMonitor, explicitly ignoring non-relevant events and using a compile-time exhaustiveness check for future additions.

</details>