### PR TITLE
✨ feat(diff) [#10.10.4]: Frontend Monaco Editor 연동 및 API 구현

### DIFF
--- a/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
+++ b/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
@@ -371,11 +371,14 @@ const DiffEditor = dynamic(
 - [x] Backend Fix: 중복 Route Decorator 제거 및 최종 점검 완료
 - [ ] Frontend Integration (API 연동 및 Diff 렌더링)
 
-### Day 3 (01/24-25)
-- [ ] Frontend: Monaco Diff Editor 연동 (`@monaco-editor/react`)
-- [ ] Frontend: Diff API 호출 및 데이터 바인딩
-- [ ] Frontend: Resolution Action 핸들링 (Local/Remote/Both)
-- [ ] Integration: End-to-End Test (SyncMonitor -> DiffViewer flow)
+### Day 3 (01/24)
+- [x] Frontend Integration 계획 수립 및 문서화
+
+### Day 4 (01/25)
+- [x] Frontend: Monaco Diff Editor UI 구현 (DiffEditor Integration)
+- [x] Frontend: Conflict Resolution API Integration (GET /diff)
+- [ ] Frontend: Resolution Action 핸들링 및 E2E Test
+- [ ] Phase 2 Final Review & Merge
 
 ### Integration Checklist
 - [ ] `ConflictDiffViewer` 연동 시 `onResolve` 핸들러가 `keep_both` 케이스를 처리하는지 확인 필수.

--- a/web_ui/src/components/sync/ConflictDiffViewer.tsx
+++ b/web_ui/src/components/sync/ConflictDiffViewer.tsx
@@ -1,9 +1,9 @@
-// web_ui/src/components/sync/ConflictDiffViewer.tsx
-
 'use client';
 
-import React from 'react';
-import { CONFLICT_RESOLUTION_STRATEGIES, type ConflictResolutionStrategy } from '../../types/sync';
+import React, { useEffect, useState } from 'react';
+import { DiffEditor } from '@monaco-editor/react';
+import { CONFLICT_RESOLUTION_STRATEGIES, type ConflictResolutionStrategy, type ConflictDiffResponse } from '../../types/sync';
+import { API_BASE, fetchAPI } from '@/lib/api';
 
 interface ConflictDiffViewerProps {
   conflictId: string;
@@ -12,11 +12,64 @@ interface ConflictDiffViewerProps {
 
 /**
  * Conflict Diff Viewer Component
- * - Displays side-by-side or inline diffs
+ * - Fetches diff data from backend
+ * - Displays side-by-side diff using Monaco DiffEditor
  * - Provides resolution actions (Local, Remote, Both)
- * - Uses centralized constants for resolution strategies
  */
 export function ConflictDiffViewer({ conflictId, onResolve }: ConflictDiffViewerProps) {
+  const [data, setData] = useState<ConflictDiffResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadDiff() {
+      if (!conflictId) return;
+      
+      try {
+        setLoading(true);
+        setError(null);
+        // GET /api/sync/conflicts/{id}/diff
+        const response = await fetchAPI<ConflictDiffResponse>(`${API_BASE}/api/sync/conflicts/${conflictId}/diff`);
+        setData(response);
+      } catch (err) {
+        console.error('Failed to load diff:', err);
+        setError(err instanceof Error ? err.message : 'Failed to load diff data');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadDiff();
+  }, [conflictId]);
+
+  if (loading) {
+    return (
+      <div className="w-full h-full flex items-center justify-center p-8 border rounded-lg bg-muted/10">
+        <span className="text-muted-foreground animate-pulse">Loading diff data...</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="w-full h-[400px] flex flex-col items-center justify-center p-8 border border-red-200 rounded-lg bg-red-50 text-red-600 gap-2">
+        <span className="font-semibold">Error loading content</span>
+        <span className="text-sm">{error}</span>
+        <button 
+           type="button"
+           onClick={() => window.location.reload()}
+           className="mt-4 px-4 py-2 bg-white border border-red-200 rounded hover:bg-red-50 text-sm"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return <div className="p-8 text-center text-muted-foreground">No diff data available</div>;
+  }
+
   return (
     <div className="conflict-diff-viewer w-full h-full flex flex-col gap-4 p-4 border rounded-lg bg-background">
       <div className="flex justify-between items-center header">
@@ -24,30 +77,42 @@ export function ConflictDiffViewer({ conflictId, onResolve }: ConflictDiffViewer
         <div className="text-sm text-muted-foreground">ID: {conflictId}</div>
       </div>
 
-      <div className="diff-area flex-1 min-h-[400px] border border-border rounded-md bg-muted/20 flex items-center justify-center">
-        <span className="text-muted-foreground">
-          Diff Viewer Placeholder (Integration Pending)
-        </span>
+      <div className="diff-area flex-1 min-h-[500px] border border-border rounded-md overflow-hidden bg-zinc-900">
+        <DiffEditor
+          height="100%"
+          language={data.file_type || 'markdown'}
+          original={data.remote_content} // Original = Remote (Incoming)
+          modified={data.local_content}  // Modified = Local (Current)
+          options={{
+            readOnly: true,
+            renderSideBySide: true,
+            minimap: { enabled: false },
+            scrollBeyondLastLine: false,
+            automaticLayout: true,
+            diffWordWrap: 'on',
+          }}
+          theme="vs-dark"
+        />
       </div>
 
-      <div className="actions flex justify-end gap-2">
+      <div className="actions flex justify-end gap-2 pt-2">
         <button 
           type="button"
-          className="px-4 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90"
+          className="px-4 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90 font-medium transition-colors"
           onClick={() => onResolve?.(CONFLICT_RESOLUTION_STRATEGIES.KEEP_LOCAL)}
         >
-          Keep Local
+          Keep Local (Modified)
         </button>
         <button 
           type="button"
-          className="px-4 py-2 bg-secondary text-secondary-foreground rounded hover:bg-secondary/80"
+          className="px-4 py-2 bg-secondary text-secondary-foreground rounded hover:bg-secondary/80 font-medium transition-colors"
           onClick={() => onResolve?.(CONFLICT_RESOLUTION_STRATEGIES.KEEP_REMOTE)}
         >
-          Keep Remote
+          Keep Remote (Original)
         </button>
         <button 
           type="button"
-          className="px-4 py-2 border border-input bg-background hover:bg-accent hover:text-accent-foreground rounded"
+          className="px-4 py-2 border border-input bg-background hover:bg-accent hover:text-accent-foreground rounded font-medium transition-colors"
           onClick={() => onResolve?.(CONFLICT_RESOLUTION_STRATEGIES.KEEP_BOTH)}
         >
           Keep Both

--- a/web_ui/src/types/sync.ts
+++ b/web_ui/src/types/sync.ts
@@ -31,3 +31,11 @@ export interface ConflictLog {
   resolutionStrategy?: ConflictResolutionStrategy;
   timestamp?: string;
 }
+
+export interface ConflictDiffResponse {
+  conflict_id: string;
+  local_content: string;
+  remote_content: string;
+  diff: Record<string, unknown>;
+  file_type: string;
+}


### PR DESCRIPTION
- 💻 Frontend: ConflictDiffViewer에 Monaco DiffEditor 적용 및 데이터 바인딩
- 🔄 API: GET /diff 엔드포인트 연동 및 로딩/에러 상태 처리
- 🏷️ Types: ConflictDiffResponse 인터페이스 추가 및 Lint 수정 (no-any)
- 📝 Docs: 01/25 Frontend 구현 완료 항목 업데이트

📌 Related:
- Issue [#274]

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

Monaco 기반 diff 뷰어를 충돌 해결 UI에 통합하고, 새로운 백엔드 diff API와 연동합니다.

New Features:
- `ConflictDiffViewer` 컴포넌트에 Monaco `DiffEditor` 기반 UI를 추가하여, 읽기 전용의 좌우 비교 렌더링과 해결(Resolution) 액션 버튼을 포함한 충돌 diff를 표시합니다.

Enhancements:
- 로딩, 에러, 빈 상태 처리를 포함해 `ConflictDiffViewer`를 백엔드 `GET /api/sync/conflicts/{id}/diff` 엔드포인트에 연결합니다.
- diff API 응답을 위한 타입 정의된 `ConflictDiffResponse` 인터페이스를 도입하고, sync 타입 모듈에 더 엄격한 타이핑을 적용합니다.

Documentation:
- 2단계(phase 2) diff 뷰어 구현 계획을 업데이트하여, 완료된 프론트엔드 Monaco 통합 및 diff API 연동 내용을 반영하고, 남아 있는 해결(Resolution)/E2E 작업을 별도로 분리합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate the Monaco-based diff viewer into the conflict resolution UI and wire it up to the new backend diff API.

New Features:
- Add a Monaco DiffEditor-based UI to display conflict diffs in the ConflictDiffViewer component, including read-only side-by-side rendering and resolution action buttons.

Enhancements:
- Connect ConflictDiffViewer to the backend GET /api/sync/conflicts/{id}/diff endpoint with loading, error, and empty-state handling.
- Introduce a typed ConflictDiffResponse interface for diff API responses and apply stricter typing in the sync types module.

Documentation:
- Update the phase 2 diff viewer implementation plan to reflect completed frontend Monaco integration and diff API wiring and to split out remaining resolution/E2E tasks.

</details>