### PR TITLE
Feature/issue 4 rag pipeline

### DIFF
--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -41,9 +41,13 @@ class StaticRetriever:
         return self._results[:k]
 
 
-def _make_doc(content: str, doc_id: str, **metadata_overrides: Any) -> Dict[str, Any]:
-    """테스트용 문서 객체 생성 헬퍼"""
-    metadata = {"id": doc_id}
+def _make_doc(
+    content: str, doc_id: str = None, **metadata_overrides: Any
+) -> Dict[str, Any]:
+    """테스트용 문서 객체 생성 헬퍼 (ID 선택 가능)"""
+    metadata = {}
+    if doc_id:
+        metadata["id"] = doc_id
     metadata.update(metadata_overrides)
     return {"content": content, "metadata": metadata, "score": 1.0}
 
@@ -195,35 +199,23 @@ def test_one_engine_empty_results():
 def test_hybrid_searcher_deduplicates_hash_key_when_id_missing():
     """
     metadata['id']가 없을 때 (content, source, chunk_index) 해시를 통한 중복 제거 검증.
+    내용(content)이 같더라도 메타데이터가 다르면 별개 문서로 취급되어야 함을 확인.
     """
-    # 1. 병합되어야 하는 쌍 (내용, 출처, 인덱스 동일)
-    shared_content = "shared content"
+    shared_content = "same content for all docs"
     shared_source = "shared-source"
     shared_chunk_idx = 0
 
-    shared_doc_faiss = {
-        "content": shared_content,
-        "metadata": {"source": shared_source, "chunk_index": shared_chunk_idx},
-        "score": 0.8,
-    }
-    shared_doc_bm25 = {
-        "content": shared_content,
-        "metadata": {"source": shared_source, "chunk_index": shared_chunk_idx},
-        "score": 0.9,
-    }
+    # 1. 병합되어야 하는 쌍 (내용, 출처, 인덱스 모두 동일)
+    shared_doc_faiss = _make_doc(
+        shared_content, source=shared_source, chunk_index=shared_chunk_idx
+    )
+    shared_doc_bm25 = _make_doc(
+        shared_content, source=shared_source, chunk_index=shared_chunk_idx
+    )
 
-    # 2. 병합되지 않아야 하는 쌍 (내용은 같으나 출처/인덱스 다름)
-    variant_content = "variant content"
-    variant_doc_faiss = {
-        "content": variant_content,
-        "metadata": {"source": "source-faiss", "chunk_index": 0},
-        "score": 0.7,
-    }
-    variant_doc_bm25 = {
-        "content": variant_content,
-        "metadata": {"source": "source-bm25", "chunk_index": 1},
-        "score": 0.6,
-    }
+    # 2. 병합되지 않아야 하는 쌍 (내용은 같으나 출처/인덱스가 다름 -> 서로 다른 논리적 문서)
+    variant_doc_faiss = _make_doc(shared_content, source="source-faiss", chunk_index=10)
+    variant_doc_bm25 = _make_doc(shared_content, source="source-bm25", chunk_index=20)
 
     faiss_retriever = StaticRetriever([shared_doc_faiss, variant_doc_faiss])
     bm25_retriever = StaticRetriever([shared_doc_bm25, variant_doc_bm25])
@@ -235,13 +227,19 @@ def test_hybrid_searcher_deduplicates_hash_key_when_id_missing():
     # shared_doc 1개(병합) + variant 2개(분리) = 총 3개 결과 기대
     assert len(results) == 3
 
-    # shared_doc 병합 여부 확인
-    shared_results = [r for r in results if r["content"] == shared_content]
+    # shared_doc 병합 여부 확인 (특정 출처/인덱스 조합이 하나만 존재하는지)
+    shared_results = [
+        r
+        for r in results
+        if r["metadata"].get("source") == shared_source
+        and r["metadata"].get("chunk_index") == shared_chunk_idx
+    ]
     assert len(shared_results) == 1
 
-    # variant_doc 분리 여부 확인
-    variant_results = [r for r in results if r["content"] == variant_content]
-    assert len(variant_results) == 2
+    # variant_doc들이 분리되어 존재하는지 확인
+    variant_sources = {r["metadata"].get("source") for r in results}
+    assert "source-faiss" in variant_sources
+    assert "source-bm25" in variant_sources
 
 
 def test_hybrid_searcher_deduplicates_same_metadata_id():


### PR DESCRIPTION
♻️ refactor [#11.2.4]: 4차 개선 - ID 누락 시 해시 기반 중복 제거 로직 안정성 검증 완료 
♻️ refactor [#11.2.4]: 5차 개선 - 테스트 헬퍼 고도화 및 해시 기반 중복 제거 검증 정교화

## Summary by Sourcery

문서 ID가 없는 경우 해시 기반 하이브리드 검색 중복 제거 동작을 검증하고, 필수 ID 없이 문서를 구성할 수 있도록 테스트 헬퍼를 개선합니다.

Bug Fixes:
- 메타데이터 ID가 없을 때, 하이브리드 검색이 콘텐츠, source, chunk_index의 해시를 사용해 결과를 중복 제거하도록 보장합니다.

Enhancements:
- 테스트에서 ID가 누락된 시나리오를 지원하기 위해, 테스트 문서 팩토리 헬퍼가 선택적으로 메타데이터 ID를 생략할 수 있도록 허용합니다.

Tests:
- ID가 제공되지 않았을 때 해시 키 기반의 중복 제거와 논리적으로 구분되는 문서의 분리를 검증하는 단위 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate hash-based hybrid search deduplication behavior when document IDs are missing and enhance the test helper for constructing documents without mandatory IDs.

Bug Fixes:
- Ensure hybrid search deduplicates results using a hash of content, source, and chunk_index when metadata IDs are absent.

Enhancements:
- Allow the test document factory helper to optionally omit metadata IDs to support ID-missing scenarios in tests.

Tests:
- Add a unit test verifying hash-key-based deduplication and separation of logically distinct documents when IDs are not provided.

</details>