### PR TITLE
♻️ refactor(i18n) [#10.11.9]: 1차 개선 - 번역 리소스 구조 일관성 확보 및 안전성 강화

### DIFF
--- a/web_ui/src/components/dashboard/sync-monitor.tsx
+++ b/web_ui/src/components/dashboard/sync-monitor.tsx
@@ -15,7 +15,7 @@ import { toast } from "sonner"
 import { useTranslations, useLocale } from "next-intl"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { ConflictDiffViewer } from "@/components/sync/ConflictDiffViewer"
-import { type ConflictResolutionStrategy, CONFLICT_STATUS } from '@/types/sync';
+import { type ConflictResolutionStrategy, CONFLICT_STATUS, CONFLICT_RESOLUTION_STRATEGIES } from '@/types/sync';
 
 // Types
 interface SyncStatus {
@@ -146,7 +146,20 @@ export function SyncMonitor() {
             method: 'POST',
         });
         
-        toast.success(t('conflicts.resolved_toast', { decision: strategy }), {
+        let decisionLabel: string = strategy;
+        switch (strategy) {
+          case CONFLICT_RESOLUTION_STRATEGIES.KEEP_LOCAL:
+            decisionLabel = t('conflicts.strategies.keep_local');
+            break;
+          case CONFLICT_RESOLUTION_STRATEGIES.KEEP_REMOTE:
+            decisionLabel = t('conflicts.strategies.keep_remote');
+            break;
+          case CONFLICT_RESOLUTION_STRATEGIES.KEEP_BOTH:
+            decisionLabel = t('conflicts.strategies.keep_both');
+            break;
+        }
+
+        toast.success(t('conflicts.resolved_toast', { decision: decisionLabel }), {
             description: `${t('conflicts.file')}: ${selectedConflictId}`
         });
         

--- a/web_ui/src/locales/en.json
+++ b/web_ui/src/locales/en.json
@@ -6,7 +6,9 @@
     "cancel": "Cancel",
     "delete": "Delete",
     "confirm": "Confirm",
-    "close": "Close"
+    "close": "Close",
+    "reset": "Reset View",
+    "legend": "Legend"
   },
   "navigation": {
     "dashboard": "Dashboard",
@@ -25,11 +27,7 @@
     "complete": "i18n infrastructure setup complete! ✅"
   },
   "graph": {
-    "title": "PARA Graph View",
-    "controls": {
-      "reset": "Reset View",
-      "legend": "Legend"
-    }
+    "title": "PARA Graph View"
   },
   "stats": {
     "title": "Statistics",
@@ -71,9 +69,9 @@
       "resolved_toast": "Resolved conflict: Keeping {decision} version",
       "file": "File",
       "strategies": {
-        "local": "Keep Local",
-        "remote": "Keep Remote",
-        "both": "Keep Both"
+        "keep_local": "Keep Local",
+        "keep_remote": "Keep Remote",
+        "keep_both": "Keep Both"
       }
     }
   }

--- a/web_ui/src/locales/ko.json
+++ b/web_ui/src/locales/ko.json
@@ -6,7 +6,9 @@
     "cancel": "취소",
     "delete": "삭제",
     "confirm": "확인",
-    "close": "닫기"
+    "close": "닫기",
+    "reset": "뷰 초기화",
+    "legend": "범례"
   },
   "navigation": {
     "dashboard": "대시보드",
@@ -25,11 +27,7 @@
     "complete": "다국어 인프라 설정 완료! ✅"
   },
   "graph": {
-    "title": "PARA 그래프 뷰",
-    "controls": {
-      "reset": "뷰 초기화",
-      "legend": "범례"
-    }
+    "title": "PARA 그래프 뷰"
   },
   "stats": {
     "title": "통계",
@@ -71,9 +69,9 @@
       "resolved_toast": "충돌 해결됨: {decision} 버전을 유지합니다",
       "file": "파일",
       "strategies": {
-        "local": "로컬 유지",
-        "remote": "원격 유지",
-        "both": "둘 다 유지"
+        "keep_local": "로컬 유지",
+        "keep_remote": "원격 유지",
+        "keep_both": "둘 다 유지"
       }
     }
   }


### PR DESCRIPTION
🔧 변경 사항:
- **[Locales]**: [en.json, ko.json]
  - `sync_monitor.conflicts.strategies` 키 이름을 코드 상수(`keep_local`)와 일치시킴
  - 공통 라벨(`reset`, `legend`)을 `common` 네임스페이스로 이동하여 중복 제거
  - `graph.controls` 제거 및 구조 단순화
- **[Component]**: [SyncMonitor]
  - 충돌 해결 Toast 메시지에 동적 키 대신 `switch` 문을 사용한 안전한 번역 적용
  - 하드코딩된 전략 이름 대신 번역된 라벨 표시 (UX 개선)

🎯 목적:
- Code Review 피드백 반영 (Naming Consistency, Common labels, Centralized mapping)
- 타입 안전성 확보 및 유지보수 용이한 번역 구조 수립

📌 Related:
- Issue [#275]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/423#pullrequestreview-3731415195) - `Naming Consistency`, `Common labels`, `Centralized mapping`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

SyncMonitor UI에서 동기화 충돌 해결 메시지의 i18n 일관성과 안전성을 개선합니다.

버그 수정:
- 충돌 해결 토스트 메시지가 더 이상 원시 전략 키가 아니라 항상 유효한, 현지화된 전략 레이블을 사용하도록 보장합니다.

개선 사항:
- 충돌 해결 전략 번역 키를 코드 상수와 정렬하고, 그 매핑을 SyncMonitor에 중앙화합니다.
- 공통 레이블을 공용 네임스페이스로 이동하고 사용되지 않는 그래프 컨트롤 항목을 정리하여 로케일 리소스를 단순화하고 중복을 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve i18n consistency and safety for sync conflict resolution messages in the SyncMonitor UI.

Bug Fixes:
- Ensure conflict resolution toast messages always use valid, localized strategy labels instead of raw strategy keys.

Enhancements:
- Align conflict resolution strategy translation keys with code constants and centralize their mapping in SyncMonitor.
- Simplify and deduplicate locale resources by moving shared labels to a common namespace and cleaning up unused graph control entries.

</details>