### PR TITLE
♻️ refactor(diff) [#10.10.4]: 5차 개선 - Hook Pattern 고도화

### DIFF
--- a/web_ui/src/components/sync/ConflictDiffViewer.tsx
+++ b/web_ui/src/components/sync/ConflictDiffViewer.tsx
@@ -1,6 +1,8 @@
+// web_ui/src/components/sync/ConflictDiffViewer.tsx  
+
 'use client';
 
-import React, { useCallback } from 'react';
+import React from 'react';
 import { DiffEditor } from '@monaco-editor/react';
 import { CONFLICT_RESOLUTION_STRATEGIES, type ConflictResolutionStrategy, type ConflictDiffResponse } from '../../types/sync';
 import { API_BASE, fetchAPI } from '@/lib/api';
@@ -17,18 +19,17 @@ interface ConflictDiffViewerProps {
  * - Uses useFetch hook for abortable async requests
  */
 export function ConflictDiffViewer({ conflictId, onResolve }: ConflictDiffViewerProps) {
-  // Stable fetch function to pass to useFetch
-  const fetchDiff = useCallback(async (signal: AbortSignal) => {
-    if (!conflictId) return null;
-    return fetchAPI<ConflictDiffResponse>(
-      `${API_BASE}/api/sync/conflicts/${conflictId}/diff`, 
-      { signal }
-    );
-  }, [conflictId]);
-
+  // Use custom hook for data fetching
+  // Dependencies ([conflictId]) explicitly control when the fetch occurs
   const { data, loading, error, refetch } = useFetch<ConflictDiffResponse | null>(
-    fetchDiff,
-    [] // fetchDiff is already stable
+    async (signal) => {
+      if (!conflictId) return null;
+      return fetchAPI<ConflictDiffResponse>(
+        `${API_BASE}/api/sync/conflicts/${conflictId}/diff`, 
+        { signal }
+      );
+    },
+    [conflictId]
   );
 
   if (loading) {


### PR DESCRIPTION
- 🏗️ Hook: useFetch에 'Latest Ref' 패턴 적용으로 fetchFn 의존성 제거 및 리렌더링 안정화
- 🧹 Refactor: ConflictDiffViewer의 데이터 페칭 로직 간소화 및 명시적 의존성 주입
- ✅ Check: Implicit Dependency 제거로 가독성 및 유지보수성 향상

📌 Related:
- Issue [#274]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/395#pullrequestreview-3703754844)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

충돌 diff 보기용 데이터 패칭 패턴을 개선하기 위해 fetch 훅 API를 안정화하고, 그 사용 시 의존성을 명시적으로 드러내도록 합니다.

개선 사항:
- `useFetch` 훅을 최신 참조(latest-ref) 패턴으로 업데이트하여, 함수 아이덴티티 변경이 아니라 명시적인 의존성 배열에 의해 fetch가 수행되도록 합니다.
- `ConflictDiffViewer`를 단순화하여 fetch 로직을 컴포넌트 내부에 인라인하고, 보다 명확한 데이터 로딩 동작을 위해 명시적인 의존성을 `useFetch`에 전달하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the data fetching pattern for conflict diff viewing by stabilizing the fetch hook API and making its usage dependencies explicit.

Enhancements:
- Update useFetch hook to use a latest-ref pattern so fetches are driven by explicit dependency arrays rather than function identity changes.
- Simplify ConflictDiffViewer to inline its fetch logic and pass explicit dependencies into useFetch for clearer data-loading behavior.

</details>