### PR TITLE
✨ feat(ux) [#10.11.11]: 다국어 404 페이지 및 미들웨어 검증

### DIFF
--- a/web_ui/src/app/[locale]/not-found.tsx
+++ b/web_ui/src/app/[locale]/not-found.tsx
@@ -1,0 +1,19 @@
+// web_ui/src/app/[locale]/not-found.tsx
+
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export default function NotFoundPage() {
+  const t = useTranslations('common.not_found');
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] text-center px-4">
+      <h1 className="text-4xl font-bold mb-4">{t('title')}</h1>
+      <p className="text-xl text-muted-foreground mb-8">{t('description')}</p>
+      <Button asChild>
+        <Link href="/">{t('home_btn')}</Link>
+      </Button>
+    </div>
+  );
+}

--- a/web_ui/src/locales/en.json
+++ b/web_ui/src/locales/en.json
@@ -8,7 +8,12 @@
     "confirm": "Confirm",
     "close": "Close",
     "reset": "Reset View",
-    "legend": "Legend"
+    "legend": "Legend",
+    "not_found": {
+      "title": "Page Not Found",
+      "description": "Sorry, the page you are looking for does not exist.",
+      "home_btn": "Go to Home"
+    }
   },
   "navigation": {
     "dashboard": "Dashboard",

--- a/web_ui/src/locales/ko.json
+++ b/web_ui/src/locales/ko.json
@@ -8,7 +8,12 @@
     "confirm": "확인",
     "close": "닫기",
     "reset": "뷰 초기화",
-    "legend": "범례"
+    "legend": "범례",
+    "not_found": {
+      "title": "페이지를 찾을 수 없습니다",
+      "description": "죄송합니다. 요청하신 페이지가 존재하지 않습니다.",
+      "home_btn": "홈으로 돌아가기"
+    }
   },
   "navigation": {
     "dashboard": "대시보드",


### PR DESCRIPTION
🔧 변경 사항:
- **[Page]**: `[locale]/not-found.tsx`
  - 다국어 지원 404 에러 페이지 신규 구현
- **[Locales]**: `en.json`, `ko.json`
  - `common.not_found` 번역 키 추가 (Title, Description, Button)
- **[Middleware]**: `middleware.ts`
  - Matcher 패턴 검증 (정적 파일 및 API 라우트 제외 확인)

🎯 목적:
- 잘못된 경로 접근 시 사용자 언어에 맞는 안내 제공 (UX 향상)
- Phase 3 Routing 최적화 작업 완료

📌 Related:
- Issue [#275]

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

다국어 앱 셸을 위해 로컬라이즈된 404 페이지와 관련 번역을 추가합니다.

새 기능:
- 사용자를 홈 페이지로 안내하는 로케일 인식 404 페이지를 `[locale]/not-found` 경로에 추가합니다.
- 지원되는 로케일에 대해 `common.not_found` 번역 항목(제목, 설명, 버튼 라벨)을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a localized 404 page and supporting translations for the multi-locale app shell.

New Features:
- Introduce a locale-aware 404 page under the `[locale]/not-found` route that guides users back to the home page.
- Add new `common.not_found` translation entries (title, description, button label) for supported locales.

</details>