### PR TITLE
🐛 fix [#11.2.1]: 4차 개선 - TextChunker 동적 프로퍼티 최적화 및 kwargs 인자 충돌 방어

### DIFF
--- a/backend/chunking.py
+++ b/backend/chunking.py
@@ -45,28 +45,29 @@ class TextChunker:
             self._splitter = splitter
         else:
             # 중복 키워드 인자 충돌 방지 (방어적 코딩)
-            splitter_kwargs.pop("chunk_size", None)
-            splitter_kwargs.pop("chunk_overlap", None)
+            kwargs = dict(splitter_kwargs)
+            kwargs.pop("chunk_size", None)
+            kwargs.pop("chunk_overlap", None)
 
             self._splitter = RecursiveCharacterTextSplitter(
-                chunk_size=chunk_size, chunk_overlap=chunk_overlap, **splitter_kwargs
+                chunk_size=chunk_size, chunk_overlap=chunk_overlap, **kwargs
             )
+
+    def _get_splitter_attr(self, attr_name: str) -> Optional[int]:
+        """스플리터에서 동적으로 속성을 읽어옵니다 (Public 및 Private 변수 호환)."""
+        return getattr(
+            self._splitter, attr_name, getattr(self._splitter, f"_{attr_name}", None)
+        )
 
     @property
     def chunk_size(self) -> Optional[int]:
         """현재 스플리터에 설정된 chunk_size 동적 반환 (런타임 변경 반영)"""
-        return getattr(
-            self._splitter, "chunk_size", getattr(self._splitter, "_chunk_size", None)
-        )
+        return self._get_splitter_attr("chunk_size")
 
     @property
     def chunk_overlap(self) -> Optional[int]:
         """현재 스플리터에 설정된 chunk_overlap 동적 반환 (런타임 변경 반영)"""
-        return getattr(
-            self._splitter,
-            "chunk_overlap",
-            getattr(self._splitter, "_chunk_overlap", None),
-        )
+        return self._get_splitter_attr("chunk_overlap")
 
     def chunk_text(self, text: str) -> List[str]:
         """텍스트를 청크 단위로 분할"""


### PR DESCRIPTION
- **[backend/chunking.py]**:
  - [__init__](backend/chunking.py:20:4-52:13) 초기화 단계에서 `splitter_kwargs`에 잠재적으로 섞여 들어올 수 있는 [chunk_size](backend/chunking.py:54:4-59:9), [chunk_overlap](backend/chunking.py:61:4-68:9)의 중복 인자를 `pop()`하여 `TypeError: multiple values for keyword argument` 발생 원천 차단
  - `_chunk_size`, `_chunk_overlap` 속성의 인스턴스 단일 캐싱 로직 전면 폐기
  - 외부에서 주입되거나 재구성된(reconfigure) 스플리터의 상태 변경을 즉시 반영하기 위해, 프로퍼티(`@property`) 호출 시점마다 `self._splitter`의 최신 public 속성(또는 private 속성)을 동적으로 읽어 반환하도록 유연성 및 동기화 무결성 확보

🔗 Related:
- Issue [#507]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/511#pullrequestreview-3835479112)

Co-authored-by: Claude-4.6-sonnet, Gemini 3 Pro

## Summary by Sourcery

TextChunker 분할기(splitter) 설정 처리 방식을 최적화하고, 청킹 파라미터에 대한 키워드 인자 충돌을 방지합니다.

버그 수정:
- 기본 splitter를 생성할 때 키워드 인자 충돌을 일으킬 수 있는 `splitter_kwargs` 내의 중복된 `chunk_size` 및 `chunk_overlap` 값을 방지하는 보호 로직을 추가했습니다.

개선 사항:
- 캐시된 인스턴스 속성에 의존하는 대신, 런타임 구성 변경 사항을 반영할 수 있도록 내부 splitter로부터 `chunk_size` 및 `chunk_overlap` 값을 동적으로 반환하도록 변경했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize TextChunker splitter configuration handling and prevent keyword argument conflicts for chunking parameters.

Bug Fixes:
- Guard against duplicate chunk_size and chunk_overlap values in splitter_kwargs that could cause keyword argument conflicts when constructing the default splitter.

Enhancements:
- Return chunk_size and chunk_overlap dynamically from the underlying splitter to reflect runtime configuration changes instead of relying on cached instance attributes.

</details>