### PR TITLE
✨ feat(api) [#10.11.12]: Backend API 다국어 지원 기본 환경 구축

### DIFF
--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -2,8 +2,17 @@
 
 import os
 from typing import Optional, Dict, Any, Callable, Union
-from fastapi import Depends, HTTPException, status, WebSocket, Query, WebSocketException
+from fastapi import (
+    Depends,
+    HTTPException,
+    status,
+    WebSocket,
+    Query,
+    WebSocketException,
+    Header,
+)
 from fastapi.security import OAuth2PasswordBearer
+from backend.services.i18n_service import SUPPORTED_LOCALES, DEFAULT_LOCALE
 
 # OAuth2 스키마 정의
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
@@ -77,3 +86,25 @@ async def get_current_user_ws(
     # TODO: [Phase 2] Verify token logic
 
     return MOCK_REGULAR_USER
+
+
+def get_locale(
+    accept_language: str = Header(default=DEFAULT_LOCALE, alias="Accept-Language")
+) -> str:
+    """
+    Parses the Accept-Language header to determine the preferred locale.
+    Returns the first matching supported locale or the default locale.
+    """
+    if not accept_language:
+        return DEFAULT_LOCALE
+
+    # e.g. "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7"
+    # Simple parsing: check the first preferred language
+    preferred = accept_language.split(",")[0].strip()
+    # Handle "ko-KR" -> "ko"
+    primary_tag = preferred.split("-")[0]
+
+    if primary_tag in SUPPORTED_LOCALES:
+        return primary_tag
+
+    return DEFAULT_LOCALE

--- a/backend/services/i18n_service.py
+++ b/backend/services/i18n_service.py
@@ -1,0 +1,46 @@
+# backend/services/i18n_service.py
+
+from typing import Dict, Any
+
+MESSAGES: Dict[str, Dict[str, str]] = {
+    "ko": {
+        "file_classified": "파일이 {category}로 분류되었습니다.",
+        "sync_completed": "동기화가 완료되었습니다.",
+        "conflict_detected": "충돌이 감지되었습니다.",
+        "not_found": "리소스를 찾을 수 없습니다.",
+        "unauthorized": "인증되지 않은 접근입니다.",
+        "server_error": "서버 내부 오류가 발생했습니다.",
+    },
+    "en": {
+        "file_classified": "File classified as {category}.",
+        "sync_completed": "Sync completed.",
+        "conflict_detected": "Conflict detected.",
+        "not_found": "Resource not found.",
+        "unauthorized": "Unauthorized access.",
+        "server_error": "Internal server error.",
+    },
+}
+
+DEFAULT_LOCALE = "ko"
+SUPPORTED_LOCALES = ["ko", "en"]
+
+
+def get_message(key: str, locale: str = DEFAULT_LOCALE, **kwargs: Any) -> str:
+    """
+    Retrieve a localized message based on the key and locale.
+    Supports simple string formatting using kwargs.
+    """
+    if locale not in SUPPORTED_LOCALES:
+        locale = DEFAULT_LOCALE
+
+    # Get message template
+    template = MESSAGES.get(locale, MESSAGES[DEFAULT_LOCALE]).get(key)
+
+    if not template:
+        # Fallback to default locale if key missing
+        template = MESSAGES[DEFAULT_LOCALE].get(key, key)
+
+    try:
+        return template.format(**kwargs)
+    except KeyError:
+        return template  # Return template as-is if formatting fails


### PR DESCRIPTION
🔧 변경 사항:
- **[Services]**: `i18n_service.py`
  - 다국어 메시지 딕셔너리(MESSAGES - ko, en) 및 조회 함수(get_message) 구현
- **[Dependencies]**: `deps.py`
  - `Accept-Language` 헤더 기반 로케일 감지 함수(`get_locale`) 추가

🎯 목적:
- API 응답 메시지의 다국어화를 위한 인프라 마련 (Pre-work)
- 클라이언트 로케일 정보의 서버 측 감지 로직 확보

📌 Related:
- Issue [#275]

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

로케일 인식 메시지 지원과 헤더 기반 로케일 감지를 추가하여 다국어 API 응답을 지원합니다.

새 기능:
- `Accept-Language` 헤더를 파싱하여, 다운스트림에서 사용할 수 있도록 클라이언트 로케일을 도출합니다.

개선 사항:
- 기본 및 지원 로케일을 포함하고, 로컬라이즈된 메시지 조회 기능을 제공하는 중앙 집중식 i18n 메시지 서비스를 도입합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add locale-aware messaging support and header-based locale detection to support multilingual API responses.

New Features:
- Provide Accept-Language header parsing to derive client locale for downstream use.

Enhancements:
- Introduce centralized i18n message service with default and supported locales plus localized message retrieval.

</details>