### PR TITLE
🐛 fix [#11.1.9]: 5차 개선 - interrupt_before 타입 체크 관대화 및 테스트 안정성 향상

### DIFF
--- a/backend/agent/graph.py
+++ b/backend/agent/graph.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Optional, Sequence, TYPE_CHECKING
+from collections.abc import (
+    Sequence,
+)  # isinstance 체크용: typing.Sequence는 런타임 체크 불가 (Python 3.9+)
+from typing import Optional, TYPE_CHECKING
 from langgraph.graph import StateGraph, END
 
 # Type Checking Only Imports
@@ -69,17 +72,31 @@ def create_workflow(
         checkpointer = get_checkpointer()
 
     # 8. Human-in-the-Loop 설정
-    # - list, tuple 등 합리적인 Sequence[str] 타입은 모두 허용
-    # - str 단독 전달: Sequence이지만 노드명 리스트 의도가 아님 → 문자 단위 순회 방지
-    # - int, bool 등 비이터러블 스칼라: 명확한 TypeError로 조기 탐지
+    # - list, tuple 등 collections.abc.Sequence 구현체는 모두 허용
+    # - str/bytes: Sequence이지만 노드명 리스트 의도가 아님 → 문자/바이트 단위 순회 방지
+    # - set, dict, generator 등 비시퀀스 이터러블: Sequence 계약 불만족 → TypeError
+    # - int, bool 등 비이터러블 스칼라: Sequence 아님 → TypeError
     # - None은 빈 리스트로 정규화하여 중단 없이 자동 실행
     if interrupt_before is not None:
-        if isinstance(interrupt_before, str) or not hasattr(interrupt_before, "__iter__"):
+        if not isinstance(interrupt_before, Sequence) or isinstance(
+            interrupt_before, (str, bytes)
+        ):
             raise TypeError(
-                f"interrupt_before는 Sequence[str] 또는 None이어야 합니다. "
+                "interrupt_before는 Sequence[str] 또는 None이어야 합니다. "
                 f"전달된 타입: {type(interrupt_before).__name__!r}"
             )
-    _interrupt_before: list[str] = list(interrupt_before) if interrupt_before is not None else []
+    _interrupt_before: list[str] = (
+        list(interrupt_before) if interrupt_before is not None else []
+    )
+
+    # 요소 타입 검증: 모든 요소가 str인지 확인 (list[int] 등 혼합 타입 조기 차단)
+    if _interrupt_before:
+        non_str_elements = [n for n in _interrupt_before if not isinstance(n, str)]
+        if non_str_elements:
+            raise TypeError(
+                f"interrupt_before의 모든 요소는 str이어야 합니다. "
+                f"잘못된 요소: {non_str_elements!r}"
+            )
 
     # 전달된 노드 이름이 실제 그래프 노드 집합에 포함되는지 조기 검증
     # 오타나 잘못된 노드 이름을 컴파일 전에 탐지하여 런타임 오류를 방지

--- a/tests/integration/agent/test_hitl.py
+++ b/tests/integration/agent/test_hitl.py
@@ -90,6 +90,21 @@ class TestHumanInTheLoop:
             f"got state.next={state.next!r}"
         )
 
+    def test_interrupt_before_accepts_tuple(self):
+        """interrupt_before에 tuple(Sequence[str]) 전달 시 TypeError 없이 정상 컴파일되는지 검증.
+
+        5차 개선에서 tuple 등 Sequence[str] 타입을 허용하도록 변경된 것을 직접 검증합니다.
+        list만 허용하던 구형에서 tuple도 허용하도록 확장된 타입 가드의 회귀를 방지합니다.
+        """
+        # tuple: collections.abc.Sequence의 구현체이므로 TypeError 없이 컴파일되어야 함
+        workflow = create_workflow(
+            checkpointer=MemorySaver(),
+            interrupt_before=("validate",),  # 유효한 노드명으로 tuple 전달
+        )
+        assert (
+            workflow is not None
+        ), "tuple을 Sequence[str]로 전달해도 정상 컴파일되어야 함"
+
     def test_interrupt_before_accepts_none(self):
         """interrupt_before=None 명시 전달 시 정상 실행되는지 검증 (None → [] 정규화 경로 확인)
 
@@ -202,11 +217,13 @@ class TestHumanInTheLoop:
         graph.py의 타입 가드가 동작하는지 확인합니다.
         - str: Sequence이지만 노드명 리스트로 허용되어서는 안 됨 (문자 단위 순회 방지)
         - int: 이터러블이 아닌 스칼라 값
+        - set: 이터러블이지만 Sequence가 아닌 비시퀀스 콠테이너
+        - dict: 이터러블이지만 Sequence가 아닌 비시퀀스 콠테이너
 
         match 패턴에 'interrupt_before'를 사용하여 에러 메시지 문구 변경에 미옷도록 합니다.
         ValueError 테스트들과 동일한 패턴으로 일관성을 유지합니다.
         """
-        # 문자열: Sequence이지만 노드명 리스트로는 허용되어서는 안 됨
+        # 문자열: Sequence이지만 노드명 리스틘로는 허용되어서는 안 됨
         with pytest.raises(TypeError, match="interrupt_before"):
             create_workflow(
                 checkpointer=MemorySaver(),
@@ -218,4 +235,38 @@ class TestHumanInTheLoop:
             create_workflow(
                 checkpointer=MemorySaver(),
                 interrupt_before=123,
+            )
+
+        # set: 이터러블이지만 Sequence가 아니므로 거뛰야 함
+        with pytest.raises(TypeError, match="interrupt_before"):
+            create_workflow(
+                checkpointer=MemorySaver(),
+                interrupt_before={"reflect"},
+            )
+
+        # dict: 이터러블이지만 Sequence가 아니므로 거뛰야 함
+        with pytest.raises(TypeError, match="interrupt_before"):
+            create_workflow(
+                checkpointer=MemorySaver(),
+                interrupt_before={"reflect": True},
+            )
+
+    def test_interrupt_before_raises_on_non_str_elements(self):
+        """interrupt_before에 str이 아닌 요소가 포함된 Sequence 전달 시 TypeError가 발생하는지 검증.
+
+        graph.py의 요소 타입 검증 로직이 동작하는지 확인합니다.
+        list[int] 등 혼합 타입 시퀀스가 조용히 통과되던 버그를 차단합니다.
+        """
+        # int 요소 혼합: LangGraph 내부에서 불명확한 오류 발생 전에 조기 차단
+        with pytest.raises(TypeError, match="interrupt_before"):
+            create_workflow(
+                checkpointer=MemorySaver(),
+                interrupt_before=[123, "reflect"],
+            )
+
+        # None 요소 혼합
+        with pytest.raises(TypeError, match="interrupt_before"):
+            create_workflow(
+                checkpointer=MemorySaver(),
+                interrupt_before=[None, "reflect"],
             )


### PR DESCRIPTION
- **[graph.py]**: list 전용 타입 가드 → Sequence[str] 기반으로 확장
  - tuple 등 합리적인 시퀀스 타입 허용 (기존 list만 허용 → 거부 불필요)
  - str 단독 전달 명시적 차단 (Sequence이지만 문자 단위 순회 방지)
  - 비이터러블(int, bool 등) 차단 유지
  - 내부에서 list()로 통일 변환 → LangGraph API 호환성 보장

- **[test_hitl.py]**: TypeError 테스트 match 패턴 안정화
  - match="list[str]" → match="interrupt_before" (파라미터명 기반, 불변)
  - ValueError 테스트들과 동일한 패턴으로 일관성 통일
  - 에러 메시지 문구 변경 시에도 테스트가 깨지지 않음

🔗 Related:
- Issue [#464]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/503#pullrequestreview-3825501623)

Co-authored-by: Claude-4.6-sonnet, Gemini 3 Pro

## Summary by Sourcery

`interrupt_before` 타입 처리를 완화하여 일반 문자열 시퀀스를 허용하고, 관련 오류 처리 테스트를 더 안정적으로 개선했습니다.

버그 수정:
- `interrupt_before`가 튜플과 같은 더 넓은 `Sequence[str]` 타입을 허용하면서도, 잘못된 스칼라 입력은 계속 거부하도록 했습니다.

개선 사항:
- `interrupt_before` 입력을 내부적으로 일관되게 처리하고 더 명확한 `TypeError` 메시지를 제공하기 위해 리스트로 정규화했습니다.

테스트:
- `interrupt_before`의 `TypeError` 테스트가 특정 메시지 텍스트 대신 파라미터 이름을 검증하도록 업데이트하여 더 견고한 매칭이 가능하도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax interrupt_before type handling to accept general string sequences and improve related error handling tests for stability.

Bug Fixes:
- Allow interrupt_before to accept broader Sequence[str] types like tuples while still rejecting invalid scalar inputs.

Enhancements:
- Normalize interrupt_before inputs to lists for consistent internal handling and clearer TypeError messaging.

Tests:
- Update interrupt_before TypeError tests to assert on parameter name rather than specific message text for more robust matching.

</details>