### PR TITLE
♻️ refactor(i18n) [#10.11.2]: 1차 개선 - LanguageSwitcher 고도화 및 Sidebar 다국어 적용

### DIFF
--- a/web_ui/src/components/common/language-switcher.tsx
+++ b/web_ui/src/components/common/language-switcher.tsx
@@ -3,7 +3,7 @@
 'use client';
 
 import { useLocale } from 'next-intl';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { type Locale, localeNames, locales } from '@/i18n/config';
@@ -12,13 +12,29 @@ export function LanguageSwitcher({ className }: { className?: string }) {
   const locale = useLocale();
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
 
   const handleLocaleChange = (newLocale: Locale) => {
-    // next-intl 미들웨어 설정을 따름: /ko/..., /en/...
-    // pathname에는 이미 locale이 포함되어 있음 (middleware 설정에 따라 다를 수 있으나 일반적인 패턴 사용)
+    // 1. 방어적 코딩: pathname이 null인 경우 처리 중단
+    if (!pathname) return;
+
+    // 2. Pathname 재구성 (Locale 교체)
+    // next-intl 미들웨어 설정을 따름 (prefix: always -> /ko/dashboard)
     const segments = pathname.split('/');
-    segments[1] = newLocale; // 첫 번째 세그먼트가 locale이라고 가정 (middleware prefix: always)
-    const newPath = segments.join('/');
+    if (segments.length > 1) {
+      segments[1] = newLocale;
+    } else {
+      // 예상치 못한 경로 구조일 경우 (예: /) 안전하게 locale 추가
+      // 실제로는 미들웨어가 먼저 리다이렉트하므로 이 분기에 도달할 확률은 낮음
+      segments.splice(1, 0, newLocale); 
+    }
+    
+    let newPath = segments.join('/');
+
+    // 3. Query Parameter 보존
+    if (searchParams && searchParams.toString()) {
+      newPath += `?${searchParams.toString()}`;
+    }
     
     router.push(newPath);
   };

--- a/web_ui/src/components/layout/sidebar.tsx
+++ b/web_ui/src/components/layout/sidebar.tsx
@@ -1,5 +1,7 @@
 // web_ui/src/components/layout/sidebar.tsx
+'use client';
 
+import { useTranslations } from 'next-intl';
 import { cn } from "@/lib/utils";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { NavItem } from "./nav-item";
@@ -7,6 +9,8 @@ import { mainNavItems, settingsItems } from "@/config/navigation";
 import { LanguageSwitcher } from "@/components/common/language-switcher";
 
 export function Sidebar({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  const t = useTranslations('sidebar');
+
   return (
     <div {...props} className={cn("hidden md:block w-64 fixed left-0 top-0 h-screen border-r bg-slate-50/50", className)}>
       <ScrollArea className="h-full py-4">
@@ -28,7 +32,7 @@ export function Sidebar({ className, ...props }: React.HTMLAttributes<HTMLDivEle
         </div>
         
         <div className="px-3 py-2 mt-auto">
-          <h2 className="mb-2 px-4 text-lg font-semibold tracking-tight">Language</h2>
+          <h2 className="mb-2 px-4 text-lg font-semibold tracking-tight">{t('language')}</h2>
           <div className="px-4">
             <LanguageSwitcher />
           </div>

--- a/web_ui/src/locales/en.json
+++ b/web_ui/src/locales/en.json
@@ -13,5 +13,8 @@
     "graph": "Graph View",
     "stats": "Statistics",
     "preferences": "Preferences"
+  },
+  "sidebar": {
+    "language": "Language"
   }
 }

--- a/web_ui/src/locales/ko.json
+++ b/web_ui/src/locales/ko.json
@@ -13,5 +13,8 @@
     "graph": "그래프 뷰",
     "stats": "통계",
     "preferences": "설정"
+  },
+  "sidebar": {
+    "language": "언어"
   }
 }


### PR DESCRIPTION
🔧 변경 사항:
- **[Component]**: [web_ui/src/components/common/language-switcher.tsx]
  - Query String 보존 로직 추가 (`useSearchParams`)
  - Pathname null 체크 등 방어적 코딩 적용
  - 언어 전환 시 기존 필터나 상태 유지 보장
- **[I18n]**: [web_ui/src/locales/*.json]
  - `sidebar.language` 번역 키 추가 ("언어" / "Language")
- **[Layout]**: [web_ui/src/components/layout/sidebar.tsx]
  - Client Component ('use client')로 전환
  - 하드코딩된 텍스트 제거 및 `useTranslations` Hook 적용

🎯 목적:
- Code Review 피드백 반영
  - Bug Risk: Query Param 유실
  - Enhancement: 하드코딩 제거)
- 사용자 경험(UX) 향상: 상태 유지 언어 전환
- UI 일관성 및 완전한 다국어 지원 초석 마련

✅ 검증 완료:
- `useSearchParams`를 통한 Query String 보존 확인
- Sidebar 'Language' 텍스트 번역 적용 확인

- 📌 Related
  - Issue [#275]
  - @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/414#pullrequestreview-3718581440) - Bug Risk (Query Param loss), Enhancement (Translation keys)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

언어 전환 동작을 개선하고 사이드바 국제화를 적용했습니다.

버그 수정:
- 언어 스위처에서 로케일을 변경할 때 쿼리 파라미터를 유지하고, 누락된 pathname을 안전하게 처리합니다.

개선 사항:
- 언어 스위처에서 로케일 인식 라우팅을 개선하여, 서로 다른 URL 구조에서도 경로를 더 안전하게 재구성할 수 있도록 했습니다.
- 하드코딩된 텍스트 대신 번역 키를 사용하여 사이드바의 언어 섹션 헤더를 현지화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine language switching behavior and apply sidebar internationalization.

Bug Fixes:
- Preserve query parameters and handle missing pathnames when changing locales in the language switcher.

Enhancements:
- Improve locale-aware routing in the language switcher to more safely reconstruct paths across different URL structures.
- Localize the sidebar language section header using translation keys instead of hardcoded text.

</details>