### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/bm25_search.py
+++ b/backend/bm25_search.py
@@ -14,10 +14,39 @@ FlowNote MVP - BM25 희소 벡터(키워드) 검색
 """
 
 import logging
-from typing import List, Dict, Optional, Any, Callable
+from collections.abc import Mapping
+from typing import (
+    List,
+    Dict,
+    Optional,
+    Any,
+    Callable,
+    Tuple,
+    NamedTuple,
+    TypedDict,
+    Union,
+)
 from rank_bm25 import BM25Okapi
 
 logger = logging.getLogger(__name__)
+
+
+class IndexFilterResult(NamedTuple):
+    """BM25 인덱스 생성 시 문서 필터링 결과를 나타내는 컨테이너."""
+
+    valid_docs: List[Dict[str, Any]]
+    corpus_tokens: List[List[str]]
+    invalid_type_count: int
+    empty_token_count: int
+    invalid_samples: List[str]
+    empty_samples: List[str]
+
+
+class AddDocumentsResult(TypedDict):
+    """문서 추가 후 통계 데이터를 나타내는 타입 딕셔너리."""
+
+    rejected_format: int
+    rebuild_stats: Dict[str, int]
 
 
 class BM25Retriever:
@@ -70,7 +99,7 @@ class BM25Retriever:
                 text = str(text) if text is not None else ""
             else:
                 hint = "unknown"
-                if doc_metadata and hasattr(doc_metadata, "get"):
+                if isinstance(doc_metadata, Mapping):
                     hint = doc_metadata.get("source", "unknown")
                 logger.warning(
                     "문자열 또는 단순 스칼라 값이 아닌 데이터가 포함되어 토크나이징을 건너뜁니다. (coerce_all_strings=True 필요)",
@@ -109,32 +138,26 @@ class BM25Retriever:
             )
             return self._default_tokenize(text)
 
-    def _rebuild_index(self):
+    def _filter_documents_for_index(self) -> IndexFilterResult:
         """
-        [내부 헬퍼 메서드] 현재 저장된 문서를 기반으로 BM25 인덱스를 재구성합니다.
+        인덱스 생성을 위한 유효 문서를 필터링하고 통계를 수집합니다.
 
