### PR TITLE
🐛 fix(i18n) [#10.11.6]: LanguageSwitcher에 Suspense 경계 추가

### DIFF
--- a/web_ui/src/components/common/language-switcher.tsx
+++ b/web_ui/src/components/common/language-switcher.tsx
@@ -1,7 +1,6 @@
-// web_ui/src/components/common/language-switcher.tsx
-
 'use client';
 
+import { Suspense } from 'react';
 import { useLocale } from 'next-intl';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
@@ -10,7 +9,7 @@ import { type Locale, localeNames, locales } from '@/i18n/config';
 
 import { createPathWithLocale } from '@/lib/i18n-utils';
 
-export function LanguageSwitcher({ className }: { className?: string }) {
+function LanguageSwitcherContent({ className }: { className?: string }) {
   const locale = useLocale();
   const router = useRouter();
   const pathname = usePathname();
@@ -48,5 +47,13 @@ export function LanguageSwitcher({ className }: { className?: string }) {
         </Button>
       ))}
     </div>
+  );
+}
+
+export function LanguageSwitcher(props: { className?: string }) {
+  return (
+    <Suspense fallback={<div className="h-9 w-[120px] animate-pulse bg-slate-100 rounded-md" />}>
+      <LanguageSwitcherContent {...props} />
+    </Suspense>
   );
 }


### PR DESCRIPTION
🔧 변경 사항:
- **[Component]**: [LanguageSwitcher] useSearchParams 사용 시 Suspense 래핑 적용
  - 클라이언트 컴포넌트에서 useSearchParams 사용 시 빌드 타임 에러 방지
  - 내부 로직을 LanguageSwitcherContent로 분리하고 Suspense로 감싸서 export

🎯 목적:
- Next.js App Router의 useSearchParams 사용 규칙 준수
- 빌드 안정성 확보 (Missing Suspense boundary 에러 해결)

📌 Related:
- Issue [#275]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/419#pullrequestreview-3724565295)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

Next.js App Router 요구사항을 준수하고 검색 파라미터 사용 시 빌드 타임 에러를 방지하기 위해 언어 스위처 컴포넌트를 Suspense 경계로 감쌉니다.

버그 수정:
- Suspense 경계 없이 언어 스위처에서 `useSearchParams`를 사용함으로 인해 발생하던 빌드 타임 에러를 방지합니다.

개선 사항:
- 언어 스위처 로직을 내부 `LanguageSwitcherContent` 컴포넌트로 리팩터링하고, 로딩 스켈레톤 폴백을 가진 Suspense로 감싼 `LanguageSwitcher`를 외부에 제공합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Wrap the language switcher component with a Suspense boundary to comply with Next.js App Router requirements and avoid build-time errors when using search params.

Bug Fixes:
- Prevent build-time errors caused by using useSearchParams in the language switcher without a Suspense boundary.

Enhancements:
- Refactor the language switcher logic into an internal LanguageSwitcherContent component and expose a Suspense-wrapped LanguageSwitcher with a loading skeleton fallback.

</details>