### PR TITLE
♻️ refactor [#11.2.3]: 8차 개선 - BM25 필터링 책임 분리 및 데이터 유실 지표(Stats) 수집 체계화

### DIFF
--- a/backend/bm25_search.py
+++ b/backend/bm25_search.py
@@ -15,10 +15,38 @@ FlowNote MVP - BM25 희소 벡터(키워드) 검색
 
 import logging
 from collections.abc import Mapping
-from typing import List, Dict, Optional, Any, Callable, Tuple
+from typing import (
+    List,
+    Dict,
+    Optional,
+    Any,
+    Callable,
+    Tuple,
+    NamedTuple,
+    TypedDict,
+    Union,
+)
 from rank_bm25 import BM25Okapi
 
 logger = logging.getLogger(__name__)
+
+
+class IndexFilterResult(NamedTuple):
+    """BM25 인덱스 생성 시 문서 필터링 결과를 나타내는 컨테이너."""
+
+    valid_docs: List[Dict[str, Any]]
+    corpus_tokens: List[List[str]]
+    invalid_type_count: int
+    empty_token_count: int
+    invalid_samples: List[str]
+    empty_samples: List[str]
+
+
+class AddDocumentsResult(TypedDict):
+    """문서 추가 후 통계 데이터를 나타내는 타입 딕셔너리."""
+
+    rejected_format: int
+    rebuild_stats: Dict[str, int]
 
 
 class BM25Retriever:
@@ -110,14 +138,12 @@ class BM25Retriever:
             )
             return self._default_tokenize(text)
 
-    def _filter_documents_for_index(
-        self,
-    ) -> Tuple[List[Dict[str, Any]], List[List[str]], int, int, List[str], List[str]]:
+    def _filter_documents_for_index(self) -> IndexFilterResult:
         """
         인덱스 생성을 위한 유효 문서를 필터링하고 통계를 수집합니다.
 
         Returns:
-            (valid_docs, corpus_tokens, invalid_type_count, empty_token_count, invalid_samples, empty_samples)
+            IndexFilterResult: 문서와 코퍼스 및 필터링된 문서 정보
         """
         valid_docs: List[Dict[str, Any]] = []
         corpus: List[List[str]] = []
@@ -151,13 +177,13 @@ class BM25Retriever:
             valid_docs.append(doc)
             corpus.append(tokens)
 
