### PR TITLE
♻️ refactor(backend) [#10.9.13]: 2차 개선 - WebSocket 연결 관리 구조 개선

### DIFF
--- a/backend/services/websocket_manager.py
+++ b/backend/services/websocket_manager.py
@@ -1,62 +1,97 @@
 # backend/services/websocket_manager.py
 
-from typing import List, Dict, Any
-from fastapi import WebSocket
+from typing import List, Dict, Any, Optional
+from fastapi import WebSocket, WebSocketDisconnect
+from dataclasses import dataclass
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class UserContext:
+    """Type-safe user context for WebSocket connections"""
+
+    user_id: int
+    username: str
+    role: str
 
 
 class ConnectionManager:
     """
     WebSocket 연결 관리자
     - 활성 연결 목록 관리 및 연결 수명 주기 제어
-    - 사용자 정보 로깅을 통한 관찰 가능성(Observability) 제공
-    - 데드 커넥션(Dead Connection) 자동 정리
+    - 사용자 정보 매핑을 통한 관찰 가능성(Observability) 제공
+    - Concurrency-safe Broadcasting & Dead Connection Pruning
     """
 
     def __init__(self):
-        self.active_connections: List[WebSocket] = []
+        # WebSocket 객체를 Key로, 사용자 정보를 Value로 저장하여 O(1) 접근 및 매핑 유지
+        self.active_connections: Dict[WebSocket, UserContext] = {}
 
     async def connect(self, websocket: WebSocket, user_info: Dict[str, Any]):
-        """클라이언트 연결 수락 및 목록에 추가 (사용자 정보 로깅 포함)"""
+        """클라이언트 연결 수락 및 컨텍스트 저장"""
         await websocket.accept()
-        self.active_connections.append(websocket)
+
+        # Convert dict to typed context
+        context = UserContext(
+            user_id=user_info.get("id", 0),
+            username=user_info.get("username", "unknown"),
+            role=user_info.get("role", "user"),
+        )
+
+        self.active_connections[websocket] = context
         logger.info(
-            f"WebSocket Client Connected: UserID={user_info.get('id')}, "
-            f"Username={user_info.get('username')}. "
+            f"WebSocket Client Connected: {context}. "
             f"Active connections: {len(self.active_connections)}"
         )
 
-    def disconnect(self, websocket: WebSocket):
-        """클라이언트 연결 해제 및 목록에서 제거"""
-        if websocket in self.active_connections:
-            self.active_connections.remove(websocket)
+    async def disconnect(self, websocket: WebSocket):
+        """클라이언트 연결 해제, 목록 제거 및 명시적 소켓 종료"""
+        context = self.active_connections.pop(websocket, None)
+
+        if context:
             logger.info(
-                f"WebSocket Client Removed. Active connections: {len(self.active_connections)}"
+                f"WebSocket Client Removed: {context}. "
+                f"Active connections: {len(self.active_connections)}"
             )
+
+        # Ensure socket is closed explicitly to prevent zombies
+        try:
+            # 1000 Normal Closure
+            await websocket.close(code=1000)
+        except Exception:
+            # Already closed or connection lost
+            pass
 
     async def broadcast(self, message: str):
         """
-        모든 활성 연결에 메시지 전송
-        전송 실패 시 해당 연결을 Dead Connection으로 간주하고 목록에서 제거하여 리소스 누수 방지
+        모든 활성 연결에 메시지 전송 (Concurrency Safe)
         """
         failed_connections: List[WebSocket] = []
 
-        for connection in self.active_connections:
+        # [Critical Fix] Take a snapshot of keys to avoid RuntimeError during concurrent modification
+        active_sockets = list(self.active_connections.keys())
+
+        for connection in active_sockets:
             try:
                 await connection.send_text(message)
             except Exception as e:
-                logger.error(f"Failed to broadcast message to client: {e}")
+                # Enhance error log with user context
+                context = self.active_connections.get(connection)
+                user_id = f"User({context.user_id})" if context else "Unknown"
+                logger.error(f"Failed to broadcast to {user_id}: {e}")
+
                 failed_connections.append(connection)
 
-        # Clean up dead connections
+        # Prune dead connections found during broadcast
         if failed_connections:
             logger.info(
                 f"Pruning {len(failed_connections)} dead connections found during broadcast."
             )
             for dead_ws in failed_connections:
-                self.disconnect(dead_ws)
+                # Reuse disconnect logic for cleanup
+                await self.disconnect(dead_ws)
 
 
 # 싱글톤 인스턴스 생성


### PR DESCRIPTION
🔧 변경 사항:
- **[Concurrency]**: Broadcast 시 `RuntimeError`(dictionary changed size during iteration) 방지를 위해 `active_connections` 스냅샷 순회 적용
- **[Safety]**: `disconnect` 메서드에서 연결 목록 제거뿐만 아니라 명시적 `close()` 호출을 추가하여 좀비 연결 방지
- **[Type Safety]**: `UserContext` Dataclass 도입으로 사용자 정보 매핑 및 로깅의 명확성 확보
- **[API]**: `websocket_endpoint`의 `finally` 블록에서 비동기 `disconnect` 호출을 통해 안전한 리소스 정리 보장

🎯 목적:
- 동시성 문제 해결 및 연결 수명 주기의 완전한 제어

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/333#pullrequestreview-3668499541) - `Concurrency`, `Explicit Close`, `Typed Context`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

동시성 안전성, 타입 인지, 그리고 WebSocket 연결의 명시적 정리를 보장하도록 WebSocket 연결 라이프사이클 관리를 개선했습니다.

New Features:
- 각 WebSocket 연결에 사용자 메타데이터를 연결하기 위해 타입이 지정된 `UserContext` 데이터클래스를 도입했습니다.

Bug Fixes:
- 활성 WebSocket 연결의 스냅샷을 순회하여 브로드캐스팅 중 동시 수정으로 인한 `RuntimeError`가 발생하지 않도록 방지했습니다.
- 브로드캐스트 정리 및 엔드포인트 종료(teardown) 과정 포함, 매니저의 disconnect 로직을 통해 닫힌/죽은 WebSocket 연결이 명시적으로 닫히고 제거되도록 보장했습니다.

Enhancements:
- 활성 연결 추적 방식을 WebSocket 리스트에서 `WebSocket -> UserContext` 매핑으로 변경하여 관측 가능성과 로깅을 개선했습니다.
- 전달 실패 시 사용자 컨텍스트 정보를 포함하도록 브로드캐스트 오류 로깅을 강화했습니다.
- 리소스 관리를 중앙 집중화하기 위해 `websocket_endpoint` 정리가 항상 매니저의 비동기 disconnect에 위임되도록 일관성을 부여했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine WebSocket connection lifecycle management to be concurrency-safe, type-aware, and ensure explicit cleanup of connections.

New Features:
- Introduce a typed UserContext dataclass to associate user metadata with each WebSocket connection.

Bug Fixes:
- Prevent RuntimeError from concurrent modification during broadcasting by iterating over a snapshot of active WebSocket connections.
- Ensure closed or dead WebSocket connections are explicitly closed and removed via the manager's disconnect logic, including during broadcast cleanup and endpoint teardown.

Enhancements:
- Change active connection tracking from a list of WebSockets to a mapping of WebSocket to UserContext to improve observability and logging.
- Enhance broadcast error logging with user context information for failed deliveries.
- Make websocket_endpoint cleanup consistently delegate to the manager's asynchronous disconnect to centralize resource handling.

</details>