### PR TITLE
✅ test(diff) [#10.10.6]: 5차 개선 - Test Helper Extraction & Robustness

### DIFF
--- a/tests/integration/test_diff_viewer_flow.py
+++ b/tests/integration/test_diff_viewer_flow.py
@@ -3,38 +3,12 @@
 import pytest
 from fastapi.testclient import TestClient
 from backend.main import app
+from tests.test_utils import validate_422_error_structure
 
 client = TestClient(app)
 
 # Shared Constant
 MOCK_CONFLICT_ID = "mock-conflict-123"
-
-
-def validate_422_error(response, expected_loc: tuple):
-    """
-    Helper function to validate FastAPI 422 Validation Error structure.
-    Checks if the response contains proper validation error details
-    pointing to the expected location (e.g., query param name).
-    """
-    error_body = response.json()
-    assert "detail" in error_body, "Error response missing 'detail' field"
-
-    detail = error_body["detail"]
-    assert isinstance(detail, list), "'detail' should be a list"
-    assert len(detail) > 0, "'detail' list is empty"
-
-    # Validate structure of ALL error items to prevent KeyError later
-    # This ensures every item is a dict and has the 'loc' key
-    assert all(
-        isinstance(e, dict) and "loc" in e for e in detail
-    ), "All error items must be dicts with a 'loc' field"
-
-    # Verify exact location match
-    # Pydantic validation errors return location as a list
-    error_locs = [tuple(e["loc"]) for e in detail]
-    assert (
-        expected_loc in error_locs
-    ), f"Expected error at {expected_loc}, found locations: {error_locs}"
 
 
 def test_get_diff_schema():
@@ -96,4 +70,4 @@ def test_resolve_conflict_scenarios(method, expected_status):
         assert result["conflict_id"] == MOCK_CONFLICT_ID
     elif expected_status == 422:
         # Use helper function to validate error structure robustly
-        validate_422_error(response, ("query", "resolution_method"))
+        validate_422_error_structure(response, ("query", "resolution_method"))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,34 @@
+# tests/test_utils.py
+
+
+def validate_422_error_structure(response, expected_loc: tuple):
+    """
+    Helper function to validate FastAPI 422 Validation Error structure.
+    Checks if the response contains proper validation error details
+    pointing to the expected location.
+
+    Args:
+        response: The response object from TestClient
+        expected_loc: Tuple representing the expected error location (e.g. ("query", "param_name"))
+    """
+    error_body = response.json()
+    assert "detail" in error_body, "Error response missing 'detail' field"
+
+    detail = error_body["detail"]
+    assert isinstance(detail, list), "'detail' should be a list"
+    assert len(detail) > 0, "'detail' list is empty"
+
+    # Validate structure of ALL error items
+    for i, e in enumerate(detail):
+        assert isinstance(e, dict), f"Error item {i} should be a dict"
+        assert "loc" in e, f"Error item {i} missing 'loc' field"
+        # Validate that 'loc' itself is a list (JSON spec) or tuple
+        assert isinstance(
+            e["loc"], (list, tuple)
+        ), f"Error item {i} 'loc' should be a list or tuple"
+
+    # Verify exact location match
+    error_locs = [tuple(e["loc"]) for e in detail]
+    assert (
+        expected_loc in error_locs
+    ), f"Expected error at {expected_loc}, found locations: {error_locs}"


### PR DESCRIPTION
- 🛠️ Refactor: 테스트 헬퍼 함수를 [tests/test_utils.py](tests/test_utils.py)로 분리하여 재사용성 확보
- 🛡️ Enhance: 에러 검증 시 `loc` 타입 체크 등 방어적 코딩 적용으로 테스트 신뢰성 향상
- 📝 Docs: 테스트 개선 작업 업데이트

📌 Related:
- Issue [#274]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/404#pullrequestreview-3704959051)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

공유되는 FastAPI 422 검증 오류(assertion)를 재사용 가능한 테스트 헬퍼로 추출하고, 이를 diff 뷰어 통합 테스트에서 사용하도록 변경합니다.

Tests:
- FastAPI 422 오류 응답을 일관되게 검증하기 위해 `tests/test_utils.py`에 중앙집중식 `validate_422_error_structure` 헬퍼를 추가합니다.
- diff 뷰어 충돌 해결 통합 테스트에서 공통 422 오류 검증 헬퍼를 사용하도록 업데이트하고, 오류 위치에 대한 구조적 검사 강도를 높입니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract shared FastAPI 422 validation error assertions into a reusable test helper and adopt it in the diff viewer integration tests.

Tests:
- Add a centralized validate_422_error_structure helper in tests/test_utils.py for consistent validation of FastAPI 422 error responses.
- Update diff viewer conflict resolution integration tests to use the shared 422 error validation helper with stronger structural checks on error locations.

</details>