### PR TITLE
♻️ refactor(api) [#10.11.15]: 1차 개선 - Pydantic 응답 모델 도입 및 API 일관성 강화

### DIFF
--- a/backend/api/endpoints/classify.py
+++ b/backend/api/endpoints/classify.py
@@ -4,18 +4,19 @@
 
 from fastapi import APIRouter, UploadFile, File, Depends
 from ...api.deps import get_locale
+from ...api.models import FileProcessingResponse
 from ...services.i18n_service import get_message
 
 router = APIRouter(prefix="/classify", tags=["classify"])
 
 
-@router.post("/file")
+@router.post("/file", response_model=FileProcessingResponse)
 async def classify_file(
     file: UploadFile = File(...), locale: str = Depends(get_locale)
-):
+) -> FileProcessingResponse:
     """파일 분류 엔드포인트 (다국어 지원)"""
-    return {
-        "status": "processing",
-        "message": get_message("file_processing", locale, filename=file.filename),
-        "file": file.filename,
-    }
+    return FileProcessingResponse(
+        status="processing",
+        message=get_message("file_processing", locale, filename=file.filename),
+        file=file.filename,
+    )

--- a/backend/api/endpoints/metadata.py
+++ b/backend/api/endpoints/metadata.py
@@ -4,21 +4,37 @@
 
 from fastapi import APIRouter, Depends
 from ...api.deps import get_locale
+from ...api.models import MetadataResponse
 from ...services.i18n_service import get_message
 
 router = APIRouter(prefix="/metadata", tags=["metadata"])
 
 
-@router.get("/{file_id}")
-async def get_metadata(file_id: str, locale: str = Depends(get_locale)):
+@router.get("/{file_id}", response_model=MetadataResponse)
+async def get_metadata(
+    file_id: str, locale: str = Depends(get_locale)
+) -> MetadataResponse:
     """메타데이터 조회 (다국어 지원)"""
     # TODO: Implement actual metadata retrieval
     metadata = {}
-    return {"file_id": file_id, "metadata": metadata}
+    return MetadataResponse(
+        status="success",
+        message=get_message("metadata_fetched", locale),
+        file_id=file_id,
+        metadata=metadata,
+    )
 
 
-@router.put("/{file_id}")
-async def update_metadata(file_id: str, locale: str = Depends(get_locale)):
+@router.put("/{file_id}", response_model=MetadataResponse)
+async def update_metadata(
+    file_id: str, locale: str = Depends(get_locale)
+) -> MetadataResponse:
     """메타데이터 업데이트 (다국어 지원)"""
     # TODO: Implement actual metadata update
-    return {"file_id": file_id, "message": get_message("metadata_updated", locale)}
+    metadata = {}
+    return MetadataResponse(
+        status="success",
+        message=get_message("metadata_updated", locale),
+        file_id=file_id,
+        metadata=metadata,
+    )

--- a/backend/api/endpoints/search.py
+++ b/backend/api/endpoints/search.py
@@ -4,17 +4,20 @@
 
 from fastapi import APIRouter, Depends
 from ...api.deps import get_locale
+from ...api.models import SearchResponse
 from ...services.i18n_service import get_message
 
 router = APIRouter(prefix="/search", tags=["search"])
 
 
-@router.get("/")
-async def search_files(q: str, locale: str = Depends(get_locale)):
+@router.get("/", response_model=SearchResponse)
+async def search_files(q: str, locale: str = Depends(get_locale)) -> SearchResponse:
     """검색 엔드포인트 (다국어 지원)"""
     results = []  # TODO: Implement actual search logic
-    return {
-        "query": q,
-        "message": get_message("search_results", locale, count=len(results)),
-        "results": results,
-    }
+    return SearchResponse(
+        status="success",
+        message=get_message("search_results", locale, count=len(results)),
+        query=q,
+        results=results,
+        count=len(results),
+    )

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -13,9 +13,43 @@ from backend.models import (
     FileMetadataInput,
     ClassifyBatchResponse,
     SaveClassificationRequest,
-    SearchRequest
-    )
+    SearchRequest,
+)
 
