### PR TITLE
🐛 fix(websocket) [#10.10.1]: 5차 개선 - disconnect 함수 시그니처 복구

### DIFF
--- a/backend/services/websocket_manager.py
+++ b/backend/services/websocket_manager.py
@@ -100,6 +100,7 @@ class ConnectionManager:
         websocket: WebSocket,
         code: int = 1000,
         reason: Optional[str] = None,
+        propagate_errors: bool = False,
     ):
         """
         클라이언트 연결 해제, 목록 제거 및 명시적 소켓 종료


### PR DESCRIPTION
- propagate_errors 파라미터 누락 수정

📌 Related:
- Issue [#274]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/381#pullrequestreview-3688611893)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

버그 수정:
- `websocket` 연결 해제 메서드에 `propagate_errors` 매개변수를 다시 추가하여, 공개 API에서 발생한 리그레션을 수정합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add the propagate_errors parameter back to the websocket disconnect method to fix a regression in its public API.

</details>