### PR TITLE
♻️ refactor(i18n) [#10.11.13]: 1차 개선 - Type Guard 도입을 통한 로케일 검증 로직 중앙화 및 타입 안전성 강화

### DIFF
--- a/web_ui/src/app/[locale]/layout.tsx
+++ b/web_ui/src/app/[locale]/layout.tsx
@@ -3,7 +3,7 @@
 import { NextIntlClientProvider } from 'next-intl';
 import { notFound } from 'next/navigation';
 import { getTranslations } from 'next-intl/server';
-import { locales, type Locale } from '@/i18n/config';
+import { locales, isValidLocale } from '@/i18n/config';
 import { Sidebar } from "@/components/layout/sidebar";
 import { MobileNav } from "@/components/layout/mobile-nav";
 import { Toaster } from "@/components/ui/sonner";
@@ -48,7 +48,7 @@ export default async function LocaleLayout({
 }) {
   const { locale } = await params;
   
-  if (!locales.includes(locale as Locale)) {
+  if (!isValidLocale(locale)) {
     notFound();
   }
 

--- a/web_ui/src/i18n/config.ts
+++ b/web_ui/src/i18n/config.ts
@@ -9,3 +9,7 @@ export const localeNames: Record<Locale, string> = {
   ko: '한국어',
   en: 'English'
 };
+
+export function isValidLocale(locale: unknown): locale is Locale {
+  return locales.includes(locale as Locale);
+}

--- a/web_ui/src/i18n/request.ts
+++ b/web_ui/src/i18n/request.ts
@@ -1,13 +1,12 @@
 import {getRequestConfig} from 'next-intl/server';
-import {locales} from './config';
+import {locales, isValidLocale} from './config';
 
 export default getRequestConfig(async ({requestLocale}) => {
   // This typically corresponds to the `[locale]` segment
   let locale = await requestLocale;
 
   // Ensure that a valid locale is used
-  // Cast locales to readonly string[] to avoid 'as any' and allow string comparison
-  if (!locale || !(locales as readonly string[]).includes(locale)) {
+  if (!locale || !isValidLocale(locale)) {
     locale = locales[0];
   }
 


### PR DESCRIPTION
🔧 변경 사항:
- **[Config]**: [i18n/config.ts]
  - `isValidLocale` 사용자 정의 타입 가드(Type Guard) 추가 (`string` -> `Locale` 타입 좁힘)
- **[Validation]**: [layout.tsx, request.ts]
  - `as Locale` 등 불안정한 타입 캐스팅 제거하고 `isValidLocale` 헬퍼 함수 사용
  - 로케일 유효성 검사 로직을 `config.ts`로 일원화 (Centralization)
- **[Cleanup]**: [layout.tsx]
  - 사용하지 않는 `Locale` 타입 import 제거 (Lint Fix)

🎯 목적:
- Code Review 피드백 반영
- 런타임 타입 검증과 정적 타입 시스템의 불일치 해소

📌 Related:
- Issue [#275]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/442#pullrequestreview-3736692462) - `Weak type safety`, `Validation split`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

공유되는 타입 안전 헬퍼를 사용해 i18n 레이어에서 로케일 검증을 중앙화하고 강화합니다.

버그 수정:
- 통합된 검증기를 사용하여, 잘못되었거나 누락된 로케일을 받을 때 요청 및 레이아웃 핸들러가 올바르게 폴백하거나 404를 반환하도록 보장합니다.

개선 사항:
- `isValidLocale` 타입 가드를 도입하여 알 수 없는 입력을 `Locale` 타입으로 좁히고, 이를 i18n 엔트리 포인트 전반에서 재사용합니다.
- 개별적으로 흩어진 캐스팅과 인라인 체크를 공유 로케일 검증기로 대체하고 사용되지 않는 import를 정리하여 i18n 요청 및 레이아웃 코드를 단순화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize and strengthen locale validation in the i18n layer using a shared type-safe helper.

Bug Fixes:
- Ensure request and layout handlers fall back or 404 correctly when receiving invalid or missing locales by using a unified validator.

Enhancements:
- Introduce an isValidLocale type guard to narrow unknown inputs to the Locale type and reuse it across i18n entry points.
- Simplify i18n request and layout code by replacing ad-hoc casts and inline checks with the shared locale validator and cleaning up unused imports.

</details>