-        주의:
-            이 메서드는 유효한 키워드가 없는 문서나 딕셔너리가 아닌 항목을
-            `self.documents` 리스트에서 영구적으로 필터링 및 제거 변경(mutate)합니다.
-            외부 호출자는 명시적 빌드가 필요한 경우 public API인 `build_index()`를 사용하세요.
+        Returns:
+            IndexFilterResult: 문서와 코퍼스 및 필터링된 문서 정보
         """
-        if not self.documents:
-            self.bm25 = None
-            return
-
-        valid_corpus = []
-        valid_docs = []
-        empty_count = 0
+        valid_docs: List[Dict[str, Any]] = []
+        corpus: List[List[str]] = []
         invalid_type_count = 0
+        empty_count = 0
+        invalid_samples: List[str] = []
+        empty_samples: List[str] = []
 
-        # NOTE:
-        # 현재 구현은 리빌드 호출 시 전체 코퍼스를 기반으로 BM25 인덱스를 재구성합니다.
-        # 대량의 문서가 업데이트될 경우 add_documents(..., rebuild=False) 호출 후
-        # 마지막에 build_index()를 한 번만 호출하는 배치 처리를 권장합니다.
         for doc in self.documents:
-            # 레거시 데이터나 외부 강제 주입 등의 이유로 dict가 아닌 값이 들어왔을 경우 방어
+            # 레거시 데이터나 외부 강제 주입 방어
             if not isinstance(doc, dict):
                 invalid_type_count += 1
+                if len(invalid_samples) < 3:
+                    invalid_samples.append(type(doc).__name__)
                 continue
 
             metadata = doc.get("metadata", {})
@@ -142,36 +165,88 @@ class BM25Retriever:
 
             if not tokens:
                 empty_count += 1
-            else:
-                valid_corpus.append(tokens)
-                valid_docs.append(doc)
+                if len(empty_samples) < 3:
+                    hint = (
+                        metadata.get("source", "unknown")
+                        if isinstance(metadata, Mapping)
+                        else "unknown"
+                    )
+                    empty_samples.append(str(hint))
+                continue
 
-        self.documents = valid_docs
+            valid_docs.append(doc)
+            corpus.append(tokens)
 
-        if invalid_type_count > 0:
+        return IndexFilterResult(
+            valid_docs=valid_docs,
+            corpus_tokens=corpus,
+            invalid_type_count=invalid_type_count,
+            empty_token_count=empty_count,
+            invalid_samples=invalid_samples,
+            empty_samples=empty_samples,
+        )
+
+    def _rebuild_index(self) -> Dict[str, int]:
+        """
+        [내부 헬퍼 메서드] 현재 저장된 문서를 기반으로 BM25 인덱스를 재구성합니다.
+
+        주의:
+            이 메서드는 유효한 키워드가 없는 문서나 딕셔너리가 아닌 항목을
+            `self.documents` 리스트에서 영구적으로 필터링 및 제거 변경(mutate)합니다.
+            외부 호출자는 명시적 빌드가 필요한 경우 public API인 `build_index()`를 사용하세요.
+
+        Returns:
+            필터링 과정에서 제거된 문서들의 통계 딕셔너리
+        """
+        stats: Dict[str, int] = {"removed_invalid_type": 0, "removed_empty_token": 0}
+
+        if not self.documents:
+            self.bm25 = None
+            return stats
+
+        filter_result = self._filter_documents_for_index()
+
+        self.documents = filter_result.valid_docs
+        invalid_count = filter_result.invalid_type_count
+        empty_count = filter_result.empty_token_count
+
+        stats["removed_invalid_type"] = invalid_count
+        stats["removed_empty_token"] = empty_count
+
+        if invalid_count > 0:
             logger.warning(
-                "딕셔너리(dict) 타입이 아닌 비정상 항목 %d개를 인덱스 재빌드 과정에서 영구 제외했습니다.",
-                invalid_type_count,
+                "딕셔너리(dict) 타입이 아닌 비정상 항목 %d개를 인덱스 재빌드 과정에서 영구 제외했습니다. (샘플: %s)",
+                invalid_count,
+                ", ".join(filter_result.invalid_samples),
             )
 
         if empty_count > 0:
             logger.warning(
-                "유효한 키워드 토큰이 없는 문서 %d개를 인덱스에서 제외했습니다.",
+                "유효한 키워드 토큰이 없는 문서 %d개를 인덱스에서 제외했습니다. (샘플 출처: %s)",
                 empty_count,
+                ", ".join(filter_result.empty_samples),
             )
 
-        if not self.documents:
+        if not filter_result.corpus_tokens:
             self.bm25 = None
-            return
+            return stats
 
-        self.bm25 = BM25Okapi(valid_corpus)
+        self.bm25 = BM25Okapi(filter_result.corpus_tokens)
         logger.info("BM25 인덱스 빌드 완료 (총 %d개 문서)", len(self.documents))
+        return stats
 
-    def build_index(self):
-        """명시적으로 BM25 인덱스를 (재)빌드합니다. 배치 업데이트 후 사용하세요."""
-        self._rebuild_index()
+    def build_index(self) -> Dict[str, int]:
+        """
+        명시적으로 BM25 인덱스를 (재)빌드합니다. 배치 업데이트 후 사용하세요.
 
-    def add_documents(self, documents: List[Dict[str, Any]], rebuild: bool = True):
+        Returns:
+            제외된 문서들의 통계 딕셔너리
+        """
+        return self._rebuild_index()
+
+    def add_documents(
+        self, documents: List[Dict[str, Any]], rebuild: bool = True
+    ) -> AddDocumentsResult:
         """
         문서 추가 및 BM25 인덱스 빌드
 
