### PR TITLE
♻️ refactor(diff) [#10.10.4]: 2차 개선 - Async Request 안정성 강화

### DIFF
--- a/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
+++ b/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
@@ -378,6 +378,7 @@ const DiffEditor = dynamic(
 - [x] Frontend: Monaco Diff Editor UI 구현 (DiffEditor Integration)
 - [x] Frontend: Conflict Resolution API Integration (GET /diff)
 - [x] Frontend Refactoring: Retry Logic 개선 & Type Safety 강화 (DiffResult)
+- [x] Frontend Refactoring: Race Condition 방지 (AbortController)
 - [ ] Frontend: Resolution Action 핸들링 및 E2E Test
 - [ ] Phase 2 Final Review & Merge
 


### PR DESCRIPTION
- 🚦 Stability: AbortController 도입으로 Race Condition 방지 (Unmount/ID Change Safety)
- 🔒 UX: 로딩 중 Retry 버튼 비활성화로 중복 요청 방지
- 📝 Docs: AbortController 리팩토링 내역 업데이트

📌 Related:
- Issue [#274]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/392#pullrequestreview-3703735784)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

비동기 diff 로딩 중에 발생할 수 있는 레이스 컨디션과 불필요한 재시도를 피하기 위해 conflict diff 뷰어의 요청 처리 방식을 개선합니다.

Enhancements:
- `AbortController` 기반 취소 기능을 conflict diff fetch에 추가하여, 요청이 겹치는 상황과 오래된 상태로의 업데이트를 방지합니다.
- 요청이 진행 중일 때는 diff 재시도 버튼을 비활성화하여 중복 API 호출을 방지합니다.

Documentation:
- 2단계 diff 뷰어 README 체크리스트에 `AbortController` 기반 레이스 컨디션 방지 방법을 문서화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the conflict diff viewer’s request handling to avoid race conditions and redundant retries during async diff loading.

Enhancements:
- Add AbortController-based cancellation to conflict diff fetches to prevent overlapping requests and stale state updates.
- Disable the diff retry button while a request is in progress to prevent duplicate API calls.

Documentation:
- Document the AbortController-based race condition prevention in the phase 2 diff viewer README checklist.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

비동기 diff 로딩 중에 발생할 수 있는 레이스 컨디션과 불필요한 재시도를 피하기 위해 conflict diff 뷰어의 요청 처리 방식을 개선합니다.

Enhancements:
- `AbortController` 기반 취소 기능을 conflict diff fetch에 추가하여, 요청이 겹치는 상황과 오래된 상태로의 업데이트를 방지합니다.
- 요청이 진행 중일 때는 diff 재시도 버튼을 비활성화하여 중복 API 호출을 방지합니다.

Documentation:
- 2단계 diff 뷰어 README 체크리스트에 `AbortController` 기반 레이스 컨디션 방지 방법을 문서화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the conflict diff viewer’s request handling to avoid race conditions and redundant retries during async diff loading.

Enhancements:
- Add AbortController-based cancellation to conflict diff fetches to prevent overlapping requests and stale state updates.
- Disable the diff retry button while a request is in progress to prevent duplicate API calls.

Documentation:
- Document the AbortController-based race condition prevention in the phase 2 diff viewer README checklist.

</details>

</details>