### PR TITLE
🚀 refactor(websocket) [#10.9.20]: 1차 개선 - 모니터링 대시보드 개선 및 문서화 강화

### DIFF
--- a/web_ui/.env.example
+++ b/web_ui/.env.example
@@ -10,3 +10,9 @@ NEXT_PUBLIC_WS_URL=ws://localhost:8000/ws
 # WebSocket SSR 폴백 URL (서버 사이드 렌더링 환경용)
 # 프로덕션 SSR: wss://your-domain.com/ws
 NEXT_PUBLIC_WS_FALLBACK_URL=ws://localhost:8000/ws
+
+# WebSocket 메트릭 대시보드 폴링 간격 (밀리초)
+# 더 빠른 업데이트: 2000-3000 (2-3초)
+# 서버 부하 절감: 10000-30000 (10-30초)
+# 기본값: 5000 (5초)
+NEXT_PUBLIC_METRICS_POLL_INTERVAL=5000

--- a/web_ui/src/components/dashboard/websocket-monitor.tsx
+++ b/web_ui/src/components/dashboard/websocket-monitor.tsx
@@ -11,6 +11,16 @@ import { Activity, Radio, Database, Clock, TrendingUp } from 'lucide-react';
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE || '';
 
 /**
+ * Polling interval for metrics fetch (milliseconds)
+ * Can be configured via NEXT_PUBLIC_METRICS_POLL_INTERVAL environment variable
+ * Default: 5000ms (5 seconds)
+ */
+const METRICS_POLL_INTERVAL = parseInt(
+  process.env.NEXT_PUBLIC_METRICS_POLL_INTERVAL || '5000',
+  10
+);
+
+/**
  * Type guard to check if an error is an AbortError
  * Works for both Error instances and DOMException
  * @param err - Unknown error to check
@@ -158,8 +168,8 @@ export default function WebSocketMonitor() {
     // Initial fetch
     fetchMetrics();
 
-    // Poll every 5 seconds
-    const interval = setInterval(fetchMetrics, 5000);
+    // Poll at configured interval (default: 5 seconds)
+    const interval = setInterval(fetchMetrics, METRICS_POLL_INTERVAL);
 
     return () => {
       clearInterval(interval);


### PR DESCRIPTION
🔧 변경 사항:
- **[Frontend]**: 폴링 간격을 환경 변수로 설정 가능하게 개선
  - METRICS_POLL_INTERVAL 상수 추가 (NEXT_PUBLIC_METRICS_POLL_INTERVAL)
  - 매직 넘버(5000) 제거로 코드 품질 향상
  - 운영 환경별 서버 부하 조절 가능
- **[Config]**: .env.example에 폴링 간격 설정 추가
  - 설정 가이드 및 권장값 제공
- **[Docs]**: README_phase1.md 대폭 개선
  - HTTP Polling 사용 명시 (경고 박스 추가)
  - 설계 의도 설명 (Why HTTP? Why Not WebSocket?)
  - 폴링 간격 설정 방법 상세 문서화
  - 성능 고려사항 및 권장값 안내
  - 코드 예시에 주석 추가 (혼동 방지)

🎯 목적:
- 코드 리뷰 피드백 완벽 반영으로 독자 혼동 방지
- 설정 가능한 폴링 간격으로 운영 유연성 확보
- 설계 의도 명확화로 아키텍처 이해도 향상

📌 Related:
- Issue [#273]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/374#pullrequestreview-3685943607)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

환경 변수를 통해 WebSocket 모니터 대시보드의 HTTP 폴링 주기를 구성 가능하게 하고, 코드 예제와 문서를 통해 HTTP 기반 메트릭 수집 방식의 설계를 명확히 합니다.

New Features:
- `NEXT_PUBLIC_METRICS_POLL_INTERVAL` 환경 변수를 통해 WebSocket 모니터의 메트릭 폴링 주기를 설정할 수 있도록 합니다.

Enhancements:
- WebSocket 모니터 구현에서 하드코딩된 5초 매직 넘버 대신 명명된 폴링 주기 상수를 사용하도록 개선합니다.

Documentation:
- 1단계 WebSocket README를 확장하여 메트릭이 HTTP 폴링을 통해 수집된다는 점을 설명하고, 폴링 주기 설정 방법을 문서화하며, 설계 근거와 성능 상의 트레이드오프를 기술합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the WebSocket monitor dashboard’s HTTP polling interval configurable via environment variables and clarify its HTTP-based metrics collection design in code examples and documentation.

New Features:
- Allow configuring the metrics polling interval for the WebSocket monitor via the NEXT_PUBLIC_METRICS_POLL_INTERVAL environment variable.

Enhancements:
- Improve the WebSocket monitor implementation to use a named polling interval constant instead of a hard-coded 5-second magic number.

Documentation:
- Expand the phase 1 WebSocket README to explain that metrics are collected via HTTP polling, document the polling interval configuration, and describe design rationale and performance trade-offs.

</details>