### PR TITLE
Feature/v7 planning

### DIFF
--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -12,6 +12,12 @@ load_dotenv()
 # 로거 설정
 logger = logging.getLogger(__name__)
 
+# 정규식 패턴 사전 컴파일 (Module Level Constant)
+# 목적: 매 호출마다의 컴파일 오버헤드 제거
+# 패턴: 영어(대문자 시작/긴 단어) 또는 한글(2글자 이상)
+KEYWORD_PATTERN = r"\b[A-Za-z][a-z]{4,}\b|\b[A-Z][a-zA-Z]+\b|[가-힣]{2,}"
+KEYWORD_REGEX = re.compile(KEYWORD_PATTERN)
+
 # 타입 힌팅용 임포트 (런타임 영향 최소화)
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
@@ -104,8 +110,8 @@ def _extract_keywords_regex(text: str) -> List[str]:
     if not text:
         return []
 
-    # 간단한 정규식: 대문자로 시작하는 단어 또는 5글자 이상 단어
-    words = re.findall(r"\b[A-Za-z][a-z]{4,}\b|\b[A-Z][a-zA-Z]+\b", text)
+    # 미리 컴파일된 정규식 사용 (Performance Optimization)
+    words = KEYWORD_REGEX.findall(text)
 
     # 중복 제거 (순서 유지) 및 상위 10개 반환
     # Python 3.7+ 에서는 dict insertion order가 보장됨


### PR DESCRIPTION
✨ feat [#11.1.5]: 🚧 Node Logic 구현 (LLM 연동 및 키워드 추출) 
🐛 fix [#11.1.5]: 1차 개선 - Refactoring for Robustness

## Summary by Sourcery

OpenAI 기반 LLM을 에이전트 파이프라인에 통합하여 키워드를 추출하고, 관련 문서를 모킹(mock) 방식으로 검색하며, 파일을 PARA 카테고리로 분류하되, 견고한 폴백과 로깅을 지원합니다.

New Features:
- 환경 설정으로부터 캐시된 `ChatOpenAI` 클라이언트를 초기화하고, 사용 불가능한 경우에도 우아하게 기능이 저하되도록 하는 LLM 팩토리를 추가했습니다.
- 정규식 기반 폴백을 갖춘 LLM 구동 키워드 추출 기능을 구현하고, RAG 동작을 시뮬레이션하기 위한 모킹 문서 검색 헬퍼를 추가했습니다.
- LLM 출력을 Pydantic을 통해 파싱하여 신뢰도와 근거(reasoning)를 포함한 구조화된 분류 결과를 생성하는 PARA 분류 노드를 추가했습니다.

Enhancements:
- 에이전트 노드가 누락된 상태 필드를 안전하게 처리하도록 강화하고, 에러 추적을 위한 로깅을 도입했으며, 기존의 스텁 로직을 실제 동작하는 구현으로 교체했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate an OpenAI-based LLM into the agent pipeline to extract keywords, retrieve mock related documents, and classify files into PARA categories with robust fallbacks and logging.

New Features:
- Add an LLM factory that initializes a cached ChatOpenAI client from environment configuration with graceful degradation when unavailable.
- Implement LLM-driven keyword extraction with a regex-based fallback and a mock document retrieval helper to simulate RAG behavior.
- Add a PARA classification node that uses LLM output parsed via Pydantic to produce structured classification results with confidence and reasoning.

Enhancements:
- Harden agent nodes to safely handle missing state fields, introduce logging for error tracing, and replace previous stub logic with functional implementations.

</details>