### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/bm25_search.py
+++ b/backend/bm25_search.py
@@ -25,6 +25,7 @@ from typing import (
     TypedDict,
 )
 from rank_bm25 import BM25Okapi
+from backend.utils import check_metadata_match
 
 logger = logging.getLogger(__name__)
 
@@ -334,7 +335,11 @@ class BM25Retriever:
         return stats
 
     def search(
-        self, query: str, k: int = 3, filter_zero_score: bool = True
+        self,
+        query: str,
+        k: int = 3,
+        filter_zero_score: bool = True,
+        metadata_filter: Optional[Dict[str, Any]] = None,
     ) -> List[Dict[str, Any]]:
         """
         쿼리에 가장 유사한 문서 검색
@@ -343,6 +348,7 @@ class BM25Retriever:
             query: 검색 쿼리
             k: 반환할 결과 수
             filter_zero_score: 점수가 0인 문서(연관성 없음)를 필터링할지 여부
+            metadata_filter: 메타데이터 필터 조건 (예: {"category": "Projects"})
 
         Returns:
             검색 결과 리스트 (content, metadata, score 포함)
@@ -365,9 +371,20 @@ class BM25Retriever:
 
         doc_scores = self.bm25.get_scores(tokenized_query)
 
-        # 높은 점수 순으로 정렬
+        # 필터링 적용할 대상 인덱스 추출
+        candidate_indices = range(len(doc_scores))
+        if metadata_filter:
+            candidate_indices = [
+                i
+                for i in candidate_indices
+                if check_metadata_match(
+                    self.documents[i].get("metadata", {}), metadata_filter
+                )
+            ]
+
+        # 높은 점수 순으로 정렬 (필터링된 후보군 내에서 k개 추출)
         top_k_indices = sorted(
-            range(len(doc_scores)), key=lambda i: doc_scores[i], reverse=True
+            candidate_indices, key=lambda i: doc_scores[i], reverse=True
         )[:k]
 
         results = []

--- a/backend/faiss_search.py
+++ b/backend/faiss_search.py
@@ -15,101 +15,136 @@ sys.path.insert(0, str(project_root))
 
 import faiss
 import numpy as np
-from typing import List, Dict, Union
+from typing import List, Dict, Union, Optional, Any
 from backend.embedding import EmbeddingGenerator
+from backend.utils import check_metadata_match
 
 
 class FAISSRetriever:
     """FAISS 기반 벡터 검색"""
-    
-    def __init__(self, dimension: int = 1536):
+
+    DEFAULT_FILTER_EXPANSION_FACTOR = 10  # 필터링 시 후보군 확장 기본 배수
+
+    def __init__(
+        self,
+        dimension: int = 1536,
+        filter_expansion_factor: int = DEFAULT_FILTER_EXPANSION_FACTOR,
+    ):
         """
         Args:
             dimension: 임베딩 벡터 차원 (text-embedding-3-small: 1536)
+            filter_expansion_factor: 메타데이터 필터링 시 FAISS에서 초기 추출할 후보군 배수
         """
         self.dimension = dimension
         self.index = faiss.IndexFlatL2(dimension)
-        self.documents = []                         # dict 객체 저장
+        self.documents = []  # dict 객체 저장
         self.embedding_generator = EmbeddingGenerator()
-    
+        self.filter_expansion_factor = filter_expansion_factor
+
     def add_documents(
-        self, 
-        embeddings: np.ndarray,         # 순서 변경
-        documents: List[Dict]           # Dict 타입으로 변경
+        self,
+        embeddings: np.ndarray,  # 순서 변경
+        documents: List[Dict],  # Dict 타입으로 변경
     ):
         """
         문서와 임베딩 추가
-        
+
         Args:
             embeddings: 임베딩 벡터 배열
             documents: 문서 dict 리스트 (content, metadata 포함)
         """
         if not documents or embeddings is None:
             return
-        
+
         if len(documents) != len(embeddings):
-            raise ValueError(f"문서 수({len(documents)})와 임베딩 수({len(embeddings)})가 일치하지 않습니다!")
-        
+            raise ValueError(
+                f"문서 수({len(documents)})와 임베딩 수({len(embeddings)})가 일치하지 않습니다!"
+            )
+
         # NumPy 배열로 변환
         if not isinstance(embeddings, np.ndarray):
             embeddings_np = np.array(embeddings, dtype=np.float32)
         else:
             embeddings_np = embeddings.astype(np.float32)
-        
+
         # FAISS 인덱스에 추가
         self.index.add(embeddings_np)
-        
+
         # 문서 dict 그대로 저장
         self.documents.extend(documents)
         print(f"✅ FAISS에 {len(documents)}개 문서 추가 완료")
-    
-    def search(self, query: str, k: int = 3) -> List[Dict]:
+
+    def search(
+        self,
+        query: str,
+        k: int = 3,
+        metadata_filter: Optional[Dict] = None,
+        filter_expansion_factor: Optional[int] = None,
+    ) -> List[Dict]:
         """
         쿼리에 가장 유사한 문서 검색
