### PR TITLE
♻️ refactor(diff) [#10.10.2]: 4차 개선 - Backend Enum 도입 및 FE 레거시 코드 정리

### DIFF
--- a/backend/api/endpoints/sync.py
+++ b/backend/api/endpoints/sync.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, HTTPException, Depends
 from typing import List, Dict, Any, Optional
 from datetime import datetime
 from pathlib import Path
+from enum import Enum
 import logging
 
 from backend.services.obsidian_sync import ObsidianSyncService
@@ -60,6 +61,14 @@ class ConflictLogResponse(BaseModel):
     status: str
     resolution_method: Optional[str]
     notes: Optional[str]
+
+
+class ResolutionStrategy(str, Enum):
+    """충돌 해결 전략"""
+
+    KEEP_LOCAL = "keep_local"
+    KEEP_REMOTE = "keep_remote"
+    KEEP_BOTH = "keep_both"
 
 
 class ConflictDiffResponse(BaseModel):
@@ -204,9 +213,10 @@ async def get_conflict_diff(conflict_id: str):
 
 
 @router.post("/conflicts/{conflict_id}/resolve")
+@router.post("/conflicts/{conflict_id}/resolve")
 async def resolve_conflict(
     conflict_id: str,
-    resolution_method: str,  # "keep_local", "keep_remote", "keep_both"
+    resolution_method: ResolutionStrategy,
 ):
     """
     충돌 해결

--- a/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
+++ b/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
@@ -365,7 +365,9 @@ const DiffEditor = dynamic(
 - [x] Backend Diff Endpoint 추가 (`GET /conflicts/{id}/diff`)
 - [x] Frontend Dependency 설치 (`@monaco-editor/react`, `react-markdown`)
 - [x] Frontend Component Scaffolding (`ConflictDiffViewer.tsx`)
-- [x] Frontend Refactoring: Strategy Constants 도입 및 Backend Protocol 통일 (`types/sync.ts`, `backend/api`)
+- [x] Frontend Refactoring: Strategy Constants 도입 및 Backend Protocol 통일
+- [x] Backend Refactoring: `ResolutionStrategy` Enum 위 도입 (Validation 강화)
+- [x] Frontend Refactoring: `SyncMonitor` 및 `api.ts` 매직 스트링 제거 (Status 상수 적용)
 - [ ] Frontend Integration (API 연동 및 Diff 렌더링)
 
 ### Integration Checklist

--- a/web_ui/src/components/dashboard/sync-monitor.tsx
+++ b/web_ui/src/components/dashboard/sync-monitor.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button"
 import { RefreshCw, CheckCircle2, XCircle, FileText, Server } from "lucide-react"
 import { ConflictResolver } from "@/components/dashboard/conflict-resolver"
 import { toast } from "sonner"
+import { CONFLICT_STATUS } from '@/types/sync';
 
 // Types
 interface SyncStatus {
@@ -290,8 +291,8 @@ export function SyncMonitor() {
                   <div className="space-y-1">
                     <div className="flex items-center gap-2">
                       <span className="font-semibold">{conflict.file_path}</span>
-                      <Badge variant={conflict.status === 'resolved' ? 'default' : 'destructive'} 
-                             className={conflict.status === 'resolved' ? 'bg-green-500' : ''}>
+                      <Badge variant={conflict.status === CONFLICT_STATUS.RESOLVED ? 'default' : 'destructive'} 
+                             className={conflict.status === CONFLICT_STATUS.RESOLVED ? 'bg-green-500' : ''}>
                         {conflict.status}
                       </Badge>
                     </div>
@@ -310,7 +311,7 @@ export function SyncMonitor() {
                         <div>L: {conflict.local_hash.substring(0, 7)}</div>
                         <div>R: {conflict.remote_hash.substring(0, 7)}</div>
                     </div>
-                    {conflict.status !== 'resolved' && (
+                    {conflict.status !== CONFLICT_STATUS.RESOLVED && (
                         <Button size="sm" onClick={() => handleResolveClick(conflict)}>Resolve</Button>
                     )}
                   </div>

--- a/web_ui/src/lib/api.ts
+++ b/web_ui/src/lib/api.ts
@@ -7,9 +7,8 @@
  */
 export const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
 
-/**
- * 공통 상태 매핑
- */
+import { CONFLICT_STATUS } from '@/types/sync';
+
 export const STATUS_MAP: Record<string, string> = {
   connected: 'connected',
   disconnected: 'disconnected',
@@ -17,9 +16,9 @@ export const STATUS_MAP: Record<string, string> = {
   stopped: 'stopped',
   success: 'success',
   failed: 'failed',
-  pending: 'pending',
+  pending: CONFLICT_STATUS.PENDING,
   completed: 'completed',
-  resolved: 'resolved',
+  resolved: CONFLICT_STATUS.RESOLVED,
   unknown: 'unknown',
 };
 


### PR DESCRIPTION
- 🛡️ Backend: `ResolutionStrategy Enum` 도입으로 parameter validation 강화
- 🧹 Frontend: `SyncMonitor 및 api.ts` 내 기존 하드코딩된 상태값(Magic String) 제거
- 📝 Docs: 리팩토링 및 검증 강화 작업 내용 업데이트

📌 Related:
- Issue [#274]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/387#pullrequestreview-3693534591)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

타입이 지정된 백엔드 enum을 도입하고 프론트엔드의 상태 처리 로직을 공유 상수와 일치하도록 정리하며, 관련 문서를 업데이트하여 동기화 충돌 해결 기능을 개선합니다.

Enhancements:
- 충돌 해결 파라미터를 검증하기 위해 백엔드에 `ResolutionStrategy` enum을 도입합니다.
- 프론트엔드에 하드코딩되어 있던 충돌 상태 문자열을 api 유틸리티와 `SyncMonitor`의 공유 `CONFLICT_STATUS` 상수로 대체합니다.
- 새로운 enum 및 상태 리팩터링 작업을 반영하도록 phase 2 diff viewer 문서를 명확히 합니다.

Documentation:
- 새로운 `ResolutionStrategy` enum과 프론트엔드 상태 리팩터링을 문서화하기 위해 phase 2 diff viewer README를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine sync conflict resolution by introducing a typed backend enum and aligning frontend status handling with shared constants while updating related documentation.

Enhancements:
- Introduce a backend ResolutionStrategy enum to validate conflict resolution parameters.
- Replace hardcoded conflict status strings in the frontend with shared CONFLICT_STATUS constants in api utilities and SyncMonitor.
- Clarify the phase 2 diff viewer documentation to reflect the new enum and status refactoring work.

Documentation:
- Update the phase 2 diff viewer README to document the new ResolutionStrategy enum and frontend status refactoring.

</details>