### PR TITLE
🚀 fix(websocket) [#10.9.19]: 2차 개선 - 지표 세분화 및 설정 유연성 강화

### DIFF
--- a/backend/api/endpoints/websocket.py
+++ b/backend/api/endpoints/websocket.py
@@ -23,7 +23,8 @@ async def get_ws_health():
             "peak": metrics["peak_connections"],
         },
         "performance": {
-            "tps": metrics["tps"],
+            "broadcast_tps": metrics["broadcast_tps"],
+            "message_tps": metrics["message_tps"],
             "total_broadcasts": metrics["total_broadcasts"],
             "total_messages": metrics["total_messages"],
             "total_data_bytes": metrics["total_bytes"],

--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -223,6 +223,11 @@ class WebSocketConfig:
     # 1KB 미만인 경우 gzip 헤더 오버헤드로 인해 오히려 크기가 커질 수 있음을 고려한 기본값입니다.
     COMPRESSION_THRESHOLD = int(os.getenv("WS_COMPRESSION_THRESHOLD", 1024))
 
+    # Metrics 관련 설정
+    # TPS 계산용 최대 샘플 수 (기본: 초당 100회 브로드캐스트 * 60초 = 6000)
+    # 메모리 상한 임계치로 사용됩니다.
+    METRICS_MAX_TPS = int(os.getenv("WS_METRICS_MAX_TPS", 100))
+
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━
 # 경로 설정

--- a/backend/services/redis_pubsub.py
+++ b/backend/services/redis_pubsub.py
@@ -170,7 +170,12 @@ class RedisBroadcaster:
         """Redis 연결 상태 확인 (Safe wrapper)"""
         try:
             return self._client.is_connected()
-        except Exception:
+        except Exception as exc:
+            # 예상치 못한 오류(설정/프로그래밍)를 로그로 남겨 관측성을 유지합니다.
+            logger.warning(
+                "Redis is_connected() check failed; treating as disconnected",
+                exc_info=exc,
+            )
             return False
 
     async def publish_or_fallback(


### PR DESCRIPTION
🔧 변경 사항:
- **[Backend]**:
  - TPS 지표를 'broadcast_tps'와 'message_tps'로 분리하여 모니터링 정밀도 향상
  - 'WS_METRICS_MAX_TPS' 설정을 추가하여 하드코딩된 deque 크기 제어 (메모리 관리 유연성)
  - Redis 연결 체크 시 예외 로깅 추가로 장애 진단 투명성 확보
  - Metrics API 응답 스키마 최적화 및 설정 로직 통합

🎯 목적:
- 운영 환경에서의 가시성 극대화 및 환경별 맞춤형 성능 최적화 지원

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/353#pullrequestreview-3677963320)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

WebSocket 성능 메트릭과 설정을 개선하여 보다 세분화된 TPS 인사이트와 설정 가능한 샘플링 한도를 제공합니다.

새로운 기능:
- WebSocket 트래픽 모니터링을 위해 `broadcast_tps`와 `message_tps` 메트릭을 별도로 노출합니다.
- TPS 샘플링 윈도우 크기를 제어하기 위한 설정값 `WS_METRICS_MAX_TPS`를 도입합니다.

개선 사항:
- 메모리 제어 향상을 위해 설정 기반 한도를 준수하도록 WebSocket 메트릭 샘플링 큐를 조정합니다.
- 관측 가능성을 높이기 위해 `is_connected()` 호출 중에 발생하는 예기치 않은 예외를 로깅하여 Redis 연결 상태 점검을 개선합니다.
- 단일 집계 값 대신 새로운 TPS 메트릭을 반환하도록 WebSocket 헬스 API 스키마를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine WebSocket performance metrics and configuration to provide more granular TPS insights and configurable sampling limits.

New Features:
- Expose separate broadcast_tps and message_tps metrics for WebSocket traffic monitoring.
- Introduce a configurable WS_METRICS_MAX_TPS setting to control TPS sampling window sizes.

Enhancements:
- Adjust WebSocket metrics sampling queues to respect configuration-based limits for better memory control.
- Improve Redis connectivity checks by logging unexpected exceptions during is_connected() calls for better observability.
- Update the WebSocket health API schema to return the new TPS metrics instead of a single aggregated value.

</details>