### PR TITLE
🐛 fix [#11.2.1]: 2차 개선 - 타입 체크 무시 버그 수정

### DIFF
--- a/backend/chunking.py
+++ b/backend/chunking.py
@@ -24,15 +24,18 @@ class TextChunker:
         *,
         chunk_size: int = 500,
         chunk_overlap: int = 50,
+        **splitter_kwargs: Any,
     ) -> None:
         """
         초기화
         - splitter를 주입하거나 기본 RecursiveCharacterTextSplitter를 사용합니다.
+        - 고급 설정이 필요한 경우 splitter_kwargs를 통해 RecursiveCharacterTextSplitter 옵션을 전달할 수 있습니다.
 
         Args:
             splitter: 의존성 주입을 위한 TextSplitter 객체
             chunk_size: 청크 크기 (기본 스플리터 사용 시)
             chunk_overlap: 청크 중첩 크기 (기본 스플리터 사용 시)
+            splitter_kwargs: (고급) 기본 RecursiveCharacterTextSplitter에 전달할 추가 옵션들
         """
         if splitter is not None:
             if not isinstance(splitter, TextSplitter):
@@ -40,28 +43,36 @@ class TextChunker:
                     f"splitter must be an instance of TextSplitter, got {type(splitter).__name__}"
                 )
             self._splitter = splitter
-            self._chunk_size: Optional[int] = None
-            self._chunk_overlap: Optional[int] = None
+            self._chunk_size: Optional[int] = getattr(
+                splitter, "chunk_size", getattr(splitter, "_chunk_size", None)
+            )
+            self._chunk_overlap: Optional[int] = getattr(
+                splitter, "chunk_overlap", getattr(splitter, "_chunk_overlap", None)
+            )
         else:
             self._chunk_size = chunk_size
             self._chunk_overlap = chunk_overlap
             self._splitter = RecursiveCharacterTextSplitter(
-                chunk_size=chunk_size, chunk_overlap=chunk_overlap
+                chunk_size=chunk_size, chunk_overlap=chunk_overlap, **splitter_kwargs
             )
 
     @property
     def chunk_size(self) -> Optional[int]:
-        """기본 스플리터 사용 시 설정된 chunk_size, 주입된 스플리터면 None"""
+        """기본 스플리터 사용 시 설정된 chunk_size 또는 주입된 스플리터의 속성 반환"""
         return self._chunk_size
 
     @property
     def chunk_overlap(self) -> Optional[int]:
-        """기본 스플리터 사용 시 설정된 chunk_overlap, 주입된 스플리터면 None"""
+        """기본 스플리터 사용 시 설정된 chunk_overlap 또는 주입된 스플리터의 속성 반환"""
         return self._chunk_overlap
 
     def chunk_text(self, text: str) -> List[str]:
         """텍스트를 청크 단위로 분할"""
         if not isinstance(text, str):
+            logger.error(
+                "Invalid text type for chunking",
+                extra={"context": {"type": type(text).__name__}},
+            )
             raise TypeError(f"text must be of type str, got {type(text).__name__}")
         if not text:
             return []
@@ -73,6 +84,10 @@ class TextChunker:
     ) -> List[Dict[str, Any]]:
         """메타데이터와 함께 청크 생성"""
         if metadata is not None and not isinstance(metadata, dict):
+            logger.error(
+                "Invalid metadata type",
+                extra={"context": {"type": type(metadata).__name__}},
+            )
             raise TypeError(
                 f"metadata must be a dictionary, got {type(metadata).__name__}"
             )


### PR DESCRIPTION
- **[backend/chunking.py]**:
  - [TextChunker](backend/chunking.py:17:0-90:9) 클래스를 `langchain_text_splitters` 기반으로 리팩터링 및 구조화
  - [chunk_size](backend/chunking.py:51:4-54:31), [chunk_overlap](backend/chunking.py:56:4-59:34) 중복 저장 제거 및 외부 의존성(TextSplitter Private Variables) 문제 우회 해결
  - `TextSplitter` 객체 외부 주입 지원으로 확장성 확보 (하드코딩 제거 및 명시적 설정)
  - `ai_bot_review_summary` 준수: Fail-fast 원칙을 적용하여 [metadata](backend/chunking.py:70:4-90:9) 타입 검증을 청킹 연산 이전에 수행, Falsy 값에 대한 `isinstance` 타입 검증 우선순위 수정

🔗 Related:
- Issue [#507]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/509#pullrequestreview-3835471175)

Co-authored-by: Claude-4.6-sonnet, Gemini 3 Pro

## Summary by Sourcery

기본 분할기에서 명시적인 청크 파라미터를 사용하도록 TextChunker를 개선하고, 입력 및 메타데이터에 대한 타입 검증을 강화하며, 간접적인 splitter kwargs 처리를 제거해 설정을 단순화합니다.

버그 수정:
- 청킹 전에 엄격한 타입 체크를 적용하여, 문자열이 아닌 text 및 dict가 아닌 metadata가 조용히 허용되는 문제를 방지합니다.

개선 사항:
- 기본 `RecursiveCharacterTextSplitter`를 사용할 때에만 `chunk_size` 및 `chunk_overlap` 파라미터를 추가하고 저장함으로써 TextChunker 설정을 명시적으로 만듭니다.
- 빈 text에 대해서는 일찍 반환하고, 타입 검증 과정에서의 로깅 부수 효과를 제거하여 청킹 동작을 단순하고 명확하게 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the TextChunker to use explicit chunking parameters for its default splitter, tighten type validation for inputs and metadata, and simplify configuration by removing indirect splitter kwargs handling.

Bug Fixes:
- Prevent invalid non-string text and non-dict metadata from being silently accepted by enforcing strict type checks before chunking.

Enhancements:
- Make TextChunker configuration explicit by adding chunk_size and chunk_overlap parameters and storing them only when using the default RecursiveCharacterTextSplitter.
- Simplify and clarify chunking behavior by returning early on empty text and by removing logging side effects from type validation.

</details>