### PR TITLE
🐛 fix(ux) [#10.11.11]: 2차 개선 - 404 페이지 런타임 에러 방지 및 로직 단순화

### DIFF
--- a/web_ui/src/app/[locale]/not-found.tsx
+++ b/web_ui/src/app/[locale]/not-found.tsx
@@ -1,15 +1,8 @@
 // web_ui/src/app/[locale]/not-found.tsx
+
 import { getTranslations } from 'next-intl/server';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
-
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
-  const { locale } = await params;
-  const t = await getTranslations({ locale, namespace: 'common.not_found' });
-  return {
-    title: t('title')
-  };
-}
 
 export default async function NotFoundPage() {
   const t = await getTranslations('common.not_found');


### PR DESCRIPTION
🔧 변경 사항:
- **[Fix]**: `[locale]/not-found.tsx`
  - `not-found.tsx`에서 지원되지 않는 `generateMetadata` 및 `params` 사용 제거 (런타임 에러 방지)
  - `getTranslations` 호출 시 암시적 로케일 추론 사용으로 코드 일관성 유지

🎯 목적:
- Code Review 피드백 반영
- Next.js 라우팅 규칙 준수 및 버그 예방

📌 Related:
- Issue [#275]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/432#pullrequestreview-3734920357) - `Incorrect params usage`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

지원되지 않는 런타임 동작을 피하고 Next.js 라우팅 규칙과 일치하도록 로컬라이즈된 404 페이지 구현을 단순화합니다.

버그 수정:
- 런타임 오류를 방지하기 위해 로컬라이즈된 404 페이지에서 지원되지 않는 `generateMetadata` 및 `params` 사용을 제거합니다.

개선 사항:
- `getTranslations`에 대한 암시적 로케일 추론에 의존하여 404 페이지에서 번역 조회 방식을 표준화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the localized 404 page implementation to avoid unsupported runtime behavior and align with Next.js routing rules.

Bug Fixes:
- Remove unsupported generateMetadata and params usage from the localized 404 page to prevent runtime errors.

Enhancements:
- Standardize translation retrieval in the 404 page by relying on implicit locale inference for getTranslations.

</details>