### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/bm25_search.py
+++ b/backend/bm25_search.py
@@ -207,8 +207,9 @@ class BM25Retriever:
             외부 호출자는 명시적 빌드가 필요한 경우 public API인 `build_index()`를 사용하세요.
 
         Returns:
-            필터링 과정에서 제거된 문서들의 통계 딕셔너리.
-            (이 통계는 `add_documents` 내부에서 병합되거나, 외부에서 `build_index()` 호출 시 반환되어 활용됩니다.)
+            RebuildStats: 필터링 과정에서 제거된 문서들의 통계 딕셔너리.
+            주의: 이 통계는 `add_documents` 내부에서 처리 결과를 병합하는 데 사용되거나,
+            public API인 `build_index()` 호출 시 반환되어 외부 관측성(Observability)을 위해 활용됩니다.
         """
         stats: RebuildStats = {
             "removed_invalid_type": 0,
@@ -420,7 +421,9 @@ if __name__ == "__main__":
         },
     ]
 
-    retriever.add_documents(docs)
+    # 문서 추가 및 인덱스 빌드 수행
+    # 반환되는 통계(AddDocumentsStats)는 테스트 목적상 로그로 이미 확인되므로 여기선 명시적으로 무시합니다.
+    _ = retriever.add_documents(docs)
 
     query = "대화를 어떻게 관리하나요"
     logger.info("\n🔍 검색 쿼리: '%s'", query)


### PR DESCRIPTION
♻️ refactor [#11.2.3]: 14차 개선 - 런타임 가드(Runtime Guard) 전수 점검 및 테스트 코드 명시성 강화

## Summary by Sourcery

BM25 인덱스 재구성 통계의 의미를 명확히 하고, 예제 사용 코드에서 테스트의 명확성을 위해 `add_documents` 반환 값을 명시적으로 무시하도록 수정합니다.

Enhancements:
- 관측 가능성을 위해 `RebuildStats` 반환 타입과 그 사용법을 문서화하도록 `_rebuild_index` docstring을 개선합니다.

Tests:
- 의도를 더 분명히 드러내기 위해 예제/테스트 코드에서 `add_documents`의 `AddDocumentsStats` 반환 값을 명시적으로 버리도록 조정합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify BM25 index rebuild statistics semantics and make example usage explicitly ignore add_documents return value for test clarity.

Enhancements:
- Improve _rebuild_index docstring to document the RebuildStats return type and its use for observability.

Tests:
- Adjust example/test code to explicitly discard the AddDocumentsStats return value from add_documents for clearer intent.

</details>