### PR TITLE
✨ feat(i18n) [#10.11.2]: LanguageSwitcher 구현 및 Navigation 통합

### DIFF
--- a/web_ui/src/components/common/language-switcher.tsx
+++ b/web_ui/src/components/common/language-switcher.tsx
@@ -1,0 +1,44 @@
+// web_ui/src/components/common/language-switcher.tsx
+
+'use client';
+
+import { useLocale } from 'next-intl';
+import { usePathname, useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { type Locale, localeNames, locales } from '@/i18n/config';
+
+export function LanguageSwitcher({ className }: { className?: string }) {
+  const locale = useLocale();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const handleLocaleChange = (newLocale: Locale) => {
+    // next-intl 미들웨어 설정을 따름: /ko/..., /en/...
+    // pathname에는 이미 locale이 포함되어 있음 (middleware 설정에 따라 다를 수 있으나 일반적인 패턴 사용)
+    const segments = pathname.split('/');
+    segments[1] = newLocale; // 첫 번째 세그먼트가 locale이라고 가정 (middleware prefix: always)
+    const newPath = segments.join('/');
+    
+    router.push(newPath);
+  };
+
+  return (
+    <div className={cn("flex flex-row gap-1 border rounded-md p-1", className)}>
+      {locales.map((cur) => (
+        <Button
+          key={cur}
+          variant={locale === cur ? 'secondary' : 'ghost'}
+          size="sm"
+          onClick={() => handleLocaleChange(cur)}
+          className={cn(
+            "flex-1 text-xs h-7 px-2",
+            locale === cur && "bg-white shadow-sm font-medium"
+          )}
+        >
+          {localeNames[cur]}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/web_ui/src/components/layout/sidebar.tsx
+++ b/web_ui/src/components/layout/sidebar.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { NavItem } from "./nav-item";
 import { mainNavItems, settingsItems } from "@/config/navigation";
+import { LanguageSwitcher } from "@/components/common/language-switcher";
 
 export function Sidebar({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return (
@@ -23,6 +24,13 @@ export function Sidebar({ className, ...props }: React.HTMLAttributes<HTMLDivEle
             {settingsItems.map(item => (
               <NavItem key={item.href} {...item} />
             ))}
+          </div>
+        </div>
+        
+        <div className="px-3 py-2 mt-auto">
+          <h2 className="mb-2 px-4 text-lg font-semibold tracking-tight">Language</h2>
+          <div className="px-4">
+            <LanguageSwitcher />
           </div>
         </div>
       </ScrollArea>


### PR DESCRIPTION
🔧 변경 사항:
- **[Component]**: [web_ui/src/components/common/language-switcher.tsx] 신규 생성
  - useLocale, usePathname, useRouter를 활용한 언어 전환 로직 구현
  - 현재 경로(pathname)를 유지하면서 locale 세그먼트만 교체하는 방식 적용
  - 직관적인 버튼 그룹 UI로 현재 언어 상태 시각화
- **[Layout]**: [web_ui/src/components/layout/sidebar.tsx] 업데이트
  - Sidebar 하단에 'Language' 섹션 추가
  - LanguageSwitcher 컴포넌트 배치로 전역 접근성 확보

🎯 목적:
- 사용자 언어 전환 기능 제공 (Phase 3 핵심 기능)
- i18n 인프라와 UI의 상호작용 구현

✅ 검증 완료:
- 컴포넌트 렌더링 확인 (Sidebar 하단)
- 버튼 클릭 시 URL locale 변경 확인 (예: /ko/... → /en/...)

- 📌 Related
  - Issue [#275]

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

언어 전환 UI 컴포넌트를 추가하고 이를 사이드바 내비게이션에 통합하여, 현재 라우트를 유지한 채 로케일을 변경할 수 있도록 합니다.

새 기능:
- 재사용 가능한 `LanguageSwitcher` 컴포넌트를 도입하여, 현재 pathname을 유지하면서 지원되는 로케일 간 전환을 가능하게 합니다.
- 전역적으로 접근할 수 있도록 사이드바 레이아웃에 전용 Language 섹션을 추가하여 언어 선택 컨트롤을 노출합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a language switching UI component and integrate it into the sidebar navigation to enable locale changes while preserving the current route.

New Features:
- Introduce a reusable LanguageSwitcher component that toggles between supported locales while keeping the current pathname.
- Expose language selection controls in the sidebar layout with a dedicated Language section for global access.

</details>