### PR TITLE
🚀 fix(websocket) [#10.9.19]: 1차 개선 - 관측성 로직 안정화 및 캡슐화 고도화

### DIFF
--- a/backend/api/endpoints/websocket.py
+++ b/backend/api/endpoints/websocket.py
@@ -24,12 +24,13 @@ async def get_ws_health():
         },
         "performance": {
             "tps": metrics["tps"],
+            "total_broadcasts": metrics["total_broadcasts"],
             "total_messages": metrics["total_messages"],
             "total_data_bytes": metrics["total_bytes"],
             "total_data_mb": round(metrics["total_bytes"] / (1024 * 1024), 2),
         },
         "redis": {
-            "connected": redis_broadcaster._client.is_connected(),
+            "connected": redis_broadcaster.is_connected(),
             "channel": manager.channel_name,
         },
         "uptime_seconds": metrics["uptime_seconds"],

--- a/backend/services/redis_pubsub.py
+++ b/backend/services/redis_pubsub.py
@@ -166,6 +166,13 @@ class RedisBroadcaster:
 
         await self._client.disconnect()
 
+    def is_connected(self) -> bool:
+        """Redis 연결 상태 확인 (Safe wrapper)"""
+        try:
+            return self._client.is_connected()
+        except Exception:
+            return False
+
     async def publish_or_fallback(
         self, channel: str, message: str, fallback: Callable[[str], Awaitable[None]]
     ):


### PR DESCRIPTION
🔧 변경 사항:
- **[Backend]**: Starlette의 'WebSocketState.DISCONNECTED' 상수를 사용한 상태 체크 로직 수정 (매직 넘버 제거)
- **[Backend]**: RedisBroadcaster에 공용 'is_connected()' 메서드 추가 및 내부 필드 접근 캡슐화
- **[Backend]**: Metrics 수집 시 deque의 'maxlen' 설정으로 메모리 누수 방지 및 TPS 집계 정밀도 향상
- **[Backend]**: 브로드캐스트 이벤트와 수신자별 메시지 전송 지표 분리 (데이터 가독성 개선)

🎯 목적:
- 코드 품질 향상 및 운영 환경에서의 메모리 안전성/캡슐화 원칙 준수

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/352#pullrequestreview-3677932176)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

웹소켓 가시성(관측) 메트릭과 연결 처리를 개선하여, 순수 WebSocket 방식과 Redis 기반 브로드캐스팅 방식 모두에서 동작이 개선되었습니다.

Bug Fixes:
- 취약한 WebSocket 종료 상태 체크(매직 넘버 사용)를 `WebSocketState.DISCONNECTED` 상수 사용으로 교체하여, 잘못된 close 처리 문제를 방지합니다.
- Redis 연결 상태 체크를 안전한 `is_connected()` 래퍼 뒤로 감싸, 연결 상태를 확인할 때 발생할 수 있는 오류를 방지합니다.

Enhancements:
- TPS 추적을 위해 길이가 제한된 타임스탬프 데크(deque)를 추가하여, 최근 활동에 대한 정밀도는 유지하면서 메모리 사용량을 제한합니다.
- 브로드캐스트 단위 메트릭과 수신자 단위 메트릭을 분리하여 `total_messages`와 별도로 `total_broadcasts`를 추적하고, 이를 WebSocket 헬스 엔드포인트를 통해 노출합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve websocket observability metrics and connection handling for both WebSocket and Redis-backed broadcasting.

Bug Fixes:
- Replace brittle WebSocket disconnect state check using magic numbers with the WebSocketState.DISCONNECTED constant to avoid incorrect close handling.
- Guard Redis connection status checks behind a safe is_connected() wrapper to prevent errors when probing connection health.

Enhancements:
- Add capped-length timestamp deque for TPS tracking to bound memory usage while maintaining recent-activity precision.
- Split broadcast-level and recipient-level metrics, tracking total_broadcasts separately from total_messages and exposing them via the websocket health endpoint.

</details>