### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/chunking.py
+++ b/backend/chunking.py
@@ -8,13 +8,11 @@ FlowNote MVP - 텍스트 청킹
 
 
 import logging
-from typing import Any, Optional, Dict, List, TypeVar, cast, Set, Tuple
+from typing import Any, Optional, Dict, List, Set, Tuple
 
 from langchain_text_splitters import TextSplitter, RecursiveCharacterTextSplitter
 
 logger = logging.getLogger(__name__)
-
-T = TypeVar("T", bound=int)
 
 
 class TextChunker:
@@ -55,32 +53,70 @@ class TextChunker:
                 chunk_size=chunk_size, chunk_overlap=chunk_overlap, **kwargs
             )
 
-        self._warned_missing_attrs: Set[Tuple[str, str]] = set()
+        self._warned_missing_attrs: Set[Tuple[int, str, str, str]] = set()
 
     def _get_splitter_attr(
         self, attr_name: str, fallback_attr: Optional[str] = None
-    ) -> Optional[T]:
-        """스플리터에서 동적으로 속성을 읽어옵니다 (Public 및 명시적 Fallback 속성 지원).
-
-        제네릭 반환 타입을 사용하여 호출 지점에서 정적 타입 안정성을 유지합니다.
-        예: ``chunk_size: Optional[int] = self._get_splitter_attr("chunk_size")``
-        """
+    ) -> Optional[int]:
+        """스플리터에서 동적으로 속성을 읽어옵니다 (Public 및 명시적 Fallback 속성 지원)."""
         # 1. Public 속성 시도
         if hasattr(self._splitter, attr_name):
-            return cast(Optional[T], getattr(self._splitter, attr_name))
+            val = getattr(self._splitter, attr_name)
+            if val is None:
+                return None
+            if isinstance(val, int) and not isinstance(val, bool):
+                return val
+            try:
+                return int(val)  # type: ignore
+            except (ValueError, TypeError):
+                logger.warning(
+                    f"Attribute '{attr_name}' on {type(self._splitter).__name__} is not a valid int",
+                    extra={
+                        "context": {
+                            "splitter_id": id(self._splitter),
+                            "splitter_type": type(self._splitter).__name__,
+                            "attr_name": attr_name,
+                            "invalid_type": type(val).__name__,
+                        }
+                    },
+                )
 
         # 2. Private/Fallback 속성 시도
         private_attr = fallback_attr or f"_{attr_name}"
         if hasattr(self._splitter, private_attr):
-            return cast(Optional[T], getattr(self._splitter, private_attr))
+            val = getattr(self._splitter, private_attr)
+            if val is None:
+                return None
+            if isinstance(val, int) and not isinstance(val, bool):
+                return val
+            try:
+                return int(val)  # type: ignore
+            except (ValueError, TypeError):
+                logger.warning(
+                    f"Attribute '{private_attr}' on {type(self._splitter).__name__} is not a valid int",
+                    extra={
+                        "context": {
+                            "splitter_id": id(self._splitter),
+                            "splitter_type": type(self._splitter).__name__,
+                            "private_attr": private_attr,
+                            "invalid_type": type(val).__name__,
+                        }
+                    },
+                )
 
         # 3. 양쪽 모두 없을 경우, 중복 로깅 방지 후 info 레벨로 기록 (침묵 회피)
-        missing_attr_key = (attr_name, private_attr)
+        missing_attr_key = (
+            id(self._splitter),
+            type(self._splitter).__name__,
+            attr_name,
+            private_attr,
+        )
         if missing_attr_key not in self._warned_missing_attrs:
             logger.info(
                 f"Could not find '{attr_name}' or '{private_attr}' on {type(self._splitter).__name__}",
                 extra={
                     "context": {
+                        "splitter_id": id(self._splitter),
                         "splitter_type": type(self._splitter).__name__,
                         "attr_name": attr_name,
                         "private_attr": private_attr,
@@ -94,14 +130,12 @@ class TextChunker:
     @property
     def chunk_size(self) -> Optional[int]:
         """현재 스플리터에 설정된 chunk_size 동적 반환 (런타임 변경 반영)"""
-        chunk_size_val: Optional[int] = self._get_splitter_attr("chunk_size")
-        return chunk_size_val
+        return self._get_splitter_attr("chunk_size")
 
     @property
     def chunk_overlap(self) -> Optional[int]:
         """현재 스플리터에 설정된 chunk_overlap 동적 반환 (런타임 변경 반영)"""
-        chunk_overlap_val: Optional[int] = self._get_splitter_attr("chunk_overlap")
-        return chunk_overlap_val
+        return self._get_splitter_attr("chunk_overlap")
 
     def chunk_text(self, text: str) -> List[str]:
         """텍스트를 청크 단위로 분할"""


### PR DESCRIPTION
🐛 fix [#11.2.1]: 10차 개선 - TextChunker 제네릭 복잡성 제거 및 로그 고유 키 고도화 
🐛 fix [#11.2.1]: 11차 개선 - _get_splitter_attr 런타임 타입 검증 고도화 및 인스턴스별 로그 독립성 보장

## Summary by Sourcery

런타임 견고성과 인스턴스별 격리를 위해 TextChunker의 splitter 속성 처리 및 로깅을 개선합니다.

개선 사항:
- `_get_splitter_attr`에서 제네릭 반환 타입을 제거하고 `Optional[int]`로 표준화하여 TextChunker를 단순화했습니다.
- `_get_splitter_attr`에 런타임 타입 검증, 안전한 정수 변환, 잘못된 속성에 대한 더 설명적인 경고를 추가하여 기능을 강화했습니다.
- 로깅 키와 저장되는 경고 상태를 splitter 인스턴스별로 관리하도록 개선하여, 인스턴스 간 로그 억제 현상을 방지하고 관측 가능성을 향상했습니다.
- `chunk_size`와 `chunk_overlap` 프로퍼티가 공용 속성 접근자에 직접 위임하도록 단순화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve TextChunker splitter attribute handling and logging for runtime robustness and per-instance isolation.

Enhancements:
- Simplify TextChunker by removing generic return typing from _get_splitter_attr and standardizing it to Optional[int].
- Strengthen _get_splitter_attr with runtime type validation, safe int coercion, and more descriptive warnings when attributes are invalid.
- Enhance logging keys and stored warning state to be splitter-instance specific, preventing cross-instance log suppression and improving observability.
- Streamline chunk_size and chunk_overlap properties to directly delegate to the shared attribute accessor.

</details>