-        return (
-            valid_docs,
-            corpus,
-            invalid_type_count,
-            empty_count,
-            invalid_samples,
-            empty_samples,
+        return IndexFilterResult(
+            valid_docs=valid_docs,
+            corpus_tokens=corpus,
+            invalid_type_count=invalid_type_count,
+            empty_token_count=empty_count,
+            invalid_samples=invalid_samples,
+            empty_samples=empty_samples,
         )
 
     def _rebuild_index(self) -> Dict[str, int]:
@@ -172,22 +198,18 @@ class BM25Retriever:
         Returns:
             필터링 과정에서 제거된 문서들의 통계 딕셔너리
         """
-        stats = {"removed_invalid_type": 0, "removed_empty_token": 0}
+        stats: Dict[str, int] = {"removed_invalid_type": 0, "removed_empty_token": 0}
 
         if not self.documents:
             self.bm25 = None
             return stats
 
-        (
-            valid_docs,
-            corpus,
-            invalid_count,
-            empty_count,
-            invalid_samples,
-            empty_samples,
-        ) = self._filter_documents_for_index()
+        filter_result = self._filter_documents_for_index()
 
-        self.documents = valid_docs
+        self.documents = filter_result.valid_docs
+        invalid_count = filter_result.invalid_type_count
+        empty_count = filter_result.empty_token_count
+
         stats["removed_invalid_type"] = invalid_count
         stats["removed_empty_token"] = empty_count
 
@@ -195,21 +217,21 @@ class BM25Retriever:
             logger.warning(
                 "딕셔너리(dict) 타입이 아닌 비정상 항목 %d개를 인덱스 재빌드 과정에서 영구 제외했습니다. (샘플: %s)",
                 invalid_count,
-                ", ".join(invalid_samples),
+                ", ".join(filter_result.invalid_samples),
             )
 
         if empty_count > 0:
             logger.warning(
                 "유효한 키워드 토큰이 없는 문서 %d개를 인덱스에서 제외했습니다. (샘플 출처: %s)",
                 empty_count,
-                ", ".join(empty_samples),
+                ", ".join(filter_result.empty_samples),
             )
 
-        if not corpus:
+        if not filter_result.corpus_tokens:
             self.bm25 = None
             return stats
 
-        self.bm25 = BM25Okapi(corpus)
+        self.bm25 = BM25Okapi(filter_result.corpus_tokens)
         logger.info("BM25 인덱스 빌드 완료 (총 %d개 문서)", len(self.documents))
         return stats
 
@@ -224,7 +246,7 @@ class BM25Retriever:
 
     def add_documents(
         self, documents: List[Dict[str, Any]], rebuild: bool = True
-    ) -> Dict[str, Any]:
+    ) -> AddDocumentsResult:
         """
         문서 추가 및 BM25 인덱스 빌드
 
@@ -240,7 +262,7 @@ class BM25Retriever:
         Returns:
             추가 및 재빌드 과정에서 제거된 처리 통계를 담은 딕셔너리
         """
-        stats: Dict[str, Any] = {"rejected_format": 0, "rebuild_stats": {}}
+        stats: AddDocumentsResult = {"rejected_format": 0, "rebuild_stats": {}}
         if not documents:
             return stats
 


### PR DESCRIPTION
- **[backend/bm25_search.py]**:
  - `_safe_tokenize` 내부에서 `doc_metadata`에 대해 `hasattr` 대신 명확한 `isinstance(..., Mapping)` 검증을 도입하여 의도치 않은 객체 속성 평가 버그를 원천 차단
  - `_rebuild_index` 내부에 혼재되어 있던 복잡한 필터링/수집 로직을 `_filter_documents_for_index` 헬퍼 메서드로 분리하여 단일 책임 원칙(SRP) 강화 및 메서드 복잡도 하향
  - `add_documents` 및 인덱스 재빌드 시 발생하는 문서 필터링 내역(Dictionary가 아닌 포맷, 빈 토큰 등)을 `stats` 딕셔너리로 집계하고 반환하도록 개선하여, 상위 호출자가 로깅에만 의존하지 않고 코드 단에서 데이터 유실에 프로그래밍 방식으로 대응할 수 있도록 아키텍처 고도화
  - 데이터 제외(Filtering) 시 Warning 로깅에 단순 개수뿐만 아니라 문제가 발생한 원본 문서의 메타데이터 샘플(`source` 등)을 추가 포함시켜 상위 파이프라인(Upstream)에서의 디버깅 편의성 극대화

🔗 Related:
- Issue [#507]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/531#pullrequestreview-3837619740)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro

## Summary by Sourcery

BM25 인덱스 재구성을 리팩터링하여 문서 필터링을 인덱스 구성 과정과 분리하고, 필터링되거나 거부된 문서에 대한 구조화된 통계를 도입합니다.

신규 기능:
- BM25 인덱스 재구성 및 문서 추가 시 구조화된 통계를 반환하여 데이터 손실을 프로그램적으로 파악할 수 있도록 합니다.

개선 사항:
- BM25 문서 필터링 및 토크나이즈 준비 과정을 전용 헬퍼로 분리하여 인덱스 재구성을 단순화하고 책임 범위를 명확히 합니다.
- 문서를 토크나이즈할 때 메타데이터의 타입 체크를 강화하여 매핑 타입이 아닌 객체에 대한 의도치 않은 속성 접근을 방지합니다.
- 상류 디버깅과 모니터링을 지원하기 위해 잘못되었거나 비어 있는 문서의 대표 샘플을 경고 로그에 포함하여 로그를 더욱 풍부하게 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor BM25 index rebuilding to separate document filtering from index construction and introduce structured statistics for filtered or rejected documents.

New Features:
- Return structured statistics from BM25 index rebuild and document addition to surface data loss programmatically.

Enhancements:
- Extract BM25 document filtering and tokenization preparation into a dedicated helper to simplify index rebuilding and clarify responsibilities.
- Strengthen metadata type checking when tokenizing documents to avoid unintended attribute access on non-mapping objects.
- Enrich warning logs with representative samples of invalid or empty documents to aid upstream debugging and monitoring.

</details>