### PR TITLE
🐛 fix(api) [#10.11.12]: 4차 개선 - 유효하지 않은 Accept-Language 엔트리 필터링 강화

### DIFF
--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -116,6 +116,7 @@ def get_locale(
 
         # Default q-value is 1.0 if not specified
         q_value = 1.0
+        is_valid_q = True
 
         for param in params:
             # Check for q-factor parameter
@@ -130,19 +131,23 @@ def get_locale(
                             if 0.0 <= parsed_q <= 1.0:
                                 q_value = parsed_q
                             else:
-                                q_value = 0.0  # Out of range -> lowest priority
+                                is_valid_q = False  # Out of range -> invalidate entry
                         else:
-                            q_value = 0.0  # Empty value
+                            is_valid_q = False  # Empty value -> invalidate entry
                     else:
-                        q_value = 0.0  # Malformed
+                        is_valid_q = False  # Malformed
                 except ValueError:
-                    q_value = 0.0  # Parsing failed
+                    is_valid_q = False  # Parsing failed
 
                 # Once we found the q parameter (valid or not), we stop looking for it in this part
                 break
 
+        if not is_valid_q:
+            continue  # Skip invalid entry
+
         # Normalize: "en-US" -> "en"
-        # Note: We prioritize the primary tag because our SUPPORTED_LOCALES rely on generic codes ('en', 'ko').
+        # Note: We prioritize the primary tag. If the mapped primary tag is not in SUPPORTED_LOCALES,
+        # it will be skipped during the final matching loop, falling back to DEFAULT_LOCALE.
         primary_lang = lang.split("-")[0].strip()
 
         if primary_lang:


### PR DESCRIPTION
🔧 변경 사항:
- **[Dependencies]**: `deps.py`
  - q-value 파싱 실패 또는 RFC 범위(0.0~1.0) 초과 시 해당 언어 엔트리 자체를 제외(Skip) 처리 (기존 0.0 부여 방식 개선)
  - 미지원 로케일의 폴백 흐름(최종 매칭 실패 시 DEFAULT_LOCALE 반환)에 대한 주석 보강

🎯 목적:
- Code Review 피드백 반영
- 잘못된 클라이언트 값에 대한 방어 로직 강화 및 코드 가독성 개선

📌 Related:
- Issue [#275]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/437#pullrequestreview-3734955916) - `Skip invalid entries`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

잘못된 q-value를 무시하도록 Accept-Language 파싱을 강화하고, 로케일 폴백 동작을 명확히 합니다.

버그 수정:
- 잘못된 형식이거나 범위를 벗어난 q-value를 가진 Accept-Language 엔트리를 최하위 우선순위 옵션으로 취급하는 대신, 무시하도록 변경합니다.

개선 사항:
- 지원되는 로케일이 하나도 일치하지 않을 때 기본 로케일로 폴백되는 동작과, 기본 언어(primary language) 처리 방식에 대한 주석을 더 명확히 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen Accept-Language parsing to ignore invalid q-values and clarify locale fallback behavior.

Bug Fixes:
- Discard Accept-Language entries with malformed or out-of-range q-values instead of treating them as lowest priority options.

Enhancements:
- Clarify comments around primary language handling and fallback to the default locale when no supported locale matches.

</details>