### PR TITLE
🐛 fix [#11.1.6]: 1차 개선 - Config 스타일 통일 및 테스트 개선

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -4,12 +4,19 @@
 Application configuration settings
 """
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import Optional
 
 
 class Settings(BaseSettings):
     """Application settings"""
+
+    # Pydantic V2 Configuration
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        case_sensitive=True,
+        extra="ignore",  # Allow extra env vars (e.g., from .env during tests)
+    )
 
     # API Configuration
     API_TITLE: str = "FlowNote API"
@@ -30,11 +37,6 @@ class Settings(BaseSettings):
     HOST: str = "0.0.0.0"
     PORT: int = 8000
     RELOAD: bool = True
-
-    class Config:
-        env_file = ".env"
-        case_sensitive = True
-        extra = "ignore"  # Fix for test runner loading extra env vars from .env
 
 
 # Global settings instance

--- a/tests/unit/agent/test_nodes.py
+++ b/tests/unit/agent/test_nodes.py
@@ -32,15 +32,26 @@ class TestAgentNodes(unittest.TestCase):
     @patch("backend.agent.nodes.get_llm")
     def test_classify_node_stubs(self, mock_get_llm):
         """LLM 초기화 실패 시 Stub 반환 검증 (Fail-safe)"""
+        # Mock LLM initialization failure
         mock_get_llm.return_value = None
 
         result = classify_node(self.base_state)
 
-        # Stub 값 확인
+        # Stub 값 검증 (구조적 검증)
         classification_result = result.get("classification_result", {})
+
+        # Category Default Check
         self.assertEqual(classification_result.get("category"), "Resources")
+        # Confidence Score Default Check
         self.assertEqual(result.get("confidence_score"), 0.0)
-        self.assertIn("initialization failed", result.get("reasoning", ""))
+
+        # Reasoning Existence Check (Specific Wording Test is Brittle)
+        # Instead of failing on exact message change, just check non-empty string exist
+        reasoning = result.get("reasoning", "")
+        self.assertIsInstance(reasoning, str)
+        self.assertTrue(
+            len(reasoning) > 0, "Reasoning should be provided even upon failure"
+        )
 
     def test_should_retry_logic(self):
         """should_retry 조건 분기 테스트"""


### PR DESCRIPTION
- **[backend/core/config.py]**:
  - `class Config` (V1) → `model_config = SettingsConfigDict` (V2) 스타일 변경
  - Pydantic V2 일관성 확보 및 유지보수성 향상

- **[tests/unit/agent/test_nodes.py]**:
  - `assertIn("string", ...)` 제거 → 구조적 검증(Key existence, Type check)으로 변경
  - 특정 에러 메시지에 의존하지 않는 견고한 테스트 작성

- **상태**: 6 passed (Unit Tests)

🔗 Related:
- Issue [#463], [#465]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/487#pullrequestreview-3806301908)

Co-authored-by: Claude-4.5-sonnet, Gemini 3 Pro

## Summary by Sourcery

Pydantic v2 규칙에 맞게 애플리케이션 설정을 정렬하고, 구현 세부 변경에 덜 민감하도록 관련 테스트를 더 견고하게 개선합니다.

Enhancements:
- 환경 로딩 및 검증 동작을 위해 애플리케이션 설정 구성을 Pydantic v2의 `SettingsConfigDict`를 사용하도록 업데이트합니다.

Tests:
- 노드 분류 실패 방지(fail-safe) 테스트의 검증 기준을 완화하여, 취약한 정확한 에러 메시지 문자열 비교 대신 구조와 타입을 검증하도록 변경합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align application configuration with Pydantic v2 conventions and make related tests more robust against implementation detail changes.

Enhancements:
- Update application settings configuration to use Pydantic v2 SettingsConfigDict for environment loading and validation behavior.

Tests:
- Relax node classification fail-safe test assertions to validate structure and types rather than brittle, exact error message contents.

</details>