### PR TITLE
🐛 fix [#11.1.5]: 2차 개선 - LangChain API 및 다국어 지원

### DIFF
--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -8,6 +8,15 @@ from pydantic import BaseModel, Field
 from backend.agent.state import AgentState
 from backend.agent.utils import get_llm, extract_keywords, search_similar_docs
 
+# Try importing specific exceptions for better error handling
+try:
+    from langchain_core.exceptions import OutputParserException
+except ImportError:
+    # 런타임에 의존성이 구버전이거나 없을 경우를 대비한 더미 클래스
+    class OutputParserException(Exception):
+        pass
+
+
 # =================================================================
 # Logger Setup
 # =================================================================
@@ -69,6 +78,7 @@ def classify_node(state: AgentState) -> Dict[str, Any]:
 
     # LLM 초기화 실패 시 Stub 반환 (안전장치)
     if not llm:
+        logger.warning("LLM not initialized, returning Stub for classify_node")
         return {
             "classification_result": {"category": "Resources", "confidence": 0.0},
             "confidence_score": 0.0,
@@ -134,13 +144,22 @@ def classify_node(state: AgentState) -> Dict[str, Any]:
             "reasoning": result.reasoning,
         }
 
-    except Exception as e:
-        logger.error("Error in classification", exc_info=True)
-        # 실패 시 Stub 반환 (안전장치)
+    except OutputParserException as e:
+        logger.error("Parsing Error in classification", exc_info=True)
+        # 파싱 에러 시 명확한 사유와 함께 실패 처리 (재시도 로직에서 활용 가능)
         return {
             "classification_result": {"category": "Unclassified", "confidence": 0.0},
             "confidence_score": 0.0,
-            "reasoning": f"Classification error: {str(e)}",
+            "reasoning": f"Output Parsing Error: {str(e)}. Response format invalid.",
+        }
+
+    except Exception as e:
+        logger.error("Unexpected Error in classification", exc_info=True)
+        # 그 외 예상치 못한 에러에 대한 안전장치 (Fail-safe)
+        return {
+            "classification_result": {"category": "Unclassified", "confidence": 0.0},
+            "confidence_score": 0.0,
+            "reasoning": f"Unexpected Classification error: {str(e)}",
         }
 
 

--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -12,6 +12,12 @@ load_dotenv()
 # 로거 설정
 logger = logging.getLogger(__name__)
 
+# 정규식 패턴 사전 컴파일 (Module Level Constant)
+# 목적: 매 호출마다의 컴파일 오버헤드 제거
+# 패턴: 영어(대문자 시작/긴 단어) 또는 한글(2글자 이상)
+KEYWORD_PATTERN = r"\b[A-Za-z][a-z]{4,}\b|\b[A-Z][a-zA-Z]+\b|[가-힣]{2,}"
+KEYWORD_REGEX = re.compile(KEYWORD_PATTERN)
+
 # 타입 힌팅용 임포트 (런타임 영향 최소화)
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
@@ -104,10 +110,8 @@ def _extract_keywords_regex(text: str) -> List[str]:
     if not text:
         return []
 
-    # Regex 확장: 영어(대문자/긴단어) OR 한글(2글자 이상)
-    # \b pattern for English, generic pattern for Korean
-    pattern = r"\b[A-Za-z][a-z]{4,}\b|\b[A-Z][a-zA-Z]+\b|[가-힣]{2,}"
-    words = re.findall(pattern, text)
+    # 미리 컴파일된 정규식 사용 (Performance Optimization)
+    words = KEYWORD_REGEX.findall(text)
 
     # 중복 제거 (순서 유지) 및 상위 10개 반환
     # Python 3.7+ 에서는 dict insertion order가 보장됨

--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -104,8 +104,10 @@ def _extract_keywords_regex(text: str) -> List[str]:
     if not text:
         return []
 
-    # 간단한 정규식: 대문자로 시작하는 단어 또는 5글자 이상 단어
-    words = re.findall(r"\b[A-Za-z][a-z]{4,}\b|\b[A-Z][a-zA-Z]+\b", text)
+    # Regex 확장: 영어(대문자/긴단어) OR 한글(2글자 이상)
+    # \b pattern for English, generic pattern for Korean
+    pattern = r"\b[A-Za-z][a-z]{4,}\b|\b[A-Z][a-zA-Z]+\b|[가-힣]{2,}"
+    words = re.findall(pattern, text)
 
     # 중복 제거 (순서 유지) 및 상위 10개 반환
     # Python 3.7+ 에서는 dict insertion order가 보장됨


### PR DESCRIPTION
- **[backend/agent/utils.py]**:
  - [_extract_keywords_regex](backend/agent/utils.py:98:0-114:28): 한글 등(Unicode) 지원을 위해 정규식 패턴 확장 (`\b[A-Za-z]...` → `[가-힣]{2,} | ...`)

- **[backend/agent/nodes.py]**:
  - [classify_node](backend/agent/nodes.py:63:0-143:9): `from_template` 내 `partial_variables` 인자 사용을 `.partial()` 체이닝으로 변경 (LangChain Idiomatic)
  - `CONFIDENCE_THRESHOLD`: [should_retry](backend/agent/nodes.py:168:0-187:18) 엣지 로직에서의 사용 목적 명시 주석 추가

- **목적**: 코드 리뷰 피드백 반영 (Correctness & Standardization)

🔗 Related:
- Issue [#463], [#464]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/485#pullrequestreview-3803345802)

Co-authored-by: Claude-4.5-sonnet, Gemini 3 Pro

## Summary by Sourcery

다국어 지원과 더 명확한 재시도 로직을 위해 키워드 추출 및 LangChain 프롬프트 구성을 개선합니다.

버그 수정:
- 기존 영어 패턴과 함께 한국어(유니코드) 단어도 올바르게 포착할 수 있도록 키워드 추출 정규식을 확장했습니다.

개선 사항:
- 분류 노드에서 LangChain 프롬프트 구성을 개선하여, 포맷 지시문에 대해 보다 관용적인 `.partial()` 체이닝을 사용하도록 했습니다.
- 조건부 재시도 로직에 사용되는 신뢰도 임계값의 목적을 문서화하고, 폴백(fallback) 처리 관련 주석을 간소화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve keyword extraction and LangChain prompt construction for multilingual support and clearer retry logic.

Bug Fixes:
- Extend keyword extraction regex to correctly capture Korean (Unicode) words alongside existing English patterns.

Enhancements:
- Refine LangChain prompt construction in the classification node to use idiomatic .partial() chaining for format instructions.
- Document the purpose of the confidence threshold used in conditional retry logic and simplify fallback handling comments.

</details>