### PR TITLE
✅ test(diff) [#10.10.6]: 4차 개선 - Validation Logic 재사용성 강화

### DIFF
--- a/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
+++ b/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
@@ -384,7 +384,7 @@ const DiffEditor = dynamic(
 ### Day 5 (01/26) - Integration Flow
 - [x] Integration: `SyncMonitor` 내 `ConflictDiffViewer` 연동 (Sheet UI, Responsive/Smooth Width)
 - [x] Logic: `POST /resolve` API 호출 (Safe URL Encoding) 및 상태 갱신 로직 구현
-- [x] Test: Integration Test 강화 (Parametrization, Schema Deep Check, Robust Error Validation)
+- [x] Test: Integration Test 강화 (Parametrization, Schema Deep Check, Robust Error Validation Helper)
 
 ## ✅ Phase 2 완료
 - Backend Diff API 및 로직 구현 완료


### PR DESCRIPTION
- 🔧 Refactor: 422 Error 검증 로직을 [validate_422_error](tests/integration/test_diff_viewer_flow.py) 헬퍼 함수로 추출하여 중복 제거
- 🛡️ Reliability: `detail` 리스트의 모든 항목에 대한 구조적 무결성 검증 추가
- 📝 Docs: 테스트 리팩토링 내역 업데이트

📌 Related:
- Issue [#274]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/403#pullrequestreview-3704935048)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

공통 422 유효성 검사 에러 체크 로직을 재사용 가능한 테스트 헬퍼로 추출하고, 관련 문서의 참조를 업데이트합니다.

Enhancements:
- 통합 테스트에서 FastAPI 422 유효성 검사 에러의 구조를 중앙에서 검증할 수 있도록 재사용 가능한 `validate_422_error` 헬퍼를 도입합니다.
- 첫 번째 항목뿐만 아니라 `detail` 리스트의 모든 항목에 대해 구조적 무결성을 검증하도록 유효성 검사 에러에 대한 assertion을 강화합니다.

Documentation:
- 통합 테스트에서 새로운 견고한 에러 검증 헬퍼를 참조하도록 diff viewer 2단계 문서를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract shared 422 validation error checks into a reusable test helper and update related documentation references.

Enhancements:
- Introduce a reusable validate_422_error helper to centralize FastAPI 422 validation error structure checks in integration tests.
- Strengthen validation error assertions to verify structural integrity for all items in the detail list, not just the first entry.

Documentation:
- Update diff viewer phase 2 documentation to reference the new robust error validation helper in integration tests.

</details>