### PR TITLE
✨ feat [#11.2.3]: 하이브리드 검색 레이어 구축을 위한 BM25 희소 벡터 검색 엔진 기본 구현

### DIFF
--- a/backend/bm25_search.py
+++ b/backend/bm25_search.py
@@ -6,122 +6,145 @@
 FlowNote MVP - BM25 희소 벡터(키워드) 검색
 """
 
-import sys
-from pathlib import Path
-
-# 프로젝트 루트를 Python 경로에 추가
-project_root = Path(__file__).parent.parent
-sys.path.insert(0, str(project_root))
-
-from typing import List, Dict, Optional
+import logging
+from typing import List, Dict, Optional, Any
 from rank_bm25 import BM25Okapi
+
+logger = logging.getLogger(__name__)
+
 
 class BM25Retriever:
     """BM25 (Rank BM25) 기반 희소 벡터(키워드) 검색"""
-    
+
     def __init__(self):
         self.bm25: Optional[BM25Okapi] = None
         self.documents: List[Dict] = []
-        
+
     def _tokenize(self, text: str) -> List[str]:
         """간단한 띄어쓰기 기반 토크나이징"""
+        if not text or not isinstance(text, str):
+            return []
         # 영문의 경우 소문자화하여 검색 품질을 높임
-        return text.lower().split()
-        
-    def add_documents(self, documents: List[Dict]):
+        return text.strip().lower().split()
+
+    def add_documents(self, documents: List[Dict[str, Any]]):
         """
         문서 추가 및 BM25 인덱스 빌드
-        
+
         Args:
             documents: 문서 dict 리스트 (content, metadata 포함)
         """
         if not documents:
             return
-            
-        self.documents.extend(documents)
-        
-        # rank_bm25는 점진적 추가가 아닌 전체 데이터 코퍼스를 한 번에 빌드해야 함
-        corpus = [self._tokenize(doc["content"]) for doc in self.documents]
-        self.bm25 = BM25Okapi(corpus)
-        print(f"✅ BM25 인덱스 빌드 완료 (총 {len(self.documents)}개 문서)")
 
-    def search(self, query: str, k: int = 3) -> List[Dict]:
+        valid_docs = [
+            doc for doc in documents if isinstance(doc, dict) and "content" in doc
+        ]
+        if not valid_docs:
+            logger.warning("유효한 문서가 없습니다.", extra={"context": len(documents)})
+            return
+
+        self.documents.extend(valid_docs)
+
+        # rank_bm25는 점진적 추가가 아닌 전체 데이터 코퍼스를 한 번에 빌드해야 함
+        corpus = [self._tokenize(doc.get("content", "")) for doc in self.documents]
+        self.bm25 = BM25Okapi(corpus)
+        logger.info("BM25 인덱스 빌드 완료 (총 %d개 문서)", len(self.documents))
+
+    def search(
+        self, query: str, k: int = 3, filter_zero_score: bool = True
+    ) -> List[Dict[str, Any]]:
         """
         쿼리에 가장 유사한 문서 검색
-        
+
         Args:
             query: 검색 쿼리
             k: 반환할 결과 수
-            
+            filter_zero_score: 점수가 0인 문서(연관성 없음)를 필터링할지 여부
+
         Returns:
             검색 결과 리스트 (content, metadata, score 포함)
         """
-        if not self.bm25 or not self.documents:
+        if not self.bm25 or not self.documents or not query:
             return []
-            
+
         tokenized_query = self._tokenize(query)
         doc_scores = self.bm25.get_scores(tokenized_query)
-        
+
         # 높은 점수 순으로 정렬
-        top_k_indices = sorted(range(len(doc_scores)), key=lambda i: doc_scores[i], reverse=True)[:k]
-        
+        top_k_indices = sorted(
+            range(len(doc_scores)), key=lambda i: doc_scores[i], reverse=True
+        )[:k]
+
         results = []
         for idx in top_k_indices:
-            score = doc_scores[idx]
-            if score > 0: # 점수가 0보다 큰(연관성 있는) 문서만 반환
-                doc = self.documents[idx]
-                results.append({
-                    "content": doc["content"],
-                    "metadata": doc["metadata"],
-                    "score": float(score),
-                    "distance": 0.0 # BM25는 distance 개념 대신 score를 사용
-                })
-                
+            score = float(doc_scores[idx])
+            if filter_zero_score and score <= 0.0:
+                continue
+
+            doc = self.documents[idx]
+            results.append(
+                {
+                    "content": doc.get("content", ""),
+                    "metadata": doc.get("metadata", {}),
+                    "score": score,
+                    # distance 필드는 하이브리드 RRF 레이어 구현 시 혼선의 원인(zero-distance-hack)이 될 수 있어 제거됨
+                }
+            )
+
         return results
-        
+
     def clear(self):
         """인덱스 초기화"""
         self.bm25 = None
         self.documents = []
-        
+
     def size(self) -> int:
         """인덱스에 저장된 문서 수"""
         return len(self.documents)
 
+
 if __name__ == "__main__":
-    print("=" * 50)
-    print("BM25 검색 테스트")
-    print("=" * 50)
-    
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logger.info("=" * 50)
+    logger.info("BM25 검색 테스트")
+    logger.info("=" * 50)
+
     retriever = BM25Retriever()
-    
+
     docs = [
         {
             "content": "FlowNote는 AI 대화 관리 도구입니다.",
-            "metadata": {"source": "test.txt", "chunk_index": 0}
+            "metadata": {"source": "test.txt", "chunk_index": 0},
         },
         {
             "content": "대화 내용을 검색하고 분석할 수 있습니다.",
-            "metadata": {"source": "test.txt", "chunk_index": 1}
+            "metadata": {"source": "test.txt", "chunk_index": 1},
         },
         {
             "content": "마크다운으로 대화를 내보낼 수 있습니다.",
-            "metadata": {"source": "test.txt", "chunk_index": 2}
-        }
+            "metadata": {"source": "test.txt", "chunk_index": 2},
+        },
     ]
-    
+
     retriever.add_documents(docs)
-    
+
     query = "대화를 어떻게 관리하나요"
-    print(f"\n🔍 검색 쿼리: '{query}'")
+    logger.info("\n🔍 검색 쿼리: '%s'", query)
     results = retriever.search(query, k=2)
-    
-    print(f"\n검색 결과 ({len(results)}개):")
-    print("-" * 50)
+
+    logger.info("\n검색 결과 (%d개):", len(results))
+    logger.info("-" * 50)
     for i, result in enumerate(results, 1):
-        print(f"\n{i}위:")
-        print(f"    - 점수: {result['score']:.4f}")
-        print(f"    - 내용: {result['content']}")
-        print(f"    - 출처: {result['metadata']['source']}")
-    
-    print("\n" + "=" * 50)
+        logger.info("\n%d위:", i)
+        logger.info("    - 점수: %.4f", result["score"])
+        # 보안 측면을 고려하여 테스트 로그에서도 내용의 일부만 마스킹하여 출력
+        content_preview = result.get("content", "")[:15] + (
+            "..." if len(result.get("content", "")) > 15 else ""
+        )
+        logger.info("    - 내용: %s", content_preview)
+        logger.info(
+            "    - 출처: %s", result.get("metadata", {}).get("source", "unknown")
+        )
+
+    logger.info("\n" + "=" * 50)


### PR DESCRIPTION
- **[backend/bm25_search.py]**:
  - `rank_bm25` 패키지의 `BM25Okapi`를 활용한 [BM25Retriever](backend/bm25_search.py:18:0-88:34) 클래스 신규 작성
  - 기존 밀집 벡터(FAISS) 검색 모듈([FAISSRetriever](backend/faiss_search.py:21:0-114:32))과 인터페이스를 맞추기 위해 [add_documents()](backend/bm25_search.py:30:4-45:88), [search()](backend/bm25_search.py:47:4-79:22) 메서드 형태를 통일
  - 1차적으로 가장 가볍고 최적화된 '띄어쓰기 기준' 영문 소문자화 토크나이징 로직 적용
  - RRF 병합에 활용하기 위해 문서 내용, 메타데이터, 점수(Score)를 딕셔너리 리스트로 반환하도록 구성

🔗 Related: Issue [#507]

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro

## Summary by Sourcery

기존의 밀집 벡터 엔진과 함께 하이브리드 검색을 지원하기 위해 BM25 기반의 희소 키워드 검색 리트리버를 추가합니다.

New Features:
- 문서 내용을 대상으로 키워드 기반 희소 벡터 검색을 제공하기 위해 `rank_bm25`를 사용하는 `BM25Retriever` 클래스를 도입합니다.
- 기존 FAISS 리트리버 인터페이스와 정렬을 맞추기 위해, 검색 결과를 `content`, `metadata`, `score`, `distance`를 포함한 딕셔너리 형태로 반환합니다.

Tests:
- 샘플 문서와 쿼리를 사용해 BM25 검색을 수동으로 검증하기 위한 인라인 메인 테스트 하네스를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a BM25-based sparse keyword search retriever to support hybrid search alongside the existing dense vector engine.

New Features:
- Introduce a BM25Retriever class using rank_bm25 to provide keyword-based sparse vector search over document content.
- Return search results as dictionaries containing content, metadata, score, and distance to align with the existing FAISS retriever interface.

Tests:
- Add an inline main test harness for manual BM25 search verification with sample documents and queries.

</details>