### PR TITLE
♻️ refactor(diff) [#10.10.2]: 3차 개선 - Magic String 제거 및 상수화

### DIFF
--- a/backend/api/endpoints/sync.py
+++ b/backend/api/endpoints/sync.py
@@ -206,14 +206,14 @@ async def get_conflict_diff(conflict_id: str):
 @router.post("/conflicts/{conflict_id}/resolve")
 async def resolve_conflict(
     conflict_id: str,
-    resolution_method: str,  # "local", "remote", "both"
+    resolution_method: str,  # "keep_local", "keep_remote", "keep_both"
 ):
     """
     충돌 해결
 
     Args:
         conflict_id: 충돌 ID
-        resolution_method: 해결 방법 (local, remote, both)
+        resolution_method: 해결 방법 (keep_local, keep_remote, keep_both)
 
     Returns:
         dict: 해결 결과

--- a/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
+++ b/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
@@ -365,7 +365,7 @@ const DiffEditor = dynamic(
 - [x] Backend Diff Endpoint 추가 (`GET /conflicts/{id}/diff`)
 - [x] Frontend Dependency 설치 (`@monaco-editor/react`, `react-markdown`)
 - [x] Frontend Component Scaffolding (`ConflictDiffViewer.tsx`)
-- [x] Frontend Refactoring: Resolution Strategy 강타입 적용 (`types/sync.ts`)
+- [x] Frontend Refactoring: Strategy Constants 도입 및 Backend Protocol 통일 (`types/sync.ts`, `backend/api`)
 - [ ] Frontend Integration (API 연동 및 Diff 렌더링)
 
 ### Integration Checklist

--- a/web_ui/src/components/sync/ConflictDiffViewer.tsx
+++ b/web_ui/src/components/sync/ConflictDiffViewer.tsx
@@ -3,7 +3,7 @@
 'use client';
 
 import React from 'react';
-import type { ConflictResolutionStrategy } from '../../types/sync';
+import { CONFLICT_RESOLUTION_STRATEGIES, type ConflictResolutionStrategy } from '../../types/sync';
 
 interface ConflictDiffViewerProps {
   conflictId: string;
@@ -14,6 +14,7 @@ interface ConflictDiffViewerProps {
  * Conflict Diff Viewer Component
  * - Displays side-by-side or inline diffs
  * - Provides resolution actions (Local, Remote, Both)
+ * - Uses centralized constants for resolution strategies
  */
 export function ConflictDiffViewer({ conflictId, onResolve }: ConflictDiffViewerProps) {
   return (
@@ -33,21 +34,21 @@ export function ConflictDiffViewer({ conflictId, onResolve }: ConflictDiffViewer
         <button 
           type="button"
           className="px-4 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90"
-          onClick={() => onResolve?.('keep_local')}
+          onClick={() => onResolve?.(CONFLICT_RESOLUTION_STRATEGIES.KEEP_LOCAL)}
         >
           Keep Local
         </button>
         <button 
           type="button"
           className="px-4 py-2 bg-secondary text-secondary-foreground rounded hover:bg-secondary/80"
-          onClick={() => onResolve?.('keep_remote')}
+          onClick={() => onResolve?.(CONFLICT_RESOLUTION_STRATEGIES.KEEP_REMOTE)}
         >
           Keep Remote
         </button>
         <button 
           type="button"
           className="px-4 py-2 border border-input bg-background hover:bg-accent hover:text-accent-foreground rounded"
-          onClick={() => onResolve?.('keep_both')}
+          onClick={() => onResolve?.(CONFLICT_RESOLUTION_STRATEGIES.KEEP_BOTH)}
         >
           Keep Both
         </button>

--- a/web_ui/src/types/sync.ts
+++ b/web_ui/src/types/sync.ts
@@ -2,13 +2,32 @@
 
 /**
  * Sync & Conflict Resolution Types
+ * Centralized constants and types to prevent magic string drift.
  */
 
-export type ConflictResolutionStrategy = 'keep_local' | 'keep_remote' | 'keep_both';
+// Resolution Strategies
+export const CONFLICT_RESOLUTION_STRATEGIES = {
+  KEEP_LOCAL: 'keep_local',
+  KEEP_REMOTE: 'keep_remote',
+  KEEP_BOTH: 'keep_both',
+} as const;
 
+// Type derived from constants
+export type ConflictResolutionStrategy = typeof CONFLICT_RESOLUTION_STRATEGIES[keyof typeof CONFLICT_RESOLUTION_STRATEGIES];
+
+// Conflict Statuses
+export const CONFLICT_STATUS = {
+  PENDING: 'pending',
+  RESOLVED: 'resolved',
+} as const;
+
+export type ConflictStatus = typeof CONFLICT_STATUS[keyof typeof CONFLICT_STATUS];
+
+// Models
 export interface ConflictLog {
   id: string;
   filePath: string;
-  status: 'resolved' | 'pending';
-  // ... other fields can be added as needed
+  status: ConflictStatus;
+  resolutionStrategy?: ConflictResolutionStrategy;
+  timestamp?: string;
 }


### PR DESCRIPTION
- 🏗️ Types: `ConflictResolutionStrategy` 상수(Constants) 정의 도입
- 🔄 Refactor: `UI 컴포넌트`에서 리터럴 대신 상수 사용으로 변경
- 🔗 Backend: `API Docstring`을 Frontend Protocol(keep_*)과 일치되도록 수정

📌 Related:
- Issue [#274]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/386#pullrequestreview-3693505370)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

중앙 집중식 충돌 해결 상수를 도입하고 프론트엔드와 백엔드 동기화 프로토콜을 정렬합니다.

향상 사항:
- 동기화 타입 모듈에서 충돌 해결 전략과 상태에 대한 공통 상수와 파생 타입을 정의합니다.
- 문자열 리터럴 대신 중앙 집중식 해결 전략 상수를 사용하도록 충돌 diff 뷰어 UI를 업데이트합니다.
- 더 풍부한 충돌 메타데이터를 위해 해결 전략과 타임스탬프 필드를 충돌 로그 모델에 추가합니다.
- 백엔드 충돌 해결 API 도크스트링을 프론트엔드 프로토콜의 해결 메서드 값과 일치하도록 정렬합니다.

문서화:
- 전략 상수 사용과 통합된 백엔드 프로토콜을 반영하도록 2단계 diff 뷰어 문서를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce centralized conflict resolution constants and align frontend and backend sync protocols.

Enhancements:
- Define shared constants and derived types for conflict resolution strategies and statuses in the sync types module.
- Update the conflict diff viewer UI to use centralized resolution strategy constants instead of string literals.
- Extend the conflict log model with resolution strategy and timestamp fields for richer conflict metadata.
- Align backend conflict resolution API docstrings with the frontend protocol values for resolution methods.

Documentation:
- Update phase 2 diff viewer documentation to reflect use of strategy constants and unified backend protocol.

</details>