### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/hybrid_search.py
+++ b/backend/hybrid_search.py
@@ -113,13 +113,13 @@ class HybridSearcher:
         if k == 0:
             return []
 
-        # Comment 1 반영: 개별 k 값에 대한 음수 검증
+        # 개별 k 값에 대한 음수 검증
         if faiss_k is not None and faiss_k < 0:
             raise ValueError(f"faiss_k must be non-negative, got {faiss_k}")
         if bm25_k is not None and bm25_k < 0:
             raise ValueError(f"bm25_k must be non-negative, got {bm25_k}")
 
-        # Comment 3 반영: None 여부 명시적 확인 (0을 허용하기 위함)
+        # None 여부 명시적 확인 (0을 허용하기 위함)
         f_k = faiss_k if faiss_k is not None else (k * 2)
         b_k = bm25_k if bm25_k is not None else (k * 2)
 

--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -1,5 +1,5 @@
 import pytest
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional, Union
 from backend.hybrid_search import HybridSearcher
 
 
@@ -42,11 +42,14 @@ class StaticRetriever:
 
 
 def _make_doc(
-    content: str, doc_id: str = None, **metadata_overrides: Any
+    content: str, doc_id: Optional[Union[str, int]] = None, **metadata_overrides: Any
 ) -> Dict[str, Any]:
-    """테스트용 문서 객체 생성 헬퍼 (ID 선택 가능)"""
+    """
+    테스트용 문서 객체 생성 헬퍼 (ID 선택 가능).
+    falsy한 ID("", 0 등)가 누락되지 않도록 is not None으로 체크합니다.
+    """
     metadata = {}
-    if doc_id:
+    if doc_id is not None:
         metadata["id"] = doc_id
     metadata.update(metadata_overrides)
     return {"content": content, "metadata": metadata, "score": 1.0}
@@ -199,7 +202,7 @@ def test_one_engine_empty_results():
 def test_hybrid_searcher_deduplicates_hash_key_when_id_missing():
     """
     metadata['id']가 없을 때 (content, source, chunk_index) 해시를 통한 중복 제거 검증.
-    내용(content)이 같더라도 메타데이터가 다르면 별개 문서로 취급되어야 함을 확인.
+    내용(content)이 같더라도 메타데이터가 다르면 별개 문서로 취급되어야 함을 확인합니다.
     """
     shared_content = "same content for all docs"
     shared_source = "shared-source"
@@ -240,6 +243,54 @@ def test_hybrid_searcher_deduplicates_hash_key_when_id_missing():
     variant_sources = {r["metadata"].get("source") for r in results}
     assert "source-faiss" in variant_sources
     assert "source-bm25" in variant_sources
+
+
+def test_hybrid_searcher_deduplicates_partial_metadata_hash():
+    """
+    메타데이터(source, chunk_index)가 일부 누락되었을 때의 해시 기반 중복 제거 검증.
+    """
+    shared_content = "partial metadata content"
+
+    # 1. source만 있고 chunk_index가 없는 경우
+    doc_a = _make_doc(shared_content, source="only-source")
+    doc_b = _make_doc(shared_content, source="only-source")
+
+    # 2. chunk_index만 있고 source가 없는 경우
+    doc_c = _make_doc("other content", chunk_index=99)
+    doc_d = _make_doc("other content", chunk_index=99)
+
+    faiss_retriever = StaticRetriever([doc_a, doc_c])
+    bm25_retriever = StaticRetriever([doc_b, doc_d])
+
+    searcher = HybridSearcher(faiss_retriever, bm25_retriever)
+    results = searcher.search("query", k=10)
+
+    # doc_a/b 병합, doc_c/d 병합 -> 총 2개 결과 기대
+    assert len(results) == 2
+
+    # 각 내용별로 결과가 하나씩만 있는지 확인
+    contents = [r["content"] for r in results]
+    assert contents.count(shared_content) == 1
+    assert contents.count("other content") == 1
+
+
+def test_hybrid_searcher_falsy_id_preservation():
+    """
+    ID가 "" 또는 "0"과 같은 falsy 값일 때도 정상적으로 식별자로 사용되는지 검증.
+    """
+    doc_zero = _make_doc("content 0", doc_id="0")
+    doc_empty = _make_doc("content empty", doc_id="")
+
+    faiss_retriever = StaticRetriever([doc_zero, doc_empty])
+    bm25_retriever = StaticRetriever([])
+
+    searcher = HybridSearcher(faiss_retriever, bm25_retriever)
+    results = searcher.search("query", k=10)
+
+    # 0과 "" ID를 가진 문서가 각각 포함되어야 함
+    ids = [r["metadata"].get("id") for r in results]
+    assert "0" in ids
+    assert "" in ids
 
 
 def test_hybrid_searcher_deduplicates_same_metadata_id():


### PR DESCRIPTION
♻️ refactor [#11.2.4]: 6차 개선 - Falsy ID 보존 및 부분 메타데이터 해시 검증 개선 
♻️ refactor [#11.2.4]: 7차 개선 - 타입 힌트 구체화 및 프로세스 노이즈 전면 제거

## Summary by Sourcery

문서 식별 및 중복 제거와 관련된 하이브리드 검색의 안정성을 개선하여, ID가 falsy 값이거나 메타데이터가 부분적으로 누락된 경우에도 잘 동작하도록 합니다.

Enhancements:
- 런타임 동작을 변경하지 않는 선에서 ID 처리 및 k 파라미터 검증과 관련된 헬퍼와 인라인 문서를 더 명확히 합니다.

Tests:
- 메타데이터가 부분적으로만(예: source 또는 chunk_index만) 존재하는 경우에도 중복 제거가 올바르게 동작하는지 확인하는 테스트 커버리지를 추가합니다.
- 빈 문자열이나 `"0"`과 같은 falsy ID가 하이브리드 검색 결과에서 식별자로서 유지되고 활용되는지를 검증하는 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve hybrid search robustness around document identification and deduplication, especially when IDs are falsy or metadata is partially missing.

Enhancements:
- Clarify helper and inline documentation around ID handling and k-parameter validation without changing runtime behavior.

Tests:
- Add coverage to ensure deduplication works when only partial metadata (source or chunk_index) is present.
- Add tests verifying that falsy IDs such as empty string or "0" are preserved and used as identifiers in hybrid search results.

</details>