-        
+
         Args:
             query: 검색 쿼리
             k: 반환할 결과 수
-            
+            metadata_filter: 메타데이터 필터 조건 (예: {"category": "Projects"})
+            filter_expansion_factor: 이 검색에만 일시적으로 적용할 후보군 확장 배수 (None이면 인스턴스 값 사용)
+
         Returns:
             검색 결과 리스트 (content, metadata, score 포함)
         """
         if self.index.ntotal == 0:
             return []
-        
+
         # 쿼리 임베딩 생성
         result = self.embedding_generator.generate_embeddings([query])
-        query_embedding = result["embeddings"][0]       # dict에서 첫 번째 임베딩 추출
-        
-        # NumPy 배열로 변환 (FAISS가 기대하는 형태: (1, 1536))
+        query_embedding = result["embeddings"][0]
+
+        # NumPy 배열로 변환
         query_vector = np.array([query_embedding], dtype=np.float32)
-    
-        # 검색
-        distances, indices = self.index.search(query_vector, min(k, self.index.ntotal))
-        
-        # 결과 반환 (dict 구조 유지)
+
+        # 필터링이 있는 경우, 필터링 후 k개를 맞추기 위해 넉넉하게 후보군을 가져옴
+        expansion = filter_expansion_factor or self.filter_expansion_factor
+        search_k = min(self.index.ntotal, k * expansion if metadata_filter else k)
+        distances, indices = self.index.search(query_vector, search_k)
+
+        # 결과 반환 및 필터링
         results = []
         for dist, idx in zip(distances[0], indices[0]):
-            if idx < len(self.documents):
-                doc = self.documents[idx]
-                
-                # 유사도 계산 (거리 → 유사도)
-                similarity = 1 / (1 + float(dist))
-                
-                results.append({
-                    "content": doc["content"],              # content 키 사용
-                    "metadata": doc["metadata"],            # metadata 유지
-                    "score": similarity,                    # score로 통일
-                    "distance": float(dist)
-                })
-        
+            if idx < 0 or idx >= len(self.documents):
+                continue
+
+            doc = self.documents[idx]
+
+            # 메타데이터 필터 체크
+            if metadata_filter and not check_metadata_match(
+                doc.get("metadata", {}), metadata_filter
+            ):
+                continue
+
+            # 유사도 계산
+            similarity = 1 / (1 + float(dist))
+
+            results.append(
+                {
+                    "content": doc.get("content", ""),
+                    "metadata": doc.get("metadata", {}),
+                    "score": similarity,
+                    "distance": float(dist),
+                }
+            )
+
+            # k개 채워지면 중단
+            if len(results) >= k:
+                break
+
         return results
-    
+
     def clear(self):
         """인덱스 초기화"""
         self.index = faiss.IndexFlatL2(self.dimension)
         self.documents = []
-    
+
     def size(self) -> int:
         """인덱스에 저장된 문서 수"""
         return self.index.ntotal
@@ -123,54 +158,54 @@ if __name__ == "__main__":
     print("=" * 50)
     print("FAISS 검색 테스트")
     print("=" * 50)
-    
+
     # 1. Retriever 초기화
     retriever = FAISSRetriever()
-    
+
     # 2. 테스트 문서 (dict 구조)
     docs = [
         {
             "content": "FlowNote는 AI 대화 관리 도구입니다.",
-            "metadata": {"source": "test.txt", "chunk_index": 0}
+            "metadata": {"source": "test.txt", "chunk_index": 0},
         },
         {
             "content": "대화 내용을 검색하고 분석할 수 있습니다.",
-            "metadata": {"source": "test.txt", "chunk_index": 1}
+            "metadata": {"source": "test.txt", "chunk_index": 1},
         },
         {
             "content": "마크다운으로 대화를 내보낼 수 있습니다.",
-            "metadata": {"source": "test.txt", "chunk_index": 2}
-        }
+            "metadata": {"source": "test.txt", "chunk_index": 2},
+        },
     ]
-    
+
     # 3. 임베딩 생성
     embedding_generator = EmbeddingGenerator()
     texts = [doc["content"] for doc in docs]
-    
+
     # ✅ 수정: result에서 embeddings 추출!
     result = embedding_generator.generate_embeddings(texts)
-    embeddings = result["embeddings"]                   # 추가
-    
+    embeddings = result["embeddings"]  # 추가
+
     print(f"\n✅ 임베딩 생성 완료:")
     print(f" - 청크 수: {len(embeddings)}")
     print(f" - 토큰 수: {result['tokens']}")
     print(f" - 예상 비용: ${result['cost']:.6f}")
     print(f" - 벡터 차원: {len(embeddings[0])}")
-    
+
     # 4. NumPy 배열로 변환 (FAISS가 기대하는 형태)
     embeddings_np = np.array(embeddings, dtype=np.float32)
-    
+
     # 5. 문서 추가
     retriever.add_documents(embeddings_np, docs)
     print(f"\n✅ FAISS 인덱스 추가 완료")
     print(f"    - 총 문서 수: {len(docs)}")
     print(f"    - 인덱스 크기: {retriever.size()}")
-    
+
     # 6. 검색
     query = "대화를 어떻게 관리하나요?"
     print(f"\n🔍 검색 쿼리: '{query}'")
     results = retriever.search(query, k=2)
-    
+
     print(f"\n검색 결과 ({len(results)}개):")
     print("-" * 50)
     for i, result in enumerate(results, 1):
@@ -178,10 +213,8 @@ if __name__ == "__main__":
         print(f"    - 유사도: {result['score']:.4f}")
         print(f"    - 내용: {result['content']}")
         print(f"    - 출처: {result['metadata']['source']}")
-    
+
     print("\n" + "=" * 50)
-
-
 
 
 """result_3

