### PR TITLE
🚀 fix(websocket) [#10.9.19]: 3차 개선 - 메트릭 설정 검증 및 윈도우 유연화

### DIFF
--- a/backend/api/endpoints/websocket.py
+++ b/backend/api/endpoints/websocket.py
@@ -23,8 +23,8 @@ async def get_ws_health():
             "peak": metrics["peak_connections"],
         },
         "performance": {
+            "window_seconds": WebSocketConfig.METRICS_WINDOW_SECONDS,
             "broadcast_tps": metrics["broadcast_tps"],
-            "message_tps": metrics["message_tps"],
             "total_broadcasts": metrics["total_broadcasts"],
             "total_messages": metrics["total_messages"],
             "total_data_bytes": metrics["total_bytes"],

--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -224,9 +224,13 @@ class WebSocketConfig:
     COMPRESSION_THRESHOLD = int(os.getenv("WS_COMPRESSION_THRESHOLD", 1024))
 
     # Metrics 관련 설정
-    # TPS 계산용 최대 샘플 수 (기본: 초당 100회 브로드캐스트 * 60초 = 6000)
-    # 메모리 상한 임계치로 사용됩니다.
-    METRICS_MAX_TPS = int(os.getenv("WS_METRICS_MAX_TPS", 100))
+    # TPS 계산용 최대 샘플 수 (기본: 초당 100회 브로드캐스트)
+    # 메모리 상한 임계치(Clamping: 1 ~ 1000)를 적용하여 비정상 설정을 방지합니다.
+    _RAW_MAX_TPS = int(os.getenv("WS_METRICS_MAX_TPS", 100))
+    METRICS_MAX_TPS = max(1, min(_RAW_MAX_TPS, 1000))
+
+    # TPS 계산 시간 윈도우 (기본: 60초)
+    METRICS_WINDOW_SECONDS = int(os.getenv("WS_METRICS_WINDOW_SECONDS", 60))
 
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━


### PR DESCRIPTION
🔧 변경 사항:
- **[Backend]**:
  - 'WS_METRICS_MAX_TPS'에 클램핑(1~1000) 적용으로 비정상 메모리 할당 방지
  - TPS 샘플링 윈도우를 'METRICS_WINDOW_SECONDS' 상수로 분리 및 유연화
  - 지표 계산 로직 내 하드코딩된 시간(60s)을 설정 참조 방식으로 일괄 변경
  - Health API 응답에 'window_seconds' 정보를 추가하여 지표 해석 정밀도 향상

🎯 목적:
- 환경 변수 오설정에 대한 방어 로직 구축 및 다양한 부하 환경 대응 유연성 확보

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/354#pullrequestreview-3677984718)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

WebSocket TPS 메트릭 구성 값을 제한(clamp)하고, TPS 샘플링 윈도우의 기간을 설정 가능하게 만든 뒤 해당 윈도우 값을 health API에서 노출합니다.

New Features:
- `METRICS_WINDOW_SECONDS`를 통해 설정 가능한 TPS 메트릭 시간 윈도우를 추가하고, 이를 WebSocket 메트릭 계산 전반에 사용합니다.
- WebSocket health API 응답에 TPS 메트릭의 `window_seconds` 값을 노출합니다.

Bug Fixes:
- 메트릭 샘플링에 사용하기 전에 `WS_METRICS_MAX_TPS`를 안전한 범위로 조정(clamp)하여 비정상적인 메모리 사용을 방지합니다.

Enhancements:
- WebSocket 메트릭 계산 시 하드코딩된 60초 윈도우 대신 설정값에 의존하도록 로직을 개선했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clamp WebSocket TPS metrics configuration and make TPS sampling window duration configurable, exposing the window value in the health API.

New Features:
- Add configurable TPS metrics time window via METRICS_WINDOW_SECONDS and use it across WebSocket metrics calculations.
- Expose the TPS metrics window_seconds value in the WebSocket health API response.

Bug Fixes:
- Prevent abnormal memory usage by clamping WS_METRICS_MAX_TPS to a safe range before using it for metrics sampling.

Enhancements:
- Refine WebSocket metrics calculations to rely on configuration instead of hardcoded 60-second windows.

</details>