### PR TITLE
🚀 fix(websocket) [#10.9.19]: 4차 개선 - 제로 디비전 방어 로직 및 API 하위 호환성 확보

### DIFF
--- a/backend/api/endpoints/websocket.py
+++ b/backend/api/endpoints/websocket.py
@@ -25,6 +25,7 @@ async def get_ws_health():
         "performance": {
             "window_seconds": WebSocketConfig.METRICS_WINDOW_SECONDS,
             "broadcast_tps": metrics["broadcast_tps"],
+            "message_tps": metrics["message_tps"],
             "total_broadcasts": metrics["total_broadcasts"],
             "total_messages": metrics["total_messages"],
             "total_data_bytes": metrics["total_bytes"],

--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -230,7 +230,9 @@ class WebSocketConfig:
     METRICS_MAX_TPS = max(1, min(_RAW_MAX_TPS, 1000))
 
     # TPS 계산 시간 윈도우 (기본: 60초)
-    METRICS_WINDOW_SECONDS = int(os.getenv("WS_METRICS_WINDOW_SECONDS", 60))
+    # ZeroDivisionError 및 메모리 폭증 방지를 위해 최소 1초 ~ 최대 3600초(1시간)로 제한합니다.
+    _RAW_WINDOW = int(os.getenv("WS_METRICS_WINDOW_SECONDS", 60))
+    METRICS_WINDOW_SECONDS = max(1, min(_RAW_WINDOW, 3600))
 
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━


### PR DESCRIPTION
🔧 변경 사항:
- **[Backend]**:
  - 'METRICS_WINDOW_SECONDS'에 Clamping(1s~3600s) 적용으로 ZeroDivisionError 예방
  - Health API 응답에 'message_tps' 지표 복구 (하위 호환성 유지 및 분석 가용성 확보)
  - 설정값 검증 로직 강화를 통한 런타임 안정성 극대화

🎯 목적:
- 잘못된 환경 변수 설정에 의한 시스템 크래시 방지 및 외부 소비자와의 규격 일관성 유지

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/355#pullrequestreview-3678004634)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

WebSocket 메트릭 설정 값을 안전한 범위로 제한하고, 하위 호환성을 위해 전체 헬스 메트릭 출력을 복원합니다.

버그 수정:
- WebSocket 메트릭 윈도우 설정을 1–3600초 범위로 제한하여 `ZeroDivisionError`와 과도한 메모리 사용을 방지합니다.
- 기존 사용자의 하위 호환성을 유지하기 위해 WebSocket 헬스 API 응답에 `message_tps` 메트릭을 다시 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clamp WebSocket metrics configuration to safe bounds and restore full health metrics output for backward compatibility.

Bug Fixes:
- Prevent ZeroDivisionError and excessive memory usage by clamping the WebSocket metrics window configuration to a 1–3600 second range.
- Restore the `message_tps` metric in the WebSocket health API response to maintain backward compatibility with existing consumers.

</details>