--- a/backend/hybrid_search.py
+++ b/backend/hybrid_search.py
@@ -19,7 +19,9 @@ class Retriever(Protocol):
     HybridSearcher가 사용하는 모든 리트리버는 이 프로토콜을 준수해야 합니다.
     """
 
-    def search(self, query: str, k: int) -> List[Dict[str, Any]]:
+    def search(
+        self, query: str, k: int, metadata_filter: Optional[Dict[str, Any]] = None
+    ) -> List[Dict[str, Any]]:
         """
         검색을 수행하고 정렬된 리스트를 반환합니다.
 
@@ -29,6 +31,11 @@ class Retriever(Protocol):
         - score: 검색 점수 (float, 내림차순 정렬 가정)
           (참고: RRF는 절대 점수가 아닌 순위(Rank)를 기반으로 작동하지만,
           인터페이스 일관성을 위해 score 필드 포함을 권장합니다.)
+
+        Args:
+            query: 검색 질의
+            k: 반환할 결과 수
+            metadata_filter: 메타데이터 필터 조건 (예: {"category": "Projects"})
         """
         ...
 
@@ -89,6 +96,7 @@ class HybridSearcher:
         faiss_k: Optional[int] = None,
         bm25_k: Optional[int] = None,
         alpha: float = 0.5,
+        metadata_filter: Optional[Dict[str, Any]] = None,
     ) -> List[Dict[str, Any]]:
         """
         하이브리드 검색 수행 후 RRF 점수로 정렬하여 반환
@@ -99,6 +107,7 @@ class HybridSearcher:
             faiss_k: FAISS에서 가져올 후보 수 (기본값: k * 2, 0 이상)
             bm25_k: BM25에서 가져올 후보 수 (기본값: k * 2, 0 이상)
             alpha: [0, 1] 범위의 가중치. 1.0에 가까울수록 Dense(FAISS) 결과 비중이 커짐.
+            metadata_filter: 메타데이터 필터 조건 (예: {"category": "Projects"})
 
         Returns:
             RRF 점수 기반으로 재정렬된 하이브리드 검색 결과 리스트 (content, metadata, score 포함)
@@ -124,8 +133,12 @@ class HybridSearcher:
         b_k = bm25_k if bm25_k is not None else (k * 2)
 
         # 1. 각 검색 엔진에서 결과 가져오기
