### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -41,9 +41,13 @@ class StaticRetriever:
         return self._results[:k]
 
 
-def _make_doc(content: str, doc_id: str, **metadata_overrides: Any) -> Dict[str, Any]:
-    """테스트용 문서 객체 생성 헬퍼"""
-    metadata = {"id": doc_id}
+def _make_doc(
+    content: str, doc_id: str = None, **metadata_overrides: Any
+) -> Dict[str, Any]:
+    """테스트용 문서 객체 생성 헬퍼 (ID 선택 가능)"""
+    metadata = {}
+    if doc_id:
+        metadata["id"] = doc_id
     metadata.update(metadata_overrides)
     return {"content": content, "metadata": metadata, "score": 1.0}
 
@@ -190,6 +194,52 @@ def test_one_engine_empty_results():
     results = searcher.search("test", k=3)
     assert len(results) == 1
     assert results[0]["content"] == "DocA"
+
+
+def test_hybrid_searcher_deduplicates_hash_key_when_id_missing():
+    """
+    metadata['id']가 없을 때 (content, source, chunk_index) 해시를 통한 중복 제거 검증.
+    내용(content)이 같더라도 메타데이터가 다르면 별개 문서로 취급되어야 함을 확인.
+    """
+    shared_content = "same content for all docs"
+    shared_source = "shared-source"
+    shared_chunk_idx = 0
+
+    # 1. 병합되어야 하는 쌍 (내용, 출처, 인덱스 모두 동일)
+    shared_doc_faiss = _make_doc(
+        shared_content, source=shared_source, chunk_index=shared_chunk_idx
+    )
+    shared_doc_bm25 = _make_doc(
+        shared_content, source=shared_source, chunk_index=shared_chunk_idx
+    )
+
+    # 2. 병합되지 않아야 하는 쌍 (내용은 같으나 출처/인덱스가 다름 -> 서로 다른 논리적 문서)
+    variant_doc_faiss = _make_doc(shared_content, source="source-faiss", chunk_index=10)
+    variant_doc_bm25 = _make_doc(shared_content, source="source-bm25", chunk_index=20)
+
+    faiss_retriever = StaticRetriever([shared_doc_faiss, variant_doc_faiss])
+    bm25_retriever = StaticRetriever([shared_doc_bm25, variant_doc_bm25])
+
+    searcher = HybridSearcher(faiss_retriever, bm25_retriever)
+
+    results = searcher.search("query", k=10)
+
+    # shared_doc 1개(병합) + variant 2개(분리) = 총 3개 결과 기대
+    assert len(results) == 3
+
+    # shared_doc 병합 여부 확인 (특정 출처/인덱스 조합이 하나만 존재하는지)
+    shared_results = [
+        r
+        for r in results
+        if r["metadata"].get("source") == shared_source
+        and r["metadata"].get("chunk_index") == shared_chunk_idx
+    ]
+    assert len(shared_results) == 1
+
+    # variant_doc들이 분리되어 존재하는지 확인
+    variant_sources = {r["metadata"].get("source") for r in results}
+    assert "source-faiss" in variant_sources
+    assert "source-bm25" in variant_sources
 
 
 def test_hybrid_searcher_deduplicates_same_metadata_id():


### PR DESCRIPTION
♻️ refactor [#11.2.4]: 4차 개선 - ID 누락 시 해시 기반 중복 제거 로직 안정성 검증 완료 
♻️ refactor [#11.2.4]: 5차 개선 - 테스트 헬퍼 고도화 및 해시 기반 중복 제거 검증 정교화

## Summary by Sourcery

하이브리드 검색 테스트 헬퍼를 다듬고, 문서 ID가 없을 때 해시 기반 중복 제거에 대한 커버리지를 추가합니다.

Bug Fixes:
- 하이브리드 검색의 해시 기반 중복 제거가 ID가 없는 경우 동일한 논리 문서를 올바르게 병합하고, 메타데이터가 다른 서로 다른 문서는 그대로 유지하는지 검증합니다.

Enhancements:
- 중복 제거 테스트에서 ID 누락 시나리오를 지원할 수 있도록, 테스트 문서 팩토리 헬퍼가 ID 없이 문서를 생성할 수 있게 합니다.

Tests:
- 메타데이터 ID가 생략되었을 때 해시 키 기반 중복 제거 동작을 검증하는 하이브리드 검색 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine hybrid search test helpers and add coverage for hash-based deduplication when document IDs are missing.

Bug Fixes:
- Verify that hybrid search hash-based deduplication correctly merges identical logical documents when IDs are absent and preserves distinct documents with differing metadata.

Enhancements:
- Allow the test document factory helper to create documents without IDs to support ID-missing scenarios in deduplication tests.

Tests:
- Add a hybrid search test that validates hash-key-based deduplication behavior when metadata IDs are omitted.

</details>