### PR TITLE
Feature/v7 planning

### DIFF
--- a/backend/agent/graph.py
+++ b/backend/agent/graph.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import (
+    Sequence,
+)  # isinstance 체크용: typing.Sequence는 런타임 체크 불가 (Python 3.9+)
 from typing import Optional, TYPE_CHECKING
 from langgraph.graph import StateGraph, END
 
@@ -22,7 +25,7 @@ from backend.agent.checkpointer import get_checkpointer
 
 def create_workflow(
     checkpointer: Optional[BaseCheckpointSaver] = None,
-    interrupt_before: list[str] | None = None,
+    interrupt_before: Sequence[str] | None = None,
 ) -> CompiledStateGraph:
     """
     LangGraph 에이전트 워크플로우를 생성하고 컴파일합니다.
@@ -30,9 +33,10 @@ def create_workflow(
     Args:
         checkpointer (Optional[BaseCheckpointSaver]): 상태 저장을 위한 체크포인터.
             None일 경우 get_checkpointer()를 통해 환경에 맞는 Saver를 자동 선택합니다.
-        interrupt_before (list[str] | None): Human-in-the-Loop를 위해 실행 전 중단할
+        interrupt_before (Sequence[str] | None): Human-in-the-Loop를 위해 실행 전 중단할
             노드 이름 목록. 예: ["reflect"] - validate 후 reflect 진입 전 사용자 개입 허용.
-            None 또는 빈 리스트([])이면 중단 없이 자동 실행됩니다.
+            list, tuple 등 Sequence[str] 타입을 허용합니다.
+            None 또는 빈 시퀀스이면 중단 없이 자동 실행됩니다.
 
     Returns:
         CompiledStateGraph: 실행 가능한 에이전트 객체 (Persistence + HitL 기능 포함)
@@ -68,14 +72,31 @@ def create_workflow(
         checkpointer = get_checkpointer()
 
     # 8. Human-in-the-Loop 설정
-    # interrupt_before가 None이면 빈 리스트로 처리 (중단 없이 자동 실행)
-    # None 또는 list[str] 이외의 타입은 명확한 TypeError로 조기 탐지
-    if interrupt_before is not None and not isinstance(interrupt_before, list):
-        raise TypeError(
-            f"interrupt_before는 list[str] 또는 None이어야 합니다. "
-            f"전달된 타입: {type(interrupt_before).__name__!r}"
-        )
-    _interrupt_before = interrupt_before if interrupt_before is not None else []
+    # - list, tuple 등 collections.abc.Sequence 구현체는 모두 허용
+    # - str/bytes: Sequence이지만 노드명 리스트 의도가 아님 → 문자/바이트 단위 순회 방지
+    # - set, dict, generator 등 비시퀀스 이터러블: Sequence 계약 불만족 → TypeError
+    # - int, bool 등 비이터러블 스칼라: Sequence 아님 → TypeError
+    # - None은 빈 리스트로 정규화하여 중단 없이 자동 실행
+    if interrupt_before is not None:
+        if not isinstance(interrupt_before, Sequence) or isinstance(
+            interrupt_before, (str, bytes)
+        ):
+            raise TypeError(
+                "interrupt_before는 Sequence[str] 또는 None이어야 합니다. "
+                f"전달된 타입: {type(interrupt_before).__name__!r}"
+            )
+    _interrupt_before: list[str] = (
+        list(interrupt_before) if interrupt_before is not None else []
+    )
+
+    # 요소 타입 검증: 모든 요소가 str인지 확인 (list[int] 등 혼합 타입 조기 차단)
+    if _interrupt_before:
+        non_str_elements = [n for n in _interrupt_before if not isinstance(n, str)]
+        if non_str_elements:
+            raise TypeError(
+                f"interrupt_before의 모든 요소는 str이어야 합니다. "
+                f"잘못된 요소: {non_str_elements!r}"
+            )
 
     # 전달된 노드 이름이 실제 그래프 노드 집합에 포함되는지 조기 검증
     # 오타나 잘못된 노드 이름을 컴파일 전에 탐지하여 런타임 오류를 방지

--- a/tests/integration/agent/test_hitl.py
+++ b/tests/integration/agent/test_hitl.py
@@ -90,6 +90,21 @@ class TestHumanInTheLoop:
             f"got state.next={state.next!r}"
         )
 
+    def test_interrupt_before_accepts_tuple(self):
+        """interrupt_before에 tuple(Sequence[str]) 전달 시 TypeError 없이 정상 컴파일되는지 검증.
+
+        5차 개선에서 tuple 등 Sequence[str] 타입을 허용하도록 변경된 것을 직접 검증합니다.
+        list만 허용하던 구형에서 tuple도 허용하도록 확장된 타입 가드의 회귀를 방지합니다.
+        """
+        # tuple: collections.abc.Sequence의 구현체이므로 TypeError 없이 컴파일되어야 함
+        workflow = create_workflow(
+            checkpointer=MemorySaver(),
+            interrupt_before=("validate",),  # 유효한 노드명으로 tuple 전달
+        )
+        assert (
+            workflow is not None
+        ), "tuple을 Sequence[str]로 전달해도 정상 컴파일되어야 함"
+
     def test_interrupt_before_accepts_none(self):
         """interrupt_before=None 명시 전달 시 정상 실행되는지 검증 (None → [] 정규화 경로 확인)
 