-        faiss_results = self.faiss_retriever.search(query, k=f_k)
-        bm25_results = self.bm25_retriever.search(query, k=b_k)
+        faiss_results = self.faiss_retriever.search(
+            query, k=f_k, metadata_filter=metadata_filter
+        )
+        bm25_results = self.bm25_retriever.search(
+            query, k=b_k, metadata_filter=metadata_filter
+        )
 
         # 2. RRF 병합 식별을 위한 Dictionary 정리
         rrf_scores: Dict[str, float] = {}

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -9,12 +9,55 @@ FlowNote MVP - 유틸리티 함수
 import os
 import tiktoken
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Dict, Any, List, Union
 from datetime import datetime
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━
+# 💙 새로 추가하는 함수들
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+def check_metadata_match(
+    doc_metadata: Optional[Dict[str, Any]], metadata_filter: Optional[Dict[str, Any]]
+) -> bool:
+    """
+    문서의 메타데이터가 필터 조건에 부합하는지 확인합니다.
+
+    Args:
+        doc_metadata: 문서에서 추출한 메타데이터 딕셔너리
+        metadata_filter: 적용할 필터 조건 (예: {"category": "Projects", "tags": ["AI", "Tech"]})
+
+    Returns:
+        bool: 모든 필터 조건을 만족하면 True, 하나라도 불일치하면 False.
+              필터가 None이거나 비어있으면 항상 True를 반환합니다.
+    """
+    if not metadata_filter:
+        return True
+
+    # 메타데이터가 없는 경우 (필터는 존재하는데 데이터가 없음)
+    if not isinstance(doc_metadata, dict):
+        return False
+
+    for filter_key, filter_value in metadata_filter.items():
+        # 방어적 코딩: filter_value가 None인 경우 (특정 키의 부재 또는 명시적 None 체크 원할 때)
+        doc_value = doc_metadata.get(filter_key)
+
+        # 리스트 형태의 필터 (OR 조건)
+        if isinstance(filter_value, list):
+            if doc_value not in filter_value:
+                return False
+        # 단일 값 비교
+        else:
+            if doc_value != filter_value:
+                return False
+
+    return True
+
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━
 # 기존 함수들
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
 
 def count_tokens(text: str, model: str = "gpt-4") -> int:
     """토큰 수 계산"""
@@ -29,7 +72,7 @@ def count_tokens(text: str, model: str = "gpt-4") -> int:
 def read_file_content(file_path: str) -> str:
     """파일 내용 읽기"""
     try:
-        with open(file_path, 'r', encoding='utf-8') as f:
+        with open(file_path, "r", encoding="utf-8") as f:
             return f.read()
     except Exception as e:
         raise Exception(f"파일 읽기 실패: {str(e)}")
@@ -37,7 +80,7 @@ def read_file_content(file_path: str) -> str:
 
 def format_file_size(size_bytes: int) -> str:
     """파일 크기를 읽기 쉬운 형식으로 변환"""
-    for unit in ['B', 'KB', 'MB', 'GB']:
+    for unit in ["B", "KB", "MB", "GB"]:
         if size_bytes < 1024.0:
             return f"{size_bytes:.1f} {unit}"
         size_bytes /= 1024.0
@@ -47,45 +90,45 @@ def format_file_size(size_bytes: int) -> str:
 def estimate_cost(tokens: int, cost_per_token: float) -> float:
     """
     토큰 수를 기반으로 비용 추정
-    
+
     Args:
         tokens: 토큰 수
         cost_per_token: 토큰당 비용
-        
+
     Returns:
         추정 비용 (USD)
     """
     return tokens * cost_per_token
 
 
-
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━
 # 💙 새로 추가하는 함수들
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+
 def load_pdf(file) -> str:
     """
     Streamlit 업로드된 PDF 파일을 읽어서 텍스트 추출
-    
+
     Args:
         file: Streamlit UploadedFile 객체
-        
+
     Returns:
         str: 추출된 텍스트
     """
     try:
         import pypdf
-        
+
         # PDF 리더 생성
         pdf_reader = pypdf.PdfReader(file)
-        
+
         # 모든 페이지의 텍스트 추출
         text = ""
         for page in pdf_reader.pages:
             text += page.extract_text() + "\n"
-        
+
         return text.strip()
-        
+
     except Exception as e:
         raise Exception(f"PDF 읽기 실패: {str(e)}")
 
@@ -93,7 +136,7 @@ def load_pdf(file) -> str:
 def save_to_markdown(text: str, filepath: str, title: str = "Untitled"):
     """
     텍스트를 마크다운 파일로 저장
-    
+
     Args:
         text: 저장할 텍스트
         filepath: 저장할 파일 경로
@@ -101,9 +144,9 @@ def save_to_markdown(text: str, filepath: str, title: str = "Untitled"):
     """
     # 디렉토리 생성
     Path(filepath).parent.mkdir(parents=True, exist_ok=True)
-    
+
     # 마크다운 형식으로 저장
-    with open(filepath, 'w', encoding='utf-8') as f:
+    with open(filepath, "w", encoding="utf-8") as f:
         f.write(f"# {title}\n\n")
         f.write(f"생성일: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n")
         f.write("---\n\n")

