### PR TITLE
♻️ refactor(backend) [#10.9.15]: 1차 개선 - Redis Pub/Sub 구조 개선 및 성능 최적화

### DIFF
--- a/backend/services/websocket_manager.py
+++ b/backend/services/websocket_manager.py
@@ -5,7 +5,7 @@ import logging
 from typing import List, Dict, Any, Optional
 from dataclasses import dataclass
 from fastapi import WebSocket, WebSocketDisconnect
-from backend.services.redis_pubsub import redis_client
+from backend.services.redis_pubsub import redis_broadcaster
 
 logger = logging.getLogger(__name__)
 
@@ -22,50 +22,31 @@ class UserContext:
 class ConnectionManager:
     """
     WebSocket 연결 관리자
-    - Redis Pub/Sub 통합으로 멀티 프로세스 브로드캐스트 지원
-    - 활성 연결 목록 관리 및 연결 수명 주기 제어
-    - Concurrency-safe Broadcasting & Dead Connection Pruning
+    - WebSocket 라이프사이클 관리 (Connect/Disconnect)
+    - RedisBroadcaster를 통한 메시지 전파 (Orchestration delegated)
+    - 단순화된 에러 핸들링 및 병렬 정리 구현
     """
 
     def __init__(self):
         self.active_connections: Dict[WebSocket, UserContext] = {}
+        # Channel name is kept simple here; could be moved to config if needed
         self.channel_name = "flownote_sync"
-        self.redis_task: Optional[asyncio.Task] = None
 
     async def initialize(self):
-        """
-        시스템 시작 시 호출: Redis 연결 및 구독 리스너 실행
-        실패 시 로컬 전용 모드로 동작 (Graceful Degradation)
-        """
-        try:
-            await redis_client.connect()
-            # 구독 리스너를 비동기 태스크로 실행
-            self.redis_task = asyncio.create_task(
-                redis_client.subscribe(self.channel_name, self._local_broadcast)
-            )
-            logger.info(
-                f"ConnectionManager initialized. Listening on Redis channel: {self.channel_name}"
-            )
-        except Exception as e:
-            logger.warning(
-                f"Redis initialization failed ({e}). ConnectionManager running in LOCAL broadcast mode."
-            )
+        """시스템 시작 시 호출: Redis 오케스트레이션 시작"""
+        await redis_broadcaster.start(self.channel_name, self._local_broadcast)
 
     async def shutdown(self):
-        """시스템 종료 시 호출: 리소스 정리"""
-        if self.redis_task:
-            self.redis_task.cancel()
-            try:
-                await self.redis_task
-            except asyncio.CancelledError:
-                pass
+        """시스템 종료 시 호출: Redis 정리 및 모든 소켓 병렬 종료"""
+        await redis_broadcaster.stop()
 
-        await redis_client.disconnect()
-
-        # 모든 활성 연결 종료 (Graceful Close)
+        # Parallel shutdown for performance: avoid serial teardown latency
         active_sockets = list(self.active_connections.keys())
-        for ws in active_sockets:
-            await self.disconnect(ws)
+        if active_sockets:
+            # Run disconnects concurrently
+            await asyncio.gather(
+                *(self.disconnect(ws) for ws in active_sockets), return_exceptions=True
+            )
 
     async def connect(self, websocket: WebSocket, user_info: Dict[str, Any]):
         """클라이언트 연결 수락 및 컨텍스트 저장"""
@@ -96,44 +77,30 @@ class ConnectionManager:
         try:
             await websocket.close(code=1000)
         except Exception as exc:
-            logger.debug(
-                "Best-effort WebSocket close failed (possibly already closed or connection lost).",
-                exc_info=exc,
-            )
+            # Minimal log mostly for debug since connection might be already closed
+            logger.debug("WebSocket close skipped/failed", exc_info=exc)
 
     async def _prune_connection(self, websocket: WebSocket) -> None:
-        """[Helper] Dead Connection 안전 제거"""
+        """[Helper] Dead Connection 정리 (간소화됨)"""
         try:
             await self.disconnect(websocket)
-        except (WebSocketDisconnect, RuntimeError) as exc:
-            logger.warning(f"Connection pruning failed (expected network issue): {exc}")
+        except WebSocketDisconnect:
+            # Expected network-level issue; keep log minimal
+            logger.debug("WebSocket already disconnected during pruning.")
         except Exception:
+            # Unexpected programmer errors: Log full traceback
             logger.error(
                 "Error while pruning dead connection (unexpected bug)", exc_info=True
             )
 
     async def broadcast(self, message: str):
-        """
-        메시지 전파 진입점:
-        - Redis 가용 시: Redis Publish -> (Listener) -> _local_broadcast
-        - Redis 불가 시: 직접 _local_broadcast (Fallback)
-        """
-        if redis_client.redis:
-            try:
-                await redis_client.publish(self.channel_name, message)
-            except Exception as e:
-                logger.error(
-                    f"Redis publish failed: {e}. Falling back to local broadcast."
-                )
-                await self._local_broadcast(message)
-        else:
-            await self._local_broadcast(message)
+        """메시지 전파 (Redis 우선, 실패 시 로컬 Fallback 자동 처리)"""
+        await redis_broadcaster.publish_or_fallback(
+            self.channel_name, message, self._local_broadcast
+        )
 
     async def _local_broadcast(self, message: str):
-        """
-        [Internal] 실제 로컬 연결된 클라이언트들에게 메시지 전송
-        (Redis Listener 또는 Local Fallback에 의해 호출됨)
-        """
+        """[Internal] 실제 로컬 연결된 클라이언트들에게 메시지 전송 및 정리"""
         failed_connections: List[WebSocket] = []
         active_sockets = list(self.active_connections.keys())
 
@@ -141,25 +108,22 @@ class ConnectionManager:
             try:
                 await connection.send_text(message)
             except Exception as e:
+                # Log context for better observability
                 context = self.active_connections.get(connection)
-                user_id = f"User({context.user_id})" if context else "Unknown"
-                logger.error(f"Failed to broadcast to {user_id}: {e}")
+                user_str = f"User({context.user_id})" if context else "Unknown"
+                logger.error(f"Failed to broadcast to {user_str}: {e}")
                 failed_connections.append(connection)
 
         if failed_connections:
             logger.info(
-                f"Pruning {len(failed_connections)} dead connections found during broadcast."
+                "Pruning %d dead connections found during broadcast.",
+                len(failed_connections),
             )
-            results = await asyncio.gather(
+            # Parallel pruning using asyncio.gather for performance
+            await asyncio.gather(
                 *(self._prune_connection(dead_ws) for dead_ws in failed_connections),
                 return_exceptions=True,
             )
-
-            systemic_errors = [r for r in results if isinstance(r, BaseException)]
-            if systemic_errors:
-                logger.error(
-                    f"Systemic failures during connection pruning: {len(systemic_errors)} errors detected."
-                )
 
 
 # 싱글톤 인스턴스 생성


### PR DESCRIPTION
🔧 변경 사항:
- **[Architecture]**: `RedisBroadcaster`를 도입하여 [ConnectionManager](backend/services/websocket_manager.py)에서 Redis 오케스트레이션 로직을 분리, 단일 책임 원칙(SRP) 준수
- **[Reliability]**: `RedisPubSub.disconnect` 호출 시 내부 인스턴스 참조를 초기화하여 재연결 시 Stale Connection 문제 방지
- **[Performance]**: [shutdown](backend/services/websocket_manager.py) 시 활성 WebSocket 종료 작업을 병렬(`asyncio.gather`) 처리하여 연결 수에 따른 지연 제거
- **[Code Quality]**: [_local_broadcast](backend/services/websocket_manager.py) 및 [_prune_connection](backend/services/websocket_manager.py) 로직을 간소화하여 가독성 및 유지보수성 향상

🎯 목적:
- 확장성 있는 브로드캐스트 아키텍처 구축 및 대규모 연결 해제 시의 시스템 반응성 확보

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/340#pullrequestreview-3671637028) - `SRP`, `Parallel Shutdown`, `Safe Reference Reset`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

WebSocket 브로드캐스팅을 리팩터링하여 Redis 오케스트레이션을 전담하는 전용 RedisBroadcaster에 위임하고, 종료 성능과 연결 정리(클린업)의 신뢰성을 향상시킵니다.

Bug Fixes:
- 재연결 시 오래된(stale) 연결이 남지 않도록, disconnect 시 내부 Redis 및 PubSub 참조를 초기화합니다.

Enhancements:
- WebSocket 브로드캐스트를 위한 Redis 작업, 발행(publish), 폴백(fallback) 동작을 관리하는 고수준 오케스트레이션 계층인 RedisBroadcaster를 도입합니다.
- ConnectionManager의 책임을 단순화하여 WebSocket 생명주기에 집중하게 하고, 프로세스 간 메시징은 RedisBroadcaster에 의존하도록 합니다.
- 종료 지연 시간을 줄이고 확장성을 높이기 위해 WebSocket disconnection 및 데드 연결 정리(pruning)를 병렬로 실행합니다.
- 더 명확하고 덜 장황한 에러 처리 및 로깅을 통해 로컬 브로드캐스트 및 정리(pruning) 로직을 간소화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor WebSocket broadcasting to delegate Redis orchestration to a dedicated RedisBroadcaster while improving shutdown performance and connection cleanup reliability.

Bug Fixes:
- Reset internal Redis and PubSub references on disconnect to avoid stale connections on reconnect.

Enhancements:
- Introduce a RedisBroadcaster high-level orchestration layer to manage Redis tasks, publishing, and fallback behavior for WebSocket broadcasts.
- Simplify ConnectionManager responsibilities to focus on WebSocket lifecycle while relying on RedisBroadcaster for cross-process messaging.
- Run WebSocket disconnections and dead-connection pruning in parallel to reduce shutdown latency and improve scalability.
- Streamline local broadcast and pruning logic with clearer, less verbose error handling and logging.

</details>