### PR TITLE
♻️ refactor [#10.9.5]: 3차 개선 - WebSocket 이벤트 상수화 및 Exhaustiveness Check 최적화

### DIFF
--- a/web_ui/src/components/dashboard/sync-monitor.tsx
+++ b/web_ui/src/components/dashboard/sync-monitor.tsx
@@ -123,9 +123,11 @@ export function SyncMonitor() {
         // 이 컴포넌트에서는 모니터링하지 않는 이벤트
         break;
       default:
-        // Exhaustiveness Check: 모든 케이스가 처리되지 않으면 여기서 컴파일 에러 발생
+        // Exhaustiveness Check (Dead Code in Runtime): 
+        // 모든 케이스가 처리되지 않으면 여기서 컴파일 에러가 발생합니다.
+        // 런타임에는 이 분기에 도달할 수 없습니다 (isWebSocketEvent 가드가 보장).
         const _exhaustiveCheck: never = event;
-        console.debug('[SyncMonitor] Unhandled WebSocket event:', JSON.stringify(_exhaustiveCheck));
+        void _exhaustiveCheck;
         break;
     }
   }, [lastMessage]);

--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -118,6 +118,28 @@ export const mapReadyStateToStatus = (readyState: number): WebSocketStatus => {
 };
 
 /**
+ * WebSocket 이벤트 타입 상수 (Single Source of Truth)
+ * 모든 이벤트 타입은 이 객체를 참조하여 정의해야 합니다.
+ */
+export const WS_EVENT_TYPE = {
+  FILE_CLASSIFIED: 'file_classified',
+  SYNC_STATUS_CHANGED: 'sync_status_changed',
+  CONFLICT_DETECTED: 'conflict_detected',
+  GRAPH_UPDATED: 'graph_updated',
+} as const;
+
+/**
+ * 유효한 WebSocket 이벤트 타입 목록 (Runtime Check용)
+ * WS_EVENT_TYPE 객체에서 자동으로 파생됩니다.
+ */
+export const WEBSOCKET_EVENT_TYPES = Object.values(WS_EVENT_TYPE);
+
+/**
+ * WebSocket 이벤트 타입 문자열
+ */
+export type WebSocketEventType = typeof WS_EVENT_TYPE[keyof typeof WS_EVENT_TYPE];
+
+/**
  * 파일 분류 결과 데이터 타입
  */
 export interface FileClassification {
@@ -179,31 +201,14 @@ export interface GraphData {
 }
 
 /**
- * 유효한 WebSocket 이벤트 타입 목록
- * 타입 가드 등에서 런타임 검증에 사용됩니다.
- * 새로운 이벤트 타입을 추가할 때는 이 리스트에도 반드시 추가해야 합니다.
- */
-export const WEBSOCKET_EVENT_TYPES = [
-  'file_classified',
-  'sync_status_changed',
-  'conflict_detected',
-  'graph_updated',
-] as const;
-
-/**
- * WebSocket 이벤트 타입 문자열
- */
-export type WebSocketEventType = typeof WEBSOCKET_EVENT_TYPES[number];
-
-/**
  * WebSocket 이벤트 타입 정의 (Discriminated Union)
  * 서버에서 전송되는 메시지의 구조를 정의합니다.
  */
 export type WebSocketEvent = 
-  | { type: 'file_classified'; data: FileClassification }
-  | { type: 'sync_status_changed'; data: SyncStatus }
-  | { type: 'conflict_detected'; data: WsConflict }
-  | { type: 'graph_updated'; data: GraphData };
+  | { type: typeof WS_EVENT_TYPE.FILE_CLASSIFIED; data: FileClassification }
+  | { type: typeof WS_EVENT_TYPE.SYNC_STATUS_CHANGED; data: SyncStatus }
+  | { type: typeof WS_EVENT_TYPE.CONFLICT_DETECTED; data: WsConflict }
+  | { type: typeof WS_EVENT_TYPE.GRAPH_UPDATED; data: GraphData };
 
 /**
  * WebSocket 이벤트 타입 가드
@@ -215,10 +220,6 @@ export const isWebSocketEvent = (message: unknown): message is WebSocketEvent =>
   }
 
   const candidate = message as { type?: unknown; data?: unknown };
-
-  if (typeof candidate.type !== 'string' || !('data' in candidate)) {
-    return false;
-  }
 
   if (typeof candidate.type !== 'string' || !('data' in candidate)) {
     return false;


### PR DESCRIPTION
🔧 변경 사항:
- **[Typed Constant]**: WS_EVENT_TYPE 상수 객체 도입으로 Single Source of Truth 확보 (리터럴 중복 제거)
- **[Dead Code Elim]**: SyncMonitor switch문의 default 케이스에서 unreachable 런타임 로깅 제거
- **[Refactor]**: isWebSocketEvent 내 중복 체크 로직 정리 및 상수 사용

🎯 목적:
- 이벤트 타입 관리의 일관성 및 안정성 강화
- 불필요한 런타임 코드 제거로 깔끔한 로직 유지

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/295#pullrequestreview-3647598517)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

WebSocket 이벤트 타입 정의를 중앙집중화하고, SyncMonitor에 대한 완전성(exhaustiveness) 검사 강도를 높입니다.

Enhancements:
- WebSocket 이벤트 식별자의 단일 소스 역할을 하는 타입이 지정된 `WS_EVENT_TYPE` 상수를 도입하고, 이로부터 관련 타입과 런타임 리스트를 유도합니다.
- 중앙집중화된 이벤트 타입 설정을 기반으로 `isWebSocketEvent` 타입 가드를 단순화하면서, 런타임 유효성 검사는 핵심에만 집중하도록 유지합니다.
- 도달 불가능한 런타임 로깅을 제거하고 컴파일 타임 전용 `never` 체크를 사용하여 SyncMonitor의 `switch` 완전성 검사를 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize WebSocket event type definitions and tighten exhaustiveness checking for SyncMonitor.

Enhancements:
- Introduce a typed WS_EVENT_TYPE constant as the single source of truth for WebSocket event identifiers and derive related types and runtime lists from it.
- Simplify the isWebSocketEvent type guard by relying on the centralized event type configuration while keeping runtime validation focused.
- Refine the SyncMonitor switch exhaustiveness check by removing unreachable runtime logging and using a compile-time-only never check.

</details>