### PR TITLE
🐛 fix(api) [#10.11.16]: 4차 개선 - Runtime Error 방지 및 동적 설정 참조 강화

### DIFF
--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -177,6 +177,7 @@ def extract_locale_from_header(accept_language: Optional[str]) -> str:
             lang_map[entry.primary_tag] = entry.q_value
 
     # Sort by q-value (descending) and find first supported locale
+    sorted_langs = sorted(lang_map.items(), key=lambda x: x[1], reverse=True)
     for lang, _ in sorted_langs:
         if lang in settings.SUPPORTED_LOCALES:
             return lang

--- a/backend/api/exceptions.py
+++ b/backend/api/exceptions.py
@@ -6,12 +6,13 @@ Custom exception handlers and utilities for i18n error responses
 
 from fastapi import HTTPException, Request, status
 from fastapi.responses import JSONResponse
+from typing import Optional
 from ..services.i18n_service import get_message
 from backend.core.config import settings
 
 
 def localized_http_exception(
-    status_code: int, message_key: str, locale: str = settings.DEFAULT_LOCALE, **kwargs
+    status_code: int, message_key: str, locale: Optional[str] = None, **kwargs
 ) -> HTTPException:
     """
     HTTPException을 생성하되, 로케일에 맞는 에러 메시지를 사용합니다.
@@ -19,7 +20,7 @@ def localized_http_exception(
     Args:
         status_code: HTTP 상태 코드
         message_key: i18n 메시지 키
-        locale: 로케일 (기본값: settings.DEFAULT_LOCALE)
+        locale: 로케일 (기본값: None, 런타임에 settings.DEFAULT_LOCALE 사용)
         **kwargs: 메시지 포맷팅에 사용될 추가 인자
 
     Returns:
@@ -28,6 +29,9 @@ def localized_http_exception(
     Example:
         raise localized_http_exception(404, "not_found", locale="ko")
     """
+    if locale is None:
+        locale = settings.DEFAULT_LOCALE
+
     detail = get_message(message_key, locale, **kwargs)
     return HTTPException(status_code=status_code, detail=detail)
 


### PR DESCRIPTION
🔧 변경 사항:
- **[Dependencies]**: [deps.py]
  - `extract_locale_from_header` 함수 내 `sorted_langs` 변수 정의 누락 수정 (NameError 방지)
- **[Exceptions]**: [exceptions.py]
  - `localized_http_exception` 함수의 기본 로케일 인자를 `None`으로 변경하고 런타임에 리졸브하도록 수정 (Runtime Configuration Flexibility)

🎯 목적:
- Code Review 피드백 반영
- 잠재적인 런타임 크래시 방지 및 설정 변경 대응력 확보

📌 Related:
- Issue [#275]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/452#pullrequestreview-3749429619) -`Bug Fix`, `Runtime Safety`

Co-authored-by: Gemini 3 Pro, Claude-4.5-sonnet

## Summary by Sourcery

런타임 로케일 처리 기능을 강화하고 API 로컬라이제이션 헬퍼에서 발생하는 오류를 방지합니다.

버그 수정:
- 언어 선호 목록을 반복(iteration)하기 전에 초기화하여 로케일 추출 중 발생할 수 있는 `NameError`를 방지합니다.
- HTTP 예외에서 하드코딩된 기본 로케일 사용을 피하고, 기본 로케일이 제공되지 않은 경우 런타임에 기본 로케일을 결정하도록 변경합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen runtime locale handling and prevent errors in API localization helpers.

Bug Fixes:
- Prevent NameError in locale extraction by ensuring the language preference list is initialized before iteration.
- Avoid hard‑coded default locale at definition time in HTTP exceptions by resolving the default locale at runtime when none is provided.

</details>