### PR TITLE
✨ feat [11.1.7]: 🚧 Checkpointer 구현 (Memory/Redis Persistence)

### DIFF
--- a/backend/agent/checkpointer.py
+++ b/backend/agent/checkpointer.py
@@ -1,6 +1,13 @@
 import os
 import logging
-from typing import Optional, Any
+from typing import Optional
+
+# LangGraph Base Class for Type Safety
+try:
+    from langgraph.checkpoint.base import BaseCheckpointSaver
+except ImportError:
+    # Fallback for older versions or if base module moved
+    from typing import Any as BaseCheckpointSaver
 
 from langgraph.checkpoint.memory import MemorySaver
 
@@ -17,7 +24,7 @@ except ImportError:
     Redis = None
 
 
-def get_checkpointer() -> Any:
+def get_checkpointer() -> BaseCheckpointSaver:
     """
     Checkpointer 인스턴스를 반환하는 팩토리 함수.
 
@@ -32,16 +39,17 @@ def get_checkpointer() -> Any:
 
     if redis_url and RedisSaver:
         try:
-            # Redis 연결 설정 (Synchronous for now, check langgraph async support if needed)
-            # LangGraph의 RedisSaver는 보통 동기/비동기를 지원하지만,
-            # 여기서는 편의상 동기 클라이언트로 연결합니다. (Graph 실행 모델에 따라 조정 필요)
+            # Redis 연결 설정
             connection = Redis.from_url(redis_url)
             checkpointer = RedisSaver(connection)
-            logger.info(f"Initialized Redis Checkpointer at {redis_url}")
+
+            # Security Fix: Do not log sensitive REDIS_URL
+            logger.info("Initialized Redis Checkpointer successfully.")
             return checkpointer
+
         except Exception as e:
             logger.error(
-                f"Failed to initialize Redis Checkpointer: {e}. Falling back to MemorySaver.",
+                "Failed to initialize Redis Checkpointer. Falling back to MemorySaver.",
                 exc_info=True,
             )
             return MemorySaver()

--- a/backend/agent/graph.py
+++ b/backend/agent/graph.py
@@ -5,8 +5,13 @@ from langgraph.graph import StateGraph, END
 try:
     from langgraph.graph.state import CompiledStateGraph
 except ImportError:
-    # Fallback/Dummy if version structure differs (though likely present in installed version)
     CompiledStateGraph = Any  # type: ignore
+
+# Import BaseCheckpointSaver for type safety
+try:
+    from langgraph.checkpoint.base import BaseCheckpointSaver
+except ImportError:
+    BaseCheckpointSaver = Any  # type: ignore
 
 from backend.agent.state import AgentState
 from backend.agent.nodes import (
@@ -20,13 +25,15 @@ from backend.agent.nodes import (
 from backend.agent.checkpointer import get_checkpointer
 
 
-def create_workflow(checkpointer: Optional[Any] = None) -> CompiledStateGraph:
+def create_workflow(
+    checkpointer: Optional[BaseCheckpointSaver] = None,
+) -> CompiledStateGraph:
     """
     LangGraph 에이전트 워크플로우를 생성하고 컴파일합니다.
 
     Args:
-        checkpointer (Optional[Any]): 상태 저장을 위한 체크포인터.
-                                      None일 경우 get_checkpointer()를 통해 환경에 맞는 Saver를 자동 선택합니다.
+        checkpointer (Optional[BaseCheckpointSaver]): 상태 저장을 위한 체크포인터.
+                                                     None일 경우 get_checkpointer()를 통해 환경에 맞는 Saver를 자동 선택합니다.
 
     Returns:
         CompiledStateGraph: 실행 가능한 에이전트 객체 (Persistence 기능 포함)
@@ -62,8 +69,6 @@ def create_workflow(checkpointer: Optional[Any] = None) -> CompiledStateGraph:
         checkpointer = get_checkpointer()
 
     # 8. Human-in-the-Loop 설정 (Optional)
-    # 신뢰도가 낮은 경우 사용자 개입을 위해 'reflect' 노드 실행 전 중단하도록 설정 가능
-    # interrupt_before = ["reflect"]
     interrupt_before = []
 
     # 9. 그래프 컴파일


### PR DESCRIPTION
- **[backend/agent/checkpointer.py]**:
  - [get_checkpointer()](backend/agent/checkpointer.py:19:0-56:24): 환경변수(`REDIS_URL`) 기반 팩토리 함수 구현
  - Redis 모듈 부재 시 `MemorySaver`로 자동 Fallback (Safe Default)

- **[backend/agent/graph.py]**:
  - [create_workflow()](backend/agent/graph.py:22:0-73:28): [checkpointer](backend/agent/checkpointer.py:19:0-56:24) 인자 추가 및 컴파일 시 주입
  - State Persistence 활성화 (대화 맥락 유지 기반 마련)

- **목적**: 에이전트 상태 저장소(Persistence Layer) 구축
- **비고**: 현재는 `MemorySaver`가 기본 동작함. Redis 연동 준비 완료.

🔗 Related:
- Issue [#464]

Co-authored-by: Claude-4.5-sonnet, Gemini 3 Pro

## Summary by Sourcery

환경 기반 Redis 또는 인메모리 영속성을 사용하는 LangGraph 에이전트를 위해 설정 가능한 체크포인터를 도입하고, 상태 영속성을 활성화하기 위해 이를 워크플로 컴파일 단계에 연결합니다.

새 기능:
- 환경 설정에 따라 Redis 기반 상태 영속성과 인메모리 상태 영속성 중에서 선택하는 체크포인터 팩토리를 추가합니다.
- 에이전트 워크플로 생성 시 체크포인터를 전달하고 사용할 수 있도록 하여, 에이전트 상태를 영속화하고 선택적인 human-in-the-loop 중단 지점을 지원합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable checkpointer for LangGraph agents with environment-based Redis or in-memory persistence and wire it into workflow compilation to enable state persistence.

New Features:
- Add a checkpointer factory that selects between Redis-backed and in-memory state persistence based on environment configuration.
- Allow the agent workflow creation to accept and use a checkpointer, enabling persisted agent state and optional human-in-the-loop interruption points.

</details>