### PR TITLE
♻️ refactor [#11.2.3]: 2차 개선 - BM25 희소 검색 모듈 성능 및 안정성 최적화

### DIFF
--- a/backend/bm25_search.py
+++ b/backend/bm25_search.py
@@ -25,15 +25,61 @@ class BM25Retriever:
 
     def __init__(self, tokenizer: Optional[Callable[[str], List[str]]] = None):
         self.bm25: Optional[BM25Okapi] = None
-        self.documents: List[Dict] = []
-        self.tokenizer = tokenizer or self._default_tokenize
+        self.documents: List[Dict[str, Any]] = []
+
+        # 외부 토크나이저 주입 처리 방어
+        if tokenizer is not None and not callable(tokenizer):
+            logger.warning(
+                "제공된 토크나이저가 호출 가능하지 않습니다. 기본 토크나이저를 사용합니다."
+            )
+            self.tokenizer = self._default_tokenize
+        else:
+            self.tokenizer = tokenizer or self._default_tokenize
 
     def _default_tokenize(self, text: str) -> List[str]:
         """간단한 띄어쓰기 기반 토크나이징"""
-        if not text or not isinstance(text, str):
+        # _safe_tokenize에서 이미 str 타입 여부 및 빈 문자열을 검증하므로 바로 처리
+        return text.lower().split()
+
+    def _safe_tokenize(self, text: Any) -> List[str]:
+        """텍스트를 받아 안전하게 토크나이징을 수행하는 헬퍼 메서드"""
+        if not isinstance(text, str):
+            text = str(text) if text is not None else ""
+
+        text = text.strip()
+        if not text:
             return []
-        # 영문의 경우 소문자화하여 검색 품질을 높임
-        return text.strip().lower().split()
+
+        try:
+            tokens = self.tokenizer(text)
+            if not isinstance(tokens, list):
+                logger.warning(
+                    "토크나이저 반환값이 리스트가 아닙니다.",
+                    extra={"context": type(tokens).__name__},
+                )
+                return []
+            return tokens
+        except Exception as e:
+            logger.exception(
+                "토크나이징 중 예상치 못한 에러가 발생했습니다.",
+                extra={"context": type(e).__name__},
+            )
+            return []
+
+    def _rebuild_index(self):
+        """현재 저장된 문서를 기반으로 BM25 인덱스를 재구성합니다."""
+        if not self.documents:
+            self.bm25 = None
+            return
+
+        # NOTE:
+        # 현재 구현은 문서가 추가될 때마다 전체 코퍼스를 기반으로 BM25 인덱스를
+        # 다시 빌드합니다. 이는 O(N) 동작이며, 상대적으로 작은/거의 정적인 코퍼스를
+        # 대상으로 하는 간단한 구현입니다. 더 큰 코퍼스나 잦은 업데이트가 필요한
+        # 경우에는 별도의 `build_index()` 단계와 배치 추가 전략을 고려해야 합니다.
+        corpus = [self._safe_tokenize(doc.get("content", "")) for doc in self.documents]
+        self.bm25 = BM25Okapi(corpus)
+        logger.info("BM25 인덱스 빌드 완료 (총 %d개 문서)", len(self.documents))
 
     def add_documents(self, documents: List[Dict[str, Any]]):
         """
@@ -53,15 +99,7 @@ class BM25Retriever:
             return
 
         self.documents.extend(valid_docs)
-
-        # NOTE:
-        # 현재 구현은 문서가 추가될 때마다 전체 코퍼스를 기반으로 BM25 인덱스를
-        # 다시 빌드합니다. 이는 O(N) 동작이며, 상대적으로 작은/거의 정적인 코퍼스를
-        # 대상으로 하는 간단한 구현입니다. 더 큰 코퍼스나 잦은 업데이트가 필요한
-        # 경우에는 별도의 `build_index()` 단계와 배치 추가 전략을 고려해야 합니다.
-        corpus = [self.tokenizer(doc.get("content", "")) for doc in self.documents]
-        self.bm25 = BM25Okapi(corpus)
-        logger.info("BM25 인덱스 빌드 완료 (총 %d개 문서)", len(self.documents))
+        self._rebuild_index()
 
     def search(
         self, query: str, k: int = 3, filter_zero_score: bool = True
@@ -77,13 +115,18 @@ class BM25Retriever:
         Returns:
             검색 결과 리스트 (content, metadata, score 포함)
         """
-        if query is not None:
-            query = query.strip()
+        if not isinstance(query, str):
+            logger.warning(
+                "검색 쿼리가 문자열이 아닙니다. 문자열로 변환하여 처리합니다.",
+                extra={"context": type(query).__name__},
+            )
+            query = str(query) if query is not None else ""
 
+        query = query.strip()
         if not self.bm25 or not self.documents or not query:
             return []
 
-        tokenized_query = self.tokenizer(query)
+        tokenized_query = self._safe_tokenize(query)
         # Avoid meaningless searches on empty token lists
         if not tokenized_query:
             return []


### PR DESCRIPTION
- **[backend/bm25_search.py]**:
  - `add_documents` 동작의 O(N) 성능 한계를 명확화하는 모듈 레벨 Docstring 및 인라인 노트 첨부
  - 다국어 처리 확장을 고려하여 외부 토크나이저 주입(DI)이 가능하도록 `__init__` 상 토크나이저 속성 추가
  - `search` 수행 시 공백 쿼리 및 의미 없는 빈 토큰(`[]`) 입력을 조기 차단하여 무의미한 연산 방지

🔗 Related:
- Issue [#507]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/525#pullrequestreview-3837357810)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro

## Summary by Sourcery

BM25 검색기의 인덱싱 특성을 명확히 하고, 커스텀 토크나이저를 허용하며, 비어 있거나 잘못된 쿼리에 대해 검색 동작을 더 견고하게 만듭니다.

개선 사항:
- 문서를 추가할 때 BM25 인덱스를 재구성하는 과정의 O(N) 복잡도와 의도된 사용 패턴을 문서화합니다.
- 커스텀 및 다국어 토크나이징 전략을 지원하기 위해 BM25 검색기에 설정 가능한 토크나이저를 주입합니다.
- 기본 토크나이징 로직의 이름을 정리하고 중앙집중화하며, 전체 코퍼스와 쿼리 토크나이징을 모두 설정 가능한 토크나이저를 통해 수행되도록 변경합니다.
- 비어 있거나 공백만 있는 쿼리, 혹은 토크나이징 결과 토큰이 없는 쿼리에 대해서는 검색을 바로 중단하여 불필요한 BM25 점수 계산 작업을 방지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify BM25 retriever indexing characteristics, allow custom tokenizers, and harden search behavior against empty or invalid queries.

Enhancements:
- Document the O(N) complexity and intended usage pattern of BM25 index rebuilding when adding documents.
- Inject a configurable tokenizer into the BM25 retriever to support custom and multilingual tokenization strategies.
- Rename and centralize the default tokenization logic while routing all corpus and query tokenization through the configurable tokenizer.
- Short-circuit searches for empty, whitespace-only, or tokenization-empty queries to avoid unnecessary BM25 scoring work.

</details>