### PR TITLE
✨ feat(websocket) [#10.9.19]: 관측성 강화 - 지표 수집 시스템 및 정밀 로깅 구현

### DIFF
--- a/docs/P/v6.0_phase1_websocket/README_phase1.md
+++ b/docs/P/v6.0_phase1_websocket/README_phase1.md
@@ -300,7 +300,8 @@ setTimeout(connect, reconnectDelay);
   - **임계값**: 1KB (`1024 bytes`). 소규모 메시지에 대한 압축 오버헤드와 일반적인 네트워크 MTU를 고려한 설정입니다.
   - **설정**: `backend/services/compression_service.py`에서 `COMPRESSION_THRESHOLD` 수정 가능
 - [x] 연결 풀 관리 (ConnectionManager 구현 완료)
-- [ ] 모니터링 대시보드 (연결 수, 메시지 처리량)
+- [x] 모니터링 및 로깅 강화 (Metrics API & Close Code Tracking 완료)
+- [ ] 대시보드 시각화 (지속 과제: Metrics API 기반 UI 연동)
 
 ## 🔗 Related Documentation
 

--- a/web_ui/src/hooks/useWebSocket.ts
+++ b/web_ui/src/hooks/useWebSocket.ts
@@ -236,10 +236,11 @@ export function useWebSocket<T = unknown>(
         }
       };
 
-      ws.current.onclose = () => {
+      ws.current.onclose = (event) => {
         if (currentSocketId !== socketIdRef.current || !isMounted.current) return;
 
-        logger.info(`[WebSocket:${currentSocketId}] Disconnected`);
+        const { code, reason } = event;
+        logger.info(`[WebSocket:${currentSocketId}] Disconnected (Code: ${code}, Reason: ${reason || 'none'})`);
         setStatus(WebSocketStatus.DISCONNECTED);
         stableOnClose();
 


### PR DESCRIPTION
🔧 변경 사항:
- **[Backend]**: ConnectionManager 내 Metrics 수집 로직(TPS, 트래픽, Peak 연결 등) 추가
- **[Backend]**: 시스템 상태 조회를 위한 'GET /health/metrics' API 엔드포인트 구현
- **[Backend/Frontend]**: WebSocket Close Code(1006, 1001 등) 및 Reason 추적 로깅 강화
- **[Docs]**: 01_19.1.md 작업 완료 반영 및 README 업데이트

🎯 목적:
- 실시간 시스템 부하 모니터링 및 연결 해제 사유 정밀 진단을 통한 운영 안정성 확보

📌 Related:
- Issue [#273]

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

WebSocket 관측 가능성(Observability) 메트릭을 도입하고, 이를 헬스 엔드포인트를 통해 노출하며, 백엔드와 프론트엔드 전반에 걸쳐 close 이벤트 로깅을 강화합니다.

New Features:
- 연결 매니저에서 가동 시간(uptime), 활성 및 최대 동시 연결 수, 메시지 수, 데이터 전송량, TPS 등을 포함한 WebSocket 시스템 메트릭을 추적합니다.
- 현재 WebSocket 상태 및 성능 메트릭을 조회할 수 있도록 GET /health/metrics API를 노출합니다.

Enhancements:
- 더 정확한 로깅과 종료 동작을 위해, 백엔드 매니저를 통해 close 코드와 사유를 전파하여 WebSocket 연결 해제 처리(disconnect handling)를 개선합니다.
- 클라이언트 측 진단 품질을 높이기 위해, 프론트엔드 WebSocket 훅의 로깅을 개선하여 close 코드와 사유를 포함하도록 합니다.
- 메트릭 API 및 close 코드 추적 작업 완료 내용을 반영하도록 WebSocket 단계(phase) 문서를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce WebSocket observability metrics and expose them via a health endpoint while enhancing close-event logging across backend and frontend.

New Features:
- Track WebSocket system metrics including uptime, active and peak connections, message count, data volume, and TPS in the connection manager.
- Expose a GET /health/metrics API to retrieve current WebSocket health and performance metrics.

Enhancements:
- Improve WebSocket disconnect handling by propagating close codes and reasons through the backend manager for more accurate logging and closure behavior.
- Enhance frontend WebSocket hook logging to include close codes and reasons for better client-side diagnostics.
- Update websocket phase documentation to reflect completion of metrics API and close code tracking work.

</details>