### PR TITLE
🐛 fix(diff) [#10.10.2]: 1차 개선 -  Dead code 제거 및 UI/UX 개선

### DIFF
--- a/backend/api/endpoints/sync.py
+++ b/backend/api/endpoints/sync.py
@@ -171,7 +171,6 @@ async def get_conflicts(
             conflicts = [c for c in conflicts if c["status"] == status]
 
         return conflicts[:limit]
-        return conflicts[:limit]
     except Exception as e:
         logger.error(f"Failed to get conflicts: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
@@ -185,19 +184,19 @@ async def get_conflict_diff(conflict_id: str):
     try:
         # TODO: 실제 프로덕션에서는 DB에서 conflict_id로 경로 정보 조회
         # 여기서는 테스트를 위해 더미 데이터 생성 (프론트엔드 연동용 Mock)
-        
+
         # Mock Data
         local_content = "# Hello FlowNote\n\nThis is the local version of the document.\nIt contains some changes that are unique to my machine."
         remote_content = "# Hello FlowNote\n\nThis is the remote version of the document.\nIt contains some changes that were synced from the server."
-        
+
         diff_result = generate_diff(local_content, remote_content)
-        
+
         return ConflictDiffResponse(
             conflict_id=conflict_id,
             local_content=local_content,
             remote_content=remote_content,
             diff=diff_result,
-            file_type="markdown"
+            file_type="markdown",
         )
     except Exception as e:
         logger.error(f"Failed to generate diff: {e}", exc_info=True)

--- a/web_ui/src/components/sync/ConflictDiffViewer.tsx
+++ b/web_ui/src/components/sync/ConflictDiffViewer.tsx
@@ -12,7 +12,7 @@ interface ConflictDiffViewerProps {
 /**
  * Conflict Diff Viewer Component
  * - Displays side-by-side or inline diffs
- * - Provides resolution actions
+ * - Provides resolution actions (Local, Remote, Both)
  */
 export function ConflictDiffViewer({ conflictId, onResolve }: ConflictDiffViewerProps) {
   return (
@@ -30,16 +30,25 @@ export function ConflictDiffViewer({ conflictId, onResolve }: ConflictDiffViewer
 
       <div className="actions flex justify-end gap-2">
         <button 
+          type="button"
           className="px-4 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90"
           onClick={() => onResolve?.('keep_local')}
         >
           Keep Local
         </button>
         <button 
+          type="button"
           className="px-4 py-2 bg-secondary text-secondary-foreground rounded hover:bg-secondary/80"
           onClick={() => onResolve?.('keep_remote')}
         >
           Keep Remote
+        </button>
+        <button 
+          type="button"
+          className="px-4 py-2 border border-input bg-background hover:bg-accent hover:text-accent-foreground rounded"
+          onClick={() => onResolve?.('keep_both')}
+        >
+          Keep Both
         </button>
       </div>
     </div>


### PR DESCRIPTION
- 🔧 Backend: get_conflicts 내 중복 return 문(Dead code) 제거
- 🎨 Frontend: ConflictDiffViewer에 'Keep Both' 해결 옵션 버튼 추가
- 🔒 Frontend: 모든 액션 버튼에 type='button' 명시 (Form 제출 방지)

📌 Related:
- Issue [#274]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/384#pullrequestreview-3693411162)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

충돌 해결 UX를 개선하고, 충돌 조회 백엔드 로직을 정리합니다.

New Features:
- 충돌 diff 뷰어에 '둘 다 유지(Keep Both)' 충돌 해결 옵션을 추가했습니다.

Bug Fixes:
- 충돌 조회 엔드포인트에서 중복된, 사용되지 않는 `return` 문을 제거했습니다.
- 예기치 않은 폼 제출을 방지하기 위해, 충돌 diff 뷰어의 액션 버튼들에 `type='button'`을 명시적으로 설정했습니다.

Enhancements:
- 사용 가능한 해결 옵션들을 나열하도록 충돌 diff 뷰어 문서를 명확히 했습니다.
- 동기화 API에서 충돌 diff 응답을 구성하는 포맷팅을 정리했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve conflict resolution UX and clean up conflict retrieval backend logic.

New Features:
- Add a 'Keep Both' conflict resolution option to the conflict diff viewer.

Bug Fixes:
- Remove a duplicated dead-code return statement in the conflicts retrieval endpoint.
- Explicitly set action buttons in the conflict diff viewer to type='button' to prevent unintended form submission.

Enhancements:
- Clarify conflict diff viewer documentation to list available resolution options.
- Tidy conflict diff response construction formatting in the sync API.

</details>