### PR TITLE
♻️ refactor [#11.2.4]: 10차 개선 - 0.0 ID 보존 검증 및 테스트 안정성 강화

### DIFF
--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -291,11 +291,14 @@ def test_hybrid_searcher_falsy_id_preservation():
     searcher = HybridSearcher(faiss_retriever, bm25_retriever)
     results = searcher.search("query", k=10)
 
-    # 0(int), 0.0(float), ""(str) ID를 가진 문서가 각각 포함되어야 함
-    ids = [r["metadata"].get("id") for r in results]
-    assert 0 in ids
-    assert 0.0 in ids
-    assert "" in ids
+    # 0(int), 0.0(float), ""(str) ID를 가진 문서가 각각 타입까지 정확히 보존되어야 함
+    # (Python에서 0 == 0.0 이므로 값만 체크하면 교차 검증이 안 됨)
+    id_and_types = [
+        (r["metadata"].get("id"), type(r["metadata"].get("id"))) for r in results
+    ]
+    assert (0, int) in id_and_types
+    assert (0.0, float) in id_and_types
+    assert ("", str) in id_and_types
 
 
 @pytest.mark.parametrize(
@@ -325,8 +328,9 @@ def test_hybrid_searcher_numeric_and_string_zero_id_merging(faiss_id, bm25_id):
 
     # 논리적으로 동일한 ID이므로 리트리버 순서와 무관하게 1개로 병합되어야 함
     assert len(results) == 1
-    # 병합된 문서의 ID 값은 '0'으로 일관되어야 함
-    assert str(results[0]["metadata"]["id"]) == "0"
+    # 병합된 문서의 ID 값은 입력된 ID 중 하나와 논리적으로 동등(문자열 표현 일치)해야 함
+    merged_id = results[0]["metadata"]["id"]
+    assert str(merged_id) == str(faiss_id)
 
 
 def test_hybrid_searcher_uuid_id_preservation():


### PR DESCRIPTION
- **[tests/unit/test_hybrid_search.py]**:
  - falsy ID 보존 테스트에 0.0(float) 케이스를 추가하여 Docstring 명세와 일치시킴
  - 숫자/문자열 0 병합 테스트의 관점을 '내부 정규화 구현'에서 '논리적 식별자 통합'으로 추상화하여 테스트 안정성 확보
  - 불필요하게 세부 구현을 지칭하던 주석 및 설명 정제
  - 총 17개 단위 테스트 시나리오에 대한 100% Pass 확인

🔗 Related:
- Issue [#507]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/551#pullrequestreview-3841819937)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro

## Summary by Sourcery

하이브리드 검색에서 falsy ID 처리에 대한 테스트를 강화하여 float 0.0을 포함하고, 0 ID 머지 동작을 명확히 합니다.

Tests:
- falsy ID 보존 테스트를 확장해 0(int)와 빈 문자열 ID뿐만 아니라 0.0(float) ID도 함께 보존되는지 확인합니다.
- 0 ID 머지 테스트 설명을 재작성하여, 논리적 식별자 통합과 리트리버 전반에 걸친 일관된 중복 제거 동작에 초점을 맞추도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen hybrid search falsy-ID handling tests to cover float 0.0 and clarify zero-ID merge behavior.

Tests:
- Extend falsy ID preservation test to ensure 0.0(float) IDs are preserved alongside 0(int) and empty-string IDs.
- Reword zero-ID merging test descriptions to focus on logical identifier unification and consistent deduplication behavior across retrievers.

</details>