### PR TITLE
✨ feat [#11.1.5]: 🚧 Node Logic 구현 (LLM 연동 및 키워드 추출)

### DIFF
--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -1,11 +1,16 @@
 import os
 import re
+import logging
 from typing import List, Optional, TYPE_CHECKING, Any
+from functools import lru_cache
 
 from dotenv import load_dotenv
 
 # 로컬 환경 변수 로드 (.env 파일이 없으면 무시됨)
 load_dotenv()
+
+# 로거 설정
+logger = logging.getLogger(__name__)
 
 # 타입 힌팅용 임포트 (런타임 영향 최소화)
 if TYPE_CHECKING:
@@ -15,7 +20,9 @@ else:
         from langchain_core.language_models import BaseChatModel
     except ImportError:
         # 런타임에 의존성이 없을 경우를 대비한 더미 클래스
-        class BaseChatModel: pass
+        class BaseChatModel:
+            pass
+
 
 # 실제 런타임용 라이브러리 임포트
 try:
@@ -24,31 +31,31 @@ try:
     from langchain_core.output_parsers import CommaSeparatedListOutputParser
 except ImportError:
     # 패키지 미설치 시 None 처리 (함수 내에서 핸들링)
-    ChatOpenAI = None # type: ignore
-    ChatPromptTemplate = None # type: ignore
-    CommaSeparatedListOutputParser = None # type: ignore
+    ChatOpenAI = None  # type: ignore
+    ChatPromptTemplate = None  # type: ignore
+    CommaSeparatedListOutputParser = None  # type: ignore
 
 
+@lru_cache(maxsize=1)
 def get_llm() -> Optional["BaseChatModel"]:
     """
     LLM 인스턴스를 반환하는 팩토리 함수.
-    환경 변수(OPENAI_API_KEY)가 설정되어 있어야 합니다.
-    실패 시 None을 반환하며, 호출 측에서 이를 처리해야 합니다.
+    LRU Cache를 사용하여 인스턴스 재생성을 방지하고 오버헤드를 줄입니다.
     """
     if ChatOpenAI is None:
-        print("Warning: langchain_openai not installed.")
+        logger.warning("langchain_openai not installed.")
         return None
-        
+
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
-        print("Warning: OPENAI_API_KEY not found in environment variables.")
+        logger.warning("OPENAI_API_KEY not found in environment variables.")
         return None
 
     try:
         # 분류 및 추출 작업에는 결정적인 출력을 위해 temperature=0 사용
         return ChatOpenAI(model="gpt-4o", temperature=0)
     except Exception as e:
-        print(f"Error initializing LLM: {e}")
+        logger.error("Error initializing LLM", exc_info=True)
         return None
 
 
@@ -58,7 +65,7 @@ def extract_keywords(text: str) -> List[str]:
     1차적으로 LLM을 시도하고, 실패 시 정규식 기반 폴백 로직을 수행합니다.
     """
     llm = get_llm()
-    
+
     # 텍스트가 너무 짧거나 LLM이 없으면 폴백
     if not llm or not text or len(text.strip()) < 10:
         return _extract_keywords_regex(text)
@@ -75,52 +82,52 @@ def extract_keywords(text: str) -> List[str]:
         
         Keywords:
         """
-        
+
         prompt = ChatPromptTemplate.from_template(template)
         # CommaSeparatedListOutputParser는 문자열 리스트를 반환합니다.
         chain = prompt | llm | CommaSeparatedListOutputParser()
-        
+
         # 텍스트 길이 제한 (토큰 비용 절감 및 컨텍스트 윈도우 보호)
         keywords = chain.invoke({"text": text[:3000]})
         return [k.strip() for k in keywords if k.strip()]
-        
+
     except Exception as e:
-        print(f"Error extracting keywords with LLM: {e}")
+        logger.error("Error extracting keywords with LLM", exc_info=True)
         return _extract_keywords_regex(text)
 
 
 def _extract_keywords_regex(text: str) -> List[str]:
     """
     정규식을 사용한 간단한 키워드 추출 (Fallback Logic).
-    대문자로 시작하는 단어(고유명사 추정)나 4글자 이상의 긴 단어를 추출합니다.
+    결정적인(Deterministic) 순서를 보장하기 위해 set 대신 dict.fromkeys를 사용하여 중복을 제거합니다.
     """
     if not text:
         return []
 
     # 간단한 정규식: 대문자로 시작하는 단어 또는 5글자 이상 단어
-    words = re.findall(r'\b[A-Za-z][a-z]{4,}\b|\b[A-Z][a-zA-Z]+\b', text)
-    
-    # 중복 제거 및 상위 10개 반환
-    unique_words = list(set(words))
+    words = re.findall(r"\b[A-Za-z][a-z]{4,}\b|\b[A-Z][a-zA-Z]+\b", text)
+
+    # 중복 제거 (순서 유지) 및 상위 10개 반환
+    # Python 3.7+ 에서는 dict insertion order가 보장됨
+    unique_words = list(dict.fromkeys(words))
     return unique_words[:10]
 
 
 def search_similar_docs(keywords: List[str]) -> str:
     """
     키워드 기반 유사 문서를 검색하는 함수 (Mock Implementation).
-    현재는 실제 Vector Store가 연동되지 않았으므로, 검색된 척하는 더미 데이터를 반환합니다.
-    추후 Pinecone/Chroma 연동 시 실제 검색 로직으로 교체됩니다 (Issue #4).
+    현재는 실제 Vector Store가 없으므로 검색된 척하는 더미 데이터를 반환합니다.
     """
     if not keywords:
         return ""
-        
+
     # Mock Response: 키워드가 포함된 가상의 문서를 반환하여 RAG 흐름 테스트
     docs = [
-        f"- Document related to '{k}' explicitly mentioning project deadlines." 
+        f"- Document related to '{k}' explicitly mentioning project deadlines."
         for k in keywords[:3]
     ]
-    
+
     if not docs:
         return "No relevant documents found."
-        
+
     return "Retrieved Context:\n" + "\n".join(docs)


### PR DESCRIPTION
- **[backend/agent/utils.py]**:
  - [get_llm()](backend/agent/utils.py:31:0-51:19): OpenAI API 연동 및 팩토리 함수 구현
  - [extract_keywords()](backend/agent/utils.py:54:0-88:44): LLM 기반 키워드 추출 및 Regex Fallback 로직 추가
  - [search_similar_docs()](backend/agent/utils.py:107:0-125:51): Mock 데이터 반환 (RAG 연동 전 단계)

- **[backend/agent/nodes.py]**:
  - [classify_node()](backend/agent/nodes.py:54:0-135:9): PydanticOutputParser를 활용한 구조적 LLM 출력 파싱 구현
  - PARA 카테고리 분류 프롬프트 템플릿 작성

- **목적**: Agent Workflow의 핵심 비즈니스 로직 1차 구현
- **상태**: Retrieve Node는 Mocking 상태, 나머지는 LLM 연동 완료

🔗 Related:
- Issue [#463], [#464]

Co-authored-by: Claude-4.5-sonnet, Gemini 3 Pro

## Summary by Sourcery

키워드 추출, 문서 검색 모킹, PARA 분류를 위한 에이전트 워크플로우 LLM 통합의 1차 버전을 구현합니다.

New Features:
- 환경 설정으로부터 채팅 모델을 초기화하는 구체적인 OpenAI 기반 LLM 팩토리를 제공합니다.
- 강건성을 위해 정규식 기반 폴백을 갖춘 LLM 기반 키워드 추출을 구현합니다.
- 벡터 스토어 통합 이전에 RAG 동작을 시뮬레이션하기 위한 유사 문서 검색 모킹 헬퍼를 추가합니다.
- Pydantic 모델을 통한 구조화된 LLM 출력 파싱을 활용하는 PARA 문서 분류 노드를 도입합니다.

Enhancements:
- 구조화된 분류 출력 스키마를 정의하고, 신뢰도와 추론(reasoning) 필드를 포함해 classify 노드에 연결합니다.
- 향후 이슈를 기반으로 한 신뢰도 및 형식 검증을 위해 validation 노드에 TODO를 주석으로 남깁니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement first iteration of agent workflow LLM integration for keyword extraction, document retrieval mocking, and PARA classification.

New Features:
- Provide a concrete OpenAI-based LLM factory that initializes a chat model from environment configuration.
- Implement LLM-driven keyword extraction with a regex-based fallback for robustness.
- Add a mock similar-document retrieval helper to simulate RAG behavior before vector store integration.
- Introduce a PARA document classification node powered by structured LLM output parsing via Pydantic models.

Enhancements:
- Define a structured classification output schema and wire it into the classify node with confidence and reasoning fields.
- Annotate validation node with future work for confidence and format checking based on upcoming issues.

</details>