### PR TITLE
♻️ refactor(backend) [#10.9.11]: 3차 개선 - WebSocket 인증 의존성 개선

### DIFF
--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -2,7 +2,7 @@
 
 import os
 from typing import Optional, Dict, Any
-from fastapi import Depends, HTTPException, status, WebSocket, Query
+from fastapi import Depends, HTTPException, status, WebSocket, Query, WebSocketException
 from fastapi.security import OAuth2PasswordBearer
 
 # OAuth2 스키마 정의
@@ -13,22 +13,21 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 MOCK_ADMIN_USER: Dict[str, Any] = {"username": "dev_admin", "id": 1, "role": "admin"}
 MOCK_REGULAR_USER: Dict[str, Any] = {"username": "dev_user", "id": 2, "role": "user"}
 
-# Backwards compatibility alias
-MOCK_USER = MOCK_ADMIN_USER
+# Note: 'MOCK_USER' alias has been removed to enforce explicit role usage.
 
 
-def _ensure_dev_environment(
-    status_code: int = status.HTTP_501_NOT_IMPLEMENTED,
-    detail: str = "Authentication Logic is not yet implemented for production.",
-) -> None:
+def _ensure_dev_environment(exception_to_raise: Exception) -> None:
     """
     [Security Guard]
     Block mock-based auth outside local/development environments.
+    Accepts a specific exception instance to raise, allowing caller to control
+    whether to fail with HTTPException (for REST) or WebSocketException (for WS).
     """
     # Note: Accessing os.getenv directly as config module doesn't expose ENVIRONMENT yet.
+    # TODO: Route this through backend.config.AppConfig when available.
     env = os.getenv("ENVIRONMENT", "production")
     if env not in ["local", "development"]:
-        raise HTTPException(status_code=status_code, detail=detail)
+        raise exception_to_raise
 
 
 def get_current_user(token: str = Depends(oauth2_scheme)) -> Dict[str, Any]:
@@ -37,7 +36,12 @@ def get_current_user(token: str = Depends(oauth2_scheme)) -> Dict[str, Any]:
     Returns Admin user in dev environment to facilitate system operations.
     """
     # Default behavior: 501 Not Implemented in production
-    _ensure_dev_environment()
+    _ensure_dev_environment(
+        HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="Authentication Logic is not yet implemented for production.",
+        )
+    )
 
     # TODO: [Phase 2] verify_token(token)
 
@@ -52,15 +56,17 @@ async def get_current_user_ws(
     Returns Regular user in dev environment to test standard access controls.
     """
     if token is None:
-        # Strictly reject missing tokens
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Missing authentication token via query parameter",
+        # Strictly reject missing tokens with WebSocket Close Code 1008 (Policy Violation)
+        raise WebSocketException(
+            code=status.WS_1008_POLICY_VIOLATION,
+            reason="Missing authentication token via query parameter",
         )
 
-    # WebSocket handshake failure should be 403 or similar, not 501
+    # Use WebSocketException for environment guard as well
     _ensure_dev_environment(
-        status_code=status.HTTP_403_FORBIDDEN, detail="Auth not implemented"
+        WebSocketException(
+            code=status.WS_1008_POLICY_VIOLATION, reason="Auth not implemented"
+        )
     )
 
     # TODO: [Phase 2] Verify token logic


### PR DESCRIPTION
🔧 변경 사항:
- **[Refactor]**: `_ensure_dev_environment`가 호출 컨텍스트(HTTP/WS)에 맞는 예외 객체를 주입받도록 구조 변경
- **[Fix]**: WebSocket 연결 거부 시 `HTTPException` 대신 `WebSocketException(1008 Policy Violation)`을 사용하여 프로토콜 시맨틱 준수
- **[Cleanup]**: 모호성을 유발하는 `MOCK_USER` 별칭 삭제 및 명시적 역할(`ADMIN`/`REGULAR`) 사용 강제

🎯 목적:
- 올바른 WebSocket 인증 실패 처리 및 개발 환경에서의 역할 기반 테스트 정확성 확보

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/328#pullrequestreview-3661575888) - `WebSocket Semantics`, `Mock Deprecation`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

개발 전용 인증 가드를 정교하게 다듬어 HTTP와 WebSocket 동작을 구분하고, 모의 사용자 역할을 명시적으로 지정하도록 강화합니다.

버그 수정:
- WebSocket 프로토콜 의미에 맞추기 위해 WebSocket 인증 실패 시 `HTTPException` 대신 종료 코드 1008과 함께 `WebSocketException`을 사용합니다.

개선 사항:
- 개발 환경용 가드가 호출자가 제공한 예외를 그대로 받아서 발생시키도록 변경하여, HTTP 및 WebSocket 의존성이 상황에 맞는 오류 타입을 사용할 수 있도록 합니다.
- 개발 코드에서 모의 사용자를 명시적으로 `ADMIN`과 `REGULAR`로만 사용하도록 하기 위해, 범용 `MOCK_USER` 별칭을 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine development-only authentication guards to differentiate HTTP and WebSocket behavior and enforce explicit mock user roles.

Bug Fixes:
- Use WebSocketException with close code 1008 for WebSocket authentication failures instead of HTTPException to align with WebSocket protocol semantics.

Enhancements:
- Change the dev-environment guard to accept and raise caller-provided exceptions so HTTP and WebSocket dependencies can use context-appropriate error types.
- Remove the generic MOCK_USER alias to require explicit use of ADMIN and REGULAR mock users in development code.

</details>