### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/faiss_search.py
+++ b/backend/faiss_search.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(project_root))
 
 import faiss
 import numpy as np
+import numbers
 from typing import List, Dict, Union, Optional, Any
 from backend.embedding import EmbeddingGenerator
 from backend.utils import check_metadata_match
@@ -24,6 +25,28 @@ class FAISSRetriever:
     """FAISS 기반 벡터 검색"""
 
     DEFAULT_FILTER_EXPANSION_FACTOR = 10  # 필터링 시 후보군 확장 기본 배수
+
+    @staticmethod
+    def _normalize_expansion_factor(value: Any) -> int:
+        """확장 배수 파라미터 유효성 검증 및 정규화 (정수 변환)"""
+        # bool은 numbers.Real의 서브클래스이지만 벡터 검색 배수로는 부적절하므로 차단
+        if isinstance(value, bool) or not isinstance(value, numbers.Real):
+            raise TypeError(
+                f"filter_expansion_factor must be a real number, got {type(value).__name__}"
+            )
+
+        if value < 1:
+            raise ValueError(f"filter_expansion_factor must be >= 1, got {value}")
+
+        normalized = int(value)
+
+        if normalized < 1:
+            # 0.5와 같이 (0.0, 1.0) 사이의 값이 들어온 경우 정수 변환 시 0이 됨
+            raise ValueError(
+                f"filter_expansion_factor must be >= 1 after normalization, got {normalized}"
+            )
+
+        return normalized
 
     def __init__(
         self,
@@ -39,7 +62,9 @@ class FAISSRetriever:
         self.index = faiss.IndexFlatL2(dimension)
         self.documents = []  # dict 객체 저장
         self.embedding_generator = EmbeddingGenerator()
-        self.filter_expansion_factor = filter_expansion_factor
+        self.filter_expansion_factor = self._normalize_expansion_factor(
+            filter_expansion_factor
+        )
 
     def add_documents(
         self,
@@ -93,6 +118,18 @@ class FAISSRetriever:
         Returns:
             검색 결과 리스트 (content, metadata, score 포함)
         """
+        # 1. 파라미터 유효성 검증 (메타데이터 필터링이 활성화된 경우에만 후보군 확장 배수 적용)
+        if metadata_filter:
+            target_factor = (
+                self.filter_expansion_factor
+                if filter_expansion_factor is None
+                else filter_expansion_factor
+            )
+            expansion = self._normalize_expansion_factor(target_factor)
+        else:
+            # 필터링을 사용하지 않는 경우 확장이 필요 없으므로 1로 고정
+            expansion = 1
+
         if self.index.ntotal == 0:
             return []
 
@@ -103,8 +140,6 @@ class FAISSRetriever:
         # NumPy 배열로 변환
         query_vector = np.array([query_embedding], dtype=np.float32)
 
-        # 필터링이 있는 경우, 필터링 후 k개를 맞추기 위해 넉넉하게 후보군을 가져옴
-        expansion = filter_expansion_factor or self.filter_expansion_factor
         search_k = min(self.index.ntotal, k * expansion if metadata_filter else k)
         distances, indices = self.index.search(query_vector, search_k)
 

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -39,17 +39,35 @@ def check_metadata_match(
         return False
 
     for filter_key, filter_value in metadata_filter.items():
-        # 방어적 코딩: filter_value가 None인 경우 (특정 키의 부재 또는 명시적 None 체크 원할 때)
         doc_value = doc_metadata.get(filter_key)
 
-        # 리스트 형태의 필터 (OR 조건)
+        # 1. 필터값이 리스트인 경우 (OR 조건: 필터 리스트 중 하나라도 일치하면 OK)
         if isinstance(filter_value, list):
-            if doc_value not in filter_value:
-                return False
-        # 단일 값 비교
+            if isinstance(doc_value, list):
+                # 리스트 vs 리스트: 교집합이 있는지 확인 (하나라도 겹치면 매칭)
+                # set() 변환은 dict 등 해시 불가능한 요소가 있을 경우 실패하므로 순회 방식으로 체크
+                match_found = False
+                for item in doc_value:
+                    if item in filter_value:
+                        match_found = True
+                        break
+                if not match_found:
+                    return False
+            else:
+                # 스칼라 vs 리스트: 필터 리스트에 포함되는지 확인
+                if doc_value not in filter_value:
+                    return False
+
+        # 2. 필터값이 스칼라인 경우 (일치 조건)
         else:
-            if doc_value != filter_value:
-                return False
+            if isinstance(doc_value, list):
+                # 리스트 vs 스칼라: 문서 리스트 내에 필터값이 포함되는지 확인
+                if filter_value not in doc_value:
+                    return False
+            else:
+                # 스칼라 vs 스칼라: 단순 값 비교
+                if doc_value != filter_value:
+                    return False
 
     return True
 

--- a/tests/unit/test_faiss_filter.py
+++ b/tests/unit/test_faiss_filter.py
@@ -20,34 +20,20 @@ def faiss_retriever():
 
 def test_faiss_retriever_filtering(faiss_retriever):
     """FAISSRetriever의 메타데이터 필터링 작동 여부 검증."""
-    # 1. 문서 준비
     docs = [
         {"content": "Project Note", "metadata": {"category": "Projects", "id": 1}},
         {"content": "Area Note", "metadata": {"category": "Areas", "id": 2}},
         {"content": "Resource Note", "metadata": {"category": "Resources", "id": 3}},
     ]
-    # 각 문서에 대해 다른 임베딩을 시뮬레이션하기 위해 수동으로 add_documents 호출
-    # (실제 임베딩 생성은 패치하지 않고 직접 넘파이 배열 전달)
     embeddings = np.array([[0.1] * 1536, [0.5] * 1536, [0.9] * 1536], dtype=np.float32)
     faiss_retriever.add_documents(embeddings, docs)
 
-    # 2. 'Projects' 필터 적용 검색
-    # search 내부에서 query 임베딩을 위해 generate_embeddings가 호출되는데 fixture에서 패치됨
     results = faiss_retriever.search(
         "query", k=10, metadata_filter={"category": "Projects"}
     )
-
     assert len(results) == 1
     assert results[0]["metadata"]["category"] == "Projects"
     assert results[0]["content"] == "Project Note"
-
-    # 3. 리스트 필터 적용
-    results_list = faiss_retriever.search(
-        "query", k=10, metadata_filter={"category": ["Areas", "Resources"]}
-    )
-    assert len(results_list) == 2
-    categories = {r["metadata"]["category"] for r in results_list}
-    assert categories == {"Areas", "Resources"}
 
 
 def test_faiss_retriever_filtering_no_match(faiss_retriever):
@@ -63,26 +49,18 @@ def test_faiss_retriever_filtering_no_match(faiss_retriever):
 
 
 def test_faiss_retriever_post_filtering_fetch_more(faiss_retriever):
-    """필터링을 위해 내부적으로 더 많은 후보군(k*10)을 가져오는지 로직 검증."""
-    # 20개의 문서를 넣고, 검색 결과 1개를 요청하지만 필터에 걸려 뒤쪽 문서가 나와야 하는 상황
+    """필터링을 위해 내부적으로 더 많은 후보군을 가져오는지 로직 검증."""
     docs = [{"content": f"note {i}", "metadata": {"match": i == 19}} for i in range(20)]
-    # 거리를 다르게 하여 i=0이 가장 가깝게 설정
     embeddings = np.array(
         [[0.1 + i * 0.01] * 1536 for i in range(20)], dtype=np.float32
     )
     faiss_retriever.add_documents(embeddings, docs)
 
-    # k=1 이지만 match=True인 문서는 가장 먼 19번 문서뿐임.
-    # 만약 k=1만큼만 내부적으로 검색하면 0번 문서가 나오고 필터에서 걸려 빈 결과가 나오겠지만,
-    # k*10 (10개) 이상을 가져오면 19번까지는 못 가더라도...
-    # 아, 20개 중 k*10=10개면 19번까지 못 가겠네요.
-    # k=2 정도로 해서 k*10=20개를 가져오게 하면 19번 문서가 포함되어야 함.
+    # k=1 이고 기본 확장 10이면 0-9만 보므로 19번 안 나옴
     results = faiss_retriever.search("query", k=1, metadata_filter={"match": True})
-
-    # k=1 인데 k*10=10 개를 가져오면 index 0~9 까지만 확인하므로 19번은 안 나옴. -> 빈 결과 정상
     assert results == []
 
-    # k=2 이면 k*10=20 개를 가져오므로 index 0~19 다 확인하여 19번이 나옴.
+    # k=2 이면 2*10=20개 보므로 19번 나옴
     results_k2 = faiss_retriever.search("query", k=2, metadata_filter={"match": True})
     assert len(results_k2) == 1
     assert results_k2[0]["content"] == "note 19"
@@ -90,19 +68,52 @@ def test_faiss_retriever_post_filtering_fetch_more(faiss_retriever):
 
 def test_faiss_retriever_configurable_expansion(faiss_retriever):
     """필터 확장 배수가 유동적으로 적용되는지 검증."""
-    # 20개 문서 중 마지막 문서만 매칭
     docs = [{"content": f"note {i}", "metadata": {"match": i == 19}} for i in range(20)]
     embeddings = np.array(
         [[0.1 + i * 0.01] * 1536 for i in range(20)], dtype=np.float32
     )
     faiss_retriever.add_documents(embeddings, docs)
 
-    # 1. 인스턴스 기본값(10) 사용 시: k=1 -> 10개 추출 -> 19번 문서 미발견 (빈 결과)
+    # 1. 기본값 10: k=1 -> 10개 -> 19번 미발견
     assert faiss_retriever.search("query", k=1, metadata_filter={"match": True}) == []
 
-    # 2. search 호출 시 확장 배수 20으로 설정: k=1 -> 20개 추출 -> 19번 문서 발견
+    # 2. 오버라이드 20: k=1 -> 20개 -> 19번 발견
     results = faiss_retriever.search(
         "query", k=1, metadata_filter={"match": True}, filter_expansion_factor=20
     )
     assert len(results) == 1
     assert results[0]["content"] == "note 19"
+
+
+def test_faiss_retriever_invalid_expansion():
+    """유효하지 않은 확장 배수 설정 시 예외 발생 검증."""
+    # 1. 생성 시 검증 (항상 수행)
+    with pytest.raises(ValueError, match="filter_expansion_factor must be >= 1"):
+        FAISSRetriever(filter_expansion_factor=0)
+
+    # 2. 검색 시 검증
+    retriever = FAISSRetriever()
+
+    # 2-1. metadata_filter가 없으면 잘못된 배수도 무시됨 (정상 작동)
+    retriever.search("query", filter_expansion_factor=-1)
+
+    # 2-2. metadata_filter가 있으면 검증 수행
+    with pytest.raises(ValueError, match="filter_expansion_factor must be >= 1"):
+        retriever.search("query", metadata_filter={"id": 1}, filter_expansion_factor=-1)
+
+
+def test_faiss_retriever_list_metadata_filtering(faiss_retriever):
+    """FAISS에서 리스트형 메타데이터(tags 등) 필터링 검증."""
+    docs = [
+        {"content": "AI Note", "metadata": {"tags": ["AI", "NLP"]}},
+        {"content": "Tech Note", "metadata": {"tags": ["Tech", "Coding"]}},
+    ]
+    embeddings = np.array([[0.1] * 1536, [0.5] * 1536], dtype=np.float32)
+    faiss_retriever.add_documents(embeddings, docs)
+
+    # 리스트 vs 리스트 매칭 (교집합)
+    results = faiss_retriever.search(
+        "query", k=10, metadata_filter={"tags": ["AI", "Search"]}
+    )
+    assert len(results) == 1
+    assert results[0]["content"] == "AI Note"

--- a/tests/unit/test_hybrid_search_filter.py
+++ b/tests/unit/test_hybrid_search_filter.py
@@ -100,3 +100,31 @@ def test_hybrid_searcher_filtering_with_other_metadata():
         "note", k=10, metadata_filter={"source": "manual.pdf", "priority": 2}
     )
     assert results_mismatch == []
+
+
+def test_hybrid_searcher_list_metadata_filtering():
+    """문서 메타데이터가 리스트인 경우(예: tags)의 필터링 검증."""
+    docs = [
+        _make_doc("AI Note", tags=["AI", "NLP"], category="Tech"),
+        _make_doc("Tech Note", tags=["Tech", "Coding"], category="Tech"),
+        _make_doc("General Note", tags=["General"], category="News"),
+    ]
+    retriever = StaticRetriever(docs)
+    searcher = HybridSearcher(retriever, StaticRetriever([]))
+
+    # 1. 리스트(Doc) vs 리스트(Filter): 교집합 존재하면 매칭
+    results = searcher.search("query", k=10, metadata_filter={"tags": ["AI", "Search"]})
+    assert len(results) == 1
+    assert results[0]["content"] == "AI Note"
+
+    # 2. 리스트(Doc) vs 스칼라(Filter): 필터값이 문서 리스트에 포함되면 매칭
+    results = searcher.search("query", k=10, metadata_filter={"tags": "Coding"})
+    assert len(results) == 1
+    assert results[0]["content"] == "Tech Note"
+
+    # 3. 스칼라(Doc) vs 리스트(Filter): 문서값이 필터 리스트에 포함되면 매칭
+    results = searcher.search(
+        "query", k=10, metadata_filter={"category": ["News", "Sports"]}
+    )
+    assert len(results) == 1
+    assert results[0]["content"] == "General Note"

--- a/tests/unit/verify_review_fixes.py
+++ b/tests/unit/verify_review_fixes.py
@@ -1,0 +1,85 @@
+import sys
+import os
+from pathlib import Path
+import pytest
+import numpy as np
+from unittest.mock import patch
+
+# 프로젝트 루트 추가
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from backend.faiss_search import FAISSRetriever
+from backend.utils import check_metadata_match
+
+
+def test_unhashable_metadata():
+    print("\n[V1] Checking unhashable metadata...")
+    doc_metadata = {
+        "tags": [{"name": "AI"}, {"name": "NLP"}]
+    }  # 리스트 내 dict (unhashable)
+
+    # 1. 일치하는 경우
+    filter1 = {"tags": [{"name": "AI"}]}
+    assert check_metadata_match(doc_metadata, filter1) == True
+
+    # 2. 일치하지 않는 경우
+    filter2 = {"tags": [{"name": "Search"}]}
+    assert check_metadata_match(doc_metadata, filter2) == False
+    print("✅ Unhashable metadata check passed!")
+
+
+def test_expansion_factor_types():
+    print("\n[V2] Checking expansion factor types...")
+    # 1. Valid float (e.g., 2.5 -> 2)
+    retriever = FAISSRetriever(filter_expansion_factor=2.5)
+    assert retriever.filter_expansion_factor == 2
+
+    # 2. Invalid types (bool)
+    with pytest.raises(TypeError, match="must be a real number"):
+        FAISSRetriever(filter_expansion_factor=True)
+
+    # 3. Invalid types (str)
+    with pytest.raises(TypeError, match="must be a real number"):
+        FAISSRetriever(filter_expansion_factor="10")
+
+    # 4. Range check (0.5 -> caught by value < 1 check)
+    with pytest.raises(ValueError, match="must be >= 1"):
+        FAISSRetriever(filter_expansion_factor=0.5)
+
+    print("✅ Expansion factor type check passed!")
+
+
+def test_expansion_factor_conditional_validation():
+    print("\n[V3] Checking conditional validation in search...")
+    with patch("backend.embedding.EmbeddingGenerator.generate_embeddings") as mock_gen:
+        mock_gen.return_value = {"embeddings": [[0.1] * 1536]}
+        retriever = FAISSRetriever()
+
+        # 1. metadata_filter가 없으면 잘못된 값을 넘겨도 무시됨 (리뷰어 요청 사항)
+        retriever.documents = [{"content": "v3-test"}]
+        retriever.index.add(np.array([[0.1] * 1536], dtype=np.float32))
+
+        try:
+            # metadata_filter=None이면 expansion=0을 무시해야 함
+            retriever.search("query", metadata_filter=None, filter_expansion_factor=0)
+            print("✅ Conditional validation (None filter) passed!")
+        except (ValueError, TypeError):
+            # If it raises, it's failing the conditional logic
+            import traceback
+
+            traceback.print_exc()
+            pytest.fail("Should not have raised Error when metadata_filter is None")
+
+        # 2. metadata_filter가 있으면 검증 수행
+        with pytest.raises(ValueError, match="must be >= 1"):
+            retriever.search(
+                "query", metadata_filter={"id": 1}, filter_expansion_factor=0
+            )
+        print("✅ Conditional validation (With filter) passed!")
+
+
+if __name__ == "__main__":
+    test_unhashable_metadata()
+    test_expansion_factor_types()
+    test_expansion_factor_conditional_validation()
+    print("\nALL REVIEWS ADDRESSED SUCCESSFULLY!")


### PR DESCRIPTION
♻️ refactor [#11.2.5]: 2차 개선 - 필터 검증 로직 견고화 및 리스트형 메타데이터(태그) 지원 확장 
♻️ refactor [#11.2.5]: 3차 개선 - 메타데이터 필터링 안정성 및 타입 검증 강화

## Summary by Sourcery

FAISS 및 하이브리드 검색의 메타데이터 필터링과 필터 확장 동작을 강화하고, 검증을 개선하며 테스트 범위를 확장했습니다.

Enhancements:
- 필터 확장 계수 처리 방식을 강화하여 값을 정규화하고, 잘못된 타입과 범위를 거부하며, 메타데이터 필터링이 활성화된 경우에만 조건부로 확장을 적용합니다.
- 메타데이터 매칭 로직을 확장하여, 모든 스칼라/리스트 조합에 대해 해시 가능 여부에 의존하지 않고 리스트 형태의 필드(예: tags)를 안정적으로 처리하도록 했습니다.

Tests:
- 리스트 기반 메타데이터 필터링 시나리오 및 스칼라/리스트 조합을 포괄하도록 FAISS 및 하이브리드 검색에 대한 단위 테스트를 추가했습니다.
- 타입 정규화, 범위 검사, 메타데이터 필터 존재 여부에 따른 조건부 동작 등을 포함하여 필터 확장 계수 검증을 확인하는 테스트를 추가했습니다.
- 해시 불가능한 메타데이터 값과 확장 계수 경계 사례(edge cases)에 대한 추가 테스트를 포함하는 검증 스크립트를 도입했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen FAISS and hybrid search metadata filtering and filter expansion behavior, with improved validation and expanded test coverage.

Enhancements:
- Harden filter expansion factor handling by normalizing values, rejecting invalid types and ranges, and conditionally applying expansion only when metadata filtering is enabled.
- Extend metadata matching logic to robustly handle list-valued fields (e.g., tags) for all scalar/list combinations without relying on hashability.

Tests:
- Add unit tests for FAISS and hybrid search to cover list-based metadata filtering scenarios and scalar/list combinations.
- Add tests verifying filter expansion factor validation, including type normalization, range checks, and conditional behavior based on the presence of metadata filters.
- Introduce a verification script with additional tests for unhashable metadata values and expansion factor edge cases.

</details>