### PR TITLE
🐛 fix(api) [#10.11.12]: 3차 개선 - Accept-Language q-value RFC 범위 검증

### DIFF
--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -125,9 +125,14 @@ def get_locale(
                     if len(parts) == 2:
                         raw_q = parts[1].strip()
                         if raw_q:
-                            q_value = float(raw_q)
+                            parsed_q = float(raw_q)
+                            # RFC 7231: q-value must be in range [0.0, 1.0]
+                            if 0.0 <= parsed_q <= 1.0:
+                                q_value = parsed_q
+                            else:
+                                q_value = 0.0  # Out of range -> lowest priority
                         else:
-                            q_value = 0.0  # Empty value treating as lowest priority
+                            q_value = 0.0  # Empty value
                     else:
                         q_value = 0.0  # Malformed
                 except ValueError:
@@ -137,6 +142,7 @@ def get_locale(
                 break
 
         # Normalize: "en-US" -> "en"
+        # Note: We prioritize the primary tag because our SUPPORTED_LOCALES rely on generic codes ('en', 'ko').
         primary_lang = lang.split("-")[0].strip()
 
         if primary_lang:


### PR DESCRIPTION
🔧 변경 사항:
- **[Dependencies]**: `deps.py`
  - q-value 파싱 시 RFC 7231 표준 `[0.0, 1.0]` 범위 검증 로직 추가
  - 범위를 벗어나는 q-value는 0.0(최하위 우선순위)으로 처리하여 예기치 않은 동작 방지
  - Primary Tag 정규화(`en-US` → [en](web_ui/src/app/[local]/graph/page.tsx))에 대한 설계 의도 주석 기재

🎯 목적:
- Code Review 피드백 반영
- 헤더 파싱 로직의 표준 준수 및 견고성 향상

📌 Related:
- Issue [#275]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/436#pullrequestreview-3734952457) - `Strict q-value validation`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

RFC 7231 범위에 맞게 Accept-Language q-값을 검증하고, API 로케일 결정 시 로케일 정규화 동작을 명확히 합니다.

버그 수정:
- RFC 7231에서 정의한 [0.0, 1.0] 범위를 벗어나는 Accept-Language q-값을 그대로 허용하지 않고, 가장 낮은 우선순위로 취급하도록 합니다.

개선 사항:
- 비어 있거나 잘못 형식화된 q-값을 명시적으로 처리하고, 지원되는 로케일에 대해 기본 언어 태그 정규화 동작을 문서화함으로써 Accept-Language 헤더 파싱의 견고성을 향상시킵니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate Accept-Language q-values against RFC 7231 range and clarify locale normalization behavior in API locale resolution.

Bug Fixes:
- Ensure Accept-Language q-values outside the RFC 7231 [0.0, 1.0] range are treated as lowest priority instead of being accepted as-is.

Enhancements:
- Improve robustness of Accept-Language header parsing by explicitly handling empty and malformed q-values and documenting primary language tag normalization for supported locales.

</details>