### PR TITLE
♻️ refactor(diff) [#10.10.4]: 1차 개선 - UX/DX 고도화 및 버그 수정

### DIFF
--- a/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
+++ b/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
@@ -377,6 +377,7 @@ const DiffEditor = dynamic(
 ### Day 4 (01/25)
 - [x] Frontend: Monaco Diff Editor UI 구현 (DiffEditor Integration)
 - [x] Frontend: Conflict Resolution API Integration (GET /diff)
+- [x] Frontend Refactoring: Retry Logic 개선 & Type Safety 강화 (DiffResult)
 - [ ] Frontend: Resolution Action 핸들링 및 E2E Test
 - [ ] Phase 2 Final Review & Merge
 

--- a/web_ui/src/types/sync.ts
+++ b/web_ui/src/types/sync.ts
@@ -24,6 +24,17 @@ export const CONFLICT_STATUS = {
 export type ConflictStatus = typeof CONFLICT_STATUS[keyof typeof CONFLICT_STATUS];
 
 // Models
+export interface DiffStats {
+  additions: number;
+  deletions: number;
+}
+
+export interface DiffResult {
+  unified: string;
+  html: string;
+  stats: DiffStats;
+}
+
 export interface ConflictLog {
   id: string;
   filePath: string;
@@ -36,6 +47,6 @@ export interface ConflictDiffResponse {
   conflict_id: string;
   local_content: string;
   remote_content: string;
-  diff: Record<string, unknown>;
+  diff: DiffResult;
   file_type: string;
 }


### PR DESCRIPTION
- 🚦 UX: Diff Loading 실패 시 페이지 새로고침 대신 Local Retry(재시도) 로직 구현
- 🛡️ Types: DiffResult 구체화(Unified, HTML, Stats)로 타입 안전성 강화
- 🐛 Fix: ConflictDiffViewer 내 setLoading undefined 에러 수정
- 📝 Docs: Local/Remote 매핑 명시 및 리팩토링 현황 업데이트

📌 Related:
- Issue [#274]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/391#pullrequestreview-3703731621)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

충돌(diff) 뷰어의 UX와 타입 안정성을 개선하고, 관련 문서를 업데이트합니다.

Bug Fixes:
- 충돌 diff 뷰어에서 diff 로드 실패 시 전체 페이지 새로고침 대신, 페이지 내에서 재시도할 수 있는 플로우로 교체합니다.

Enhancements:
- 충돌 diff 뷰어에서 로컬 재시도 동작이 가능하도록, diff 로딩 로직을 재사용 가능한 콜백으로 분리합니다.
- 구조화된 `DiffResult` 및 `DiffStats` 타입을 도입하고 이를 `ConflictDiffResponse`에 연결하여 sync diff 타이핑을 강화합니다.

Documentation:
- 개선된 재시도 로직과 더 엄격해진 `DiffResult` 타이핑을 반영하도록 diff 뷰어 2단계 문서를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the conflict diff viewer UX and type safety while updating related documentation.

Bug Fixes:
- Replace full page reload on diff load failure with an in-place retry flow in the conflict diff viewer.

Enhancements:
- Extract diff loading into a reusable callback to enable local retry behavior in the conflict diff viewer.
- Strengthen sync diff typing by introducing structured DiffResult and DiffStats types and wiring them into ConflictDiffResponse.

Documentation:
- Update diff viewer phase 2 documentation to reflect the improved retry logic and stricter DiffResult typing.

</details>