### PR TITLE
♻️ refactor [#11.2.4]: 4차 개선 - ID 누락 시 해시 기반 중복 제거 로직 안정성 검증 완료

### DIFF
--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -41,9 +41,13 @@ class StaticRetriever:
         return self._results[:k]
 
 
-def _make_doc(content: str, doc_id: str, **metadata_overrides: Any) -> Dict[str, Any]:
-    """테스트용 문서 객체 생성 헬퍼"""
-    metadata = {"id": doc_id}
+def _make_doc(
+    content: str, doc_id: str = None, **metadata_overrides: Any
+) -> Dict[str, Any]:
+    """테스트용 문서 객체 생성 헬퍼 (ID 선택 가능)"""
+    metadata = {}
+    if doc_id:
+        metadata["id"] = doc_id
     metadata.update(metadata_overrides)
     return {"content": content, "metadata": metadata, "score": 1.0}
 
@@ -195,35 +199,23 @@ def test_one_engine_empty_results():
 def test_hybrid_searcher_deduplicates_hash_key_when_id_missing():
     """
     metadata['id']가 없을 때 (content, source, chunk_index) 해시를 통한 중복 제거 검증.
+    내용(content)이 같더라도 메타데이터가 다르면 별개 문서로 취급되어야 함을 확인.
     """
-    # 1. 병합되어야 하는 쌍 (내용, 출처, 인덱스 동일)
-    shared_content = "shared content"
+    shared_content = "same content for all docs"
     shared_source = "shared-source"
     shared_chunk_idx = 0
 
-    shared_doc_faiss = {
-        "content": shared_content,
-        "metadata": {"source": shared_source, "chunk_index": shared_chunk_idx},
-        "score": 0.8,
-    }
-    shared_doc_bm25 = {
-        "content": shared_content,
-        "metadata": {"source": shared_source, "chunk_index": shared_chunk_idx},
-        "score": 0.9,
-    }
+    # 1. 병합되어야 하는 쌍 (내용, 출처, 인덱스 모두 동일)
+    shared_doc_faiss = _make_doc(
+        shared_content, source=shared_source, chunk_index=shared_chunk_idx
+    )
+    shared_doc_bm25 = _make_doc(
+        shared_content, source=shared_source, chunk_index=shared_chunk_idx
+    )
 
-    # 2. 병합되지 않아야 하는 쌍 (내용은 같으나 출처/인덱스 다름)
-    variant_content = "variant content"
-    variant_doc_faiss = {
-        "content": variant_content,
-        "metadata": {"source": "source-faiss", "chunk_index": 0},
-        "score": 0.7,
-    }
-    variant_doc_bm25 = {
-        "content": variant_content,
-        "metadata": {"source": "source-bm25", "chunk_index": 1},
-        "score": 0.6,
-    }
+    # 2. 병합되지 않아야 하는 쌍 (내용은 같으나 출처/인덱스가 다름 -> 서로 다른 논리적 문서)
+    variant_doc_faiss = _make_doc(shared_content, source="source-faiss", chunk_index=10)
+    variant_doc_bm25 = _make_doc(shared_content, source="source-bm25", chunk_index=20)
 
     faiss_retriever = StaticRetriever([shared_doc_faiss, variant_doc_faiss])
     bm25_retriever = StaticRetriever([shared_doc_bm25, variant_doc_bm25])
@@ -235,13 +227,19 @@ def test_hybrid_searcher_deduplicates_hash_key_when_id_missing():
     # shared_doc 1개(병합) + variant 2개(분리) = 총 3개 결과 기대
     assert len(results) == 3
 
-    # shared_doc 병합 여부 확인
-    shared_results = [r for r in results if r["content"] == shared_content]
+    # shared_doc 병합 여부 확인 (특정 출처/인덱스 조합이 하나만 존재하는지)
+    shared_results = [
+        r
+        for r in results
+        if r["metadata"].get("source") == shared_source
+        and r["metadata"].get("chunk_index") == shared_chunk_idx
+    ]
     assert len(shared_results) == 1
 
-    # variant_doc 분리 여부 확인
-    variant_results = [r for r in results if r["content"] == variant_content]
-    assert len(variant_results) == 2
+    # variant_doc들이 분리되어 존재하는지 확인
+    variant_sources = {r["metadata"].get("source") for r in results}
+    assert "source-faiss" in variant_sources
+    assert "source-bm25" in variant_sources
 
 
 def test_hybrid_searcher_deduplicates_same_metadata_id():


### PR DESCRIPTION
- **[tests/unit/test_hybrid_search.py]**:
  - metadata['id']가 없는 환경에서의 content/source/chunk_idx 조합 해시 식별 로직 검증 테스트 신설
  - 복합 속성 일치 시 병합(Merge) 및 부분 불일치 시 보존(Dinstinct) 정책에 대한 듀얼 시나리오 테스트 구축
  - pytest 기반 자동화 테스트 셋을 총 12개 케이스로 확장하여 RRF 엔진의 신뢰성 극대화

🔗 Related:
- Issue [#507]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/543#pullrequestreview-3841431994)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro

## Summary by Sourcery

Tests:
- 메타데이터 ID가 없는 경우에도 하이브리드 검색이 content/source/chunk_index를 사용해 결과를 중복 제거하면서, 서로 다른 변형(variants)은 그대로 유지하는지 확인하는 단위 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Add unit test ensuring hybrid search deduplicates results using content/source/chunk_index when metadata IDs are absent, while preserving distinct variants.

</details>