### PR TITLE
♻️ refactor(backend) [#10.9.15]: 3차 개선 - Redis Pub/Sub 안정성 및 모니터링 강화

### DIFF
--- a/backend/services/websocket_manager.py
+++ b/backend/services/websocket_manager.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from collections import Counter
 from typing import List, Dict, Any, Optional
 from dataclasses import dataclass
 from fastapi import WebSocket, WebSocketDisconnect
@@ -125,12 +126,14 @@ class ConnectionManager:
                 return_exceptions=True,
             )
 
-            # [Added] Monitor pruning errors for operational visibility
+            # [Added] Monitor pruning errors with aggregation for actionable insights
             errors = [r for r in results if isinstance(r, Exception)]
             if errors:
+                error_counts = Counter(type(e).__name__ for e in errors)
                 logger.warning(
-                    f"Errors during connection pruning: {len(errors)} errors occurred. "
-                    f"Sample: {errors[0]}"
+                    f"Errors during connection pruning: {len(errors)} total. "
+                    f"Breakdown: {dict(error_counts)}. "
+                    f"First Error: {errors[0]}"
                 )
 
 


### PR DESCRIPTION
🔧 변경 사항:
- **[Robustness]**: `RedisPubSub.publish`가 연결되지 않은 상태에서 호출될 경우 명시적으로 `ConnectionError`를 발생시키도록 수정하여, `publish_with_fallback`의 Fallback 메커니즘이 안정적으로 동작하도록 보장
- **[Observability]**: `_local_broadcast`에서 발생하는 Pruning 에러를 Exception Type별로 집계(`Counter`)하여 로깅, 대량 에러 발생 시 로그 가독성 및 원인 분석 용이성 확보
- **[Lifecycle]**: `RedisBroadcaster.start/stop`의 멱등성 보장 로직 추가

🎯 목적:
- Redis 연결 불안정 시의 동작 예측 가능성 확보 및 운영 로그 품질 향상

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/342#pullrequestreview-3671699996) - `Explicit Failure`, `Aggregated Logging`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

WebSocket 브로드캐스팅을 위한 Redis Pub/Sub의 견고성과 관측 가능성을 개선합니다.

버그 수정:
- Redis 연결이 없을 때 Redis publish가 명시적으로 연결 오류와 함께 실패하도록 하여, publish 폴백 메커니즘이 안정적으로 동작하도록 합니다.

개선사항:
- 메시지를 publish하기 전에 연결 상태를 검증하여 Redis publish의 안전성을 강화합니다.
- WebSocket 연결 문제에 대한 운영 가시성을 높이기 위해 연결 정리(pruning) 오류를 예외 유형별로 집계하고 로깅합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Redis Pub/Sub robustness and observability for WebSocket broadcasting.

Bug Fixes:
- Ensure Redis publish explicitly fails with a connection error when no Redis connection is available, allowing the publish fallback mechanism to reliably trigger.

Enhancements:
- Strengthen Redis publish safety by verifying connection state before publishing messages.
- Aggregate and log connection pruning errors by exception type to improve operational visibility into WebSocket connection issues.

</details>