### PR TITLE
✅ test(diff) [#10.10.6]: 최종 개선 - Helper Decoupling & Clarity

### DIFF
--- a/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
+++ b/docs/P/v6.0_phase2_diff_viewer/README_phase2.md
@@ -384,7 +384,7 @@ const DiffEditor = dynamic(
 ### Day 5 (01/26) - Integration Flow
 - [x] Integration: `SyncMonitor` 내 `ConflictDiffViewer` 연동 (Sheet UI, Responsive/Smooth Width)
 - [x] Logic: `POST /resolve` API 호출 (Safe URL Encoding) 및 상태 갱신 로직 구현
-- [x] Test: Integration Test 강화 (Parametrization, Schema Deep Check, Robust Error Validation Helper)
+- [x] Test: Integration Test 강화 (Parametrization, Schema Deep Check, Robust Error Validation Helper v2)
 
 ## ✅ Phase 2 완료
 - Backend Diff API 및 로직 구현 완료

--- a/tests/integration/test_diff_viewer_flow.py
+++ b/tests/integration/test_diff_viewer_flow.py
@@ -3,7 +3,7 @@
 import pytest
 from fastapi.testclient import TestClient
 from backend.main import app
-from tests.test_utils import validate_422_error_structure
+from tests.test_utils import validate_pydantic_error_structure
 
 client = TestClient(app)
 
@@ -69,5 +69,9 @@ def test_resolve_conflict_scenarios(method, expected_status):
         assert result["method"] == method
         assert result["conflict_id"] == MOCK_CONFLICT_ID
     elif expected_status == 422:
-        # Use helper function to validate error structure robustly
-        validate_422_error_structure(response, ("query", "resolution_method"))
+        # Explicitly assert status code for clarity, even if checked above
+        assert response.status_code == 422
+        # Use helper function with parsed JSON body
+        validate_pydantic_error_structure(
+            response.json(), ("query", "resolution_method")
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,17 +1,13 @@
-# tests/test_utils.py
-
-
-def validate_422_error_structure(response, expected_loc: tuple):
+def validate_pydantic_error_structure(error_body: dict, expected_loc: tuple):
     """
-    Helper function to validate FastAPI 422 Validation Error structure.
-    Checks if the response contains proper validation error details
+    Helper function to validate Standard Pydantic/FastAPI Validation Error structure.
+    Checks if the error body contains proper validation error details
     pointing to the expected location.
 
     Args:
-        response: The response object from TestClient
+        error_body: The parsed JSON body of the error response (dict)
         expected_loc: Tuple representing the expected error location (e.g. ("query", "param_name"))
     """
-    error_body = response.json()
     assert "detail" in error_body, "Error response missing 'detail' field"
 
     detail = error_body["detail"]


### PR DESCRIPTION
- 🔧 Refactor: 헬퍼 함수를 [validate_pydantic_error_structure](tests/test_utils.py)로 변경하고 인자를 분리하여(TestClient -> dict) 재사용성 최적화
- 🔍 Verify: 에러 케이스에서 상태 코드(422)를 명시적으로 재확인하여 테스트 명확성 강화
- 📝 Docs: 테스트 개선 작업 최종 이력 업데이트

📌 Related:
- Issue [#274]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/405#pullrequestreview-3704971141)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

diff 뷰어 플로우에 대한 통합 테스트의 에러 처리 방식을 명확히 하고, 검증 에러 테스트 헬퍼의 사용을 개선했습니다.

개선 사항:
- 검증 에러 헬퍼가 파싱된 JSON 에러 바디를 인자로 받을 수 있도록 일반화하고, 더 넓은 Pydantic/FastAPI 재사용을 위해 이름을 변경했습니다.
- diff 뷰어 통합 테스트에서 422 상태 코드를 명시적으로 검증하고, JSON 페이로드와 함께 분리된 검증 헬퍼를 사용하도록 업데이트했습니다.

문서화:
- 2단계 diff 뷰어 README 체크리스트를 업데이트하여, 견고한 에러 검증 헬퍼의 두 번째 버전을 참조하도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine validation error test helper usage and clarify integration test error handling for the diff viewer flow.

Enhancements:
- Generalize the validation error helper to accept a parsed JSON error body and rename it for broader Pydantic/FastAPI reuse.
- Update the diff viewer integration test to explicitly assert 422 status and use the decoupled validation helper with JSON payload.

Documentation:
- Update phase 2 diff viewer README checklist to reference the second version of the robust error validation helper.

</details>