### PR TITLE
🔧 chore(qa) [#10.11.13]: Frontend 빌드 및 린트 오류 수정 (QA 완료)

### DIFF
--- a/web_ui/next.config.ts
+++ b/web_ui/next.config.ts
@@ -1,7 +1,10 @@
+import createNextIntlPlugin from 'next-intl/plugin';
 import type { NextConfig } from "next";
+
+const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
 const nextConfig: NextConfig = {
   /* config options here */
 };
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/web_ui/src/app/[locale]/graph/page.tsx
+++ b/web_ui/src/app/[locale]/graph/page.tsx
@@ -2,9 +2,9 @@
 
 import { getTranslations } from 'next-intl/server';
 import GraphView from "@/components/para/GraphView";
-import { type Locale } from '@/i18n/config';
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'graph' });
   return {

--- a/web_ui/src/app/[locale]/layout.tsx
+++ b/web_ui/src/app/[locale]/layout.tsx
@@ -24,7 +24,7 @@ export function generateStaticParams() {
   return locales.map((locale) => ({ locale }));
 }
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'metadata' });
   return {
@@ -44,11 +44,11 @@ export default async function LocaleLayout({
   params
 }: {
   children: React.ReactNode;
-  params: Promise<{ locale: Locale }>;
+  params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
   
-  if (!locales.includes(locale)) {
+  if (!locales.includes(locale as Locale)) {
     notFound();
   }
 

--- a/web_ui/src/app/[locale]/page.tsx
+++ b/web_ui/src/app/[locale]/page.tsx
@@ -2,9 +2,9 @@
 
 import { getTranslations } from 'next-intl/server';
 import { SyncMonitor } from '@/components/dashboard/sync-monitor';
-import { type Locale } from '@/i18n/config';
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'dashboard' });
   return {

--- a/web_ui/src/app/[locale]/stats/page.tsx
+++ b/web_ui/src/app/[locale]/stats/page.tsx
@@ -2,9 +2,9 @@
 
 import { getTranslations } from 'next-intl/server';
 import StatsView from "@/components/dashboard/stats/StatsView";
-import { type Locale } from '@/i18n/config';
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'stats' });
   return {

--- a/web_ui/src/i18n/request.ts
+++ b/web_ui/src/i18n/request.ts
@@ -1,0 +1,18 @@
+import {getRequestConfig} from 'next-intl/server';
+import {locales} from './config';
+
+export default getRequestConfig(async ({requestLocale}) => {
+  // This typically corresponds to the `[locale]` segment
+  let locale = await requestLocale;
+
+  // Ensure that a valid locale is used
+  // Cast locales to readonly string[] to avoid 'as any' and allow string comparison
+  if (!locale || !(locales as readonly string[]).includes(locale)) {
+    locale = locales[0];
+  }
+
+  return {
+    locale,
+    messages: (await import(`../locales/${locale}.json`)).default
+  };
+});


### PR DESCRIPTION
🔧 변경 사항:
- **[Config]**: [next.config.ts, i18n/request.ts]
  - `next-intl` 플러그인 설정 및 필수 구성 파일(`request.ts`) 추가 (빌드 에러 해결)
- **[Type]**: [layout.tsx, page.tsx, graph/page.tsx, stats/page.tsx]
  - Next.js 15+ Params 타입 호환성 문제 해결 (`Promise<{ locale: Locale }>` → `Promise<{ locale: string }>`)
- **[Lint]**: [request.ts, page.tsx]
  - `no-explicit-any` 등 ESLint 규칙 위반 수정

🎯 목적:
- Phase 3 QA 체크리스트(Build, Lint) 통과
- 프로덕션 환경 배포 안정성 확보

📌 Related:
- Issue [#275]

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

next-intl 플러그인과 요청 구성을 통합하여 로컬라이즈된 빌드를 안정화하고, 레이아웃 및 페이지 메타데이터 생성기 전반에서 로케일 타입을 일치시킵니다.

향상 사항:
- 로케일 검증과 메시지 로딩을 보장하기 위해 공유 요청 핸들러를 사용하는 next-intl 플러그인 구성을 추가했습니다.
- 허용된 로케일 제한은 유지하면서, 레이아웃 및 페이지 컴포넌트가 로케일 파라미터를 문자열로 취급하도록 업데이트했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate next-intl plugin and request configuration to stabilize localized builds and align locale typing across layout and page metadata generators.

Enhancements:
- Add next-intl plugin configuration with a shared request handler to ensure locale validation and message loading.
- Update layout and page components to treat locale params as strings while preserving allowed locale enforcement.

</details>