### PR TITLE
♻️ refactor(i18n) [#10.11.2]: 2차 개선 - URL Parsing 로직 견고성 강화

### DIFF
--- a/web_ui/src/components/common/language-switcher.tsx
+++ b/web_ui/src/components/common/language-switcher.tsx
@@ -19,14 +19,17 @@ export function LanguageSwitcher({ className }: { className?: string }) {
     if (!pathname) return;
 
     // 2. Pathname 재구성 (Locale 교체)
-    // next-intl 미들웨어 설정을 따름 (prefix: always -> /ko/dashboard)
+    // 하드코딩된 인덱스 대신 현재 경로에서 로케일 세그먼트를 동적으로 탐색하여 교체
     const segments = pathname.split('/');
-    if (segments.length > 1) {
-      segments[1] = newLocale;
+    const localeIndex = segments.findIndex(seg => (locales as readonly string[]).includes(seg));
+
+    if (localeIndex !== -1) {
+      // 기존 로케일 세그먼트가 존재하면 교체
+      segments[localeIndex] = newLocale;
     } else {
-      // 예상치 못한 경로 구조일 경우 (예: /) 안전하게 locale 추가
-      // 실제로는 미들웨어가 먼저 리다이렉트하므로 이 분기에 도달할 확률은 낮음
-      segments.splice(1, 0, newLocale); 
+      // 로케일 세그먼트가 없으면 (기본 로케일 등으로 생략된 경우) 맨 앞에 추가
+      // segments[0]은 빈 문자열이므로 index 1에 삽입
+      segments.splice(1, 0, newLocale);
     }
     
     let newPath = segments.join('/');


### PR DESCRIPTION
🔧 변경 사항:
- **[Logic]**: [LanguageSwitcher]의 Locale 교체 알고리즘 개선
  - 기존: 하드코딩된 인덱스 (`segments[1]`) 사용 (라우팅 변경에 취약)
  - 개선: `locales` 배열을 기반으로 현재 경로에서 **동적으로 Locale 세그먼트를 탐색** (`findIndex`)하여 교체
  - 효과: Path 구조 변경, BasePath 설정, 또는 Locale 생략 케이스에서도 안정적으로 동작하는 견고한(Robust) 로직 확보

🎯 목적:
- Code Review 피드백 완벽 반영 (Robustness)
- 하드코딩된 가정을 제거하여 잠재적 버그 예방

✅ 검증 완료:
- 로케일이 포함된 경로 (/ko/dashboard) → 정상 교체 확인
- 로케일이 없는 경로 (만약 발생 시) → 정상 삽입 확인

- 📌 Related
  - Issue [#275]
  - @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/415#pullrequestreview-3718627882) - Robustness (Avoid hardcoded index)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

개선 사항:
- 설정된 로케일 목록에서 기존 로케일 세그먼트를 감지하고, 없을 경우 로케일을 안전하게 삽입하도록 하여 언어 스위처의 경로 처리 방식을 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Improve language switcher path handling by detecting existing locale segments from the configured locales list and falling back to safely inserting the locale when missing.

</details>