### PR TITLE
✨ feat(diff) [#10.10.2]: Diff API 구현 및 FE 환경 구축

### DIFF
--- a/backend/api/endpoints/sync.py
+++ b/backend/api/endpoints/sync.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import logging
 
 from backend.services.obsidian_sync import ObsidianSyncService
+from backend.services.diff_service import generate_diff
 from backend.config.mcp_config import mcp_config
 from backend.models.external_sync import SyncStatus, ExternalToolType
 from pydantic import BaseModel
@@ -59,6 +60,16 @@ class ConflictLogResponse(BaseModel):
     status: str
     resolution_method: Optional[str]
     notes: Optional[str]
+
+
+class ConflictDiffResponse(BaseModel):
+    """Diff 조회 응답"""
+
+    conflict_id: str
+    local_content: str
+    remote_content: str
+    diff: Dict[str, Any]
+    file_type: str
 
 
 # ==========================================
@@ -160,8 +171,36 @@ async def get_conflicts(
             conflicts = [c for c in conflicts if c["status"] == status]
 
         return conflicts[:limit]
+        return conflicts[:limit]
     except Exception as e:
         logger.error(f"Failed to get conflicts: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/conflicts/{conflict_id}/diff", response_model=ConflictDiffResponse)
+async def get_conflict_diff(conflict_id: str):
+    """
+    충돌 파일의 Diff 데이터 반환
+    """
+    try:
+        # TODO: 실제 프로덕션에서는 DB에서 conflict_id로 경로 정보 조회
+        # 여기서는 테스트를 위해 더미 데이터 생성 (프론트엔드 연동용 Mock)
+        
+        # Mock Data
+        local_content = "# Hello FlowNote\n\nThis is the local version of the document.\nIt contains some changes that are unique to my machine."
+        remote_content = "# Hello FlowNote\n\nThis is the remote version of the document.\nIt contains some changes that were synced from the server."
+        
+        diff_result = generate_diff(local_content, remote_content)
+        
+        return ConflictDiffResponse(
+            conflict_id=conflict_id,
+            local_content=local_content,
+            remote_content=remote_content,
+            diff=diff_result,
+            file_type="markdown"
+        )
+    except Exception as e:
+        logger.error(f"Failed to generate diff: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
+++ b/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
@@ -354,12 +354,24 @@ const DiffEditor = dynamic(
 );
 ```
 
-## 📝 Next Steps
+## 📅 Task Progress
 
-- [ ] 3-way Merge 지원
-- [ ] 충돌 이력 저장 및 통계
-- [ ] AI 기반 자동 해결 제안
-- [ ] 대용량 파일 Diff 최적화
+### Day 1 (01/22)
+- [x] Backend Diff Service 구현 (`diff_service.py`)
+- [x] Backend Unit Tests 작성 (`test_diff_service.py`)
+- [x] WebSocket Monitor 최적화 (Phase 1 Code Review 반영)
+
+### Day 2 (01/23)
+- [x] Backend Diff Endpoint 추가 (`GET /conflicts/{id}/diff`)
+- [x] Frontend Dependency 설치 (`@monaco-editor/react`, `react-markdown`)
+- [x] Frontend Component Scaffolding (`ConflictDiffViewer.tsx`)
+- [ ] Frontend Integration (API 연동 및 Diff 렌더링)
+
+## 📝 Future Tasks
+- [ ] 3-way Merge 알고리즘 연구 및 적용
+- [ ] 충돌 이력(History) 저장 기능
+- [ ] AI 기반 충돌 해결 가이드 제공
+- [ ] 대용량 파일 Diff 렌더링 최적화
 
 ## 🔗 Related Documentation
 

--- a/web_ui/src/components/sync/ConflictDiffViewer.tsx
+++ b/web_ui/src/components/sync/ConflictDiffViewer.tsx
@@ -1,0 +1,47 @@
+// web_ui/src/components/sync/ConflictDiffViewer.tsx
+
+'use client';
+
+import React from 'react';
+
+interface ConflictDiffViewerProps {
+  conflictId: string;
+  onResolve?: (strategy: 'keep_local' | 'keep_remote' | 'keep_both') => void;
+}
+
+/**
+ * Conflict Diff Viewer Component
+ * - Displays side-by-side or inline diffs
+ * - Provides resolution actions
+ */
+export function ConflictDiffViewer({ conflictId, onResolve }: ConflictDiffViewerProps) {
+  return (
+    <div className="conflict-diff-viewer w-full h-full flex flex-col gap-4 p-4 border rounded-lg bg-background">
+      <div className="flex justify-between items-center header">
+        <h2 className="text-lg font-semibold">Conflict Resolution</h2>
+        <div className="text-sm text-muted-foreground">ID: {conflictId}</div>
+      </div>
+
+      <div className="diff-area flex-1 min-h-[400px] border border-border rounded-md bg-muted/20 flex items-center justify-center">
+        <span className="text-muted-foreground">
+          Diff Viewer Placeholder (Integration Pending)
+        </span>
+      </div>
+
+      <div className="actions flex justify-end gap-2">
+        <button 
+          className="px-4 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90"
+          onClick={() => onResolve?.('keep_local')}
+        >
+          Keep Local
+        </button>
+        <button 
+          className="px-4 py-2 bg-secondary text-secondary-foreground rounded hover:bg-secondary/80"
+          onClick={() => onResolve?.('keep_remote')}
+        >
+          Keep Remote
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- 📡 API: `GET /conflicts/{id}/diff` 엔드포인트 추가 (Diff Service 연동)
- 📦 Deps: 프론트엔드 Diff 뷰어용 패키지 설치 (@monaco-editor/react)
- 🏗️ FE: `ConflictDiffViewer` 컴포넌트 스캐폴딩(기본 구조) 생성
- 📝 Plan: `docs/P/v6.0_phase2_diff_viewer/README_phase2.md` 업데이트

📌 Related:
- Issue [#274]

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

충돌(diff) 비교를 조회하기 위한 API 엔드포인트와 프론트엔드 스캐폴딩을 추가하고, 관련 문서를 업데이트합니다.

New Features:
- 충돌 파일에 대한 목업(diff) 데이터를 반환하기 위해 `ConflictDiffResponse` 스키마와 `GET /conflicts/{conflict_id}/diff` 엔드포인트를 도입합니다.
- 향후 diff UI와 충돌 해결 액션을 담기 위한 `ConflictDiffViewer` React 컴포넌트 스텁을 추가합니다.

Documentation:
- 현재 백엔드 및 프론트엔드 작업 진행 상황과 향후 작업 항목을 반영하도록 phase 2 diff viewer README를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an API endpoint and frontend scaffolding for viewing conflict diffs, along with updating related documentation.

New Features:
- Introduce ConflictDiffResponse schema and GET /conflicts/{conflict_id}/diff endpoint to return mock diff data for conflict files.
- Add a ConflictDiffViewer React component stub to host the future diff UI and resolution actions.

Documentation:
- Update phase 2 diff viewer README with current backend and frontend task progress and future work items.

</details>