### PR TITLE
♻️ refactor(api) [#10.11.16]: 2차 개선 - 에러 핸들러 동적 메시지 및 설정 의존성 최적화

### DIFF
--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -12,7 +12,11 @@ from fastapi import (
     Header,
 )
 from fastapi.security import OAuth2PasswordBearer
-from backend.services.i18n_service import SUPPORTED_LOCALES, DEFAULT_LOCALE
+from backend.core.config import settings
+
+# Locale configuration from settings
+SUPPORTED_LOCALES = settings.SUPPORTED_LOCALES
+DEFAULT_LOCALE = settings.DEFAULT_LOCALE
 
 # OAuth2 스키마 정의
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")

--- a/backend/api/endpoints/classify.py
+++ b/backend/api/endpoints/classify.py
@@ -24,7 +24,7 @@ async def classify_file(
     # Read file content to check size
     content = await file.read()
     if len(content) > max_file_size:
-        max_size_mb = max_file_size / (1024 * 1024)
+        max_size_mb = int(max_file_size / (1024 * 1024))
         raise localized_http_exception(
             status_code=413,
             message_key="payload_too_large",

--- a/backend/api/exceptions.py
+++ b/backend/api/exceptions.py
@@ -59,7 +59,7 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> JSONRe
 
     # If we have a predefined message key, use it; otherwise use the original detail
     if message_key:
-        detail = get_message(message_key, locale)
+        detail = get_message(message_key, locale, detail=str(exc.detail))
     else:
         detail = exc.detail
 


### PR DESCRIPTION
🔧 변경 사항:
- **[Dependencies]**: [deps.py]
  - 로케일 설정 소스를 `i18n_service`에서 `core.config.settings`로 변경 (Single Source of Truth)
- **[Exceptions]**: [exceptions.py]
  - `http_exception_handler`에서 `validation_error` 등의 동적 템플릿 처리를 위해 `detail` 인자 전달 로직 복구
- **[Endpoints]**: [classify.py]
  - `payload_too_large` 에러 메시지의 용량 표시를 정수형(int)으로 변환하여 가독성 개선

🎯 목적:
- Code Review 피드백 반영
- 설정 관리의 일원화 및 에러 메시지 포맷팅 정교화

📌 Related:
- Issue [#275]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/450#pullrequestreview-3742362617)

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

로케일 설정 소스를 통합하고, 에러 메시지 포맷을 개선하며, API 레이어 전반에서 동적 HTTP 예외 템플릿을 지원합니다.

Enhancements:
- 설정을 일원화하기 위해 지원되는 로케일 및 기본 로케일을 i18n 서비스 대신 중앙 설정에서 가져오도록 변경.
- 페이로드가 너무 큰 경우의 에러 메시지를 정수 단위의 메가바이트 값으로 표시하여 크기를 더 명확하게 표현.
- 원래의 `detail` 값을 i18n 메시지 조회에 전달하여 HTTP 예외 메시지가 동적 템플릿을 사용할 수 있도록 지원.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify locale configuration source, improve error message formatting, and support dynamic HTTP exception templates across the API layer.

Enhancements:
- Source supported locales and default locale from central settings instead of the i18n service to consolidate configuration.
- Format payload-too-large error messages with integer megabyte values for clearer size display.
- Enable HTTP exception messages to use dynamic templates by passing the original detail into the i18n message lookup.

</details>