### PR TITLE
♻️ refactor [#11.2.3]: 10차 개선 - 통계 반환 타입 복잡도 제거 및 관측성(Observability) …

### DIFF
--- a/backend/bm25_search.py
+++ b/backend/bm25_search.py
@@ -28,6 +28,14 @@ from rank_bm25 import BM25Okapi
 logger = logging.getLogger(__name__)
 
 
+def _format_samples(samples: List[str], total_count: int, max_visible: int = 3) -> str:
+    """로그에 출력할 샘플 리스트 문자열 포맷팅 헬퍼. 정해진 개수를 초과하면 '...'을 붙입니다."""
+    samples_str = ", ".join(samples[:max_visible])
+    if total_count > max_visible:
+        samples_str += ", ..."
+    return samples_str
+
+
 class BM25Retriever:
     """
     BM25 (Rank BM25) 기반 희소 벡터(키워드) 검색
@@ -173,7 +181,8 @@ class BM25Retriever:
             외부 호출자는 명시적 빌드가 필요한 경우 public API인 `build_index()`를 사용하세요.
 
         Returns:
-            필터링 과정에서 제거된 문서들의 통계 딕셔너리
+            필터링 과정에서 제거된 문서들의 통계 딕셔너리.
+            (이 반환값은 외부에서 직접 소비되지 않으며, 주로 `add_documents`의 내부 통계 병합용으로 사용됩니다.)
         """
         stats: Dict[str, int] = {
             "removed_invalid_type": 0,
@@ -191,23 +200,21 @@ class BM25Retriever:
         stats["removed_empty_token"] = filter_stats["removed_empty_token"]
 
         if stats["removed_invalid_type"] > 0:
-            samples_str = ", ".join(filter_stats["invalid_samples"])
-            if stats["removed_invalid_type"] > 3:
-                samples_str += ", ..."
             logger.warning(
                 "딕셔너리(dict) 타입이 아닌 비정상 항목 %d개를 인덱스 재빌드 과정에서 영구 제외했습니다. (샘플: %s)",
                 stats["removed_invalid_type"],
-                samples_str,
+                _format_samples(
+                    filter_stats["invalid_samples"], stats["removed_invalid_type"]
+                ),
             )
 
         if stats["removed_empty_token"] > 0:
-            samples_str = ", ".join(filter_stats["empty_samples"])
-            if stats["removed_empty_token"] > 3:
-                samples_str += ", ..."
             logger.warning(
                 "유효한 키워드 토큰이 없는 문서 %d개를 인덱스에서 제외했습니다. (샘플 출처: %s)",
                 stats["removed_empty_token"],
-                samples_str,
+                _format_samples(
+                    filter_stats["empty_samples"], stats["removed_empty_token"]
+                ),
             )
 
         if not corpus_tokens:
@@ -274,13 +281,10 @@ class BM25Retriever:
         stats["rejected_format"] = rejected_count
 
         if rejected_count > 0:
-            samples_str = ", ".join(rejected_samples)
-            if rejected_count > 3:
-                samples_str += ", ..."
             logger.warning(
                 "형식이 잘못된 문서 %d개를 추가 대상에서 제외했습니다. 샘플: %s",
                 rejected_count,
-                samples_str,
+                _format_samples(rejected_samples, rejected_count),
             )
 
         if not valid_docs:


### PR DESCRIPTION
…단순화 보강

- **[backend/bm25_search.py]**:
  - 오버엔지니어링(Over-engineering) 요소를 덜어내기 위해 `NamedTuple`과 `TypedDict` 등 추가 학습 비용을 요구하는 커스텀 타입(`IndexFilterResult`, `AddDocumentsResult`)을 모두 폐기하고 단순 `Tuple`과 `Dict` 조합으로 롤백하여 API 호출부의 복잡도 대폭 하향
  - `add_documents` 실행 시 `rebuild=False`이거나 문서가 없는 경우 `rebuild_stats`의 기본값을 `{}` 대신 `None`으로 설정하여 "인덱스 재구성 절차가 아예 실행되지 않음"을 외부 호출자가 명확히 구분할 수 있도록 의미론적 정확성 확보
  - `build_index`를 통계 딕셔너리를 반환하던 구조에서 부수효과(Side-Effect) 전문 함수인 `None` 반환으로 변경, 외부로 내부 메트릭이 불필요하게 노출되는 문제를 방지하고 캡슐화 보호
  - 필터링 제외 누락 규모 파악 시 3개의 샘플이 넘칠 경우, 로그 출력 후미에 `"..."` 표기를 병합하도록 개선하여 개발자 및 운영자의 디버깅 관측성(Observability) 극대화

🔗 Related:
- Issue [#507]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/533#pullrequestreview-3837649365)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro

## Summary by Sourcery

BM25 검색기의 문서 필터링과 통계 처리를 단순화하여 타입 복잡성을 줄이고 인덱싱 작업의 관측 가능성을 개선합니다.

개선 사항:
- 문서 필터링 및 `add_documents` 통계를 위한 결과 컨테이너에서 커스텀 `NamedTuple`/`TypedDict`를 제거하고, 대신 일반 `dict`/`tuple` 구조를 사용합니다.
- `build_index`가 내부 통계를 반환하지 않고 부수 효과로 인덱스를 재빌드하도록 변경하여, 메트릭을 캡슐화된 상태로 유지합니다.
- `add_documents`에서 인덱스 재빌드가 실제로 수행되었는지 건너뛰어졌는지를 명시적으로 구분하기 위해, 재빌드가 일어나지 않은 경우 `None` 값을 가지는 `rebuild_stats` 마커를 사용합니다.
- 잘못된 문서, 토큰이 비어 있는 문서, 형식이 깨진 문서에 대한 경고 로그를 개선하여, 샘플 엔트리를 요약해서 보여주고 긴 목록은 말줄임표로 잘라서 가독성을 높입니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify BM25 retriever document filtering and statistics handling to reduce type complexity and improve observability of indexing operations.

Enhancements:
- Replace custom NamedTuple/TypedDict result containers with plain dict/tuple structures for document filtering and add_documents statistics.
- Change build_index to perform index rebuild as a side-effect without returning internal statistics, keeping metrics encapsulated.
- Make add_documents explicitly distinguish between executed and skipped index rebuilds by using a None rebuild_stats marker when no rebuild occurs.
- Improve warning logs for invalid, empty-token, and malformed documents by summarizing sample entries and truncating long lists with an ellipsis for better readability.

</details>