### PR TITLE
♻️ refactor [#11.2.3]: 14차 개선 - 런타임 가드(Runtime Guard) 전수 점검 및 테스트 코드 명시성 보강

### DIFF
--- a/backend/bm25_search.py
+++ b/backend/bm25_search.py
@@ -207,8 +207,9 @@ class BM25Retriever:
             외부 호출자는 명시적 빌드가 필요한 경우 public API인 `build_index()`를 사용하세요.
 
         Returns:
-            필터링 과정에서 제거된 문서들의 통계 딕셔너리.
-            (이 통계는 `add_documents` 내부에서 병합되거나, 외부에서 `build_index()` 호출 시 반환되어 활용됩니다.)
+            RebuildStats: 필터링 과정에서 제거된 문서들의 통계 딕셔너리.
+            주의: 이 통계는 `add_documents` 내부에서 처리 결과를 병합하는 데 사용되거나,
+            public API인 `build_index()` 호출 시 반환되어 외부 관측성(Observability)을 위해 활용됩니다.
         """
         stats: RebuildStats = {
             "removed_invalid_type": 0,
@@ -420,7 +421,9 @@ if __name__ == "__main__":
         },
     ]
 
-    retriever.add_documents(docs)
+    # 문서 추가 및 인덱스 빌드 수행
+    # 반환되는 통계(AddDocumentsStats)는 테스트 목적상 로그로 이미 확인되므로 여기선 명시적으로 무시합니다.
+    _ = retriever.add_documents(docs)
 
     query = "대화를 어떻게 관리하나요"
     logger.info("\n🔍 검색 쿼리: '%s'", query)


### PR DESCRIPTION
- **[backend/bm25_search.py]**:
  - `_format_samples`의 기본 파라미터가 제거됨에 따라, 모듈 내 모든 호출부(3곳)가 필수 인자인 `DEFAULT_SAMPLE_MAX_VISIBLE`을 올바르게 전달하고 있는지 전수 조사 및 검증하여 런타임 `TypeError` 발생 가능성을 원천 차단
  - `build_index`의 반환 타입 변경(`None` -> `RebuildStats`)에 발맞추어, 하단 테스트 블록(`if __name__ == "__main__":`) 내 `add_documents` 호출 시 반환되는 통계 값을 의도적으로 무시(Ignore)함을 주석과 `_` 할당을 통해 명시적으로 표현하여 코드 가독성 및 의도 전달력 향상
  - `_rebuild_index` 메서드의 `Returns` 설명을 최신 API 명세(`build_index`의 반환)와 일치하도록 보강하여 개발자 간 협업 시 발생할 수 있는 문서 정합성 혼선 해결

🔗 Related:
- Issue [#507]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/537#pullrequestreview-3837669494)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro

## Summary by Sourcery

bm25_search 인덱스 재빌드의 반환 의미를 명확히 하고, 테스트 하니스가 `add_documents` 통계를 명시적으로 무시하도록 합니다.

Enhancements:
- 관측 가능성을 위해 `build_index`에서의 사용 방식과 `RebuildStats` 반환 타입에 맞춰 `_rebuild_index`의 docstring을 정렬합니다.
- 가독성을 위해 해당 동작을 문서화하면서, bm25_search 모듈의 테스트 하니스가 `add_documents` 통계를 명시적으로 버리도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify bm25_search index rebuild return semantics and make test harness explicitly ignore add_documents statistics.

Enhancements:
- Align _rebuild_index docstring with the RebuildStats return type and its use in build_index for observability.
- Make the bm25_search module’s test harness explicitly discard add_documents statistics while documenting that behavior for readability.

</details>