### PR TITLE
♻️ refactor [#11.2.3]: 6차 개선 - 검색 인덱스 무결성 강화 및 데이터 누락 파이프라인 디버깅 개선

### DIFF
--- a/backend/bm25_search.py
+++ b/backend/bm25_search.py
@@ -21,7 +21,14 @@ logger = logging.getLogger(__name__)
 
 
 class BM25Retriever:
-    """BM25 (Rank BM25) 기반 희소 벡터(키워드) 검색"""
+    """
+    BM25 (Rank BM25) 기반 희소 벡터(키워드) 검색
+
+    주의 (Side-Effect):
+        내부 무결성 보장을 위해, 인덱스를 재빌드(rebuild)할 때
+        비정상적인 형식의 데이터나 유효한 키워드 토큰을 생성하지 못하는(비어있는) 문서는
+        상위 호출자의 의도와 상관없이 `self.documents` 배열 리스트에서 영구적으로 제외(Filter-out)됩니다.
+    """
 
     def __init__(
         self,
@@ -105,7 +112,11 @@ class BM25Retriever:
     def _rebuild_index(self):
         """
         [내부 헬퍼 메서드] 현재 저장된 문서를 기반으로 BM25 인덱스를 재구성합니다.
-        외부 호출자는 명시적 빌드가 필요한 경우 public API인 `build_index()`를 사용하세요.
+
+        주의:
+            이 메서드는 유효한 키워드가 없는 문서나 딕셔너리가 아닌 항목을
+            `self.documents` 리스트에서 영구적으로 필터링 및 제거 변경(mutate)합니다.
+            외부 호출자는 명시적 빌드가 필요한 경우 public API인 `build_index()`를 사용하세요.
         """
         if not self.documents:
             self.bm25 = None
@@ -114,12 +125,18 @@ class BM25Retriever:
         valid_corpus = []
         valid_docs = []
         empty_count = 0
+        invalid_type_count = 0
 
         # NOTE:
         # 현재 구현은 리빌드 호출 시 전체 코퍼스를 기반으로 BM25 인덱스를 재구성합니다.
         # 대량의 문서가 업데이트될 경우 add_documents(..., rebuild=False) 호출 후
         # 마지막에 build_index()를 한 번만 호출하는 배치 처리를 권장합니다.
         for doc in self.documents:
+            # 레거시 데이터나 외부 강제 주입 등의 이유로 dict가 아닌 값이 들어왔을 경우 방어
+            if not isinstance(doc, dict):
+                invalid_type_count += 1
+                continue
+
             metadata = doc.get("metadata", {})
             tokens = self._safe_tokenize(doc.get("content", ""), doc_metadata=metadata)
 
@@ -130,6 +147,12 @@ class BM25Retriever:
                 valid_docs.append(doc)
 
         self.documents = valid_docs
+
+        if invalid_type_count > 0:
+            logger.warning(
+                "딕셔너리(dict) 타입이 아닌 비정상 항목 %d개를 인덱스 재빌드 과정에서 영구 제외했습니다.",
+                invalid_type_count,
+            )
 
         if empty_count > 0:
             logger.warning(
@@ -151,6 +174,11 @@ class BM25Retriever:
     def add_documents(self, documents: List[Dict[str, Any]], rebuild: bool = True):
         """
         문서 추가 및 BM25 인덱스 빌드
+
+        주의:
+            성공적으로 추가된 문서라 하더라도, `rebuild=True`에 의해 즉시 실행되거나 향후
+            `build_index()`에 의해 실행되는 인덱스 재구성 과정에서 유효한 검색 토큰(단어)을
+            만들어내지 못하는 문서들은 `self.documents` 배열에서 조용히 제거(Filter-out)됩니다.
 
         Args:
             documents: 문서 dict 리스트 (content, metadata 포함)


### PR DESCRIPTION
- **[backend/bm25_search.py]**:
  - `doc_metadata`에 대한 `.get()` 호출 전 `hasattr(..., "get")` 가드 로직을 추가하여 `AttributeError` 예방 및 비-딕셔너리 메타데이터로 인한 크래시 방어
  - `add_documents` 시 문서 유효성 검증 탈락(문서 형식이 다르거나 content 누락) 사유와 누락된 개수를 명확히 로깅하여 상위 파이프라인의 데이터 오염을 쉽게 추적 가능하게 개선
  - `_rebuild_index`에서 유효한 키워드가 없는 문서를 BM25 인덱스(`corpus`)와 실제 문서 리스트(`self.documents`)에서 동기화하여 제거하고, 제외된 수량을 로깅함으로써 매칭 불일치(out-of-sync) 버그 및 오작동 예방
  - `_rebuild_index`를 내부 호출용 Private 메서드로 명시(docstring)하고 사용자에게는 Public API인 `build_index()` 사용을 안내하여 캡슐화 명확화

🔗 Related:
- Issue [#507]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/529#pullrequestreview-3837564515)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro

## Summary by Sourcery

인덱스를 재구축하는 동안 문서와 토큰을 검증하고 메타데이터 처리를 강화함으로써 BM25 검색 인덱스의 견고성을 향상합니다.

버그 수정:
- 로깅 힌트를 생성하는 동안 딕셔너리가 아닌 문서 메타데이터에 접근할 때 발생하는 `AttributeError`를 방지합니다.
- 유효한 토큰이 없는 문서를 필터링하고, 문서 목록을 인덱스와 정렬된 상태로 유지하여 BM25 인덱스가 서로 맞지 않게(out-of-sync) 되는 문제를 방지합니다.

개선 사항:
- `add_documents` 로깅을 개선하여 잘못된 문서를 거부한 개수와 이유를 보고하고, 유효한 문서가 없을 때는 작업을 깔끔하게 건너뜁니다.
- docstring을 업데이트하여 내부 헬퍼인 `_rebuild_index`와 공개 API인 `build_index`의 의도된 사용 방식의 차이를 명확히 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen BM25 search index robustness by validating documents and tokens during index rebuild and by hardening metadata handling.

Bug Fixes:
- Prevent AttributeError when accessing non-dict document metadata while generating logging hints.
- Avoid out-of-sync BM25 indices by filtering out documents with no valid tokens and keeping the document list aligned with the index.

Enhancements:
- Improve add_documents logging by reporting counts and reasons for rejecting invalid documents, and skip work cleanly when no valid documents exist.
- Clarify the intended usage of the internal _rebuild_index helper versus the public build_index API via updated docstring.

</details>