### PR TITLE
✨ feat(i18n) [#10.11.9]: 번역 리소스 확장 (Stats, Graph, Conflict Strategy)

### DIFF
--- a/docs/AR/v5.0/v5_phase3_visualization/README_phase3.md
+++ b/docs/AR/v5.0/v5_phase3_visualization/README_phase3.md
@@ -68,6 +68,10 @@ web_ui/src/
         - **Language Switcher**: 현재 페이지 및 쿼리 파라미터를 유지하며 즉시 언어 전환
         - **Component Translations**: Sidebar, MobileNav, Dashboard, SyncMonitor 등 주요 UI 다국어화
         - **Locale-aware Formatting**: 날짜(`Intl.DateTimeFormat`) 및 숫자 자동 포맷팅
+    - **Translation Namespaces**:
+        - `common`, `navigation`: 공통 UI 요소
+        - `dashboard`, `stats`, `graph`: 페이지별 콘텐츠
+        - `sync_monitor`: 동기화 및 충돌 해결 전략
 ```
 
 ## 🚀 Testing Features

--- a/web_ui/src/locales/en.json
+++ b/web_ui/src/locales/en.json
@@ -24,6 +24,21 @@
     "title": "FlowNote v6.0 - Phase 3: i18n",
     "complete": "i18n infrastructure setup complete! ✅"
   },
+  "graph": {
+    "title": "PARA Graph View",
+    "controls": {
+      "reset": "Reset View",
+      "legend": "Legend"
+    }
+  },
+  "stats": {
+    "title": "Statistics",
+    "charts": {
+      "activity": "Activity Heatmap",
+      "trend": "Weekly Trend",
+      "distribution": "PARA Distribution"
+    }
+  },
   "sync_monitor": {
     "title": "Sync Monitor",
     "refresh": "Refresh",
@@ -54,7 +69,12 @@
       "resolve_btn": "Resolve",
       "resolved_via": "Resolved via",
       "resolved_toast": "Resolved conflict: Keeping {decision} version",
-      "file": "File"
+      "file": "File",
+      "strategies": {
+        "local": "Keep Local",
+        "remote": "Keep Remote",
+        "both": "Keep Both"
+      }
     }
   }
 }

--- a/web_ui/src/locales/ko.json
+++ b/web_ui/src/locales/ko.json
@@ -24,6 +24,21 @@
     "title": "FlowNote v6.0 - 3단계: 다국어(i18n) 적용",
     "complete": "다국어 인프라 설정 완료! ✅"
   },
+  "graph": {
+    "title": "PARA 그래프 뷰",
+    "controls": {
+      "reset": "뷰 초기화",
+      "legend": "범례"
+    }
+  },
+  "stats": {
+    "title": "통계",
+    "charts": {
+      "activity": "활동 히트맵",
+      "trend": "주간 트렌드",
+      "distribution": "PARA 분포"
+    }
+  },
   "sync_monitor": {
     "title": "동기화 모니터",
     "refresh": "새로고침",
@@ -54,7 +69,12 @@
       "resolve_btn": "해결",
       "resolved_via": "해결 방법",
       "resolved_toast": "충돌 해결됨: {decision} 버전을 유지합니다",
-      "file": "파일"
+      "file": "파일",
+      "strategies": {
+        "local": "로컬 유지",
+        "remote": "원격 유지",
+        "both": "둘 다 유지"
+      }
     }
   }
 }


### PR DESCRIPTION
🔧 변경 사항:
- **[Locales]**: [en.json, ko.json]
  - `stats`, `graph` 네임스페이스 신규 추가 (차트, 컨트롤 관련 키)
  - `sync_monitor.conflicts` 하위에 `strategies` 키 추가 (충돌 해결 옵션)
- **[Docs]**: [README_phase3.md]
  - Translation Namespaces 구조 문서화 업데이트
  - 번역 파일 확장 작업 완료 상태 업데이트

🎯 목적:
- Phase 3의 모든 주요 페이지(Graph, Stats)에 대한 다국어 지원 기반 마련
- 충돌 해결 UI의 세밀한 번역 지원

📌 Related:
- Issue [#275]

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

통계, 그래프, 동기화 모니터 충돌 전략 기능에 대한 i18n 번역 리소스와 문서를 확장합니다.

새로운 기능:
- 차트 및 컨트롤 텍스트의 현지화를 지원하기 위해 통계 및 그래프 페이지용 새로운 번역 네임스페이스를 추가합니다.
- 동기화 모니터 번역에 현지화된 충돌 해결 전략 레이블을 도입합니다.

문서:
- 업데이트된 번역 네임스페이스 구조를 문서화하고, README_phase3.md에서 3단계(Phase 3) 번역 범위가 완료되었음을 표시합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend i18n translation resources and documentation for stats, graph, and sync monitor conflict strategy features.

New Features:
- Add new translation namespaces for stats and graph pages to support localized chart and control text.
- Introduce localized conflict resolution strategy labels under the sync monitor translations.

Documentation:
- Document the updated translation namespace structure and mark Phase 3 translation coverage as complete in README_phase3.md.

</details>