### PR TITLE
🚀 fix(websocket) [#10.9.20]: 4차 개선 - 타입 정확성 및 디버깅 정보 보존 완성

### DIFF
--- a/web_ui/src/components/dashboard/websocket-monitor.tsx
+++ b/web_ui/src/components/dashboard/websocket-monitor.tsx
@@ -13,13 +13,16 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE || '';
 /**
  * Type guard to check if an error is an AbortError
  * Works for both Error instances and DOMException
+ * @param err - Unknown error to check
+ * @returns true if err is an AbortError with precise type narrowing
  */
-function isAbortError(err: unknown): err is { name: string } {
+function isAbortError(err: unknown): err is { name: 'AbortError' } {
   return (
     err !== null &&
     typeof err === 'object' &&
     'name' in err &&
-    (err as { name: unknown }).name === 'AbortError'
+    typeof (err as { name: unknown }).name === 'string' &&
+    (err as { name: string }).name === 'AbortError'
   );
 }
 
@@ -77,7 +80,8 @@ export default function WebSocketMonitor() {
         if (isAbortError(err)) {
           return;
         }
-        setError(err instanceof Error ? err.message : 'Unknown error');
+        // Preserve error information for debugging (convert non-Error throws to string)
+        setError(err instanceof Error ? err.message : String(err));
         console.error("Failed to fetch WebSocket metrics", err);
       } finally {
         setLoading(false);


### PR DESCRIPTION
🔧 변경 사항:
- **[Frontend]**:
  - isAbortError 타입 가드를 리터럴 타입으로 개선 ('AbortError' 정확한 narrowing)
  - typeof 검증 추가로 name 속성 타입 안전성 강화
  - 에러 메시지 처리 개선 (String(err)로 정보 보존)
  - JSDoc에 @param, @returns 추가로 문서화 완성

🎯 목적:
- 런타임 동작과 타입 선언의 완벽한 일치
- 디버깅 시 최대한의 정보 보존으로 문제 해결 효율 향상
- TypeScript 타입 시스템의 완전한 활용

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/369#pullrequestreview-3680609367)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

웹소켓 모니터의 오류 처리와 AbortError 타입 내로잉을 개선하여 더 정확한 타이핑과 디버깅 정보를 제공합니다.

버그 수정:
- WebSocket 메트릭을 가져오는 과정에서 `Error`가 아닌 값이 throw된 경우, 표시하기 전에 안전하게 문자열로 변환되도록 보장합니다.

개선 사항:
- 더 안전한 TypeScript 내로잉을 위해, 추가 런타임 체크와 함께 리터럴 `'AbortError'` 이름을 사용하는 AbortError 타입 가드를 강화합니다.
- AbortError 타입 가드에 명시적인 JSDoc 파라미터와 반환 설명을 추가하여 사용 방법을 더 명확히 문서화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve WebSocket monitor error handling and AbortError type narrowing for more accurate typing and better debugging information.

Bug Fixes:
- Ensure non-Error thrown values in WebSocket metrics fetch are safely converted to strings before displaying.

Enhancements:
- Tighten the AbortError type guard to use the literal 'AbortError' name with additional runtime checks for safer TypeScript narrowing.
- Document the AbortError type guard with explicit JSDoc parameters and return description for clearer usage.

</details>