### PR TITLE
♻️ refactor(backend) [#10.9.15]: 2차 개선 - Redis Pub/Sub 안정성 및 캡슐화 강화

### DIFF
--- a/backend/services/websocket_manager.py
+++ b/backend/services/websocket_manager.py
@@ -120,10 +120,18 @@ class ConnectionManager:
                 len(failed_connections),
             )
             # Parallel pruning using asyncio.gather for performance
-            await asyncio.gather(
+            results = await asyncio.gather(
                 *(self._prune_connection(dead_ws) for dead_ws in failed_connections),
                 return_exceptions=True,
             )
+
+            # [Added] Monitor pruning errors for operational visibility
+            errors = [r for r in results if isinstance(r, Exception)]
+            if errors:
+                logger.warning(
+                    f"Errors during connection pruning: {len(errors)} errors occurred. "
+                    f"Sample: {errors[0]}"
+                )
 
 
 # 싱글톤 인스턴스 생성


### PR DESCRIPTION
🔧 변경 사항:
- **[Robustness]**: `RedisBroadcaster.start/stop` 메서드에 멱등성(Idempotency)을 보장하는 Guard Clause 추가로 중복 실행 및 리소스 누수 방지
- **[Refactor]**: Redis Fallback 로직을 `RedisPubSub` 클래스로 이동하여 캡슐화 강화 및 `RedisBroadcaster`의 복잡성 제거
- **[Observability]**: `_local_broadcast` 병렬 수행 시 발생하는 Pruning 에러를 집계하고 로깅하여 운영 가시성 회복

🎯 목적:
- 시스템 생명주기 반복 호출에 대한 안전장치 마련 및 모듈 간 책임 명확화

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/341#pullrequestreview-3671669792) - `Idempotency`, `Encapsulation`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

Redis 기반 브로드캐스팅을 개선하여 로컬 폴백 및 정리(pruning) 작업 동안 더 안전하고, 더 잘 캡슐화되며, 더 잘 관찰(모니터링)될 수 있도록 합니다.

개선 사항:
- RedisPubSub 내부에 Redis publish 폴백 동작을 캡슐화하여 RedisBroadcaster의 복잡성을 줄이고, 에러 처리 로직을 중앙집중화합니다.
- RedisBroadcaster의 시작/종료 라이프사이클 메서드에 멱등(idempotent) 가드를 추가하여 중복 태스크 및 리소스 누수를 방지합니다.
- WebSocket 로컬 브로드캐스트에서 연결 정리(pruning) 오류를 집계 및 로그로 남겨, 연결 정리 과정의 관측 가능성을 향상합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine Redis-based broadcasting to be safer, better encapsulated, and more observable during local fallback and pruning operations.

Enhancements:
- Encapsulate Redis publish fallback behavior inside RedisPubSub, reducing RedisBroadcaster complexity and centralizing error handling.
- Add idempotent guards to RedisBroadcaster start/stop lifecycle methods to prevent duplicate tasks and resource leaks.
- Improve connection pruning observability in WebSocket local broadcasts by aggregating and logging pruning errors.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Redis 기반 브로드캐스팅을 개선하여 로컬 폴백 및 정리(pruning) 작업 동안 더 안전하고, 더 잘 캡슐화되며, 더 잘 관찰(모니터링)될 수 있도록 합니다.

개선 사항:
- RedisPubSub 내부에 Redis publish 폴백 동작을 캡슐화하여 RedisBroadcaster의 복잡성을 줄이고, 에러 처리 로직을 중앙집중화합니다.
- RedisBroadcaster의 시작/종료 라이프사이클 메서드에 멱등(idempotent) 가드를 추가하여 중복 태스크 및 리소스 누수를 방지합니다.
- WebSocket 로컬 브로드캐스트에서 연결 정리(pruning) 오류를 집계 및 로그로 남겨, 연결 정리 과정의 관측 가능성을 향상합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine Redis-based broadcasting to be safer, better encapsulated, and more observable during local fallback and pruning operations.

Enhancements:
- Encapsulate Redis publish fallback behavior inside RedisPubSub, reducing RedisBroadcaster complexity and centralizing error handling.
- Add idempotent guards to RedisBroadcaster start/stop lifecycle methods to prevent duplicate tasks and resource leaks.
- Improve connection pruning observability in WebSocket local broadcasts by aggregating and logging pruning errors.

</details>

</details>