### PR TITLE
♻️ refactor [#11.2.3]: 4차 개선 - BM25 외부 토크나이저 호환성 및 객체 무결성 방어

### DIFF
--- a/backend/bm25_search.py
+++ b/backend/bm25_search.py
@@ -23,9 +23,21 @@ logger = logging.getLogger(__name__)
 class BM25Retriever:
     """BM25 (Rank BM25) 기반 희소 벡터(키워드) 검색"""
 
-    def __init__(self, tokenizer: Optional[Callable[[str], List[str]]] = None):
+    def __init__(
+        self,
+        tokenizer: Optional[Callable[[str], List[str]]] = None,
+        coerce_all_strings: bool = False,
+    ):
+        """
+        BM25 검색 엔진 초기화
+
+        Args:
+            tokenizer: 사용자 지정 토크나이저. 반환되는 이터러블/제너레이터는 즉시 `list()`로 소비됩니다.
+            coerce_all_strings: `dict`나 `list` 등 비문자열 객체가 content로 들어왔을 때, 조용히 건너뛰지 않고 무조건 `str()`로 강제 변환할지 여부.
+        """
         self.bm25: Optional[BM25Okapi] = None
         self.documents: List[Dict[str, Any]] = []
+        self.coerce_all_strings = coerce_all_strings
 
         # 외부 토크나이저 주입 처리 방어
         if tokenizer is not None and not callable(tokenizer):
@@ -41,16 +53,21 @@ class BM25Retriever:
         # _safe_tokenize에서 이미 str 타입 여부 및 빈 문자열을 검증하므로 바로 처리
         return text.lower().split()
 
-    def _safe_tokenize(self, text: Any) -> List[str]:
+    def _safe_tokenize(
+        self, text: Any, doc_metadata: Optional[Dict] = None
+    ) -> List[str]:
         """텍스트를 받아 안전하게 토크나이징을 수행하는 헬퍼 메서드"""
         if not isinstance(text, str):
-            # 스칼라(숫자, 불리언)만 안전하게 캐스팅하고 딕셔너리, 리스트 등은 무시
-            if isinstance(text, (int, float, bool)):
-                text = str(text)
+            # 스칼라(숫자, 불리언)이거나 설정 상 강제 문자열 변환이 켜져있을 경우
+            if self.coerce_all_strings or isinstance(text, (int, float, bool)):
+                text = str(text) if text is not None else ""
             else:
+                hint = (
+                    doc_metadata.get("source", "unknown") if doc_metadata else "unknown"
+                )
                 logger.warning(
-                    "문자열 또는 단순 스칼라 값이 아닌 데이터가 포함되어 토크나이징을 건너뜁니다.",
-                    extra={"context": type(text).__name__},
+                    "문자열 또는 단순 스칼라 값이 아닌 데이터가 포함되어 토크나이징을 건너뜁니다. (coerce_all_strings=True 필요)",
+                    extra={"context": type(text).__name__, "doc_source": hint},
                 )
                 return []
 
@@ -60,6 +77,15 @@ class BM25Retriever:
 
         try:
             tokens = self.tokenizer(text)
+
+            # 토크나이저가 문자열을 반환하면 list('text') -> ['t', 'e', 'x', 't'] 로 산산조각 나는 것을 방지
+            if isinstance(tokens, (str, bytes)):
+                logger.warning(
+                    "토크나이저 반환값이 문자열/바이트입니다. 문자 단위 분해가 일어나지 않도록 기본 토크나이저로 대체합니다.",
+                    extra={"context": type(tokens).__name__},
+                )
+                return self._default_tokenize(text)
+
             try:
                 tokens = list(tokens)
             except TypeError:
@@ -86,7 +112,12 @@ class BM25Retriever:
         # 현재 구현은 리빌드 호출 시 전체 코퍼스를 기반으로 BM25 인덱스를 재구성합니다.
         # 대량의 문서가 업데이트될 경우 add_documents(..., rebuild=False) 호출 후
         # 마지막에 build_index()를 한 번만 호출하는 배치 처리를 권장합니다.
-        corpus = [self._safe_tokenize(doc.get("content", "")) for doc in self.documents]
+        corpus = [
+            self._safe_tokenize(
+                doc.get("content", ""), doc_metadata=doc.get("metadata", {})
+            )
+            for doc in self.documents
+        ]
         self.bm25 = BM25Okapi(corpus)
         logger.info("BM25 인덱스 빌드 완료 (총 %d개 문서)", len(self.documents))
 


### PR DESCRIPTION
- **[backend/bm25_search.py]**:
  - `_safe_tokenize`에서 문자열이나 스칼라 값만 변환을 허용하고, 복합 객체(Dict, List 등)는 강제 변환(`str`)하지 않고 빈 리스트로 처리하여 코퍼스 오염 방지
  - 외부 써드파티 토크나이저(Generator, Tuple 반환 등)의 유연한 호환성을 위해 `list()` 래핑 구조를 적용하고 `TypeError` 시에만 기본 동작(`_default_tokenize`)으로 폴백하도록 예외 처리 분할
  - `add_documents`에 `rebuild=True` 옵션을 추가하고 명시적 `build_index` 메서드를 외부로 노출하여 O(N) 병목을 방지하는 배치 업데이트 지원 체계 마련

🔗 Related:
- Issue [#507]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/527#pullrequestreview-3837492580)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro

## Summary by Sourcery

BM25 토크나이저의 안정성을 개선하고, 배치 문서 업데이트 시 인덱스를 명시적으로 재구성할 수 있는 제어 기능을 추가합니다.

새로운 기능:
- BM25 인덱스를 명시적으로 (재)구성하기 위한 public 메서드 `build_index` 를 노출합니다.
- 매 호출마다 인덱스를 재구성하지 않고 배치 업데이트를 지원할 수 있도록 `add_documents` 에 `rebuild` 플래그를 추가합니다.

개선 사항:
- 코퍼스가 손상되는 것을 방지하기 위해 `_safe_tokenize` 를 강화하여 문자열이 아니거나 스칼라가 아닌 객체는 건너뛰도록 했습니다.
- 토크나이저 출력을 일반적인 iterable로 취급하고, 변환에 실패할 경우 기본 토크나이저로 폴백하도록 하여 외부 토크나이저와의 호환성을 개선했습니다.
- 폴백 동작을 명확히 하기 위해 토크나이저 관련 문제에 대한 로그 메시지를 개선했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve BM25 tokenizer robustness and add explicit index rebuild controls for batch document updates.

New Features:
- Expose a public build_index method to explicitly (re)build the BM25 index.
- Add a rebuild flag to add_documents to support batch updates without rebuilding on every call.

Enhancements:
- Harden _safe_tokenize to skip non-string, non-scalar objects to avoid corrupting the corpus.
- Improve compatibility with external tokenizers by treating tokenizer outputs as generic iterables and falling back to the default tokenizer when conversion fails.
- Enhance logging messages for tokenizer-related issues to clarify fallback behavior.

</details>