### PR TITLE
🚀 fix(websocket) [#10.9.19]: 9차 개선 - Generic _clamp 및 NamedTuple 도입으로 타입 안전성 완성

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(project_root))
 
 import os
 import logging
-from collections import namedtuple
+from typing import NamedTuple, TypeVar, Union
 from dotenv import load_dotenv
 
 # 2️⃣ 로컬 .env 로드 (우선!)
@@ -32,13 +32,20 @@ logger = logging.getLogger(__name__)
 # 유틸리티 함수 및 구조체
 # ────────────────────────────────────────────────────────
 
-
-def _clamp(value: int, min_val: int, max_val: int) -> int:
-    """수치를 허용 범위 내로 제한하는 헬퍼 함수"""
-    return max(min_val, min(value, max_val))
+T = TypeVar("T", int, float)
 
 
-ConfigRange = namedtuple("ConfigRange", ["min", "max"])
+class ConfigRange(NamedTuple):
+    """설정값의 범위를 정의하는 구조체"""
+
+    min: Union[int, float]
+    max: Union[int, float]
+
+
+def _clamp(value: T, r: ConfigRange) -> T:
+    """수치를 허용 범위(ConfigRange) 내로 제한하는 헬퍼 함수"""
+    return max(r.min, min(value, r.max))
+
 
 # 3️⃣ Streamlit 배포 환경에서 덮어쓰기
 try:
@@ -272,7 +279,7 @@ class WebSocketConfig:
             _RAW_MAX_TPS_ENV,
             DEFAULT_METRICS_MAX_TPS,
         )
-    METRICS_MAX_TPS = _clamp(_RAW_MAX_TPS, TPS_RANGE.min, TPS_RANGE.max)
+    METRICS_MAX_TPS = _clamp(_RAW_MAX_TPS, TPS_RANGE)
 
     # TPS 계산 시간 윈도우
     _RAW_WINDOW_ENV = os.getenv(
@@ -287,7 +294,7 @@ class WebSocketConfig:
             _RAW_WINDOW_ENV,
             DEFAULT_METRICS_WINDOW_SECONDS,
         )
-    METRICS_WINDOW_SECONDS = _clamp(_RAW_WINDOW, WINDOW_RANGE.min, WINDOW_RANGE.max)
+    METRICS_WINDOW_SECONDS = _clamp(_RAW_WINDOW, WINDOW_RANGE)
 
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━


### PR DESCRIPTION
🔧 변경 사항:
- **[Backend]**:
  - 'ConfigRange'를 typing.NamedTuple로 전환하여 IDE 정적 분석 지원 강화
  - '_clamp' 헬퍼를 제네릭(int/float)으로 확장 및 ConfigRange 객체 직접 수용 방식으로 개선
  - 설정값 검증 호출부의 보일러플레이트 제거 (가독성 향상)
  - config 파일 내 중복 임포트 정리 및 유틸리티 섹션 정형화

🎯 목적:
- 설정 인프라의 확장성 확보 및 런타임 수치 연산에 대한 타입 시스템 안정 보장

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/360#pullrequestreview-3678089500)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

구성(clamping) 유틸리티를 일반화하여 타입 안전성을 높이고 구성 값 검증을 단순화합니다.

개선 사항:
- 기존의 namedtuple 기반 `ConfigRange`를 `typing.NamedTuple` 구조로 교체하여 정적 분석 지원을 개선합니다.
- `_clamp` 헬퍼를 `int`와 `float`에 대해 제네릭으로 만들고, 호출 시 보일러플레이트를 줄이기 위해 `ConfigRange` 객체를 직접 받도록 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Generalize configuration clamping utilities to improve type safety and simplify configuration value validation.

Enhancements:
- Replace the legacy namedtuple-based ConfigRange with a typing.NamedTuple structure for better static analysis support.
- Update the _clamp helper to be generic over int and float and to accept ConfigRange objects directly, reducing boilerplate at call sites.

</details>