--- a/tests/unit/test_bm25_filter.py
+++ b/tests/unit/test_bm25_filter.py
@@ -1,0 +1,61 @@
+import pytest
+from backend.bm25_search import BM25Retriever
+
+
+def test_bm25_retriever_filtering():
+    """BM25Retriever의 실제 필터링 로직 작동 여부 검증."""
+    retriever = BM25Retriever()
+
+    docs = [
+        {"content": "apple banana", "metadata": {"category": "fruit", "color": "red"}},
+        {
+            "content": "banana cherry",
+            "metadata": {"category": "fruit", "color": "yellow"},
+        },
+        {"content": "cherry date", "metadata": {"category": "fruit", "color": "red"}},
+        {
+            "content": "carrot egg",
+            "metadata": {"category": "vegetable", "color": "orange"},
+        },
+        {"content": "extra doc 1", "metadata": {"category": "other"}},
+        {"content": "extra doc 2", "metadata": {"category": "other"}},
+    ]
+
+    retriever.add_documents(docs)
+
+    # 1. 'fruit' 카테고리만 검색
+    results = retriever.search("banana", k=10, metadata_filter={"category": "fruit"})
+    assert len(results) == 2
+    for r in results:
+        assert r["metadata"]["category"] == "fruit"
+        assert "banana" in r["content"]
+
+    # 2. 'red' 색상만 검색 (banana cherry 제외되어야 함)
+    results_red = retriever.search(
+        "banana cherry", k=10, metadata_filter={"color": "red"}
+    )
+    assert len(results_red) == 2
+    for r in results_red:
+        assert r["metadata"]["color"] == "red"
+
+    contents_red = [r["content"] for r in results_red]
+    assert "apple banana" in contents_red
+    assert "cherry date" in contents_red
+
+    # 3. 리스트 필터링
+    # 'banana'는 yellow 문서에, 'carrot'은 orange 문서에 매칭되어 두 문서 모두 반환되어야 함
+    results_list = retriever.search(
+        "banana carrot", k=10, metadata_filter={"color": ["yellow", "orange"]}
+    )
+    assert len(results_list) == 2
+    colors_list = {r["metadata"]["color"] for r in results_list}
+    assert colors_list == {"yellow", "orange"}
+
+
+def test_bm25_retriever_filtering_empty_results():
+    """조건에 맞는 문서가 없을 때 빈 결과 반환."""
+    retriever = BM25Retriever()
+    retriever.add_documents([{"content": "test", "metadata": {"a": 1}}])
+
+    assert retriever.search("test", k=10, metadata_filter={"a": 2}) == []
+    assert retriever.search("test", k=10, metadata_filter={"b": 1}) == []