+
+# Common i18n Response Models
+class BaseResponse(BaseModel):
+    """기본 응답 모델 (다국어 메시지 포함)"""
+
+    status: str
+    message: str
+
+
+class HealthCheckResponse(BaseResponse):
+    """헬스체크 응답"""
+
+    pass
+
+
+class FileProcessingResponse(BaseResponse):
+    """파일 처리 응답"""
+
+    file: str
+
+
+class SearchResponse(BaseResponse):
+    """검색 응답"""
+
+    query: str
+    results: List[Dict[str, Any]] = Field(default_factory=list)
+    count: int = 0
+
+
+class MetadataResponse(BaseResponse):
+    """메타데이터 조회/업데이트 응답"""
+
+    file_id: str
+    metadata: Optional[Dict[str, Any]] = None
 
 
 __all__ = [
@@ -25,9 +59,14 @@ __all__ = [
     "FileMetadataInput",
     "ClassifyBatchRequest",
     "ClassifyBatchResponse",
-    
     # File Management
     "FileMetadata",
     "SaveClassificationRequest",
     "SearchRequest",
+    # i18n Response Models
+    "BaseResponse",
+    "HealthCheckResponse",
+    "FileProcessingResponse",
+    "SearchResponse",
+    "MetadataResponse",
 ]

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -5,16 +5,17 @@
 from fastapi import APIRouter, Depends
 from . import endpoints
 from .deps import get_locale
+from .models import HealthCheckResponse
 from ..services.i18n_service import get_message
 
 router = APIRouter(prefix="/api")
 
 
 # Health check endpoint
-@router.get("/health")
-async def health_check(locale: str = Depends(get_locale)):
+@router.get("/health", response_model=HealthCheckResponse)
+async def health_check(locale: str = Depends(get_locale)) -> HealthCheckResponse:
     """서버 상태 확인 (다국어 지원)"""
-    return {"status": "ok", "message": get_message("status_ok", locale)}
+    return HealthCheckResponse(status="ok", message=get_message("status_ok", locale))
 
 
 # Include endpoint routers

--- a/backend/services/i18n_service.py
+++ b/backend/services/i18n_service.py
@@ -21,6 +21,7 @@ MESSAGES: Dict[str, Dict[str, str]] = {
         "status_ok": "서버가 정상 작동 중입니다",
         "search_results": "{count}개의 검색 결과를 찾았습니다",
         "metadata_updated": "메타데이터가 업데이트되었습니다",
+        "metadata_fetched": "메타데이터를 조회했습니다",
     },
     "en": {
         "file_classified": "File classified as {category}.",
@@ -36,6 +37,7 @@ MESSAGES: Dict[str, Dict[str, str]] = {
         "status_ok": "Server is running",
         "search_results": "Found {count} search results",
         "metadata_updated": "Metadata updated",
+        "metadata_fetched": "Metadata fetched",
     },
 }
 


### PR DESCRIPTION
🔧 변경 사항:
- **[Models]**: [models.py]
  - 공통 응답 모델 정의 (`BaseResponse`, `HealthCheckResponse`, `FileProcessingResponse`, `SearchResponse`, `MetadataResponse`)
- **[Services]**: [i18n_service.py]
  - `metadata_fetched` 메시지 키 추가 (GET 엔드포인트용)
- **[Endpoints]**: [routes.py, classify.py, search.py, metadata.py]
  - 모든 엔드포인트에 `response_model` 및 타입 힌트 적용
  - `update_metadata` 엔드포인트에 응답 본문 추가 (일관성 확보)
  - `get_metadata`에 다국어 메시지 추가
  - 딕셔너리 반환 대신 Pydantic 모델 인스턴스 반환

🎯 목적:
- Code Review 피드백 반영
- API 응답 구조 표준화 및 타입 안전성 향상
- OpenAPI 문서 자동 생성 품질 개선

📌 Related:
- Issue [#275]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/447#pullrequestreview-3742301817) - `Response consistency`, `Structured models`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

공유 Pydantic 모델을 사용해 API 응답을 표준화하고, 엔드포인트를 지역화된 메시지와 정렬했습니다.

New Features:
- 상태 점검(health check), 파일 처리, 검색, 메타데이터 작업을 위해 i18n을 지원하는 공용 Pydantic 응답 모델을 도입했습니다.

Enhancements:
- health, classify, search, metadata 엔드포인트 전반에 걸쳐 명시적인 `response_model` 애너테이션과 타입이 지정된 반환 값을 적용하여 응답 형태를 일관되게 강제했습니다.
- 영향을 받는 모든 엔드포인트에서 기존의 원시 딕셔너리 대신 구조화된 Pydantic 응답 객체를 반환하도록 변경했습니다.
- i18n 서비스를 통해 메타데이터 조회 작업에 대해 지역화된 성공 메시지 지원을 추가했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize API responses using shared Pydantic models and align endpoints with localized messaging.

New Features:
- Introduce shared i18n-aware Pydantic response models for health checks, file processing, search, and metadata operations.

Enhancements:
- Apply explicit response_model annotations and typed return values across health, classify, search, and metadata endpoints to enforce consistent response shapes.
- Return structured Pydantic response objects instead of raw dictionaries for all affected endpoints.
- Add localized success message support for metadata fetch operations via the i18n service.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

공유 Pydantic 모델을 사용해 API 응답을 표준화하고, 엔드포인트를 지역화된 메시지와 정렬했습니다.

New Features:
- 상태 점검(health check), 파일 처리, 검색, 메타데이터 작업을 위해 i18n을 지원하는 공용 Pydantic 응답 모델을 도입했습니다.

Enhancements:
- health, classify, search, metadata 엔드포인트 전반에 걸쳐 명시적인 `response_model` 애너테이션과 타입이 지정된 반환 값을 적용하여 응답 형태를 일관되게 강제했습니다.
- 영향을 받는 모든 엔드포인트에서 기존의 원시 딕셔너리 대신 구조화된 Pydantic 응답 객체를 반환하도록 변경했습니다.
- i18n 서비스를 통해 메타데이터 조회 작업에 대해 지역화된 성공 메시지 지원을 추가했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize API responses using shared Pydantic models and align endpoints with localized messaging.

New Features:
- Introduce shared i18n-aware Pydantic response models for health checks, file processing, search, and metadata operations.

Enhancements:
- Apply explicit response_model annotations and typed return values across health, classify, search, and metadata endpoints to enforce consistent response shapes.
- Return structured Pydantic response objects instead of raw dictionaries for all affected endpoints.
- Add localized success message support for metadata fetch operations via the i18n service.

</details>

</details>