### PR TITLE
🐛 fix(diff) [#10.10.2]: 5차 개선 - 중복 라우트 제거 및 안정화

### DIFF
--- a/backend/api/endpoints/sync.py
+++ b/backend/api/endpoints/sync.py
@@ -213,7 +213,6 @@ async def get_conflict_diff(conflict_id: str):
 
 
 @router.post("/conflicts/{conflict_id}/resolve")
-@router.post("/conflicts/{conflict_id}/resolve")
 async def resolve_conflict(
     conflict_id: str,
     resolution_method: ResolutionStrategy,

--- a/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
+++ b/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
@@ -368,6 +368,7 @@ const DiffEditor = dynamic(
 - [x] Frontend Refactoring: Strategy Constants 도입 및 Backend Protocol 통일
 - [x] Backend Refactoring: `ResolutionStrategy` Enum 위 도입 (Validation 강화)
 - [x] Frontend Refactoring: `SyncMonitor` 및 `api.ts` 매직 스트링 제거 (Status 상수 적용)
+- [x] Backend Fix: 중복 Route Decorator 제거 및 최종 점검 완료
 - [ ] Frontend Integration (API 연동 및 Diff 렌더링)
 
 ### Integration Checklist


### PR DESCRIPTION
- 🔧 Backend: 중복 선언된 Router Decorator 제거 (API Duplicate Fix)
- ✅ Check: 전체 파일 코드 스캔 및 안정성 검증 완료

📌 Related:
- Issue [#274]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/388#pullrequestreview-3693577037)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

중복된 백엔드 충돌 해결 라우트를 제거하고, 정리 작업을 반영하도록 관련 문서 체크리스트를 업데이트합니다.

Bug Fixes:
- 충돌 해결 엔드포인트에 대한 중복된 라우트 데코레이터를 제거하여 불필요한 API 등록을 방지합니다.

Documentation:
- 백엔드 중복 라우트 정리 완료 사항을 반영하기 위해 phase 2 diff viewer README 체크리스트를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove a duplicated backend conflict resolution route and update related documentation checklist to reflect the cleanup.

Bug Fixes:
- Eliminate a duplicate route decorator for the conflict resolution endpoint to prevent redundant API registrations.

Documentation:
- Update the phase 2 diff viewer README checklist to note completion of the backend duplicate route cleanup.

</details>