### PR TITLE
✨ feat(backend) [#10.9.11]: 1차 개선 - WebSocket JWT 인증 준비 및 보안 강화

### DIFF
--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -1,23 +1,43 @@
 # backend/api/deps.py
 
+import os
 from typing import Optional, Dict, Any
 from fastapi import Depends, HTTPException, status, WebSocket, Query
 from fastapi.security import OAuth2PasswordBearer
 
-# OAuth2 스키마 정의 (스캐폴딩)
+# OAuth2 스키마 정의
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+# [Security] Mock User Definition (Centralized)
+MOCK_USER = {"username": "dev_user", "id": 1, "role": "admin"}
+
+
+def _ensure_dev_environment():
+    """
+    [Security Guard]
+    프로덕션 환경에서 실수로 인증이 우회되는 것을 방지합니다.
+    환경 변수 `ENVIRONMENT`가 'local' 또는 'development'일 때만 통과합니다.
+    """
+    env = os.getenv("ENVIRONMENT", "production")
+    if env not in ["local", "development"]:
+        # 실제 구현이 없는 상태에서 프로덕션 호출 시 명확하게 실패
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="Authentication Logic is not yet implemented for production.",
+        )
 
 
 def get_current_user(token: str = Depends(oauth2_scheme)) -> Dict[str, Any]:
     """
     HTTP 요청에 대한 JWT 인증 의존성 함수입니다.
-    현재는 스캐폴딩 단계로, 실제 검증 로직은 추후 구현됩니다.
     """
-    # TODO: [Phase 2] Implement JWT decoding
-    # TODO: [Phase 2] Validate token and fetch user from DB
+    # 1. Security Check
+    _ensure_dev_environment()
 
-    # Mock return for development
-    return {"username": "dev_user", "id": 1, "role": "admin"}
+    # TODO: [Phase 2] Implement Logic
+    # verify_token(token)
+
+    return MOCK_USER
 
 
 async def get_current_user_ws(
@@ -25,13 +45,26 @@ async def get_current_user_ws(
 ) -> Dict[str, Any]:
     """
     WebSocket 연결을 위한 인증 의존성 함수입니다.
-    쿼리 파라미터 `token`을 통해 인증을 수행합니다.
+    쿼리 파라미터 `token`을 검증합니다.
     """
+    # 1. Missing Token Handling
     if token is None:
-        # TODO: [Phase 2] Decide whether to reject connection or allow anonymous with restrictions
-        # await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
-        pass
+        # 토큰이 없으면 핸드쉐이크 단계에서 즉시 거부 (401 Unauthorized)
+        # 의도치 않은 익명 접근(Anonymous)을 방지합니다.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing authentication token via query parameter",
+        )
 
-    # TODO: [Phase 2] Verify token logic similar to get_current_user
+    # 2. Security Check (Environment)
+    try:
+        _ensure_dev_environment()
+    except HTTPException:
+        # WebSocket 연결 시점의 서버 에러/구현 미비는 1011(Internal Error) 또는 403으로 처리
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Auth not implemented"
+        )
 
-    return {"username": "ws_user", "id": 1, "role": "user"}
+    # TODO: [Phase 2] Verify token logic
+
+    return MOCK_USER


### PR DESCRIPTION
🔧 변경 사항:
- **[Auth]**: `backend/api/deps.py`에 JWT 인증 의존성 함수 추가
  - **Security**: 프로덕션 환경에서의 Mock 인증 우회 방지를 위한 환경 변수 체크 로직(`_ensure_dev_environment`) 적용
  - **Validation**: WebSocket 연결 시 토큰 누락에 대한 명시적 거부(401) 처리
  - **Consistency**: HTTP/WS 간 Mock 사용자 데이터(`MOCK_USER`) 통일
- **[WebSocket]**: `backend/api/endpoints/websocket.py` 엔드포인트에 강화된 인증 의존성 주입

🎯 목적:
- Phase 2 보안 강화를 위한 안전한 인증 기반 마련 및 개발 단계에서의 임시 접근 제어 체계 확립

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/326#pullrequestreview-3661505563) - `Security Guards`, `Mock Consistency`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Sourcery 요약

HTTP 및 WebSocket 흐름에서 보안 JWT 기반 인증을 준비하기 위해, 환경 가드가 포함된 중앙 집중식 모의 인증(mock authentication)을 도입합니다.

새로운 기능:
- 개발 시 인증을 위해 중앙 집중식 `MOCK_USER` 정의를 추가합니다.
- 로컬/개발 환경 외에서는 모의 인증이 사용되지 않도록 환경 가드를 추가합니다.
- WebSocket 연결에 대해 토큰 필수 인증 동작을 명시적으로 도입합니다.

개선사항:
- HTTP와 WebSocket 인증 의존성을 정렬하여 동일한 모의 사용자 데이터와 보안 검사를 공유하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce centralized mock authentication with environment guards to prepare for secure JWT-based auth in both HTTP and WebSocket flows.

New Features:
- Add a centralized MOCK_USER definition for development-time authentication.
- Add an environment guard to prevent mock authentication from being used outside local/development environments.
- Introduce explicit token-required authentication behavior for WebSocket connections.

Enhancements:
- Align HTTP and WebSocket authentication dependencies to share the same mock user data and security checks.

</details>