### PR TITLE
♻️ refactor [#11.2.4]: 8차 개선 - ID 타입 유연성 확장 및 숫자형 0 ID 검증 완비

### DIFF
--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -1,4 +1,5 @@
 import pytest
+import uuid
 from typing import List, Dict, Any, Optional, Union, Hashable
 from backend.hybrid_search import HybridSearcher
 
@@ -295,14 +296,25 @@ def test_hybrid_searcher_falsy_id_preservation():
     assert "" in ids
 
 
-def test_hybrid_searcher_numeric_and_string_zero_id_merging():
+@pytest.mark.parametrize(
+    "faiss_id, bm25_id",
+    [
+        ("0", 0),  # FAISS='0', BM25=0
+        (0, "0"),  # FAISS=0, BM25='0' (역순 조합)
+    ],
+)
+def test_hybrid_searcher_numeric_and_string_zero_id_merging(faiss_id, bm25_id):
     """
     동일 내용에 대해 하나는 문자열 '0', 하나는 숫자 0 ID를 가질 때
     내부적으로 동일 문서로 인식하여 병합되는지 검증 (Hash 키 변환 로직 확인).
+
+    두 리트리버(FAISS/BM25)에 할당되는 ID 조합을 파라미터로 주어,
+    리트리버 순서와 무관하게 항상 1개 결과로 병합되는지 확인한다.
+    (내부적으로 str(id) 정규화에 의존함을 명시함)
     """
     shared_content = "same content zero id"
-    doc_a = _make_doc(shared_content, doc_id="0")
-    doc_b = _make_doc(shared_content, doc_id=0)
+    doc_a = _make_doc(shared_content, doc_id=faiss_id)
+    doc_b = _make_doc(shared_content, doc_id=bm25_id)
 
     faiss_retriever = StaticRetriever([doc_a])
     bm25_retriever = StaticRetriever([doc_b])
@@ -312,8 +324,29 @@ def test_hybrid_searcher_numeric_and_string_zero_id_merging():
 
     # 내부적으로 str(id)를 사용하므로 1개로 병합되어야 함
     assert len(results) == 1
-    # 첫 번째로 조회된(FAISS) 문서의 ID 타입이 유지되거나, 최소한 값은 '0'임
+    # 병합된 문서의 ID는 값 기준으로 '0'이어야 함 (타입은 첫 발견 문서에 따라 다를 수 있으나 str 변환값은 동일)
     assert str(results[0]["metadata"]["id"]) == "0"
+
+
+def test_hybrid_searcher_uuid_id_preservation():
+    """
+    _make_doc 및 HybridSearcher가 str/int 외의 Hashable 타입(예: UUID)을
+    정상적으로 지원하고 보존하는지 검증.
+    """
+    shared_content = "uuid content"
+    unique_id = uuid.uuid4()
+
+    doc = _make_doc(shared_content, doc_id=unique_id)
+
+    faiss_retriever = StaticRetriever([doc])
+    bm25_retriever = StaticRetriever([])
+
+    searcher = HybridSearcher(faiss_retriever, bm25_retriever)
+    results = searcher.search("query", k=10)
+
+    # UUID 객체가 그대로 메타데이터에 보존되어야 함
+    assert results[0]["metadata"]["id"] == unique_id
+    assert isinstance(results[0]["metadata"]["id"], uuid.UUID)
 
 
 def test_hybrid_searcher_deduplicates_same_metadata_id():


### PR DESCRIPTION
- **[tests/unit/test_hybrid_search.py]**:
  - _make_doc 헬퍼의 doc_id 타입을 Optional[Hashable]로 확장하여 UUID 등 다양한 ID 형식에 대한 유연성 확보
  - 숫자형 0(int) ID가 문자열 '0'과 동일하게 안전하게 보존되는지 확인하는 test_hybrid_searcher_falsy_id_preservation 시나리오 보강
  - 숫자형 0과 문자열 '0'이 동일 문서로서 정상적으로 병합(De-duplication)되는지 검증하는 신규 테스트 추가
  - 총 15개 단위 테스트 시나리오에 대한 100% Pass 확인

🔗 Related:
- Issue [#507]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/549#pullrequestreview-3841718582)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro

## Summary by Sourcery

유연한 문서 ID 타입과 falsy ID 처리에 대한 하이브리드 검색 테스트 커버리지를 확장합니다.

Enhancements:
- 향후 유연성을 위해(예: UUID) 모든 해시 가능 ID 타입을 허용하도록 테스트 문서 팩토리 헬퍼를 일반화했습니다.

Tests:
- 숫자 0과 빈 문자열 ID가 검색 결과에서 각각 독립적으로 유지되는지 확인하기 위해 falsy ID 보존 테스트를 강화했습니다.
- 숫자 0과 문자열 "0"처럼 동등한 의미를 가지는 ID를 가진 문서들이 하나의 논리적 문서로 올바르게 병합되는지 검증하는 테스트를 추가했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expand hybrid search test coverage around flexible document ID types and falsy ID handling.

Enhancements:
- Generalize the test document factory helper to accept any hashable ID type for future flexibility (e.g., UUIDs).

Tests:
- Strengthen falsy ID preservation tests to ensure numeric 0 and empty-string IDs are independently retained in search results.
- Add a test verifying that documents with equivalent numeric and string zero IDs are correctly merged as a single logical document.

</details>