### PR TITLE
🚀 fix(websocket) [#10.9.19]: 5차 개선 - 설정 파싱 견고화 및 API 방어적 로직 구현

### DIFF
--- a/backend/api/endpoints/websocket.py
+++ b/backend/api/endpoints/websocket.py
@@ -19,23 +19,23 @@ async def get_ws_health():
     return {
         "status": "healthy",
         "connections": {
-            "active": metrics["active_connections"],
-            "peak": metrics["peak_connections"],
+            "active": metrics.get("active_connections", 0),
+            "peak": metrics.get("peak_connections", 0),
         },
         "performance": {
             "window_seconds": WebSocketConfig.METRICS_WINDOW_SECONDS,
-            "broadcast_tps": metrics["broadcast_tps"],
-            "message_tps": metrics["message_tps"],
-            "total_broadcasts": metrics["total_broadcasts"],
-            "total_messages": metrics["total_messages"],
-            "total_data_bytes": metrics["total_bytes"],
-            "total_data_mb": round(metrics["total_bytes"] / (1024 * 1024), 2),
+            "broadcast_tps": metrics.get("broadcast_tps", 0.0),
+            "message_tps": metrics.get("message_tps", 0.0),
+            "total_broadcasts": metrics.get("total_broadcasts", 0),
+            "total_messages": metrics.get("total_messages", 0),
+            "total_data_bytes": metrics.get("total_bytes", 0),
+            "total_data_mb": round(metrics.get("total_bytes", 0) / (1024 * 1024), 2),
         },
         "redis": {
             "connected": redis_broadcaster.is_connected(),
             "channel": manager.channel_name,
         },
-        "uptime_seconds": metrics["uptime_seconds"],
+        "uptime_seconds": metrics.get("uptime_seconds", 0.0),
     }
 
 


### PR DESCRIPTION
🔧 변경 사항:
- **[Backend]**:
  - 설정 파일 내 환경 변수 파싱 시 예외 처리 추가 (잘못된 값 유입 시 기본값 자동 폴백 및 경고 로깅)
  - Health API 응답 시 '.get()' 메서드 및 기본값을 사용하여 런타임 KeyErrors 및 크래시 예방
  - 'WS_METRICS_WINDOW_SECONDS' 파싱 로직의 기동 시점 안정성 확보

🎯 목적:
- 오설정(Misconfiguration)에 의한 서비스 기동 실패 방지 및 API 소비자에 대한 안정적인 데이터 인터페이스 제공

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/356#pullrequestreview-3678019219)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

유효하지 않은 메트릭 값과 잘못 설정된 환경 변수를 대비해 WebSocket 구성 및 헬스 API를 강화하여 런타임 오류와 서비스 시작 실패를 방지합니다.

버그 수정:
- `WS_METRICS_MAX_TPS` 및 `WS_METRICS_WINDOW_SECONDS` 환경 변수에 잘못된 값이 설정된 경우, 안전한 기본값으로 대체하고 경고를 로그로 남겨 크래시를 방지합니다.
- 누락된 필드에 대해 기본값이 설정된 메트릭 조회를 사용하여, WebSocket 헬스 엔드포인트에서 `KeyError` 및 나누기 연산 오류가 발생하지 않도록 합니다.

개선 사항:
- 설정 단계에서 더 안전한 정수 변환과 범위 클램핑을 적용하여, WebSocket 압축 임계값과 메트릭 윈도 파싱을 더 견고하게 만듭니다.
- 메트릭 데이터가 일부 누락되었거나 손상된 경우에도 헬스 API 응답이 안정적으로 유지되도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden WebSocket configuration and health API against invalid metrics and misconfigured environment variables to prevent runtime errors and service startup failures.

Bug Fixes:
- Prevent crashes from invalid WS_METRICS_MAX_TPS and WS_METRICS_WINDOW_SECONDS environment variables by falling back to safe defaults and logging warnings.
- Avoid KeyError and division errors in the WebSocket health endpoint by using defaulted metric lookups for missing fields.

Enhancements:
- Make WebSocket compression threshold and metrics window parsing more robust with safer integer conversion and bounds clamping in configuration.
- Ensure health API responses remain stable even when metrics data is partially missing or malformed.

</details>