### PR TITLE
♻️ refactor(diff) [#10.10.4]: 3차 개선 - Custom Hook 도입 및 Code Clean-up

### DIFF
--- a/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
+++ b/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
@@ -378,7 +378,7 @@ const DiffEditor = dynamic(
 - [x] Frontend: Monaco Diff Editor UI 구현 (DiffEditor Integration)
 - [x] Frontend: Conflict Resolution API Integration (GET /diff)
 - [x] Frontend Refactoring: Retry Logic 개선 & Type Safety 강화 (DiffResult)
-- [x] Frontend Refactoring: Race Condition 방지 (AbortController)
+- [x] Frontend Refactoring: Race Condition 방지 & Custom Hook 도입 (`useFetch`)
 - [ ] Frontend: Resolution Action 핸들링 및 E2E Test
 - [ ] Phase 2 Final Review & Merge
 

--- a/web_ui/src/hooks/useFetch.ts
+++ b/web_ui/src/hooks/useFetch.ts
@@ -1,0 +1,76 @@
+// web_ui/src/hooks/useFetch.ts
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+interface FetchState<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Custom hook for abortable fetch
+ * - Handles AbortController automatically
+ * - Prevents race conditions
+ * - Initial loading state is true
+ */
+export function useFetch<T>(
+  fetchFn: (signal: AbortSignal) => Promise<T>,
+  deps: ReadonlyArray<unknown> = []
+) {
+  const [state, setState] = useState<FetchState<T>>({
+    data: null,
+    loading: true,
+    error: null,
+  });
+
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const fetchData = useCallback(async () => {
+    // Cancel previous request
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    setState(prev => ({ ...prev, loading: true, error: null }));
+
+    try {
+      const result = await fetchFn(controller.signal);
+      
+      // Update state only if this is the latest request
+      if (abortControllerRef.current === controller) {
+        setState({ data: result, loading: false, error: null });
+        abortControllerRef.current = null;
+      }
+    } catch (err) {
+      // Ignore abort errors
+      if (err instanceof Error && err.name === 'AbortError') {
+        return;
+      }
+      
+      // Update error state only if this is the latest request
+      if (abortControllerRef.current === controller) {
+        setState(prev => ({
+           ...prev,
+           loading: false,
+           error: err instanceof Error ? err.message : 'Unknown error'
+        }));
+        abortControllerRef.current = null;
+      }
+    }
+  }, [...deps]);
+
+  useEffect(() => {
+    fetchData();
+    return () => {
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+    };
+  }, [fetchData]);
+
+  return { ...state, refetch: fetchData };
+}


### PR DESCRIPTION
- 📦 Hook: 재사용 가능한 useFetch Hook 도입 (AbortController & State Management 캡슐화)
- 🧹 Refactor: ConflictDiffViewer의 비동기 로직을 Hook으로 위임하여 가독성 향상
- 🔇 Log: 프로덕션 환경 로그 노이즈(AbortError) 제거
- 📝 Docs: 리팩토링 진행 상황 업데이트

📌 Related:
- Issue [#274]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/393#pullrequestreview-3703742965)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet♻️ refactor(diff) [#10.10.4]: 3차 개선 - Custom Hook 도입 및 Code Clean-up

- 📦 Hook: 재사용 가능한 useFetch Hook 도입 (AbortController & State Management 캡슐화)
- 🧹 Refactor: ConflictDiffViewer의 비동기 로직을 Hook으로 위임하여 가독성 향상
- 🔇 Log: 프로덕션 환경 로그 노이즈(AbortError) 제거
- 📝 Docs: 리팩토링 진행 상황 업데이트

📌 Related:
- Issue [#274]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/393#pullrequestreview-3703742965)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

재사용 가능한 중단 가능한(fetch 취소 가능한) 페치 훅을 도입하고, 새로운 diff 뷰어 리팩터링을 반영하도록 문서를 업데이트합니다.

New Features:
- 로딩 및 에러 상태 관리가 포함된 중단 가능한 비동기 요청을 캡슐화하는 일반적인 `useFetch` React 훅을 추가합니다.

Enhancements:
- 소비 측 코드를 단순화하고 중복된 비동기 제어 로직을 줄이기 위해, `AbortController` 기반 경쟁 상태(race condition) 방지 로직을 공유 훅으로 중앙집중화합니다.

Documentation:
- 경쟁 상태 방지를 위한 `useFetch` 기반 리팩터링 내용을 문서화하기 위해 Phase 2 diff 뷰어 README 체크리스트를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a reusable abortable fetch hook and update documentation to reflect the new diff viewer refactoring.

New Features:
- Add a generic useFetch React hook that encapsulates abortable asynchronous requests with loading and error state management.

Enhancements:
- Centralize AbortController-based race condition prevention in a shared hook to simplify consumers and reduce duplicated async control logic.

Documentation:
- Update Phase 2 diff viewer README checklist to document the useFetch-based refactoring for race condition prevention.

</details>