### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/chunking.py
+++ b/backend/chunking.py
@@ -8,11 +8,13 @@ FlowNote MVP - 텍스트 청킹
 
 
 import logging
-from typing import Any, Optional, Dict, List
+from typing import Any, Optional, Dict, List, TypeVar, cast, Set, Tuple
 
 from langchain_text_splitters import TextSplitter, RecursiveCharacterTextSplitter
 
 logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=int)
 
 
 class TextChunker:
@@ -53,41 +55,53 @@ class TextChunker:
                 chunk_size=chunk_size, chunk_overlap=chunk_overlap, **kwargs
             )
 
+        self._warned_missing_attrs: Set[Tuple[str, str]] = set()
+
     def _get_splitter_attr(
         self, attr_name: str, fallback_attr: Optional[str] = None
-    ) -> Optional[Any]:
-        """스플리터에서 동적으로 속성을 읽어옵니다 (Public 및 명시적 Fallback 속성 지원)."""
+    ) -> Optional[T]:
+        """스플리터에서 동적으로 속성을 읽어옵니다 (Public 및 명시적 Fallback 속성 지원).
+
+        제네릭 반환 타입을 사용하여 호출 지점에서 정적 타입 안정성을 유지합니다.
+        예: ``chunk_size: Optional[int] = self._get_splitter_attr("chunk_size")``
+        """
         # 1. Public 속성 시도
         if hasattr(self._splitter, attr_name):
-            return getattr(self._splitter, attr_name)
+            return cast(Optional[T], getattr(self._splitter, attr_name))
 
         # 2. Private/Fallback 속성 시도
         private_attr = fallback_attr or f"_{attr_name}"
         if hasattr(self._splitter, private_attr):
-            return getattr(self._splitter, private_attr)
+            return cast(Optional[T], getattr(self._splitter, private_attr))
 
-        # 3. 양쪽 모두 없을 경우, 잠재적 설정 오류를 경고 로깅으로 남김 (침묵 회피)
-        logger.warning(
-            f"Could not find '{attr_name}' or '{private_attr}' on {type(self._splitter).__name__}",
-            extra={
-                "context": {
-                    "splitter_type": type(self._splitter).__name__,
-                    "attr_name": attr_name,
-                    "private_attr": private_attr,
-                }
-            },
-        )
+        # 3. 양쪽 모두 없을 경우, 중복 로깅 방지 후 info 레벨로 기록 (침묵 회피)
+        missing_attr_key = (attr_name, private_attr)
+        if missing_attr_key not in self._warned_missing_attrs:
+            logger.info(
+                f"Could not find '{attr_name}' or '{private_attr}' on {type(self._splitter).__name__}",
+                extra={
+                    "context": {
+                        "splitter_type": type(self._splitter).__name__,
+                        "attr_name": attr_name,
+                        "private_attr": private_attr,
+                    }
+                },
+            )
+            self._warned_missing_attrs.add(missing_attr_key)
+
         return None
 
     @property
-    def chunk_size(self) -> Optional[Any]:
+    def chunk_size(self) -> Optional[int]:
         """현재 스플리터에 설정된 chunk_size 동적 반환 (런타임 변경 반영)"""
-        return self._get_splitter_attr("chunk_size")
+        chunk_size_val: Optional[int] = self._get_splitter_attr("chunk_size")
+        return chunk_size_val
 
     @property
-    def chunk_overlap(self) -> Optional[Any]:
+    def chunk_overlap(self) -> Optional[int]:
         """현재 스플리터에 설정된 chunk_overlap 동적 반환 (런타임 변경 반영)"""
-        return self._get_splitter_attr("chunk_overlap")
+        chunk_overlap_val: Optional[int] = self._get_splitter_attr("chunk_overlap")
+        return chunk_overlap_val
 
     def chunk_text(self, text: str) -> List[str]:
         """텍스트를 청크 단위로 분할"""


### PR DESCRIPTION
🐛 fix [#11.2.1]: 8차 개선 - TextChunker 제네릭 정적 타입 복구 및 로깅 과부하(Log Noise) 방지 
🐛 fix [#11.2.1]: 9차 개선 - TextChunker 제네릭 엄격성(bound=int) 부여 및 오탐 방지용 복합 키 도입

## Summary by Sourcery

TextChunker splitter 속성 타이핑을 강화하고, 예상된 splitter 속성이 없을 때 중복되는 로그를 줄입니다.

개선 사항:
- `chunk_size`와 `chunk_overlap`에 대해 정적 타입 안전성을 유지하기 위해, splitter 속성을 읽기 위한 제네릭 타입의 헬퍼를 추가합니다.
- `chunk_size`와 `chunk_overlap`에 대해 splitter 속성 접근자가 정수 타입을 반환하도록 제한하고, `Any` 사용을 제거합니다.
- 누락된 splitter 속성에 대한 로그 중복을 줄이고 심각도를 낮춘 새로운 로깅 방식을 도입하여 로그 노이즈를 방지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen TextChunker splitter attribute typing and reduce redundant logging when expected splitter attributes are missing.

Enhancements:
- Add a generically-typed helper for reading splitter attributes to preserve static type safety for chunk_size and chunk_overlap.
- Constrain splitter attribute accessors to integer return types for chunk_size and chunk_overlap and remove Any usage.
- Introduce de-duplicated, lower-severity logging for missing splitter attributes to avoid log noise.

</details>