### PR TITLE
Feature/v7 planning

### DIFF
--- a/tests/integration/agent/test_hitl.py
+++ b/tests/integration/agent/test_hitl.py
@@ -9,12 +9,27 @@ Human-in-the-Loop (HitL) 기능 테스트.
 """
 
 import uuid
+import inspect
 import pytest
 from langgraph.checkpoint.memory import MemorySaver
+from backend.agent.graph import create_workflow
 
 
 class TestHumanInTheLoop:
     """interrupt_before 파라미터를 통한 Human-in-the-Loop 동작 검증"""
+
+    # ------------------------------------------------------------------
+    # 헬퍼 메서드: 테스트 간 공통 셋업 중복 제거
+    # ------------------------------------------------------------------
+
+    def _make_config(self, prefix: str = "test") -> dict:
+        """고유한 thread_id를 포함하는 LangGraph configurable 딕셔너리 반환.
+
+        각 테스트에서 독립적인 상태 격리를 보장하기 위해
+        매 호출마다 새로운 UUID를 생성합니다.
+        """
+        thread_id = f"{prefix}-{uuid.uuid4()}"
+        return {"configurable": {"thread_id": thread_id}}
 
     def _make_initial_state(self, file_name: str = "hitl_test.md") -> dict:
         return {
@@ -26,12 +41,13 @@ class TestHumanInTheLoop:
             "confidence_score": 0.0,
         }
 
+    # ------------------------------------------------------------------
+    # 정상 실행 경로 테스트
+    # ------------------------------------------------------------------
+
     def test_workflow_runs_without_interrupt(self):
         """interrupt_before=None(기본값)일 때 워크플로우가 끝까지 자동 실행되는지 검증"""
-        from backend.agent.graph import create_workflow
-
-        thread_id = f"test-no-interrupt-{uuid.uuid4()}"
-        config = {"configurable": {"thread_id": thread_id}}
+        config = self._make_config("test-no-interrupt")
 
         # interrupt_before 없이 실행 (기본값: None → [])
         workflow = create_workflow(checkpointer=MemorySaver())
@@ -51,6 +67,59 @@ class TestHumanInTheLoop:
             f"got state.next={state.next!r}"
         )
 
+    def test_interrupt_before_accepts_empty_list(self):
+        """interrupt_before=[]일 때 정상 실행되는지 검증 (빈 리스트 처리 확인)"""
+        config = self._make_config("test-empty-interrupt")
+
+        workflow = create_workflow(
+            checkpointer=MemorySaver(),
+            interrupt_before=[],  # 명시적 빈 리스트
+        )
+
+        result = workflow.invoke(self._make_initial_state(), config=config)
+        assert (
+            result is not None
+        ), "Workflow should run normally with empty interrupt_before"
+
+        # 명시적 빈 리스트를 전달했을 때도 기본 설정과 동일하게
+        # 워크플로우가 완전히 종료(terminal state)되는지 검증
+        # LangGraph의 state.next는 tuple 타입: 완전 종료 시 () 반환
+        state = workflow.get_state(config)
+        assert not state.next, (
+            f"Workflow with interrupt_before=[] should reach terminal state, "
+            f"got state.next={state.next!r}"
+        )
+
+    def test_interrupt_before_accepts_none(self):
+        """interrupt_before=None 명시 전달 시 정상 실행되는지 검증 (None → [] 정규화 경로 확인)
+
+        create_workflow 내부에서 None을 []로 정규화하는 로직이
+        리팩터링 시에도 올바르게 동작하는지 보장하기 위한 안전장치입니다.
+        """
+        config = self._make_config("test-none-interrupt")
+
+        # 기본값이 아닌 명시적 None 전달로 정규화 경로를 직접 검증
+        workflow = create_workflow(
+            checkpointer=MemorySaver(),
+            interrupt_before=None,
+        )
+
+        result = workflow.invoke(self._make_initial_state(), config=config)
+        assert (
+            result is not None
+        ), "Workflow should run normally with interrupt_before=None (normalized to [])"
+
+        # terminal state 검증: None 전달도 [] 와 동일하게 완전 종료되어야 함
+        state = workflow.get_state(config)
+        assert not state.next, (
+            f"Workflow with interrupt_before=None should reach terminal state, "
+            f"got state.next={state.next!r}"
+        )
+
+    # ------------------------------------------------------------------
+    # 인터럽트 동작 테스트
+    # ------------------------------------------------------------------
+
     def test_workflow_interrupts_before_reflect_node(self):
         """
         interrupt_before=['reflect'] 설정 시 reflect 노드 진입 전에 중단되는지 검증.
