### PR TITLE
♻️ refactor(i18n) [#10.11.2]: 4차 개선 - 로직 캡슐화 및 유지보수성 향상

### DIFF
--- a/web_ui/src/components/common/language-switcher.tsx
+++ b/web_ui/src/components/common/language-switcher.tsx
@@ -8,6 +8,8 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { type Locale, localeNames, locales } from '@/i18n/config';
 
+import { createPathWithLocale } from '@/lib/i18n-utils';
+
 export function LanguageSwitcher({ className }: { className?: string }) {
   const locale = useLocale();
   const router = useRouter();
@@ -18,26 +20,8 @@ export function LanguageSwitcher({ className }: { className?: string }) {
     // 1. 방어적 코딩: pathname이 null인 경우 처리 중단
     if (!pathname) return;
 
-    // 2. Pathname 재구성 (Locale 교체)
-    // 하드코딩된 인덱스 대신 현재 경로에서 로케일 세그먼트를 동적으로 탐색하여 교체
-    const segments = pathname.split('/');
-    const localeIndex = segments.findIndex(seg => (locales as readonly string[]).includes(seg));
-
-    if (localeIndex !== -1) {
-      // 기존 로케일 세그먼트가 존재하면 교체
-      segments[localeIndex] = newLocale;
-    } else {
-      // 로케일 세그먼트가 없으면 (기본 로케일 등으로 생략된 경우)
-      // 루트 경로('/')인 경우 Trailing Slash 방지를 위해 덮어쓰기
-      if (segments.length === 2 && segments[1] === '') {
-        segments[1] = newLocale;
-      } else {
-        // 그 외의 경우 맨 앞에 locale 추가
-        segments.splice(1, 0, newLocale);
-      }
-    }
-    
-    let newPath = segments.join('/');
+    // 2. Pathname 재구성 (유틸리티 함수 사용)
+    let newPath = createPathWithLocale(pathname, newLocale);
 
     // 3. Query Parameter 보존
     if (searchParams && searchParams.toString()) {


### PR DESCRIPTION
🔧 변경 사항:
- **[Utility]**: [web_ui/src/lib/i18n-utils.ts] 신규 생성
  - [createPathWithLocale](web_ui/src/lib/i18n-utils.ts) 함수 구현: URL 조작 로직을 별도 모듈로 분리
  - 복잡한 분기 처리(루트 경로 감지, 로케일 탐색/교체)를 캡슐화하여 재사용성 확보
  - `isRootPath` 변수를 사용하여 암시적 조건식(`['', '']`)의 의도를 명확히 표현
- **[Component]**: [web_ui/src/components/common/language-switcher.tsx] 리팩토링
  - 비즈니스 로직을 제거하고 UI 및 이벤트 핸들링에만 집중하도록 개선
  - 코드 가독성 대폭 향상

🎯 목적:
- Code Review 피드백 완벽 반영 (Separation of Concerns, Readable Code)
- URL 구조 변경 시 영향 범위를 유틸리티 함수 하나로 국한 (Maintainability)
- 테스트 용이성 확보 (순수 함수 분리)

✅ 검증 완료:
- 기존 기능(언어 전환, Query Param 보존, Trailing Slash 방지) 정상 동작 확인
- 모듈 분리로 인한 사이드 이펙트 없음

- 📌 Related
  - Issue [#275]
  - @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/417#pullrequestreview-3718751842) - Extract utility function, Improve readability

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

언어 전환 컴포넌트를 단순화하고 유지보수성을 향상시키기 위해, 로케일 전환 URL 로직을 재사용 가능한 유틸리티로 리팩터링했습니다.

개선 사항:
- 앱 전반에서 재사용할 수 있도록 URL 로케일 조작 로직을 전용 i18n 유틸리티 함수로 추출했습니다.
- 경로 구성 작업을 유틸리티로 위임하여 LanguageSwitcher 컴포넌트가 UI 및 이벤트 처리에만 집중하도록 단순화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor locale switching URL logic into a reusable utility to simplify the language switcher component and improve maintainability.

Enhancements:
- Extract URL locale manipulation into a dedicated i18n utility function for reuse across the app.
- Simplify the LanguageSwitcher component to focus on UI and event handling by delegating path construction to the utility.

</details>