### PR TITLE
🐛 fix [#11.2.1]: 12차 개선 - TextChunker의 헬퍼 추상화 및 에러 값 안전 표출 반영

### DIFF
--- a/backend/chunking.py
+++ b/backend/chunking.py
@@ -55,14 +55,21 @@ class TextChunker:
 
         self._warned_missing_attrs: Set[Tuple[int, str, str, str]] = set()
 
+    MAX_INVALID_VALUE_REPR_LEN: int = 100
+
+    def _get_splitter_context(self) -> Dict[str, Any]:
+        return {
+            "splitter_id": id(self._splitter),
+            "splitter_type": type(self._splitter).__name__,
+        }
+
     def _coerce_splitter_int_attr(
-        self, attr_name: str, *, private: bool = False
+        self, attr_name: str, *, is_private: bool = False
     ) -> Optional[int]:
-        name = f"_{attr_name}" if private else attr_name
-        if not hasattr(self._splitter, name):
+        if not hasattr(self._splitter, attr_name):
             return None
 
-        val = getattr(self._splitter, name)
+        val = getattr(self._splitter, attr_name)
         if val is None:
             return None
         if isinstance(val, int) and not isinstance(val, bool):
@@ -72,44 +79,47 @@ class TextChunker:
             return int(val)  # type: ignore[arg-type]
         except (ValueError, TypeError):
             val_repr = repr(val)
-            safe_val = val_repr[:100] + "..." if len(val_repr) > 100 else val_repr
-            context: Dict[str, Any] = {
-                "splitter_id": id(self._splitter),
-                "splitter_type": type(self._splitter).__name__,
-                "invalid_type": type(val).__name__,
-                "invalid_value": safe_val,
-            }
-            if private:
-                context["private_attr"] = name
-            else:
-                context["attr_name"] = name
+            max_len = self.MAX_INVALID_VALUE_REPR_LEN
+            safe_val = (
+                val_repr[:max_len] + "..." if len(val_repr) > max_len else val_repr
+            )
+
+            context = self._get_splitter_context()
+            context.update(
+                {
+                    "invalid_type": type(val).__name__,
+                    "invalid_value": safe_val,
+                    "private_attr" if is_private else "attr_name": attr_name,
+                }
+            )
 
             logger.warning(
-                f"Attribute '{name}' on {type(self._splitter).__name__} is not a valid int",
+                f"Attribute '{attr_name}' on {context['splitter_type']} is not a valid int",
                 extra={"context": context},
             )
             return None
 
     def _log_missing_splitter_attr(self, attr_name: str, private_attr: str) -> None:
+        context = self._get_splitter_context()
         missing_attr_key = (
-            id(self._splitter),
-            type(self._splitter).__name__,
+            context["splitter_id"],
+            context["splitter_type"],
             attr_name,
             private_attr,
         )
         if missing_attr_key in self._warned_missing_attrs:
             return
 
+        context.update(
+            {
+                "attr_name": attr_name,
+                "private_attr": private_attr,
+            }
+        )
+
         logger.info(
-            f"Could not find '{attr_name}' or '{private_attr}' on {type(self._splitter).__name__}",
-            extra={
-                "context": {
-                    "splitter_id": id(self._splitter),
-                    "splitter_type": type(self._splitter).__name__,
-                    "attr_name": attr_name,
-                    "private_attr": private_attr,
-                }
-            },
+            f"Could not find '{attr_name}' or '{private_attr}' on {context['splitter_type']}",
+            extra={"context": context},
         )
         self._warned_missing_attrs.add(missing_attr_key)
 
@@ -118,13 +128,13 @@ class TextChunker:
     ) -> Optional[int]:
         """스플리터에서 동적으로 속성을 읽어옵니다 (Public 및 명시적 Fallback 속성 지원)."""
         # 1. Public 속성 시도
-        val = self._coerce_splitter_int_attr(attr_name, private=False)
+        val = self._coerce_splitter_int_attr(attr_name, is_private=False)
         if val is not None:
             return val
 
         # 2. Private/Fallback 속성 시도
         private_attr = fallback_attr or f"_{attr_name}"
-        val = self._coerce_splitter_int_attr(private_attr, private=True)
+        val = self._coerce_splitter_int_attr(private_attr, is_private=True)
         if val is not None:
             return val
 


### PR DESCRIPTION
- **[backend/chunking.py]**:
  - [_get_splitter_attr](backend/chunking.py:115:4-132:19) 함수에 혼재되어 있던 타입 캐스팅, 조건 판별, 예외 핸들링 분기의 중복 코드를 신규 헬퍼 함수([_coerce_splitter_int_attr](backend/chunking.py:57:4-90:23), [_log_missing_splitter_attr](backend/chunking.py:92:4-113:56))로 완전히 분리 추출하여 DRY(Don't Repeat Yourself) 원칙 달성 및 복잡도(Complexity) 대폭 하향 조정
  - 런타임 타입 검사 중 비정상 값(Non-int) 적발 시 발생하는 `logger.warning` 내부 구조화된 Context에, 오류의 실제 값을 최대 100자로 안전하게 자른(Safe Truncated) 문자열 형식(`invalid_value`)을 추가하여 보안/개인정보 유출 리스크 없이 강력한 디버깅 분석 편의성(Debuggability) 제공
  - `@ai_bot_review_summary` 기준에 근거한 완전 무결성(Robust Constraint) 유지 및 E2E 테스트 통과 확인

🔗 Related:
- Issue [#507]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/519#pullrequestreview-3835505394)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro

## Summary by Sourcery

TextChunker에서 splitter 속성 처리 방식을 리팩터링하여 중복을 줄이고, 잘못되었거나 누락된 splitter 속성에 대한 로깅의 안정성을 개선했습니다.

개선 사항:
- splitter 정수 속성을 강제 형변환(coercing)하고 누락된 splitter 속성을 로깅하는 도우미 메서드를 추출하여 `_get_splitter_attr` 로직을 단순화하고 중복을 제거했습니다.
- splitter 속성 값이 잘못된 경우, 해당 값의 문자열 표현을 안전하게 잘라(truncate) 포함하도록 경고 로그를 강화하면서도 프라이버시는 유지했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor splitter attribute handling in TextChunker to reduce duplication and improve logging robustness for invalid or missing splitter attributes.

Enhancements:
- Extract helper methods for coercing splitter integer attributes and logging missing splitter attributes to simplify and de-duplicate _get_splitter_attr logic.
- Enhance warning logs for invalid splitter attribute values by including a safely truncated string representation of the offending value while preserving privacy.

</details>