@@ -183,29 +258,53 @@ class BM25Retriever:
         Args:
             documents: 문서 dict 리스트 (content, metadata 포함)
             rebuild: 문서 추가 후 즉시 인덱스를 재빌드할지 여부
+
+        Returns:
+            추가 및 재빌드 과정에서 제거된 처리 통계를 담은 딕셔너리
         """
+        stats: AddDocumentsResult = {"rejected_format": 0, "rebuild_stats": {}}
         if not documents:
-            return
+            return stats
 
         initial_count = len(documents)
-        valid_docs = [
-            doc for doc in documents if isinstance(doc, dict) and "content" in doc
-        ]
+        valid_docs = []
+        rejected_samples = []
+
+        for doc in documents:
+            if isinstance(doc, dict) and "content" in doc:
+                valid_docs.append(doc)
+            else:
+                if len(rejected_samples) < 3:
+                    if isinstance(doc, dict):
+                        metadata = doc.get("metadata")
+                        hint = (
+                            metadata.get("source", "unknown")
+                            if isinstance(metadata, Mapping)
+                            else "unknown"
+                        )
+                        rejected_samples.append(f"Content missing (source: {hint})")
+                    else:
+                        rejected_samples.append(type(doc).__name__)
 
         rejected_count = initial_count - len(valid_docs)
+        stats["rejected_format"] = rejected_count
+
         if rejected_count > 0:
             logger.warning(
-                "형식이 잘못된 문서 %d개를 추가 대상에서 제외했습니다 (dict 타입이 아니거나 'content' 키 누락).",
+                "형식이 잘못된 문서 %d개를 추가 대상에서 제외했습니다. 샘플: %s",
                 rejected_count,
+                ", ".join(rejected_samples),
             )
 
         if not valid_docs:
             logger.warning("유효한 문서가 없어 추가 작업을 건너뜁니다.")
-            return
+            return stats
 
         self.documents.extend(valid_docs)
         if rebuild:
-            self._rebuild_index()
+            stats["rebuild_stats"] = self._rebuild_index()
+
+        return stats
 
     def search(
         self, query: str, k: int = 3, filter_zero_score: bool = True


### PR DESCRIPTION
♻️ refactor [#11.2.3]: 8차 개선 - BM25 필터링 책임 분리 및 데이터 유실 지표(Stats) 수집 체계화 
♻️ refactor [#11.2.3]: 9차 개선 - NamedTuple 및 TypedDict 도입으로 리턴 타입 컨트랙트 강건성 확보

## Summary by Sourcery

BM25 검색기의 문서 처리를 개선하기 위해, 인덱스 필터링을 인덱스 재구성과 분리하고, 거부되거나 필터링된 문서에 대한 구조화된 통계를 추가합니다.

New Features:
- 타입이 지정된 반환 값을 통해 BM25 인덱스 재구성과 문서 추가에 대한 구조화된 통계를 노출합니다.

Enhancements:
- 타입 계약과 관측 가능성을 강화하기 위해 BM25 인덱스 필터링 및 `add_documents` 결과에 전용 컨테이너(`NamedTuple` 및 `TypedDict`)를 도입합니다.
- BM25 인덱싱 중 잘못된 문서 타입, 토큰이 비어 있는 문서, 형식이 잘못된 입력에 대해 샘플링된 예시를 로그에 남기도록 로깅을 개선합니다.
- 토크나이즈 및 통계 수집 과정에서 선택적 메타데이터 필드를 읽을 때 `Mapping` 검사를 사용하여 메타데이터 처리를 강화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine BM25 retriever document handling by separating index filtering from index rebuilding and adding structured statistics about rejected or filtered documents.

New Features:
- Expose structured statistics for BM25 index rebuilds and document additions via typed return values.

Enhancements:
- Introduce dedicated containers (NamedTuple and TypedDict) for BM25 index filtering and add_documents results to strengthen type contracts and observability.
- Improve logging with sampled examples for invalid document types, empty-token documents, and malformed inputs during BM25 indexing.
- Harden metadata handling by using Mapping checks when reading optional metadata fields during tokenization and stats collection.

</details>