### PR TITLE
✨ feat(diff) [#10.10.5]: Frontend Integration (SyncMonitor + DiffViewer)

### DIFF
--- a/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
+++ b/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
@@ -379,8 +379,12 @@ const DiffEditor = dynamic(
 - [x] Frontend: Conflict Resolution API Integration (GET /diff)
 - [x] Frontend Refactoring: Retry Logic 개선 & Type Safety 강화 (DiffResult)
 - [x] Frontend Refactoring: Race Condition 방지 & Custom Hook 도입 (`useFetch`)
-- [ ] Frontend: Resolution Action 핸들링 및 E2E Test
-- [ ] Phase 2 Final Review & Merge
+- [ ] Frontend: Resolution Action 핸들링 및 E2E Test (-> Day 5 이동)
+
+### Day 5 (01/26) - Integration Flow
+- [x] Integration: `SyncMonitor` 내 `ConflictDiffViewer` 연동 (Sheet UI)
+- [x] Logic: `POST /resolve` API 호출 및 상태 갱신 로직 구현
+- [ ] Test: End-to-End Conflict Resolution Flow 검증
 
 ### Integration Checklist
 - [ ] `ConflictDiffViewer` 연동 시 `onResolve` 핸들러가 `keep_both` 케이스를 처리하는지 확인 필수.


### PR DESCRIPTION
- 🧩 Integrate: SyncMonitor에 ConflictDiffViewer를 Sheet(Modal) 형태로 통합
- 🔄 Logic: 충돌 해결(Resolution) API 호출 및 목록 자동 갱신 로직 구현
- 🗑️ Cleanup: 미사용 Import 제거(Legacy ConflictResolver 등) 및 Lint Warning 해결
- 📝 Docs: 01/26 Integration 작업 내역 업데이트

📌 Related:
- Issue [#274]

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

충돌(diff) 뷰어를 SyncMonitor에 통합하고, 백엔드 충돌 해결 API와 연동하며 관련 문서를 업데이트합니다.

New Features:
- 동기화 대시보드에서 충돌을 해결할 수 있도록, 시트 기반 모달을 사용해 SyncMonitor에 ConflictDiffViewer를 임베드합니다.

Enhancements:
- SyncMonitor에서 ID 기준으로 충돌을 추적하도록 충돌 선택 상태를 개선하고, 해결 처리 로직을 단순화합니다.
- 충돌 해결 액션을 백엔드 `POST /resolve` 엔드포인트에 연결하고, 해결 후 충돌 목록이 새로 고침되도록 트리거합니다.

Documentation:
- 새 SyncMonitor 연동 플로우와 해결 API 사용법을 반영해 phase 2 diff 뷰어 통합 README를 업데이트하고, 일자별 작업 분류를 조정합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate the conflict diff viewer into SyncMonitor and wire it to the backend conflict resolution API while updating related documentation.

New Features:
- Embed ConflictDiffViewer in SyncMonitor using a sheet-based modal for resolving conflicts from the sync dashboard.

Enhancements:
- Refine conflict selection state in SyncMonitor to track conflicts by ID and simplify resolution handling.
- Hook up conflict resolution actions to the backend POST /resolve endpoint and trigger refresh of the conflict list after resolution.

Documentation:
- Update phase 2 diff viewer integration README with the new SyncMonitor integration flow and resolution API usage, and adjust the day-by-day task breakdown.

</details>