### PR TITLE
♻️ refactor [#11.2.4]: 6차 개선 - Falsy ID 보존 및 부분 메타데이터 해시 검증 개선

### DIFF
--- a/backend/hybrid_search.py
+++ b/backend/hybrid_search.py
@@ -113,13 +113,13 @@ class HybridSearcher:
         if k == 0:
             return []
 
-        # Comment 1 반영: 개별 k 값에 대한 음수 검증
+        # 개별 k 값에 대한 음수 검증
         if faiss_k is not None and faiss_k < 0:
             raise ValueError(f"faiss_k must be non-negative, got {faiss_k}")
         if bm25_k is not None and bm25_k < 0:
             raise ValueError(f"bm25_k must be non-negative, got {bm25_k}")
 
-        # Comment 3 반영: None 여부 명시적 확인 (0을 허용하기 위함)
+        # None 여부 명시적 확인 (0을 허용하기 위함)
         f_k = faiss_k if faiss_k is not None else (k * 2)
         b_k = bm25_k if bm25_k is not None else (k * 2)
 

--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -1,5 +1,5 @@
 import pytest
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Union
 from backend.hybrid_search import HybridSearcher
 
 
@@ -42,11 +42,11 @@ class StaticRetriever:
 
 
 def _make_doc(
-    content: str, doc_id: Optional[Any] = None, **metadata_overrides: Any
+    content: str, doc_id: Optional[Union[str, int]] = None, **metadata_overrides: Any
 ) -> Dict[str, Any]:
     """
     테스트용 문서 객체 생성 헬퍼 (ID 선택 가능).
-    6차 리뷰 반영: falsy한 ID("", 0 등)가 누락되지 않도록 is not None으로 체크.
+    falsy한 ID("", 0 등)가 누락되지 않도록 is not None으로 체크합니다.
     """
     metadata = {}
     if doc_id is not None:
@@ -202,7 +202,7 @@ def test_one_engine_empty_results():
 def test_hybrid_searcher_deduplicates_hash_key_when_id_missing():
     """
     metadata['id']가 없을 때 (content, source, chunk_index) 해시를 통한 중복 제거 검증.
-    내용(content)이 같더라도 메타데이터가 다르면 별개 문서로 취급되어야 함을 확인 (6차 리뷰 반영).
+    내용(content)이 같더라도 메타데이터가 다르면 별개 문서로 취급되어야 함을 확인합니다.
     """
     shared_content = "same content for all docs"
     shared_source = "shared-source"
@@ -247,7 +247,7 @@ def test_hybrid_searcher_deduplicates_hash_key_when_id_missing():
 
 def test_hybrid_searcher_deduplicates_partial_metadata_hash():
     """
-    메타데이터(source, chunk_index)가 일부 누락되었을 때의 해시 기반 중복 제거 검증 (6차 리뷰 반영).
+    메타데이터(source, chunk_index)가 일부 누락되었을 때의 해시 기반 중복 제거 검증.
     """
     shared_content = "partial metadata content"
 
@@ -276,7 +276,7 @@ def test_hybrid_searcher_deduplicates_partial_metadata_hash():
 
 def test_hybrid_searcher_falsy_id_preservation():
     """
-    ID가 "" 또는 "0"과 같은 falsy 값일 때도 정상적으로 식별자로 사용되는지 검증 (6차 리뷰 반영).
+    ID가 "" 또는 "0"과 같은 falsy 값일 때도 정상적으로 식별자로 사용되는지 검증.
     """
     doc_zero = _make_doc("content 0", doc_id="0")
     doc_empty = _make_doc("content empty", doc_id="")


### PR DESCRIPTION
- **[tests/unit/test_hybrid_search.py]**:
  - _make_doc 헬퍼 내 doc_id 체크 방식을 'is not None'으로 엄격화하여 falsy(0, "") ID 누락 방지
  - 메타데이터(source, chunk_index)가 일부 누락된 환경에서도 해시 기반 중복 제거가 작동하는지 검증하는 테스트 추가
  - Falsy ID(ID="0", ID="")가 유효한 식별자로 보존 및 식별되는지 검증하는 시나리오 추가
  - 테스트 코드 전수 리팩토링 및 14개 단위 테스트 합격 확인

🔗 Related:
- Issue [#507]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/547#pullrequestreview-3841636184)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro

## Summary by Sourcery

메타데이터가 부분적으로 누락된 경우에도 해시 기반 중복 제거를 검증하고, falsy 문서 ID를 유지하도록 하이브리드 검색 테스트를 개선합니다.

Enhancements:
- 테스트 문서 팩토리 헬퍼를 명확히 하여, `None`만 누락된 ID로 처리하고 빈 문자열이나 0과 같은 falsy 값은 그대로 유지되도록 합니다.

Tests:
- `source`만 있거나 `chunk_index` 메타데이터만 있는 경우에도 해시 기반 중복 제거가 올바르게 동작하는지 검증하는 테스트를 추가합니다.
- `"0"` 및 `""`와 같은 falsy ID가 유지되며, 하이브리드 검색 결과에서 유효한 식별자로 사용됨을 확인하는 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine hybrid search tests to preserve falsy document IDs and validate hash-based deduplication when metadata is partially missing.

Enhancements:
- Clarify the test document factory helper to treat only None as a missing ID, allowing falsy values like empty strings or zero to be preserved.

Tests:
- Add tests ensuring hash-based deduplication works correctly when only source or only chunk_index metadata is present.
- Add tests confirming that falsy IDs such as "0" and "" are retained and used as valid identifiers in hybrid search results.

</details>