### PR TITLE
🐛 fix [#11.2.1]: 8차 개선 - TextChunker 제네릭 정적 타입 복구 및 로깅 과부하(Log Noise) 방지

### DIFF
--- a/backend/chunking.py
+++ b/backend/chunking.py
@@ -8,13 +8,13 @@ FlowNote MVP - 텍스트 청킹
 
 
 import logging
-from typing import Any, Optional, Dict, List, TypeVar, cast
+from typing import Any, Optional, Dict, List, TypeVar, cast, Set, Tuple
 
 from langchain_text_splitters import TextSplitter, RecursiveCharacterTextSplitter
 
 logger = logging.getLogger(__name__)
 
-T = TypeVar("T")
+T = TypeVar("T", bound=int)
 
 
 class TextChunker:
@@ -55,7 +55,7 @@ class TextChunker:
                 chunk_size=chunk_size, chunk_overlap=chunk_overlap, **kwargs
             )
 
-        self._warned_missing_attrs = set()
+        self._warned_missing_attrs: Set[Tuple[str, str]] = set()
 
     def _get_splitter_attr(
         self, attr_name: str, fallback_attr: Optional[str] = None
@@ -75,7 +75,8 @@ class TextChunker:
             return cast(Optional[T], getattr(self._splitter, private_attr))
 
         # 3. 양쪽 모두 없을 경우, 중복 로깅 방지 후 info 레벨로 기록 (침묵 회피)
-        if attr_name not in self._warned_missing_attrs:
+        missing_attr_key = (attr_name, private_attr)
+        if missing_attr_key not in self._warned_missing_attrs:
             logger.info(
                 f"Could not find '{attr_name}' or '{private_attr}' on {type(self._splitter).__name__}",
                 extra={
@@ -86,7 +87,7 @@ class TextChunker:
                     }
                 },
             )
-            self._warned_missing_attrs.add(attr_name)
+            self._warned_missing_attrs.add(missing_attr_key)
 
         return None
 


### PR DESCRIPTION
- **[backend/chunking.py]**:
  - [_get_splitter_attr](backend/chunking.py:59:4-90:19) 헬퍼 함수의 반환 타입을 `Any`에서 `TypeVar("T")` / `cast` 기반의 제네릭(`Optional[T]`)으로 전환하여, 반환받는 [chunk_size](backend/chunking.py:92:4-96:29), [chunk_overlap](backend/chunking.py:98:4-102:32) 프로퍼티는 다시 엄격하고 안전한 `Optional[int]`의 정적 타입 안정성 보장 체계로 원복함.
  - 잦은 속성 접근(루프 동작 등)으로 인한 동일한 속성 부재 실패의 Log Flooding(도배)을 방지하기 위해 생성자에 `_warned_missing_attrs` Set형 가드를 인스턴스 단위로 도입 (Once-only 제어 체계 확립).
  - 로깅 레벨을 `warning`에서 `info`로 하향 조정하여, 에러 성격이 아닌 단순 추적 지표로써의 맥락(`context`)만 제공하도록 관측성 설계 고도화.

🔗 Related:
- Issue [#507]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/515#pullrequestreview-3835488626)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro

## Summary by Sourcery

TextChunker에서 타입 안전한 splitter 속성 접근을 복원하고 로그 노이즈를 줄입니다.

Bug Fixes:
- `chunk_size`와 `chunk_overlap`이 느슨한 타입의 값 대신 올바른 `Optional[int]` 타입을 노출하도록 보장합니다.
- 각 TextChunker 인스턴스별로 경고한 splitter 속성을 추적하여, 누락된 속성에 대한 반복적인 로그 스팸을 방지합니다.

Enhancements:
- `TypeVar`와 `casting`을 사용한 splitter 속성 접근을 위한 제네릭 헬퍼를 도입하고, 누락된 속성에 대한 로그 레벨을 warning에서 info로 낮춰 관측 가능성을 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore type-safe splitter attribute access and reduce logging noise in TextChunker.

Bug Fixes:
- Ensure chunk_size and chunk_overlap expose correct Optional[int] types instead of loosely typed values.
- Prevent repeated missing-attribute log spam by tracking warned splitter attributes per TextChunker instance.

Enhancements:
- Introduce a generic helper for splitter attribute access using TypeVar and casting while downgrading missing-attribute logs from warning to info for better observability.

</details>