### PR TITLE
♻️ refactor(diff) [#10.10.4]: 4차 개선 -  Hook Stability & Data Freshness

### DIFF
--- a/web_ui/src/hooks/useFetch.ts
+++ b/web_ui/src/hooks/useFetch.ts
@@ -35,7 +35,8 @@ export function useFetch<T>(
     const controller = new AbortController();
     abortControllerRef.current = controller;
 
-    setState(prev => ({ ...prev, loading: true, error: null }));
+    // Reset data to avoid showing stale content
+    setState(prev => ({ ...prev, loading: true, error: null, data: null }));
 
     try {
       const result = await fetchFn(controller.signal);
@@ -61,7 +62,8 @@ export function useFetch<T>(
         abortControllerRef.current = null;
       }
     }
-  }, [...deps]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchFn, ...deps]);
 
   useEffect(() => {
     fetchData();


### PR DESCRIPTION
- 🔧 Hook: useFetch 의존성 배열에 fetchFn 추가 및 Stale Closure 방지 로직 적용
- 🧹 Refactor: ConflictDiffViewer에서 fetchFn을 useCallback으로 감싸 Hook 규칙 준수
- 🔄 Logic: 새로운 Fetch 시작 시 이전 Data를 null로 초기화하여 Stale UI 노출 방지
- 🐛 Fix: 멀티 라인 수정 중 발생한 구문 오류(Syntax Error) 해결

📌 Related:
- Issue [#274]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/394#pullrequestreview-3703747885)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

공유 `useFetch` 훅을 사용하도록 Conflict diff viewer를 리팩터링하여, 훅 의존성 처리와 데이터 신선도를 개선하면서 fetch 동작을 안정화했습니다.

버그 수정:
- 새로운 요청 시 데이터를 초기화하고 `useFetch`의 의존성을 올바르게 연결함으로써, fetch 로직에서 발생할 수 있는 오래된 UI 및 stale closure 문제를 수정했습니다.

개선 사항:
- `ConflictDiffViewer`의 인라인 async fetch 로직을 공유 `useFetch` 훅으로 대체하여, 요청 중단(Abort) 가능성과 더 깔끔한 상태 관리를 구현했습니다.
- `useFetch`에 전달되는 fetch 함수가 `useCallback`으로 메모이제이션되도록 하여 훅의 안정성을 유지하고 React hook 규칙을 준수하도록 했습니다.
- `useFetch`가 의존성 배열에 fetch 함수를 포함하고, 새로운 요청을 시작할 때 이전 데이터를 초기화하도록 업데이트하여 오래된 콘텐츠가 표시되지 않도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor conflict diff viewer to use the shared useFetch hook and stabilize its fetch behavior while improving hook dependency handling and data freshness.

Bug Fixes:
- Fix potential stale UI and stale closure issues in fetching logic by resetting data on new requests and correctly wiring dependencies in useFetch.

Enhancements:
- Replace inline async fetching logic in ConflictDiffViewer with the shared useFetch hook for abortable requests and cleaner state handling.
- Ensure the fetch function passed into useFetch is memoized with useCallback to maintain hook stability and comply with React hook rules.
- Update useFetch to include the fetch function in its dependencies and clear previous data when starting a new request to avoid showing stale content.

</details>