### PR TITLE
🐛 fix [#11.1.3]: 1차 개선 - AgentState 타입 유연성 및 노드 안정성 강화

### DIFF
--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -1,6 +1,6 @@
 # backend/agent/nodes.py
 
-from typing import Literal, Dict, Any
+from typing import Literal, Dict, Any, List, Optional
 from backend.agent.state import AgentState
 from backend.agent.utils import get_llm, extract_keywords, search_similar_docs
 
@@ -14,6 +14,7 @@ def analyze_node(state: AgentState) -> Dict[str, Any]:
     입력 분석 노드: 문서 내용에서 핵심 키워드 추출
     """
     # 헬퍼 함수 호출 (Stub)
+    # file_content는 Required 필드이므로 직접 접근 가능
     keywords = extract_keywords(state["file_content"])
     # State 업데이트: extracted_keywords
     return {"extracted_keywords": keywords}
@@ -23,8 +24,11 @@ def retrieve_node(state: AgentState) -> Dict[str, Any]:
     """
     맥락 검색 노드: 키워드 기반 유사 문서 검색 (RAG)
     """
+    # NotRequired 필드 안전한 접근
+    keywords = state.get("extracted_keywords", [])
+
     # 헬퍼 함수 호출 (Stub)
-    context = search_similar_docs(state["extracted_keywords"])
+    context = search_similar_docs(keywords)
     # State 업데이트: retrieved_context
     return {"retrieved_context": context}
 
@@ -35,17 +39,23 @@ def classify_node(state: AgentState) -> Dict[str, Any]:
     """
     llm = get_llm()
 
-    if llm:
-        # TODO: 실제 LLM 호출 및 Pydantic 파싱
-        # result = llm.invoke(...)
-        # return result.dict()
-        pass
+    if not llm:
+        # Stub: LLM 미설정 시 기본값 반환
+        return {
+            "classification_result": {"category": "Resources", "confidence": 0.0},
+            "confidence_score": 0.0,
+            "reasoning": "LLM not initialized (Stub)",
+        }
 
-    # Stub: 기본값 반환 (개발 초기 단계)
+    # TODO: 실제 LLM 호출 및 Pydantic 파싱 로직 구현
+    # result = llm.invoke(...)
+    # return result.dict()
+
+    # 임시 Stub (구현 전까지 유지)
     return {
-        "classification_result": {"category": "Resources", "confidence": 0.0},
+        "classification_result": {"category": "Projects", "confidence": 0.0},
         "confidence_score": 0.0,
-        "reasoning": "LLM not initialized (Stub)",
+        "reasoning": "LLM implementation pending",
     }
 
 
@@ -62,8 +72,9 @@ def reflect_node(state: AgentState) -> Dict[str, Any]:
     """
     회고 노드: 낮은 신뢰도 원인 분석 및 재시도 카운트 증가
     """
-    # 재시도 횟수 증가
-    return {"retry_count": state["retry_count"] + 1}
+    # 재시도 횟수 증가 (안전한 접근)
+    current_count = state.get("retry_count", 0)
+    return {"retry_count": current_count + 1}
 
 
 # =================================================================
@@ -78,12 +89,15 @@ def should_retry(state: AgentState) -> Literal["end", "retry"]:
     Returns:
         Literal["end", "retry"]: 종료 또는 재시도 경로
     """
+    confidence = state.get("confidence_score", 0.0)
+    retry_count = state.get("retry_count", 0)
+
     # 1. 신뢰도가 충분히 높으면 종료
-    if state["confidence_score"] >= 0.7:
+    if confidence >= 0.7:
         return "end"
 
     # 2. 최대 재시도 횟수 초과 시 종료
-    if state["retry_count"] >= 3:
+    if retry_count >= 3:
         return "end"
 
     # 3. 그 외의 경우 재시도 (Reflection 노드로 이동)

--- a/backend/agent/state.py
+++ b/backend/agent/state.py
@@ -1,6 +1,6 @@
 # backend/agent/state.py
 
-from typing import TypedDict, List, Optional
+from typing import TypedDict, List, Optional, NotRequired
 
 
 class AgentState(TypedDict):
@@ -18,16 +18,18 @@ class AgentState(TypedDict):
         reasoning: LLM의 추론 과정 설명
     """
 
-    # 입력
+    # 입력 (필수)
     file_content: str
     file_name: str
 
-    # 내부 처리
-    extracted_keywords: List[str]  # 초기값: []
-    retrieved_context: Optional[str]  # 초기값: None
-    retry_count: int  # 초기값: 0
+    # 내부 처리 (선택적)
+    extracted_keywords: NotRequired[List[str]]  # 초기값: []
+    retrieved_context: NotRequired[Optional[str]]  # 초기값: None
+    retry_count: NotRequired[int]  # 초기값: 0
 
-    # 출력
-    classification_result: Optional[dict]  # 초기값: None (Pydantic 모델 or Dict)
-    confidence_score: float  # 초기값: 0.0
-    reasoning: Optional[str]  # 초기값: None
+    # 출력 (선택적)
+    classification_result: NotRequired[
+        Optional[dict]
+    ]  # 초기값: None (Pydantic 모델 or Dict)
+    confidence_score: NotRequired[float]  # 초기값: 0.0
+    reasoning: NotRequired[Optional[str]]  # 초기값: None

--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -1,17 +1,23 @@
 # backend/agent/utils.py
 
-from typing import List, Optional
+from typing import List, Optional, Any
+
+try:
+    from langchain_core.language_models import BaseChatModel
+except ImportError:
+    # 런타임에 의존성이 없을 경우를 대비한 더미 타입 (Type Hinting)
+    BaseChatModel = Any  # type: ignore
 
 # 실제 구현 시 필요한 라이브러리 임포트 (TODO)
 # from langchain_openai import ChatOpenAI
 
 
-def get_llm():
+def get_llm() -> Optional["BaseChatModel"]:
     """
     LLM 인스턴스를 반환하는 팩토리 함수 (Stub)
 
     Returns:
-        BaseChatModel or None: 초기화된 LLM 인스턴스 (현재는 None 반환)
+        Optional[BaseChatModel]: 초기화된 LLM 인스턴스 (현재는 None 반환)
     """
     # TODO: 실제 구현 시 ChatOpenAI 인스턴스 반환 및 설정
     # llm = ChatOpenAI(model="gpt-4o", temperature=0)


### PR DESCRIPTION
- 관련 파일 및 내용
  - **[backend/agent/state.py]**:
    - `NotRequired` 도입하여 선택적 필드(`extracted_keywords` 등)의 초기화 제약 완화
    - TypeScript의 Optional 속성과 유사한 유연한 타입 정의 적용

  - **[backend/agent/nodes.py]**:
    - `state.get()` 메서드로 변경하여 `NotRequired` 필드 접근 시 안전성 확보
    - [classify_node](backend/agent/nodes.py): LLM 인스턴스 존재 여부 체크 로직 반전 (`if not llm: return stub`)하여 가독성 및 확장성 개선

  - **[backend/agent/utils.py]**:
    - `from typing import Any` 추가하여 ImportError 핸들링 시 NameError 방지

- **목적**: 코드 리뷰 피드백 반영 (타입 시스템 정합성 및 잠재적 런타임 에러 예방)

🔗 Related:
- Issue [#463]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/473#pullrequestreview-3801290219)

Co-authored-by: Claude-4.5-sonnet, Gemini 3 Pro

## Summary by Sourcery

중간 및 출력 필드를 선택적(optional)로 취급할 수 있도록 `AgentState` 타입 정의를 완화하고, 누락된 상태 값과 존재하지 않는 LLM 인스턴스에 대해 노드 로직을 더 견고하게 만들었습니다.

버그 수정:
- `extracted_keywords`, `retry_count`, `confidence_score`와 같이 선택적인 `AgentState` 필드가 누락된 경우에도 런타임 오류가 발생하지 않도록, 안전한 기본값 및 `get` 기반 접근을 사용했습니다.
- `langchain_core`가 설치되어 있지 않은 경우, `Any` 기반의 더미 `BaseChatModel` 정의로 대체하여 누락된 LLM 의존성 타입을 안전하게 처리합니다.

개선 사항:
- 파이프라인의 선택적 필드를 더 정확하게 모델링하고 초기화 제약을 줄이기 위해 `AgentState`에 `NotRequired`를 사용했습니다.
- LLM이 설정되어 있지 않은 경우 명시적인 기본값을 반환하도록 `classify_node` 스텁 로직을 조정하고, 스텁 출력 메타데이터를 더 명확히 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax AgentState typing to treat intermediate and output fields as optional and harden node logic against missing state and absent LLM instances.

Bug Fixes:
- Prevent runtime errors when optional AgentState fields such as extracted_keywords, retry_count, and confidence_score are missing by using safe defaults and get-based access.
- Handle missing LLM dependency type safely by falling back to a dummy Any-based BaseChatModel definition when langchain_core is not installed.

Enhancements:
- Use NotRequired in AgentState to more accurately model optional pipeline fields and reduce initialization constraints.
- Adjust classify_node stub logic to return an explicit default when no LLM is configured and clarify the stub output metadata.

</details>