### PR TITLE
🚀 fix(websocket) [#10.9.20]: 3차 개선 - 타입 가드 및 에러 타입 안전성 강화

### DIFF
--- a/web_ui/src/components/dashboard/websocket-monitor.tsx
+++ b/web_ui/src/components/dashboard/websocket-monitor.tsx
@@ -10,6 +10,19 @@ import { Activity, Radio, Database, Clock, TrendingUp } from 'lucide-react';
 // API URL: Use environment variable or default to relative path for production safety
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE || '';
 
+/**
+ * Type guard to check if an error is an AbortError
+ * Works for both Error instances and DOMException
+ */
+function isAbortError(err: unknown): err is { name: string } {
+  return (
+    err !== null &&
+    typeof err === 'object' &&
+    'name' in err &&
+    (err as { name: unknown }).name === 'AbortError'
+  );
+}
+
 // Strict typing for better type safety
 type SystemStatus = 'healthy' | 'degraded' | 'down';
 
@@ -59,10 +72,9 @@ export default function WebSocketMonitor() {
         } else {
           setError(`Failed to fetch metrics: ${res.status}`);
         }
-      } catch (err) {
-        // Ignore AbortError from cleanup (works for both Error and DOMException)
-        // Using unknown for type safety and checking name property existence
-        if (err && typeof err === 'object' && 'name' in err && err.name === 'AbortError') {
+      } catch (err: unknown) {
+        // Ignore AbortError from cleanup
+        if (isAbortError(err)) {
           return;
         }
         setError(err instanceof Error ? err.message : 'Unknown error');


### PR DESCRIPTION
🔧 변경 사항:
- **[Frontend]**:
  - isAbortError 타입 가드 헬퍼 함수 추가 (재사용 가능한 타입 안전 체크)
  - catch 매개변수에 명시적 unknown 타입 선언 (암묵적 any 제거)
  - JSDoc 주석으로 타입 가드 동작 방식 문서화
  - Error/DOMException 모두 처리하는 견고한 에러 핸들링

🎯 목적:
- TypeScript 타입 시스템 완전 활용으로 컴파일 타임 안전성 극대화
- 자체 문서화 코드로 유지보수성 및 재사용성 향상
- 크로스 브라우저 호환성 확보

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/368#pullrequestreview-3680587897)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

웹소켓 대시보드의 오류 처리 방식을 개선하기 위해 재사용 가능한 AbortError 타입 가드와 보다 엄격한 오류 캐치 타이핑을 도입합니다.

개선 사항:
- 웹소켓 모니터에서 `Error`와 `DOMException` 인스턴스를 모두 지원하는 재사용 가능한 `isAbortError` 타입 가드를 도입합니다.
- `catch` 매개변수를 `unknown` 타입으로 지정하고, AbortError 감지를 공용 타입 가드에 위임함으로써 오류 처리를 강화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve websocket dashboard error handling with a reusable AbortError type guard and stricter typings for error catching.

Enhancements:
- Introduce a reusable isAbortError type guard that supports both Error and DOMException instances in the websocket monitor.
- Strengthen error handling by typing catch parameters as unknown and delegating AbortError detection to the shared type guard.

</details>