### PR TITLE
🐛 fix [#11.1.9]: 4차 개선 - interrupt_before 타입 가드 추가 및 유효성 검증 강화

### DIFF
--- a/backend/agent/graph.py
+++ b/backend/agent/graph.py
@@ -69,6 +69,12 @@ def create_workflow(
 
     # 8. Human-in-the-Loop 설정
     # interrupt_before가 None이면 빈 리스트로 처리 (중단 없이 자동 실행)
+    # None 또는 list[str] 이외의 타입은 명확한 TypeError로 조기 탐지
+    if interrupt_before is not None and not isinstance(interrupt_before, list):
+        raise TypeError(
+            f"interrupt_before는 list[str] 또는 None이어야 합니다. "
+            f"전달된 타입: {type(interrupt_before).__name__!r}"
+        )
     _interrupt_before = interrupt_before if interrupt_before is not None else []
 
     # 전달된 노드 이름이 실제 그래프 노드 집합에 포함되는지 조기 검증

--- a/tests/integration/agent/test_hitl.py
+++ b/tests/integration/agent/test_hitl.py
@@ -195,3 +195,24 @@ class TestHumanInTheLoop:
                 checkpointer=MemorySaver(),
                 interrupt_before=["reflecc"],  # 'reflect'의 오타
             )
+
+    def test_interrupt_before_raises_on_invalid_type(self):
+        """interrupt_before에 list가 아닌 잘못된 타입 전달 시 TypeError가 발생하는지 검증.
+
+        graph.py의 isinstance 타입 가드가 동작하는지 확인합니다.
+        - str: 이터러블이지만 list[str]로 의도된 파라미터가 아님
+        - int: 이터러블이 아닌 스칼라 값
+        """
+        # 문자열: 이터러블이지만 노드명 리스트로 허용되어서는 안 됨
+        with pytest.raises(TypeError, match="list\\[str\\]"):
+            create_workflow(
+                checkpointer=MemorySaver(),
+                interrupt_before="reflect",
+            )
+
+        # 정수: 이터러블이 아닌 스칼라
+        with pytest.raises(TypeError, match="list\\[str\\]"):
+            create_workflow(
+                checkpointer=MemorySaver(),
+                interrupt_before=123,
+            )


### PR DESCRIPTION
- **[graph.py]**: interrupt_before 타입 가드(isinstance) 추가
  - list[str] 또는 None이 아닌 값(string, int, bool 등) 전달 시 TypeError 발생
  - 기존: string 전달 시 문자 단위 순회 → 오해의 소지가 있는 ValueError 발생
  - 개선: isinstance 체크로 모든 잘못된 타입을 명확한 TypeError로 조기 탐지
  - 특히 빈 문자열("")을 인자로 받으면 예외 없이 통과되던 버그 선제 차단

- **[test_hitl.py]**: test_interrupt_before_raises_on_invalid_type 추가
  - interrupt_before="reflect" (문자열) → TypeError 발생 검증
  - interrupt_before=123 (정수) → TypeError 발생 검증
  - match 패턴: 'list[str]' (타입 시그니처, 언어/리팩터링에 독립적)

- `match= 패턴 범위` 미반영
  - 현재 match="interrupt_before"는 이 함수의 오류임을 충분히 특정함
  - 더 좁히면 한국어 문구 결합 재발 → 현재 균형점 유지

- `_make_config UUID 비결정성` 미반영
  - UUID 비결정성은 테스트 격리를 위한 의도된 설계 (YAGNI 원칙)

🔗 Related:
- Issue [#464]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/501#pullrequestreview-3825335562)

Co-authored-by: Claude-4.6-sonnet, Gemini 3 Pro

## Summary by Sourcery

에이전트 워크플로우 `interrupt` 설정에 대한 입력 검증을 강화하고, 잘못된 타입에 대한 회귀 테스트를 추가합니다.

버그 수정:
- `interrupt_before`가 `None`이거나 노드 이름의 리스트가 아닐 때, 문자열이나 기타 잘못된 타입이 잘못 처리되지 않도록 `create_workflow`가 명확한 `TypeError`를 발생시키도록 합니다.

테스트:
- 문자열이나 정수처럼 리스트가 아닌 값을 `interrupt_before`에 전달할 경우, 적절한 메시지와 함께 `TypeError`가 발생하는지 검증하는 통합 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen input validation for the agent workflow interrupt configuration and add regression tests for invalid types.

Bug Fixes:
- Ensure create_workflow raises a clear TypeError when interrupt_before is not None or a list of node names, preventing incorrect handling of strings and other invalid types.

Tests:
- Add integration tests verifying that passing non-list values such as strings or integers to interrupt_before results in a TypeError with an appropriate message.

</details>