### PR TITLE
♻️ refactor [#10.9.5]: 4차 개선 - WebSocket 타입 정의 정교화 및 가드 보완

### DIFF
--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -132,7 +132,12 @@ export const WS_EVENT_TYPE = {
  * 유효한 WebSocket 이벤트 타입 목록 (Runtime Check용)
  * WS_EVENT_TYPE 객체에서 자동으로 파생됩니다.
  */
-export const WEBSOCKET_EVENT_TYPES = Object.values(WS_EVENT_TYPE);
+/**
+ * 유효한 WebSocket 이벤트 타입 목록 (Runtime Check용)
+ * WS_EVENT_TYPE 객체에서 자동으로 파생됩니다.
+ * Literal Type 정보를 유지하기 위해 readonly 타입을 단언합니다.
+ */
+export const WEBSOCKET_EVENT_TYPES = Object.values(WS_EVENT_TYPE) as readonly WebSocketEventType[];
 
 /**
  * WebSocket 이벤트 타입 문자열
@@ -221,7 +226,14 @@ export const isWebSocketEvent = (message: unknown): message is WebSocketEvent =>
 
   const candidate = message as { type?: unknown; data?: unknown };
 
-  if (typeof candidate.type !== 'string' || !('data' in candidate)) {
+  // 1. type 필드가 문자열인지 확인
+  if (typeof candidate.type !== 'string') {
+    return false;
+  }
+
+  // 2. data 필드 존재 여부 확인
+  // 주의: data의 내부 구조(필드 등)는 검증하지 않는 "얕은 검사"입니다.
+  if (!('data' in candidate)) {
     return false;
   }
 


### PR DESCRIPTION
🔧 변경 사항:
- **[Typed Constant]**: WEBSOCKET_EVENT_TYPES에 readonly 타입 단언 추가로 Literal Type 보존
- **[Validation]**: isWebSocketEvent 가드 로직을 분리하여 data 필드 검사를 명확히 하고 주석 보강

🎯 목적:
- 타입 추론 정확도 향상 (Type Widening 방지)
- 런타임 검증 로직의 가독성 및 의도 명확화"

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/296#pullrequestreview-3647600625)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

더 명확한 타입 지정 및 런타임 검사를 위해 WebSocket 이벤트 타입 정의와 검증 가드를 개선합니다.

개선 사항:
- `readonly` 타입 배열 단언을 통해 파생된 WebSocket 이벤트 타입 상수의 리터럴 타입을 유지합니다.
- WebSocket 이벤트 가드 검사를 명확히 분리하여, `type` 필드를 명시적으로 검증하고 `data` 필드의 존재 여부를 얕게 확인하며, 이에 대한 문서화 주석을 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine WebSocket event type definitions and validation guard for clearer typing and runtime checks.

Enhancements:
- Preserve literal types for derived WebSocket event type constants by asserting a readonly typed array.
- Clarify and separate WebSocket event guard checks to explicitly validate the type field and shallowly verify the presence of the data field, with improved documentation comments.

</details>