### PR TITLE
♻️ refactor(ux) [#10.11.11]: 1차 개선 - 404 페이지 시맨틱 구조 및 서버 컴포넌트 전환

### DIFF
--- a/web_ui/src/app/[locale]/not-found.tsx
+++ b/web_ui/src/app/[locale]/not-found.tsx
@@ -1,19 +1,26 @@
 // web_ui/src/app/[locale]/not-found.tsx
-
-import { useTranslations } from 'next-intl';
+import { getTranslations } from 'next-intl/server';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 
-export default function NotFoundPage() {
-  const t = useTranslations('common.not_found');
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'common.not_found' });
+  return {
+    title: t('title')
+  };
+}
+
+export default async function NotFoundPage() {
+  const t = await getTranslations('common.not_found');
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-[60vh] text-center px-4">
+    <section className="flex flex-col items-center justify-center min-h-[60vh] text-center px-4">
       <h1 className="text-4xl font-bold mb-4">{t('title')}</h1>
       <p className="text-xl text-muted-foreground mb-8">{t('description')}</p>
       <Button asChild>
         <Link href="/">{t('home_btn')}</Link>
       </Button>
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
🔧 변경 사항:
- **[Refactor]**: `[locale]/not-found.tsx`
  - Root Element를 `div`에서 `section`으로 변경하여 시맨틱 구조 개선
  - Server Component 패턴(`async/await getTranslations`) 적용으로 렌더링 성능 및 안전성 확보
  - `generateMetadata` 추가로 'Page Not Found' 타이틀 동적 적용

🎯 목적:
- Code Review 피드백 반영 (Semantic Markup)
- SSR 호환성 및 SEO 강화

📌 Related:
- Issue [#275]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/431#pullrequestreview-3734910232)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

로케일별 not-found 페이지를 서버 컴포넌트로 전환하고, 제목에 대한 의미론적 마크업과 로컬라이즈된 메타데이터를 추가합니다.

Enhancements:
- 더 나은 시맨틱 구조를 위해 not-found 레이아웃 컨테이너를 `section` 요소로 변경합니다.
- not-found 경험을 위해 서버 사이드 번역 가져오기와 동적 메타데이터 생성을 도입합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Convert the locale-specific not-found page into a server component with semantic markup and localized metadata for its title.

Enhancements:
- Switch the not-found layout container to a section element for better semantics.
- Adopt server-side translation fetching and dynamic metadata generation for the not-found experience.

</details>