### PR TITLE
✨ feat(backend) [#10.9.11]: WebSocket JWT 인증 준비 (Scaffolding)

### DIFF
--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -1,0 +1,37 @@
+# backend/api/deps.py
+
+from typing import Optional, Dict, Any
+from fastapi import Depends, HTTPException, status, WebSocket, Query
+from fastapi.security import OAuth2PasswordBearer
+
+# OAuth2 스키마 정의 (스캐폴딩)
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+def get_current_user(token: str = Depends(oauth2_scheme)) -> Dict[str, Any]:
+    """
+    HTTP 요청에 대한 JWT 인증 의존성 함수입니다.
+    현재는 스캐폴딩 단계로, 실제 검증 로직은 추후 구현됩니다.
+    """
+    # TODO: [Phase 2] Implement JWT decoding
+    # TODO: [Phase 2] Validate token and fetch user from DB
+
+    # Mock return for development
+    return {"username": "dev_user", "id": 1, "role": "admin"}
+
+
+async def get_current_user_ws(
+    websocket: WebSocket, token: Optional[str] = Query(None)
+) -> Dict[str, Any]:
+    """
+    WebSocket 연결을 위한 인증 의존성 함수입니다.
+    쿼리 파라미터 `token`을 통해 인증을 수행합니다.
+    """
+    if token is None:
+        # TODO: [Phase 2] Decide whether to reject connection or allow anonymous with restrictions
+        # await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        pass
+
+    # TODO: [Phase 2] Verify token logic similar to get_current_user
+
+    return {"username": "ws_user", "id": 1, "role": "user"}

--- a/backend/api/endpoints/websocket.py
+++ b/backend/api/endpoints/websocket.py
@@ -1,0 +1,38 @@
+# backend/api/endpoints/websocket.py
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Depends
+from backend.api import deps
+import logging
+
+# 로거 설정
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.websocket("/ws")
+async def websocket_endpoint(
+    websocket: WebSocket, current_user: dict = Depends(deps.get_current_user_ws)
+):
+    """
+    WebSocket 연결 엔드포인트
+
+    쿼리 파라미터 `token`을 통해 JWT 인증을 수행하며,
+    인증된 사용자만 연결이 허용됩니다.
+
+    Note: 현재는 Phase 1 구현 준비 단계로 기본 Echo 로직만 포함되어 있습니다.
+    추후 ConnectionManager 및 Redis Pub/Sub 연동이 필요합니다.
+    """
+    # 인증 성공 시 연결 수락
+    await websocket.accept()
+    logger.info(
+        f"WebSocket Client Connected: UserID={current_user.get('id')}, Username={current_user.get('username')}"
+    )
+
+    try:
+        while True:
+            data = await websocket.receive_text()
+            # TODO: Handle messages (e.g., subscription requests)
+            await websocket.send_text(f"Message received: {data}")
+    except WebSocketDisconnect:
+        logger.info(f"WebSocket Client Disconnected: UserID={current_user.get('id')}")


### PR DESCRIPTION
🔧 변경 사항:
- **[Auth]**: `backend/api/deps.py`에 JWT 토큰 검증 및 사용자 식별을 위한 의존성 함수(`get_current_user_ws`) 스캐폴딩 추가
- **[WebSocket]**: `backend/api/endpoints/websocket.py`에 인증 의존성이 주입된 WebSocket 엔드포인트 스텁 생성

🎯 목적:
- Phase 2 보안 강화를 위한 백엔드 인증 기반 마련 및 WebSocket 연결 시 사용자 식별 구조 확립
- WebSocket Security

📌 Related:
- Issue [#273]

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

백엔드 API의 WebSocket 연결 및 HTTP 요청에서 JWT 기반 인증을 지원하기 위한 초기 스캐폴딩을 도입합니다.

새로운 기능:
- JWT 기반 의존성을 통해 인증된 연결을 허용하고, 현재는 기본적인 에코 동작을 구현하는 WebSocket 엔드포인트를 추가했습니다.
- 개발 중에는 모의 사용자 데이터를 반환하도록, HTTP 라우트와 WebSocket 연결 모두에서 사용할 JWT 인증 의존성에 대한 스캐폴딩을 추가했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce initial scaffolding for JWT-based authentication support on WebSocket connections and HTTP requests in the backend API.

New Features:
- Add a WebSocket endpoint that accepts authenticated connections via a JWT-based dependency and currently implements a basic echo behavior.
- Add scaffolding for JWT authentication dependencies for both HTTP routes and WebSocket connections, returning mock user data during development.

</details>