### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/chunking.py
+++ b/backend/chunking.py
@@ -43,28 +43,31 @@ class TextChunker:
                     f"splitter must be an instance of TextSplitter, got {type(splitter).__name__}"
                 )
             self._splitter = splitter
-            self._chunk_size: Optional[int] = getattr(
-                splitter, "chunk_size", getattr(splitter, "_chunk_size", None)
-            )
-            self._chunk_overlap: Optional[int] = getattr(
-                splitter, "chunk_overlap", getattr(splitter, "_chunk_overlap", None)
-            )
         else:
-            self._chunk_size = chunk_size
-            self._chunk_overlap = chunk_overlap
+            # 중복 키워드 인자 충돌 방지 (방어적 코딩)
+            kwargs = dict(splitter_kwargs)
+            kwargs.pop("chunk_size", None)
+            kwargs.pop("chunk_overlap", None)
+
             self._splitter = RecursiveCharacterTextSplitter(
-                chunk_size=chunk_size, chunk_overlap=chunk_overlap, **splitter_kwargs
+                chunk_size=chunk_size, chunk_overlap=chunk_overlap, **kwargs
             )
+
+    def _get_splitter_attr(self, attr_name: str) -> Optional[int]:
+        """스플리터에서 동적으로 속성을 읽어옵니다 (Public 및 Private 변수 호환)."""
+        return getattr(
+            self._splitter, attr_name, getattr(self._splitter, f"_{attr_name}", None)
+        )
 
     @property
     def chunk_size(self) -> Optional[int]:
-        """기본 스플리터 사용 시 설정된 chunk_size 또는 주입된 스플리터의 속성 반환"""
-        return self._chunk_size
+        """현재 스플리터에 설정된 chunk_size 동적 반환 (런타임 변경 반영)"""
+        return self._get_splitter_attr("chunk_size")
 
     @property
     def chunk_overlap(self) -> Optional[int]:
-        """기본 스플리터 사용 시 설정된 chunk_overlap 또는 주입된 스플리터의 속성 반환"""
-        return self._chunk_overlap
+        """현재 스플리터에 설정된 chunk_overlap 동적 반환 (런타임 변경 반영)"""
+        return self._get_splitter_attr("chunk_overlap")
 
     def chunk_text(self, text: str) -> List[str]:
         """텍스트를 청크 단위로 분할"""


### PR DESCRIPTION
🐛 fix [#11.2.1]: 4차 개선 - TextChunker 동적 프로퍼티 최적화 및 kwargs 인자 충돌 방어 
🐛 fix [#11.2.1]: 5차 개선 - TextChunker의 kwargs 딕셔너리 변이 방지 및 접근 로직 추상화 구현

## Summary by Sourcery

텍스트 청킹 컴포넌트를 개선하여 분할기 설정을 동적으로 조회할 수 있도록 하고, 기본 분할기를 구성할 때 키워드 충돌이 발생하지 않도록 합니다.

버그 수정:
- `splitter_kwargs`에서 기본 텍스트 분할기를 초기화할 때 `chunk_size`와 `chunk_overlap`에 대한 키워드 인자 충돌을 방지합니다.
- 실행 시점 설정 변경을 반영할 수 있도록, 기본 분할기로부터 `chunk_size`와 `chunk_overlap`을 항상 동적으로 읽어오도록 보장합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the text chunking component to support dynamic retrieval of splitter configuration and prevent keyword conflicts when constructing the default splitter.

Bug Fixes:
- Avoid keyword argument collisions for chunk_size and chunk_overlap when initializing the default text splitter from splitter_kwargs.
- Ensure chunk_size and chunk_overlap are always read dynamically from the underlying splitter, reflecting runtime configuration changes.

</details>