### PR TITLE
♻️ refactor [#11.2.3]: 12차 개선 - 반환 타입 컨트랙트 최적화(TypedDict) 및 헬퍼 인자 명시

### DIFF
--- a/backend/bm25_search.py
+++ b/backend/bm25_search.py
@@ -28,6 +28,8 @@ from rank_bm25 import BM25Okapi
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_SAMPLE_MAX_VISIBLE = 3
+
 
 class FilterStats(TypedDict):
     """문서 필터링 과정에서 수집된 통계와 샘플 데이터."""
@@ -206,7 +208,7 @@ class BM25Retriever:
 
         Returns:
             필터링 과정에서 제거된 문서들의 통계 딕셔너리.
-            (이 반환값은 외부에서 직접 소비되지 않으며, 주로 `add_documents`의 내부 통계 병합용으로 사용됩니다.)
+            (이 통계는 `add_documents` 내부에서 병합되거나, 외부에서 `build_index()` 호출 시 반환되어 활용됩니다.)
         """
         stats: RebuildStats = {
             "removed_invalid_type": 0,
@@ -228,7 +230,9 @@ class BM25Retriever:
                 "딕셔너리(dict) 타입이 아닌 비정상 항목 %d개를 인덱스 재빌드 과정에서 영구 제외했습니다. (샘플: %s)",
                 stats["removed_invalid_type"],
                 _format_samples(
-                    filter_stats["invalid_samples"], stats["removed_invalid_type"], 3
+                    filter_stats["invalid_samples"],
+                    stats["removed_invalid_type"],
+                    DEFAULT_SAMPLE_MAX_VISIBLE,
                 ),
             )
 
@@ -237,7 +241,9 @@ class BM25Retriever:
                 "유효한 키워드 토큰이 없는 문서 %d개를 인덱스에서 제외했습니다. (샘플 출처: %s)",
                 stats["removed_empty_token"],
                 _format_samples(
-                    filter_stats["empty_samples"], stats["removed_empty_token"], 3
+                    filter_stats["empty_samples"],
+                    stats["removed_empty_token"],
+                    DEFAULT_SAMPLE_MAX_VISIBLE,
                 ),
             )
 
@@ -311,7 +317,9 @@ class BM25Retriever:
             logger.warning(
                 "형식이 잘못된 문서 %d개를 추가 대상에서 제외했습니다. 샘플: %s",
                 rejected_count,
-                _format_samples(rejected_samples, rejected_count, 3),
+                _format_samples(
+                    rejected_samples, rejected_count, DEFAULT_SAMPLE_MAX_VISIBLE
+                ),
             )
 
         if not valid_docs:


### PR DESCRIPTION
- **[backend/bm25_search.py]**:
  - `add_documents`와 `_filter_documents_for_index` 등에서 반환되는 통계 딕셔너리의 구조를 명확히 하고 잠재적 키(Key) 오타를 방지하기 위해 가벼운 파이썬 표준 `TypedDict` (`FilterStats`, `RebuildStats`, `AddDocumentsStats`)를 선언하여 타입 힌팅 강화
  - `build_index`에서 통계 반환을 폐기했던 것을 다시 롤백하여 `RebuildStats`를 반환하도록 복원, 외부 호출자(Public API Consumer)가 인덱스 재구성 시 유실되는 문서 통계 지표를 온전히 활용할 수 있도록 컨트랙트 재정립
  - 샘플 포맷팅 헬퍼인 `_format_samples`에서 `max_visible=3` 기본값을 제거하고, 각 호출부에서 `3`을 명시적으로 전달받도록 설계하여 로깅 가시성 통제권을 호출자에게 위임하고 기본값 의존(Magic Number) 우려 해소

🔗 Related:
- Issue [#507]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/535#pullrequestreview-3837661421)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro

## Summary by Sourcery

BM25 검색 인덱스 통계 계약 및 로깅 헬퍼를 개선합니다.

New Features:
- BM25 검색 모듈에서 필터, 재빌드, 문서 추가 통계를 위한 `TypedDict` 기반 계약을 도입합니다.

Enhancements:
- BM25 인덱스 재빌드가 외부 사용자를 위해 다시 구조화된 통계를 반환하도록 합니다.
- 전용 통계 타입을 사용해 내부 필터링 및 재빌드 헬퍼의 타입 힌트를 더 엄격하게 합니다.
- 호출자가 샘플 노출 여부를 명시적으로 제어할 수 있도록 로깅 포매터 헬퍼에서 기본 max-visible 샘플 개수를 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine BM25 search index statistics contracts and logging helpers.

New Features:
- Introduce TypedDict-based contracts for filter, rebuild, and add-documents statistics in the BM25 search module.

Enhancements:
- Make BM25 index rebuild return structured statistics again for external consumers.
- Tighten type hints for internal filtering and rebuild helpers using dedicated statistics types.
- Remove the default max-visible sample count from the logging formatter helper so callers explicitly control sample visibility.

</details>