### PR TITLE
♻️ refactor(i18n) [#10.11.2]: 3차 개선 - Trailing Slash 방지 및 Edge Case 처리

### DIFF
--- a/web_ui/src/components/common/language-switcher.tsx
+++ b/web_ui/src/components/common/language-switcher.tsx
@@ -27,9 +27,14 @@ export function LanguageSwitcher({ className }: { className?: string }) {
       // 기존 로케일 세그먼트가 존재하면 교체
       segments[localeIndex] = newLocale;
     } else {
-      // 로케일 세그먼트가 없으면 (기본 로케일 등으로 생략된 경우) 맨 앞에 추가
-      // segments[0]은 빈 문자열이므로 index 1에 삽입
-      segments.splice(1, 0, newLocale);
+      // 로케일 세그먼트가 없으면 (기본 로케일 등으로 생략된 경우)
+      // 루트 경로('/')인 경우 Trailing Slash 방지를 위해 덮어쓰기
+      if (segments.length === 2 && segments[1] === '') {
+        segments[1] = newLocale;
+      } else {
+        // 그 외의 경우 맨 앞에 locale 추가
+        segments.splice(1, 0, newLocale);
+      }
     }
     
     let newPath = segments.join('/');


### PR DESCRIPTION
🔧 변경 사항:
- **[Logic]**: [LanguageSwitcher] URL 생성 로직 정교화
  - 루트 경로('/') 전환 시 불필요한 Trailing Slash (`/ko/`)가 생성되는 문제 해결
  - `path.split('/')` 결과가 `['', '']`일 때 단순 삽입 대신 세그먼트 교체 방식 적용
  - 결과: `'/'` → `'/ko'` (Clean URL 유지)

🎯 목적:
- Code Review 피드백 완벽 반영 (Trailing Slash issue)
- URL 구조의 일관성 유지 및 리다이렉트 문제 예방
- SEO 친화적인 URL 생성 보장

✅ 검증 완료:
- 루트 경로에서 언어 전환 시 `/ko` 형태로 올바르게 이동 확인
- 일반 경로(`/dashboard`)에서는 `/ko/dashboard` 형태로 정상 동작 유지

- 📌 Related
  - Issue [#275]
  - @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/416#pullrequestreview-3718655603) - Trailing Slash issue fixed

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

버그 수정:
- 비어 있는 경로 세그먼트를 올바르게 처리하여 루트 경로에서 로케일을 전환할 때 불필요한 후행 슬래시(예: `/ko/`)가 생성되지 않도록 방지했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent generation of unnecessary trailing slashes (e.g. `/ko/`) when switching locale on the root path by correctly handling empty path segments.

</details>