@@ -197,22 +212,61 @@ class TestHumanInTheLoop:
             )
 
     def test_interrupt_before_raises_on_invalid_type(self):
-        """interrupt_before에 list가 아닌 잘못된 타입 전달 시 TypeError가 발생하는지 검증.
+        """interrupt_before에 Sequence[str]이 아닌 잘못된 타입 전달 시 TypeError가 발생하는지 검증.
 
-        graph.py의 isinstance 타입 가드가 동작하는지 확인합니다.
-        - str: 이터러블이지만 list[str]로 의도된 파라미터가 아님
+        graph.py의 타입 가드가 동작하는지 확인합니다.
+        - str: Sequence이지만 노드명 리스트로 허용되어서는 안 됨 (문자 단위 순회 방지)
         - int: 이터러블이 아닌 스칼라 값
+        - set: 이터러블이지만 Sequence가 아닌 비시퀀스 콠테이너
+        - dict: 이터러블이지만 Sequence가 아닌 비시퀀스 콠테이너
+
+        match 패턴에 'interrupt_before'를 사용하여 에러 메시지 문구 변경에 미옷도록 합니다.
+        ValueError 테스트들과 동일한 패턴으로 일관성을 유지합니다.
         """
-        # 문자열: 이터러블이지만 노드명 리스트로 허용되어서는 안 됨
-        with pytest.raises(TypeError, match="list\\[str\\]"):
+        # 문자열: Sequence이지만 노드명 리스틘로는 허용되어서는 안 됨
+        with pytest.raises(TypeError, match="interrupt_before"):
             create_workflow(
                 checkpointer=MemorySaver(),
                 interrupt_before="reflect",
             )
 
         # 정수: 이터러블이 아닌 스칼라
-        with pytest.raises(TypeError, match="list\\[str\\]"):
+        with pytest.raises(TypeError, match="interrupt_before"):
             create_workflow(
                 checkpointer=MemorySaver(),
                 interrupt_before=123,
+            )
+
+        # set: 이터러블이지만 Sequence가 아니므로 거뛰야 함
+        with pytest.raises(TypeError, match="interrupt_before"):
+            create_workflow(
+                checkpointer=MemorySaver(),
+                interrupt_before={"reflect"},
+            )
+
+        # dict: 이터러블이지만 Sequence가 아니므로 거뛰야 함
+        with pytest.raises(TypeError, match="interrupt_before"):
+            create_workflow(
+                checkpointer=MemorySaver(),
+                interrupt_before={"reflect": True},
+            )
+
+    def test_interrupt_before_raises_on_non_str_elements(self):
+        """interrupt_before에 str이 아닌 요소가 포함된 Sequence 전달 시 TypeError가 발생하는지 검증.
+
+        graph.py의 요소 타입 검증 로직이 동작하는지 확인합니다.
+        list[int] 등 혼합 타입 시퀀스가 조용히 통과되던 버그를 차단합니다.
+        """
+        # int 요소 혼합: LangGraph 내부에서 불명확한 오류 발생 전에 조기 차단
+        with pytest.raises(TypeError, match="interrupt_before"):
+            create_workflow(
+                checkpointer=MemorySaver(),
+                interrupt_before=[123, "reflect"],
+            )
+
+        # None 요소 혼합
+        with pytest.raises(TypeError, match="interrupt_before"):
+            create_workflow(
+                checkpointer=MemorySaver(),
+                interrupt_before=[None, "reflect"],
             )


### PR DESCRIPTION
🐛 fix [#11.1.9]: 4차 개선 - interrupt_before 타입 가드 추가 및 유효성 검증 강화

## Summary by Sourcery

에이전트 워크플로우의 `interrupt_before` 설정에 대한 검증을 강화하고, 잘못된 타입 처리에 대한 테스트를 확장합니다.

버그 수정:
- `interrupt_before`에 잘못된 값이 묵묵히 허용되지 않도록, 리스트가 아닌 타입이 제공될 경우 명확한 `TypeError`를 발생시킵니다.

테스트:
- 문자열과 정수와 같은 리스트가 아닌 타입에 대해 `interrupt_before`가 `TypeError`를 발생시키며 거부하는지 검증하는 통합 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen validation for the agent workflow's interrupt_before configuration and extend tests to cover invalid type handling.

Bug Fixes:
- Raise a clear TypeError when interrupt_before is provided with a non-list type instead of silently accepting invalid values.

Tests:
- Add integration tests verifying that interrupt_before rejects non-list types such as strings and integers with a TypeError.

</details>