### PR TITLE
♻️ refactor [#10.11.10]: 1차 개선 - Metadata 및 Page 구조 최적화

### DIFF
--- a/web_ui/src/app/[locale]/graph/page.tsx
+++ b/web_ui/src/app/[locale]/graph/page.tsx
@@ -2,8 +2,9 @@
 
 import { getTranslations } from 'next-intl/server';
 import GraphView from "@/components/para/GraphView";
+import { type Locale } from '@/i18n/config';
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'graph' });
   return {
@@ -11,13 +12,12 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   };
 }
 
-export default async function GraphPage({ params }: { params: Promise<{ locale: string }> }) {
-  const { locale } = await params;
-  const t = await getTranslations({ locale, namespace: 'graph' });
+export default async function GraphPage() {
+  const t = await getTranslations('graph');
   
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between space-y-2">
+      <div className="flex items-center justify-between gap-2">
         <h2 className="text-3xl font-bold tracking-tight">{t('title')}</h2>
       </div>
       <GraphView />

--- a/web_ui/src/app/[locale]/page.tsx
+++ b/web_ui/src/app/[locale]/page.tsx
@@ -2,8 +2,9 @@
 
 import { getTranslations } from 'next-intl/server';
 import { SyncMonitor } from '@/components/dashboard/sync-monitor';
+import { type Locale } from '@/i18n/config';
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'dashboard' });
   return {

--- a/web_ui/src/app/[locale]/stats/page.tsx
+++ b/web_ui/src/app/[locale]/stats/page.tsx
@@ -2,8 +2,9 @@
 
 import { getTranslations } from 'next-intl/server';
 import StatsView from "@/components/dashboard/stats/StatsView";
+import { type Locale } from '@/i18n/config';
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'stats' });
   return {
@@ -11,13 +12,12 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   };
 }
 
-export default async function StatsPage({ params }: { params: Promise<{ locale: string }> }) {
-  const { locale } = await params;
-  const t = await getTranslations({ locale, namespace: 'stats' });
+export default async function StatsPage() {
+  const t = await getTranslations('stats');
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between space-y-2">
+      <div className="flex items-center justify-between gap-2">
         <h2 className="text-3xl font-bold tracking-tight">{t('title')}</h2>
       </div>
       <StatsView />


### PR DESCRIPTION
🔧 변경 사항:
- **[Refactor]**: [Graph, Stats, Dashboard]
  - Page 컴포넌트에서 중복된 `await params` 제거 및 `getTranslations` 암시적 로케일 사용
  - `params` 타이핑을 `{ locale: Locale }`로 통일하여 타입 안전성 강화
- **[Style]**: [Graph, Stats]
  - Flex Row 컨테이너의 잘못된 spacing(`space-y-2`)을 `gap-2`로 수정 (CSS Fix)

🎯 목적:
- Code Review 피드백 반영 (Redundant async, Type consistency, CSS bug)
- 코드 간결성 및 유지보수성 향상

📌 Related:
- Issue [#275]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/429#pullrequestreview-3734890891) - `Redundant async`, `Type consistency`, `CSS bug`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

그래프, 통계, 대시보드 페이지에 대한 로케일 처리 및 레이아웃 간격을 다듬었습니다.

버그 수정:
- 그래프 및 통계 헤더에서 세로 간격을 사용하던 방식을 gap 기반 레이아웃으로 교체하여 잘못된 flex row 간격 문제를 수정했습니다.

개선 사항:
- 공용 `Locale` 타입을 사용하여 그래프, 통계, 대시보드 페이지 전반의 메타데이터 로케일 타입을 통일했습니다.
- 중복되는 params 기반 로케일 추출 로직을 제거하고, 암시적인 번역 로케일 해석에 의존하도록 하여 그래프 및 통계 페이지 컴포넌트를 단순화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine locale handling and layout spacing for the graph, stats, and dashboard pages.

Bug Fixes:
- Fix incorrect flex row spacing on graph and stats headers by replacing vertical spacing with gap-based layout.

Enhancements:
- Unify metadata locale typing across graph, stats, and dashboard pages using the shared Locale type.
- Simplify graph and stats page components by removing redundant params-based locale extraction and relying on implicit translation locale resolution.

</details>