### PR TITLE
🐛 fix [#11.2.1]: 6차 개선 - TextChunker 속성 참조 헬퍼 함수의 유연성 확장 및 무음 실패 방어

### DIFF
--- a/backend/chunking.py
+++ b/backend/chunking.py
@@ -55,18 +55,16 @@ class TextChunker:
 
     def _get_splitter_attr(
         self, attr_name: str, fallback_attr: Optional[str] = None
-    ) -> Optional[int]:
+    ) -> Optional[Any]:
         """스플리터에서 동적으로 속성을 읽어옵니다 (Public 및 명시적 Fallback 속성 지원)."""
         # 1. Public 속성 시도
-        val = getattr(self._splitter, attr_name, None)
-        if val is not None:
-            return val
+        if hasattr(self._splitter, attr_name):
+            return getattr(self._splitter, attr_name)
 
         # 2. Private/Fallback 속성 시도
         private_attr = fallback_attr or f"_{attr_name}"
-        val = getattr(self._splitter, private_attr, None)
-        if val is not None:
-            return val
+        if hasattr(self._splitter, private_attr):
+            return getattr(self._splitter, private_attr)
 
         # 3. 양쪽 모두 없을 경우, 잠재적 설정 오류를 경고 로깅으로 남김 (침묵 회피)
         logger.warning(
@@ -75,18 +73,19 @@ class TextChunker:
                 "context": {
                     "splitter_type": type(self._splitter).__name__,
                     "attr_name": attr_name,
+                    "private_attr": private_attr,
                 }
             },
         )
         return None
 
     @property
-    def chunk_size(self) -> Optional[int]:
+    def chunk_size(self) -> Optional[Any]:
         """현재 스플리터에 설정된 chunk_size 동적 반환 (런타임 변경 반영)"""
         return self._get_splitter_attr("chunk_size")
 
     @property
-    def chunk_overlap(self) -> Optional[int]:
+    def chunk_overlap(self) -> Optional[Any]:
         """현재 스플리터에 설정된 chunk_overlap 동적 반환 (런타임 변경 반영)"""
         return self._get_splitter_attr("chunk_overlap")
 


### PR DESCRIPTION
- **[backend/chunking.py]**:
  - [_get_splitter_attr](backend/chunking.py:55:4-80:19) 헬퍼 함수에 `fallback_attr` 파라미터를 명시적으로 추가하여, 특정 커스텀 스플리터가 강제된 `_{attr_name}` 프라이빗 네이밍 컨벤션을 따르지 않더라도 유연하게 대응할 수 있도록 커플링(Coupling) 완화
  - 외부 스플리터에서 퍼블릭 및 폴백(프라이빗) 속성을 모두 찾지 못했을 경우 조용히 `None`을 내려주어 발생할 수 있는 잠재적 혼란(Silently Fail)을 방지하기 위해, 명확한 구조적 컨텍스트(`extra={"context": ...}`)를 담은 `logger.warning` 오류 로깅 가시성 확보 추가

🔗 Related:
- Issue [#507]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/513#pullrequestreview-3835484265)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro

## Summary by Sourcery

예상된 속성이 누락된 경우 명시적인 폴백(fallback) 이름을 허용하고 로깅을 추가하여 splitter 속성 간 결합을 완화합니다.

Enhancements:
- 접두사가 없는 커스텀 splitter 구현을 지원하기 위해 splitter attribute helper에 선택적 폴백 속성 매개변수를 추가했습니다.
- 기본 및 폴백 splitter 속성이 모두 발견되지 않을 경우, 조용한 오구성을 피하기 위해 구조화된 경고를 기록하도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax splitter attribute coupling by allowing an explicit fallback name and adding logging when expected attributes are missing.

Enhancements:
- Add an optional fallback attribute parameter to the splitter attribute helper to support non-prefixed custom splitter implementations.
- Log a structured warning when neither the primary nor fallback splitter attributes are found to avoid silent misconfiguration.

</details>