@@ -60,10 +129,7 @@ class TestHumanInTheLoop:
         - 이 경우 LangGraph는 state.next에 'reflect'를 남겨 중단 지점을 표시
         - LLM이 Mock되어 최저 신뢰도(confidence_score=0.0)로 retry 경로를 유도
         """
-        from backend.agent.graph import create_workflow
-
-        thread_id = f"test-interrupt-reflect-{uuid.uuid4()}"
-        config = {"configurable": {"thread_id": thread_id}}
+        config = self._make_config("test-interrupt-reflect")
 
         # reflect 노드 진입 전 중단 설정
         workflow = create_workflow(
@@ -93,28 +159,12 @@ class TestHumanInTheLoop:
                 not saved_state.next
             ), "Workflow completed without hitting reflect node (no retry needed)"
 
-    def test_interrupt_before_accepts_empty_list(self):
-        """interrupt_before=[]일 때 정상 실행되는지 검증 (빈 리스트 처리 확인)"""
-        from backend.agent.graph import create_workflow
-
-        thread_id = f"test-empty-interrupt-{uuid.uuid4()}"
-        config = {"configurable": {"thread_id": thread_id}}
-
-        workflow = create_workflow(
-            checkpointer=MemorySaver(),
-            interrupt_before=[],  # 명시적 빈 리스트
-        )
-
-        result = workflow.invoke(self._make_initial_state(), config=config)
-        assert (
-            result is not None
-        ), "Workflow should run normally with empty interrupt_before"
+    # ------------------------------------------------------------------
+    # 시그니처 검증 테스트
+    # ------------------------------------------------------------------
 
     def test_create_workflow_signature_has_interrupt_before(self):
         """create_workflow 함수가 interrupt_before 파라미터를 받는지 시그니처 검증"""
-        import inspect
-        from backend.agent.graph import create_workflow
-
         sig = inspect.signature(create_workflow)
         assert (
             "interrupt_before" in sig.parameters
@@ -126,11 +176,13 @@ class TestHumanInTheLoop:
             default is None
         ), f"'interrupt_before' default should be None, got {default!r}"
 
+    # ------------------------------------------------------------------
+    # 노드 이름 검증 테스트 (graph.py 조기 탐지 로직 보장)
+    # ------------------------------------------------------------------
+
     def test_interrupt_before_raises_on_unknown_node(self):
         """interrupt_before에 존재하지 않는 노드 이름 전달 시 ValueError가 발생하는지 검증"""
-        from backend.agent.graph import create_workflow
-
-        with pytest.raises(ValueError, match="알 수 없는 노드 이름"):
+        with pytest.raises(ValueError, match="interrupt_before"):
             create_workflow(
                 checkpointer=MemorySaver(),
                 interrupt_before=["nonexistent_node"],
@@ -138,9 +190,7 @@ class TestHumanInTheLoop:
 
     def test_interrupt_before_raises_on_typo_node(self):
         """interrupt_before 노드 이름 오타(예: 'reflecc') 시 ValueError가 발생하는지 검증"""
-        from backend.agent.graph import create_workflow
-
-        with pytest.raises(ValueError, match="알 수 없는 노드 이름"):
+        with pytest.raises(ValueError, match="interrupt_before"):
             create_workflow(
                 checkpointer=MemorySaver(),
                 interrupt_before=["reflecc"],  # 'reflect'의 오타


### PR DESCRIPTION
🐛 fix [#11.1.9]: 2차 개선 - 테스트 결합도 완화 및 셋업 중복 제거 
🐛 fix [#11.1.9]: 3차 개선 - interrupt_before=[] 검증 강화

## Summary by Sourcery

Human-in-the-Loop 워크플로우의 `interrupt_before` 처리 로직을 강화하고, 테스트 중복을 줄였습니다.

Bug Fixes:
- 잘못된 노드 이름이 `interrupt_before`에 사용될 경우, `interrupt_before`를 언급하는 메시지를 가진 `ValueError`가 발생하는지 검증을 강화했습니다.

Enhancements:
- 중복을 줄이고 테스트마다 고유한 `thread_id`를 보장하기 위해 공통 설정 구성을 헬퍼로 분리했습니다.
- `interrupt_before`가 빈 리스트이거나 명시적으로 `None`으로 설정된 경우에도 워크플로우가 끝까지 실행되는지 검증하는 테스트를 추가했습니다.
- 향후 리팩터링으로부터 안전성을 높이기 위해, `create_workflow`가 기본값이 `None`인 `interrupt_before` 파라미터를 외부에 노출하는지 검증하는 테스트를 추가했습니다.

Tests:
- Human-in-the-Loop 통합 테스트에서 공통 설정을 공유하면서도, 테스트 간 워크플로우 상태는 서로 격리되도록 리팩터링했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen Human-in-the-Loop workflow interrupt_before handling and reduce test duplication.

Bug Fixes:
- Tighten validation of interrupt_before by asserting that invalid node names raise ValueError with a message referencing interrupt_before.

Enhancements:
- Extract shared configuration setup into a helper to reduce duplication and ensure isolated thread_id per test.
- Add tests verifying that the workflow runs to completion when interrupt_before is an empty list or explicitly set to None.
- Add tests asserting that create_workflow exposes an interrupt_before parameter with a default of None to guard against future refactors.

Tests:
- Refactor Human-in-the-Loop integration tests to share common setup while keeping workflow state isolated across tests.

</details>