### PR TITLE
📄 docs [#11.1.4]: ✅ v7.0 Phase 1 작업 완료 항목 업데이트

### DIFF
--- a/docs/P/v7.0_planning/v7.0_task_list.md
+++ b/docs/P/v7.0_planning/v7.0_task_list.md
@@ -11,17 +11,17 @@
   - 기존 `Classifier` 로직을 **LangGraph**의 `StateGraph`로 리팩토링합니다.
   - 단일 LLM 호출을 **노드(Node)** 단위로 분리 (예: `analyze_node` → `retrieve_node` → `classify_node` → `validate_node`)
 - **작업 항목**:
-  - [ ] `langgraph` 라이브러리 설치 및 설정
-  - [ ] 기본 `State` 스키마 정의 (`messages`, `current_doc`, `classification_result`)
-  - [ ] `ClassifierAgent` 클래스 구현
+  - [x] `langgraph` 라이브러리 설치 및 설정
+  - [x] 기본 `State` 스키마 정의 (`messages`, `current_doc`, `classification_result`)
+  - [x] `ClassifierAgent` 클래스 구현
 
 ### Issue #2: [Feat] Self-Correction (자가 수정) 로직 구현
 - **설명**:
   - 분류 신뢰도(Confidence Score)가 임계값(예: 70%) 미만일 경우, 에이전트가 스스로 재검토하는 루프(Loop)를 구현합니다.
 - **작업 항목**:
-  - [ ] `validate_node` 추가: 신뢰도 검사
-  - [ ] `reflect_node` 추가: 낮은 신뢰도의 원인 분석 및 재시도 프롬프트 생성
-  - [ ] Conditional Edge 설정 (신뢰도 높음 → 종료, 낮음 → 재시도)
+  - [x] `validate_node` 추가: 신뢰도 검사
+  - [x] `reflect_node` 추가: 낮은 신뢰도의 원인 분석 및 재시도 프롬프트 생성
+  - [x] Conditional Edge 설정 (신뢰도 높음 → 종료, 낮음 → 재시도)
 
 ### Issue #3: [Feat] Context-Aware Memory (Redis 연동)
 - **설명**:


### PR DESCRIPTION
- **[docs/P/v7.0_planning/v7.0_task_list.md]**:
  - Issue [#463]: LangGraph 설정 및 기본 State 정의 완료
  - Issue [#464]: 자가 수정(Self-Correction) 로직(validate, reflect node) 구현 완료
  - 작업 내역 반영하여 체크리스트 업데이트

- **진행 상황**: Phase 1 기초 구조화 및 Workflow 1차 조립 완료

🔗 Related:
- Issue [#463],[#464]

Co-authored-by: Claude-4.5-sonnet, Gemini 3 Pro

## Summary by Sourcery

v7.0 계획 작업 목록을 업데이트하여 1단계 LangGraph 설정 및 자기 수정(self-correction) 워크플로 완료 여부를 반영합니다.

Documentation:
- v7.0 계획 체크리스트에서 LangGraph 설정 및 `ClassifierAgent` 구현 작업을 완료된 것으로 표시합니다.
- v7.0 계획 체크리스트에서 자기 수정(self-correction) `validate`/`reflect` 노드와 조건부 엣지 구성 작업을 완료된 것으로 표시합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update v7.0 planning task list to reflect completion of Phase 1 LangGraph setup and self-correction workflow.

Documentation:
- Mark LangGraph setup and ClassifierAgent implementation tasks as completed in the v7.0 planning checklist.
- Mark self-correction validate/reflect nodes and conditional edge configuration as completed in the v7.0 planning checklist.

</details>