### PR TITLE
♻️ refactor(backend) [#10.9.15]: 4차 개선 - Redis Pub/Sub 예외 처리 정교화 및 로깅 개선

### DIFF
--- a/backend/services/websocket_manager.py
+++ b/backend/services/websocket_manager.py
@@ -133,7 +133,7 @@ class ConnectionManager:
                 logger.warning(
                     f"Errors during connection pruning: {len(errors)} total. "
                     f"Breakdown: {dict(error_counts)}. "
-                    f"First Error: {errors[0]}"
+                    f"First Error Detail: {repr(errors[0])}"
                 )
 
 


### PR DESCRIPTION
🔧 변경 사항:
- **[Bug Fix]**: `publish_with_fallback`에서 광범위한 `Exception` 포로 인한 잠재적 버그(직렬화/프로그래밍 에러 등) 은폐 방지. 오직 연결/Redis 관련 에러(`ConnectionError`, `RedisError`)만 Fallback으로 처리하도록 범위 축소.
- **[Observability]**: Pruning 에러 로그에 첫 번째 에러의 상세 정보(`repr`)를 포함시켜, 에러 유형뿐만 아니라 구체적인 상태를 즉시 파악할 수 있도록 개선.

🎯 목적:
- 잘못된 에러 핸들링으로 인한 버그 은폐 방지 및 운영 로그의 실질적 가치 향상

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/343#pullrequestreview-3671735333)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

Redis Pub/Sub 오류 처리를 개선하여 연결 관련 실패에 대해서만 로컬 폴백이 트리거되도록 하고, 연결 정리(pruning) 문제에 대한 관측 가능성을 향상했습니다.

Bug Fixes:
- `publish_with_fallback`이 오직 `ConnectionError` 및 `RedisError`만 폴백 대상 실패로 취급하도록 제한하여, 관련 없는 프로그래밍 오류나 직렬화 오류가 숨겨지지 않도록 했습니다.

Enhancements:
- Redis 브로드캐스터의 docstring과 로깅 주석에서 Redis 연결 실패의 의미와 멱등(idempotent)적인 시작 동작을 더 명확히 했습니다.
- WebSocket 연결 정리(pruning) 로그에 첫 번째 정리 오류의 `repr`을 포함하여, 더 상세한 오류 컨텍스트가 드러나도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine Redis Pub/Sub error handling so that only connection-related failures trigger the local fallback and improve observability of connection pruning issues.

Bug Fixes:
- Restrict publish_with_fallback to treat only ConnectionError and RedisError as fallback-eligible failures, preventing unrelated programming or serialization errors from being swallowed.

Enhancements:
- Clarify Redis connection failure semantics and idempotent start behavior in Redis broadcaster docstrings and logging comments.
- Include repr of the first pruning error in WebSocket connection pruning logs to expose more detailed error context.

</details>