### PR TITLE
🚀 fix(websocket) [#10.9.19]: 13차 개선 - 독스트링 오타 수정

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -37,7 +37,7 @@ T = TypeVar("T", int, float)
 class ConfigRange(Generic[T]):
     """
     설정값의 범위를 정의하는 구조체 (Immutable)
-    - slots=True를 통해 메모리 및 속도 최최적화 (Python 3.10+)
+    - slots=True를 통해 메모리 및 속도 최적화 (Python 3.10+)
     - 더 이상 NamedTuple이 아니므로 인덱싱이나 언패킹 대신 속성 접근(.min, .max)을 사용해야 합니다.
     """
 


### PR DESCRIPTION
🔧 변경 사항:
- **[Backend]**: ConfigRange 독스트링 오타 수정 ('최최적화' → '최적화')

🎯 목적:
- 문서 품질 향상 및 코드 가독성 완성

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/364#pullrequestreview-3678198259)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

자잘한 작업(Chores):
- `ConfigRange` 설정의 docstring에서 잘못 표기된 한국어 단어를 수정했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Fix a misspelled Korean word in the ConfigRange configuration docstring.

</details>