### PR TITLE
🐛 fix [#11.1.3]: 2차 개선 - 타입 정합성 및 스텁 로직 일관성 확보

### DIFF
--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -39,23 +39,16 @@ def classify_node(state: AgentState) -> Dict[str, Any]:
     """
     llm = get_llm()
 
-    if not llm:
-        # Stub: LLM 미설정 시 기본값 반환
-        return {
-            "classification_result": {"category": "Resources", "confidence": 0.0},
-            "confidence_score": 0.0,
-            "reasoning": "LLM not initialized (Stub)",
-        }
-
     # TODO: 실제 LLM 호출 및 Pydantic 파싱 로직 구현
-    # result = llm.invoke(...)
-    # return result.dict()
+    # if llm:
+    #     result = llm.invoke(...)
+    #     return result.dict()
 
-    # 임시 Stub (구현 전까지 유지)
+    # Stub: 현재 단계에서는 항상 기본값 반환 (LLM 연동 전)
     return {
-        "classification_result": {"category": "Projects", "confidence": 0.0},
+        "classification_result": {"category": "Resources", "confidence": 0.0},
         "confidence_score": 0.0,
-        "reasoning": "LLM implementation pending",
+        "reasoning": "Stub: LLM logic pending implementation",
     }
 
 

--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -1,12 +1,9 @@
 # backend/agent/utils.py
 
-from typing import List, Optional, Any
+from typing import List, Optional, TYPE_CHECKING, Any
 
-try:
+if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
-except ImportError:
-    # 런타임에 의존성이 없을 경우를 대비한 더미 타입 (Type Hinting)
-    BaseChatModel = Any  # type: ignore
 
 # 실제 구현 시 필요한 라이브러리 임포트 (TODO)
 # from langchain_openai import ChatOpenAI


### PR DESCRIPTION
- 관련 파일 및 내용
  - **[backend/agent/utils.py]**:
    - `TYPE_CHECKING` 블록을 도입하여 런타임 의존성 없이 타입 힌팅 강화
    - `BaseChatModel` 임포트 패턴을 Pythonic한 표준으로 개선
  - **[backend/agent/nodes.py]**:
    - [classify_node]: LLM 설정 여부와 관계없이 일관된 스텁(`Resources`)을 반환하도록 로직 통일
    - 불필요한 분기 처리를 제거하여 코드 단순화 및 테스트 예측 가능성 향상

- **목적**: 코드 리뷰 피드백 반영 (Type Safety 및 Logic Consistency)

🔗 Related:
- Issue [#463]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/474#pullrequestreview-3801319627)

Co-authored-by: Claude-4.5-sonnet, Gemini 3 Pro

## Summary by Sourcery

에이전트 노드 스텁 동작과 타입 힌팅 패턴을 정렬하여 타입 안정성을 개선하고, 구현이 완료될 때까지 LLM 의존 로직을 명시적인 스텁으로 유지합니다.

버그 수정:
- LLM 초기화 상태와 관계없이 항상 `Resources` 분류를 반환하도록 `classify_node` 스텁을 통일했습니다.

개선 사항:
- 불필요한 분기 로직을 제거하고 스텁 동작을 명시적이고 예측 가능하게 만들어 `classify_node`를 단순화했습니다.
- 런타임 강한 의존성을 추가하지 않으면서 타입 힌트를 위해 `TYPE_CHECKING`을 사용하도록 `utils`에서 `BaseChatModel` 임포트를 정제했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align agent node stubbing behavior and type-hinting patterns to improve type safety and keep LLM-dependent logic as explicit stubs until implementation.

Bug Fixes:
- Unify the classify_node stub to consistently return a Resources classification regardless of LLM initialization state.

Enhancements:
- Simplify classify_node by removing unnecessary branching and making the stub behavior explicit and predictable.
- Refine BaseChatModel importing in utils to use TYPE_CHECKING for type hints without introducing a hard runtime dependency.

</details>