### PR TITLE
♻️ refactor(test) [#10.9.7]: 2차 개선 - Mock 객체 구조 개선 및 중복 제거

### DIFF
--- a/web_ui/vitest.config.ts
+++ b/web_ui/vitest.config.ts
@@ -1,3 +1,5 @@
+// web_ui/vitest.config.ts
+
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'path'


### PR DESCRIPTION
🔧 변경 사항:
- **[Refactor]**: MockWebSocket 내부의 CloseEvent 생성 로직을 [createMockCloseEvent](web_ui/src/hooks/__tests__/useWebSocket.test.ts) 헬퍼 함수로 추출하여 중복 제거
- **[Clean Code]**: 테스트 더블(Test Double)에서 불필요한 DOM 프로퍼티 제거 및 필요한 필드만 정의하여 가독성 향상
- **[Consistency]**: [simulateClose](web_ui/src/hooks/__tests__/useWebSocket.test.ts)와 [close](web_ui/src/hooks/__tests__/useWebSocket.test.ts) 메서드 간의 이벤트 생성 동작 통일

🎯 목적: 테스트 코드의 유지보수성 향상 및 잠재적 버그 예방

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/309#pullrequestreview-3649794451)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

WebSocket 테스트 더블에서 공통 close 이벤트 팩토리를 사용하도록 리팩터링하고, 목 이벤트 데이터를 간소화합니다.

Enhancements:
- WebSocket 테스트용 `CloseEvent` 생성을 중앙집중화하기 위해 재사용 가능한 `createMockCloseEvent` 헬퍼를 도입합니다.
- 일관된 close 이벤트 구조를 사용하도록 목 WebSocket의 `close` 및 `simulateClose` 동작을 정렬(통일)합니다.

Tests:
- 가독성과 유지보수성을 향상시키기 위해 `useWebSocket` 테스트에서 `CloseEvent` 목 속성을 단순화하고 최소화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor WebSocket test doubles to use a shared close-event factory and streamline mock event data.

Enhancements:
- Introduce a reusable createMockCloseEvent helper to centralize CloseEvent construction for WebSocket tests.
- Align mock WebSocket close and simulateClose behaviors to use a consistent close-event shape.

Tests:
- Simplify and minimize CloseEvent mock properties in useWebSocket tests to improve readability and maintainability.

</details>