### PR TITLE
📝 docs [#10.9.16]: 1차 개선 - 문서 구조 정규화 및 압축 임계값 상세 설명 추가

### DIFF
--- a/docs/P/v6.0_phase1_websocket/README_phase1.md
+++ b/docs/P/v6.0_phase1_websocket/README_phase1.md
@@ -1,6 +1,4 @@
-# 01_18.1.md
-
-## Phase 1: WebSocket 실시간 업데이트
+# Phase 1: WebSocket 실시간 업데이트
 
 ## 📋 Overview
 
@@ -298,7 +296,9 @@ setTimeout(connect, reconnectDelay);
 - [x] Frontend Integration Tests (`SyncMonitor` 컴포넌트 연동 완료)
 - [x] WebSocket 인증 추가 (JWT)
 - [x] Redis Pub/Sub 통합 (분산 서버 지원 완료)
-- [x] 메시지 압축 (gzip) 구현 완료 (1KB 임계값)
+- [x] 메시지 압축 (gzip) 구현 완료
+  - **임계값**: 1KB (`1024 bytes`). 소규모 메시지에 대한 압축 오버헤드와 일반적인 네트워크 MTU를 고려한 설정입니다.
+  - **설정**: `backend/services/compression_service.py`에서 `COMPRESSION_THRESHOLD` 수정 가능
 - [x] 연결 풀 관리 (ConnectionManager 구현 완료)
 - [ ] 모니터링 대시보드 (연결 수, 메시지 처리량)
 


### PR DESCRIPTION
🔧 변경 사항:
- **[Docs]**:
  - `README_phase1.md`의 H1 헤딩을 의미 있는 제목으로 복원
  - gzip 압축 임계값(1KB) 설정 근거 및 커스터마이징 방법 문서화

🎯 목적:
- 문서 내비게이션 일관성 유지 및 기술적 결정 사항에 대한 컨텍스트 제공

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/348#pullrequestreview-3674229521)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

1단계 WebSocket 문서의 제목을 표준화하고 gzip 압축 임계값에 대한 세부 내용을 명확히 합니다.

Documentation:
- 일관된 내비게이션을 위해 1단계 WebSocket README에 의미 있는 H1 제목을 복원합니다.
- gzip 메시지 압축 임계값의 근거와 이를 백엔드 설정에서 커스터마이즈하는 방법을 문서화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize the phase 1 WebSocket docs heading and clarify gzip compression threshold details.

Documentation:
- Restore a meaningful H1 title in the Phase 1 WebSocket README for consistent navigation.
- Document the gzip message compression threshold rationale and how to customize it in the backend configuration.

</details>