### PR TITLE
✨ build [#11.2.2]: 하이브리드 검색 레이어 구축을 위한 rank_bm25 의존성 추가

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -133,3 +133,4 @@ xxhash==3.6.0
 zipp==3.23.0
 zstandard==0.25.0
 exceptiongroup>=1.0.0; python_version < '3.11'
+rank-bm25==0.2.2


### PR DESCRIPTION
- **[requirements.txt]**:
  - 기존 밀집 벡터(FAISS) 검색을 보완하기 위해 키워드 기반의 희소 벡터 알고리즘 적용 목적
  - Python 환경 표준 BM25 검색 유틸리티인 `rank_bm25` 패키지 의존성 명시적 추가
  - 검색 결과의 교차 보정(RRF) 파이프라인(Hybrid Search) 생성을 위한 기반 환경 세팅 완료

🔗 Related: Issue [#507]

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro