### PR TITLE
🐛 fix [#11.1.9]: 2차 개선 - 테스트 결합도 완화 및 셋업 중복 제거

### DIFF
--- a/tests/integration/agent/test_hitl.py
+++ b/tests/integration/agent/test_hitl.py
@@ -81,6 +81,15 @@ class TestHumanInTheLoop:
             result is not None
         ), "Workflow should run normally with empty interrupt_before"
 
+        # 명시적 빈 리스트를 전달했을 때도 기본 설정과 동일하게
+        # 워크플로우가 완전히 종료(terminal state)되는지 검증
+        # LangGraph의 state.next는 tuple 타입: 완전 종료 시 () 반환
+        state = workflow.get_state(config)
+        assert not state.next, (
+            f"Workflow with interrupt_before=[] should reach terminal state, "
+            f"got state.next={state.next!r}"
+        )
+
     def test_interrupt_before_accepts_none(self):
         """interrupt_before=None 명시 전달 시 정상 실행되는지 검증 (None → [] 정규화 경로 확인)
 


### PR DESCRIPTION
- **[test_hitl.py]** 전면 개선

  - **결합도 완화**
    - match="알 수 없는 노드 이름" → match="interrupt_before"로 변경
    - 한국어 문구 의존에서 API 파라미터명(불변) 기반 검증으로 전환
    - 현지화(i18n) 또는 메시지 리팩터링 시에도 테스트가 깨지지 않음

  - **셋업 중복 제거**
    - `_make_config` (prefix) 헬퍼 추가: thread_id/config 생성 로직 단일화
    - `create_workflow`, `MemorySaver`, `inspect import`를 파일 상단으로 통합
    - 각 테스트 내 `from backend.agent.graph import create_workflow` 반복 제거

  - **None 정규화 경로 검증 추가**
    - `test_interrupt_before_accepts_none` 신규 추가
    - `interrupt_before=None` 명시 전달 시 `completion + state.next==()` 검증
    - None → [] 정규화 로직 리팩터링 시 회귀 방지

🔗 Related:
- Issue [#464]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/499#pullrequestreview-3825248536)

Co-authored-by: Claude-4.6-sonnet, Gemini 3 Pro

## Sourcery의 요약

Human-in-the-Loop 워크플로우 인터럽트 처리에 대한 테스트 결합을 느슨하게 하고 설정 중복을 줄입니다.

테스트:
- HITL 통합 테스트에서 테스트별 스레드 ID를 생성하고 공통 워크플로우 설정을 재사용하기 위해, 공유 설정 헬퍼를 도입합니다.
- `interrupt_before`에 대해 명시적인 `None` 및 빈 리스트 값을 다루는 테스트를 추가하여, 정규화와 최종 상태 동작을 검증합니다.
- `interrupt_before` 오류 기대 테스트를 현지화된 문자열 대신 파라미터 기반 메시지를 단언하도록 업데이트합니다.
- 시그니처 테스트를 통해 `create_workflow`가 기본값이 `None`인 `interrupt_before`를 노출하는지 검증합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax test coupling and reduce setup duplication for Human-in-the-Loop workflow interrupt handling.

Tests:
- Introduce a shared configuration helper to generate per-test thread IDs and reuse common workflow setup in HITL integration tests.
- Add tests covering explicit None and empty list values for interrupt_before to validate normalization and terminal state behavior.
- Update interrupt_before error expectation tests to assert on parameter-based messages instead of localized strings.
- Verify via signature test that create_workflow exposes interrupt_before with a default of None.

</details>