### PR TITLE
♻️ refactor [#10.9.6]: 6차 개선 - Throttle 로직 캡슐화 및 매직 넘버 제거

### DIFF
--- a/web_ui/src/components/para/GraphView.tsx
+++ b/web_ui/src/components/para/GraphView.tsx
@@ -21,13 +21,11 @@ import { isWebSocketEvent, WS_EVENT_TYPE } from '@/types/websocket';
 import { logger } from '@/lib/logger';
 import { UI_CONFIG } from '@/config/ui';
 import { API_BASE } from '@/lib/api';
+import { getToastThrottleDelay } from '@/lib/ui';
 
-// Review Reflection: Calculate throttle duration outside component to avoid recalculation
-// Ensures robustness by validating nonnegative value with Math.max
-const GRAPH_UPDATE_THROTTLE = Math.max(
-  0,
-  UI_CONFIG.TOAST.THROTTLE_MS.GRAPH_UPDATE ?? UI_CONFIG.TOAST.THROTTLE_MS.DEFAULT ?? 3000
-);
+// Review Reflection: Use centralized helper to calculate throttle duration
+// Encapsulates fallback logic and safety checks
+const GRAPH_UPDATE_THROTTLE = getToastThrottleDelay('GRAPH_UPDATE');
 
 interface GraphData {
   nodes: Node[];

--- a/web_ui/src/config/ui.ts
+++ b/web_ui/src/config/ui.ts
@@ -16,6 +16,7 @@ export const UI_CONFIG = {
       DEFAULT: 2000,
       GRAPH_UPDATE: 3000,
       SYNC_UPDATE: 3000,
+      FALLBACK: 3000,
     },
     
     /** Specific IDs for toasts to prevent stacking (de-duplication) */


### PR DESCRIPTION
🔧 변경 사항:
- **[Helper]**: getToastThrottleDelay 유틸리티 함수 구현으로 throttle 계산 로직 캡슐화
- **[Config]**: UI_CONFIG에 FALLBACK 상수 추가하여 매직 넘버(3000) 대체 및 관리 용이성 확보
- **[Cleaning]**: GraphView 코드를 단순화하고 의존성을 명확히 분리

🎯 목적:
- 코드 재사용성 향상 및 유지보수 포인트 단일화
- 안전한 설정값 처리 로직의 표준화

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/304#pullrequestreview-3647615545)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

토스트 스로틀 지연 시간 계산을 공용 헬퍼로 캡슐화하고, 폴백 타임아웃 설정을 중앙에서 관리하도록 합니다.

Enhancements:
- 인라인으로 작성되어 있던 GraphView 토스트 스로틀 지연 시간 계산을 재사용 가능한 `getToastThrottleDelay` 헬퍼로 교체하여 로직을 표준화합니다.
- 하드코딩된 매직 넘버를 제거하고 설정 관리를 단순화하기 위해 UI_CONFIG 토스트 설정에 `FALLBACK` 타임아웃 상수를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Encapsulate toast throttle delay calculation in a shared helper and centralize the fallback timeout configuration.

Enhancements:
- Replace inline GraphView toast throttle calculation with a reusable getToastThrottleDelay helper to standardize logic.
- Add a FALLBACK timeout constant to UI_CONFIG toast settings to eliminate hard-coded magic numbers and simplify configuration management.

</details>