### PR TITLE
✨ feat(api) [#10.11.16]: Error Handling 다국어화 구현

### DIFF
--- a/backend/api/endpoints/classify.py
+++ b/backend/api/endpoints/classify.py
@@ -5,6 +5,7 @@
 from fastapi import APIRouter, UploadFile, File, Depends
 from ...api.deps import get_locale
 from ...api.models import FileProcessingResponse
+from ...api.exceptions import localized_http_exception
 from ...services.i18n_service import get_message
 
 router = APIRouter(prefix="/classify", tags=["classify"])
@@ -15,6 +16,20 @@ async def classify_file(
     file: UploadFile = File(...), locale: str = Depends(get_locale)
 ) -> FileProcessingResponse:
     """파일 분류 엔드포인트 (다국어 지원)"""
+
+    # Validation example: Check file size (10MB limit)
+    MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+
+    # Read file content to check size
+    content = await file.read()
+    if len(content) > MAX_FILE_SIZE:
+        raise localized_http_exception(
+            status_code=400, message_key="bad_request", locale=locale
+        )
+
+    # Reset file pointer
+    await file.seek(0)
+
     return FileProcessingResponse(
         status="processing",
         message=get_message("file_processing", locale, filename=file.filename),

--- a/backend/api/exceptions.py
+++ b/backend/api/exceptions.py
@@ -1,0 +1,121 @@
+# backend/api/exceptions.py
+
+"""
+Custom exception handlers and utilities for i18n error responses
+"""
+
+from fastapi import HTTPException, Request, status
+from fastapi.responses import JSONResponse
+from ..services.i18n_service import get_message, DEFAULT_LOCALE
+
+
+def localized_http_exception(
+    status_code: int, message_key: str, locale: str = DEFAULT_LOCALE, **kwargs
+) -> HTTPException:
+    """
+    HTTPException을 생성하되, 로케일에 맞는 에러 메시지를 사용합니다.
+
+    Args:
+        status_code: HTTP 상태 코드
+        message_key: i18n 메시지 키
+        locale: 로케일 (기본값: DEFAULT_LOCALE)
+        **kwargs: 메시지 포맷팅에 사용될 추가 인자
+
+    Returns:
+        HTTPException 인스턴스
+
+    Example:
+        raise localized_http_exception(404, "not_found", locale="ko")
+    """
+    detail = get_message(message_key, locale, **kwargs)
+    return HTTPException(status_code=status_code, detail=detail)
+
+
+async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    """
+    전역 HTTPException 핸들러 (다국어 지원)
+
+    Accept-Language 헤더를 기반으로 에러 메시지를 현지화합니다.
+    """
+    from .deps import get_locale
+
+    # Extract locale from request headers
+    accept_language = request.headers.get("Accept-Language")
+    locale = DEFAULT_LOCALE
+
+    # Simple locale extraction (reuse logic from deps.py would be better)
+    if accept_language:
+        try:
+            # Use the get_locale dependency logic
+            from .deps import _parse_language_entry, SUPPORTED_LOCALES
+
+            for part in accept_language.split(","):
+                entry = _parse_language_entry(part)
+                if entry and entry.primary_tag in SUPPORTED_LOCALES:
+                    locale = entry.primary_tag
+                    break
+        except Exception:
+            pass  # Fallback to default locale
+
+    # Map status codes to message keys
+    status_to_key = {
+        400: "bad_request",
+        401: "unauthorized",
+        403: "forbidden",
+        404: "not_found",
+        405: "method_not_allowed",
+        422: "validation_error",
+        500: "server_error",
+    }
+
+    message_key = status_to_key.get(exc.status_code)
+
+    # If we have a predefined message key, use it; otherwise use the original detail
+    if message_key:
+        detail = get_message(message_key, locale, detail=str(exc.detail))
+    else:
+        detail = exc.detail
+
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"status": "error", "message": detail, "status_code": exc.status_code},
+    )
+
+
+async def validation_exception_handler(
+    request: Request, exc: Exception
+) -> JSONResponse:
+    """
+    Pydantic 검증 오류 핸들러 (다국어 지원)
+    """
+    from fastapi.exceptions import RequestValidationError
+
+    if not isinstance(exc, RequestValidationError):
+        raise exc
+
+    # Extract locale
+    accept_language = request.headers.get("Accept-Language")
+    locale = DEFAULT_LOCALE
+
+    if accept_language:
+        try:
+            from .deps import _parse_language_entry, SUPPORTED_LOCALES
+
+            for part in accept_language.split(","):
+                entry = _parse_language_entry(part)
+                if entry and entry.primary_tag in SUPPORTED_LOCALES:
+                    locale = entry.primary_tag
+                    break
+        except Exception:
+            pass
+
+    # Format validation errors
+    errors = exc.errors()
+    error_details = "; ".join([f"{err['loc'][-1]}: {err['msg']}" for err in errors])
+
+    message = get_message("validation_error", locale, detail=error_details)
+
+    return JSONResponse(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        content={"status": "error", "message": message, "errors": errors},
+    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -94,6 +94,18 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Exception Handlers (i18n support)
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+from fastapi.exceptions import RequestValidationError
+from backend.api.exceptions import http_exception_handler, validation_exception_handler
+
+app.add_exception_handler(HTTPException, http_exception_handler)
+app.add_exception_handler(RequestValidationError, validation_exception_handler)
+logger.info("✅ 전역 예외 처리기 등록 완료 (i18n 지원)")
+
+
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # 라우터 등록
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/backend/services/i18n_service.py
+++ b/backend/services/i18n_service.py
@@ -22,6 +22,11 @@ MESSAGES: Dict[str, Dict[str, str]] = {
         "search_results": "{count}개의 검색 결과를 찾았습니다",
         "metadata_updated": "메타데이터가 업데이트되었습니다",
         "metadata_fetched": "메타데이터를 조회했습니다",
+        # Error Messages
+        "bad_request": "잘못된 요청입니다",
+        "forbidden": "접근 권한이 없습니다",
+        "validation_error": "입력값 검증 실패: {detail}",
+        "method_not_allowed": "허용되지 않은 메서드입니다",
     },
     "en": {
         "file_classified": "File classified as {category}.",
@@ -38,6 +43,11 @@ MESSAGES: Dict[str, Dict[str, str]] = {
         "search_results": "Found {count} search results",
         "metadata_updated": "Metadata updated",
         "metadata_fetched": "Metadata fetched",
+        # Error Messages
+        "bad_request": "Bad request",
+        "forbidden": "Access forbidden",
+        "validation_error": "Validation failed: {detail}",
+        "method_not_allowed": "Method not allowed",
     },
 }
 


### PR DESCRIPTION
🔧 변경 사항:
- **[Services]**: [i18n_service.py]
  - 에러 메시지 키 추가 (`bad_request`, `forbidden`, `validation_error`, `method_not_allowed`)
- **[Exceptions]**: [exceptions.py] (신규)
  - `localized_http_exception`: 로케일 기반 HTTPException 생성 유틸리티
  - `http_exception_handler`: 전역 HTTPException 핸들러 (Accept-Language 헤더 기반 다국어 지원)
  - `validation_exception_handler`: Pydantic 검증 오류 핸들러 (다국어 지원)
- **[Main]**: [main.py]
  - 전역 예외 처리기 등록 (HTTPException, RequestValidationError)
- **[Endpoints]**: [classify.py]
  - 파일 크기 검증 로직 추가 및 `localized_http_exception` 사용 예시

🎯 목적:
- API 에러 응답의 다국어 지원
- 일관된 에러 응답 구조 제공 (`status`, `message`, `status_code`)
- 클라이언트 로케일에 맞는 에러 메시지 자동 반환

📌 Related:
- Issue [#275]

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

로컬라이즈된 API 오류 처리를 구현하고 이를 분류 및 검증 플로우에 적용합니다.

New Features:
- 중앙 집중식 i18n 인식 HTTP 예외 유틸리티와 HTTP 및 검증 오류를 위한 전역 예외 처리기를 도입합니다.
- i18n 서비스에 일반적인 HTTP 오류에 대한 로컬라이즈된 오류 메시지 키를 추가합니다.
- 분류(classify) 엔드포인트에 최대 업로드 크기를 적용하고, 초과 시 로컬라이즈된 오류 응답을 반환합니다.

Enhancements:
- API 오류에 대해 `status`, `message`, `status_code`를 포함하는 표준화된 오류 응답 페이로드 형식을 통일합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement localized API error handling and apply it to classification and validation flows.

New Features:
- Introduce a centralized i18n-aware HTTP exception utility and global exception handlers for HTTP and validation errors.
- Add localized error message keys for common HTTP errors in the i18n service.
- Enforce a maximum upload size on the classify endpoint with localized error responses when exceeded.

Enhancements:
- Standardize error response payloads to include status, message, and status_code for API errors.

</details>