--- a/tests/unit/test_faiss_filter.py
+++ b/tests/unit/test_faiss_filter.py
@@ -1,0 +1,108 @@
+import pytest
+import numpy as np
+from typing import Optional, Dict
+from unittest.mock import patch, MagicMock
+from backend.faiss_search import FAISSRetriever
+
+
+@pytest.fixture
+def faiss_retriever():
+    with patch("backend.embedding.EmbeddingGenerator.generate_embeddings") as mock_gen:
+        # Mock embedding return (1536 dim)
+        mock_gen.return_value = {
+            "embeddings": [[0.1] * 1536],
+            "tokens": 10,
+            "cost": 0.0,
+        }
+        retriever = FAISSRetriever()
+        yield retriever
+
+
+def test_faiss_retriever_filtering(faiss_retriever):
+    """FAISSRetriever의 메타데이터 필터링 작동 여부 검증."""
+    # 1. 문서 준비
+    docs = [
+        {"content": "Project Note", "metadata": {"category": "Projects", "id": 1}},
+        {"content": "Area Note", "metadata": {"category": "Areas", "id": 2}},
+        {"content": "Resource Note", "metadata": {"category": "Resources", "id": 3}},
+    ]
+    # 각 문서에 대해 다른 임베딩을 시뮬레이션하기 위해 수동으로 add_documents 호출
+    # (실제 임베딩 생성은 패치하지 않고 직접 넘파이 배열 전달)
+    embeddings = np.array([[0.1] * 1536, [0.5] * 1536, [0.9] * 1536], dtype=np.float32)
+    faiss_retriever.add_documents(embeddings, docs)
+
+    # 2. 'Projects' 필터 적용 검색
+    # search 내부에서 query 임베딩을 위해 generate_embeddings가 호출되는데 fixture에서 패치됨
+    results = faiss_retriever.search(
+        "query", k=10, metadata_filter={"category": "Projects"}
+    )
+
+    assert len(results) == 1
+    assert results[0]["metadata"]["category"] == "Projects"
+    assert results[0]["content"] == "Project Note"
+
+    # 3. 리스트 필터 적용
+    results_list = faiss_retriever.search(
+        "query", k=10, metadata_filter={"category": ["Areas", "Resources"]}
+    )
+    assert len(results_list) == 2
+    categories = {r["metadata"]["category"] for r in results_list}
+    assert categories == {"Areas", "Resources"}
+
+
+def test_faiss_retriever_filtering_no_match(faiss_retriever):
+    """필터 조건에 맞는 문서가 없을 때 빈 결과 반환."""
+    docs = [{"content": "test", "metadata": {"category": "Projects"}}]
+    embeddings = np.array([[0.1] * 1536], dtype=np.float32)
+    faiss_retriever.add_documents(embeddings, docs)
+
+    results = faiss_retriever.search(
+        "query", k=10, metadata_filter={"category": "Archives"}
+    )
+    assert results == []
+
+
+def test_faiss_retriever_post_filtering_fetch_more(faiss_retriever):
+    """필터링을 위해 내부적으로 더 많은 후보군(k*10)을 가져오는지 로직 검증."""
+    # 20개의 문서를 넣고, 검색 결과 1개를 요청하지만 필터에 걸려 뒤쪽 문서가 나와야 하는 상황
+    docs = [{"content": f"note {i}", "metadata": {"match": i == 19}} for i in range(20)]
+    # 거리를 다르게 하여 i=0이 가장 가깝게 설정
+    embeddings = np.array(
+        [[0.1 + i * 0.01] * 1536 for i in range(20)], dtype=np.float32
+    )
+    faiss_retriever.add_documents(embeddings, docs)
+
+    # k=1 이지만 match=True인 문서는 가장 먼 19번 문서뿐임.
+    # 만약 k=1만큼만 내부적으로 검색하면 0번 문서가 나오고 필터에서 걸려 빈 결과가 나오겠지만,
+    # k*10 (10개) 이상을 가져오면 19번까지는 못 가더라도...
+    # 아, 20개 중 k*10=10개면 19번까지 못 가겠네요.
+    # k=2 정도로 해서 k*10=20개를 가져오게 하면 19번 문서가 포함되어야 함.
+    results = faiss_retriever.search("query", k=1, metadata_filter={"match": True})
+
+    # k=1 인데 k*10=10 개를 가져오면 index 0~9 까지만 확인하므로 19번은 안 나옴. -> 빈 결과 정상
+    assert results == []
+
+    # k=2 이면 k*10=20 개를 가져오므로 index 0~19 다 확인하여 19번이 나옴.
+    results_k2 = faiss_retriever.search("query", k=2, metadata_filter={"match": True})
+    assert len(results_k2) == 1
+    assert results_k2[0]["content"] == "note 19"
+
+
+def test_faiss_retriever_configurable_expansion(faiss_retriever):
+    """필터 확장 배수가 유동적으로 적용되는지 검증."""
+    # 20개 문서 중 마지막 문서만 매칭
+    docs = [{"content": f"note {i}", "metadata": {"match": i == 19}} for i in range(20)]
+    embeddings = np.array(
+        [[0.1 + i * 0.01] * 1536 for i in range(20)], dtype=np.float32
+    )
+    faiss_retriever.add_documents(embeddings, docs)
+
+    # 1. 인스턴스 기본값(10) 사용 시: k=1 -> 10개 추출 -> 19번 문서 미발견 (빈 결과)
+    assert faiss_retriever.search("query", k=1, metadata_filter={"match": True}) == []
+
+    # 2. search 호출 시 확장 배수 20으로 설정: k=1 -> 20개 추출 -> 19번 문서 발견
+    results = faiss_retriever.search(
+        "query", k=1, metadata_filter={"match": True}, filter_expansion_factor=20
+    )
+    assert len(results) == 1
+    assert results[0]["content"] == "note 19"

--- a/tests/unit/test_hybrid_search.py
+++ b/tests/unit/test_hybrid_search.py
@@ -13,10 +13,14 @@ class DummyRetriever:
         self.name = name
         self.last_k = None
         self.last_query = None
+        self.last_filter = None
 
-    def search(self, query: str, k: int) -> List[Dict[str, Any]]:
+    def search(
+        self, query: str, k: int, metadata_filter: Optional[Dict[str, Any]] = None
+    ) -> List[Dict[str, Any]]:
         self.last_query = query
         self.last_k = k
+        self.last_filter = metadata_filter
         # HybridSearcher가 기대하는 최소 필드(content, metadata, score)를 맞춰줍니다.
         return [
             {
@@ -35,10 +39,14 @@ class StaticRetriever:
         self._results = results
         self.last_query = None
         self.last_k = None
+        self.last_filter = None
 
-    def search(self, query: str, k: int) -> List[Dict[str, Any]]:
+    def search(
+        self, query: str, k: int, metadata_filter: Optional[Dict[str, Any]] = None
+    ) -> List[Dict[str, Any]]:
         self.last_query = query
         self.last_k = k
+        self.last_filter = metadata_filter
         return self._results[:k]
 
 
@@ -165,11 +173,11 @@ def test_hybrid_searcher_rrf_scoring_logic():
     # 수동 결과 설정
     # 문서 A는 FAISS 1위, BM25 없음
     # 문서 B는 FAISS 2위, BM25 1위
-    faiss.search = lambda q, k: [
+    faiss.search = lambda q, k, metadata_filter=None: [
         {"content": "DocA", "metadata": {"id": "A"}, "score": 0.9},  # rank 1
         {"content": "DocB", "metadata": {"id": "B"}, "score": 0.8},  # rank 2
     ]
-    bm25.search = lambda q, k: [
+    bm25.search = lambda q, k, metadata_filter=None: [
         {"content": "DocB", "metadata": {"id": "B"}, "score": 20.0},  # rank 1
         {"content": "DocC", "metadata": {"id": "C"}, "score": 15.0},  # rank 2
     ]
@@ -191,10 +199,10 @@ def test_one_engine_empty_results():
     bm25 = DummyRetriever("bm25")
     searcher = HybridSearcher(faiss, bm25)
 
-    faiss.search = lambda q, k: [
+    faiss.search = lambda q, k, metadata_filter=None: [
         {"content": "DocA", "metadata": {"id": "A"}, "score": 1.0}
     ]
-    bm25.search = lambda q, k: []
+    bm25.search = lambda q, k, metadata_filter=None: []
 
     results = searcher.search("test", k=3)
     assert len(results) == 1

--- a/tests/unit/test_hybrid_search_filter.py
+++ b/tests/unit/test_hybrid_search_filter.py
@@ -1,0 +1,102 @@
+import pytest
+from backend.hybrid_search import HybridSearcher
+from typing import List, Dict, Any, Optional
+from backend.utils import check_metadata_match
+
+
+class StaticRetriever:
+    """고정된 검색 결과를 반환하는 리트리버 (테스트용)."""
+
+    def __init__(self, results: List[Dict[str, Any]]):
+        self._results = results
+
+    def search(
+        self, query: str, k: int, metadata_filter: Optional[Dict[str, Any]] = None
+    ) -> List[Dict[str, Any]]:
+        filtered = self._results
+        if metadata_filter:
+            filtered = [
+                doc
+                for doc in self._results
+                if check_metadata_match(doc.get("metadata", {}), metadata_filter)
+            ]
+        return filtered[:k]
+
+
+def _make_doc(content: str, **metadata: Any) -> Dict[str, Any]:
+    return {"content": content, "metadata": metadata, "score": 1.0}
+
+
+def test_hybrid_searcher_para_category_filtering():
+    """PARA 카테고리 필터링이 하이브리드 검색에서 정상 작동하는지 검증."""
+    docs_faiss = [
+        _make_doc("Project Alpha note", category="Projects"),
+        _make_doc("Area Health note", category="Areas"),
+        _make_doc("Resource Python note", category="Resources"),
+    ]
+    docs_bm25 = [
+        _make_doc("Project Beta note", category="Projects"),
+        _make_doc("Archive Old note", category="Archives"),
+    ]
+
+    retriever_faiss = StaticRetriever(docs_faiss)
+    retriever_bm25 = StaticRetriever(docs_bm25)
+    searcher = HybridSearcher(retriever_faiss, retriever_bm25)
+
+    # 1. 'Projects' 카테고리만 필터링
+    results = searcher.search("note", k=10, metadata_filter={"category": "Projects"})
+
+    # 두 리트리버에서 Projects 카테고리인 문서들만 모여야 함
+    assert len(results) == 2
+    for r in results:
+        assert r["metadata"]["category"] == "Projects"
+
+    contents = [r["content"] for r in results]
+    assert "Project Alpha note" in contents
+    assert "Project Beta note" in contents
+
+    # 2. 여러 카테고리 선택 (리스트 필터)
+    results_multiple = searcher.search(
+        "note", k=10, metadata_filter={"category": ["Areas", "Resources"]}
+    )
+    assert len(results_multiple) == 2
+    categories = {r["metadata"]["category"] for r in results_multiple}
+    assert categories == {"Areas", "Resources"}
+
+
+def test_hybrid_searcher_filtering_returns_empty_when_no_match():
+    """필터 조건에 맞는 문서가 없을 때 빈 결과를 반환하는지 검증."""
+    docs = [_make_doc("some content", category="Projects")]
+    retriever = StaticRetriever(docs)
+    searcher = HybridSearcher(retriever, StaticRetriever([]))
+
+    results = searcher.search("query", k=10, metadata_filter={"category": "Archives"})
+    assert results == []
+
+
+def test_hybrid_searcher_filtering_with_other_metadata():
+    """카테고리 외 다른 메타데이터 필드 필터링 검증."""
+    docs = [
+        _make_doc("note 1", source="manual.pdf", priority=1),
+        _make_doc("note 2", source="auto.log", priority=2),
+    ]
+    retriever = StaticRetriever(docs)
+    searcher = HybridSearcher(retriever, StaticRetriever([]))
+
+    # source 필터
+    results = searcher.search("note", k=10, metadata_filter={"source": "manual.pdf"})
+    assert len(results) == 1
+    assert results[0]["content"] == "note 1"
+
+    # 복합 필터
+    results_complex = searcher.search(
+        "note", k=10, metadata_filter={"source": "auto.log", "priority": 2}
+    )
+    assert len(results_complex) == 1
+    assert results_complex[0]["content"] == "note 2"
+
+    # 복합 필터 (불일치)
+    results_mismatch = searcher.search(
+        "note", k=10, metadata_filter={"source": "manual.pdf", "priority": 2}
+    )
+    assert results_mismatch == []


### PR DESCRIPTION
✨ feat [#11.2.5]: 하이브리드 검색을 위한 메타데이터 필터링(PARA 카테고리) 기능 구현 
♻️ refactor [#11.2.5]: 1차 개선 - 메타데이터 필터링 로직 공통화 및 FAISS 추출 후보군 파라미터화

## Summary by Sourcery

FAISS, BM25 및 하이브리드 검색에 메타데이터 기반 필터링을 도입하여 PARA 카테고리 및 기타 메타데이터 인식 쿼리를 지원하고, 필터된 검색 시 구성 가능한 FAISS 후보 확장을 지원합니다.

New Features:
- 필터된 쿼리에 대해 구성 가능한 후보 확장 계수를 포함하여, FAISSRetriever 검색에 메타데이터 필터링 지원을 추가합니다.
- BM25Retriever 검색에 메타데이터 필터링 지원을 추가하고, HybridSearcher를 통해 필터를 전파하여, 하이브리드 RAG 쿼리가 PARA 카테고리와 같은 메타데이터로 제한될 수 있도록 합니다.
- 스칼라 및 리스트 값에 대한 지원과 함께, 문서 메타데이터를 필터 조건과 비교 평가하는 공용 유틸리티 `check_metadata_match`를 도입합니다.

Enhancements:
- HybridSearcher 및 retriever 프로토콜을 확장하여 선택적 메타데이터 필터를 허용하고, 이를 하위 retriever로 전달해 일관된 동작을 보장합니다.

Tests:
- 필터된 검색에서 FAISSRetriever 메타데이터 필터링 동작 및 구성 가능한 후보 확장 계수에 대한 단위 테스트를 추가합니다.
- BM25Retriever 메타데이터 필터링 동작(스칼라, 리스트, 미매칭 시나리오 전반)에 대한 단위 테스트를 추가합니다.
- HybridSearcher에 대해, 통합된 FAISS 및 BM25 결과에서 PARA 카테고리 및 임의 메타데이터 필터링을 검증하는 단위 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce metadata-based filtering for FAISS, BM25, and hybrid search to support PARA category and other metadata-aware queries, including configurable FAISS candidate expansion for filtered searches.

New Features:
- Add metadata filtering support to FAISSRetriever search, including configurable candidate expansion factors for filtered queries.
- Add metadata filtering support to BM25Retriever search and propagate filters through HybridSearcher so hybrid RAG queries can be constrained by metadata such as PARA categories.
- Introduce a shared check_metadata_match utility to evaluate document metadata against filter conditions with support for scalar and list values.

Enhancements:
- Extend the HybridSearcher and retriever protocol to accept optional metadata filters and pass them through to underlying retrievers for consistent behavior.

Tests:
- Add unit tests for FAISSRetriever metadata filtering behavior and configurable expansion factors under filtered search.
- Add unit tests for BM25Retriever metadata filtering behavior across scalar, list, and no-match scenarios.
- Add unit tests for HybridSearcher to validate PARA category and arbitrary metadata filtering across combined FAISS and BM25 results.

</details>