### PR TITLE
♻️ refactor [#11.2.5]: 6차 개선 - 필터링 시맨틱 엄격화 및 보안성 강화

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -26,6 +26,8 @@ def check_metadata_match(
     Args:
         doc_metadata: 문서에서 추출한 메타데이터 딕셔너리
         metadata_filter: 적용할 필터 조건 (예: {"category": "Projects", "tags": ["AI", "Tech"]})
+            * 정책: 필터 값이 빈 리스트([])인 경우, 유효한 매칭 후보가 없는 것으로 간주하여
+              해당 조건에 대해 즉시 False를 반환합니다.
 
     Returns:
         bool: 모든 필터 조건을 만족하면 True, 하나라도 불일치하면 False.
@@ -39,17 +41,21 @@ def check_metadata_match(
         return False
 
     for filter_key, filter_value in metadata_filter.items():
-        doc_value = doc_metadata.get(filter_key)
+        # 1. 존재성 확인: 필터에서 요구하는 키가 문서에 아예 없는 경우 실패
+        if filter_key not in doc_metadata:
+            return False
 
-        # 1. 빈 리스트 필터([]) 처리: 어떤 값과도 매칭될 수 없으므로 False (보안적 관점)
+        doc_value = doc_metadata[filter_key]
+
+        # 2. 빈 리스트 필터([]) 처리: 어떤 값과도 매칭될 수 없으므로 False (보안 정책)
         if isinstance(filter_value, list) and not filter_value:
             return False
 
-        # 2. 리스트 정규화 및 교집합 검사
+        # 3. 리스트 정규화 및 교집합 검사 (None 포함)
         filter_raw = filter_value if isinstance(filter_value, list) else [filter_value]
         doc_raw = doc_value if isinstance(doc_value, list) else [doc_value]
 
-        # OR 세만틱: 문서 값 중 하나라도 필터 후보군(None 포함)에 포함되는지 확인
+        # OR 세만틱: 문서 값 중 하나라도 필터 후보군에 포함되는지 확인
         if not any(v in filter_raw for v in doc_raw):
             return False
 

--- a/tests/unit/test_utils_metadata_filter.py
+++ b/tests/unit/test_utils_metadata_filter.py
@@ -55,14 +55,14 @@ def test_check_metadata_match_edge_cases():
 
 def test_check_metadata_match_none_semantics():
     """None 값 및 빈 리스트에 대한 매칭 세만틱 검증 (엄격한 필터링 모델)."""
-    # 1. 필터가 명시적인 None인 경우 -> 문서 값이 실제로 None이거나 없는 경우만 매칭
+    # 1. 필터가 명시적인 None인 경우 -> 문서 값이 실제로 None인 경우만 매칭
     assert check_metadata_match({"category": None}, {"category": None}) is True
     assert check_metadata_match({"category": "A"}, {"category": None}) is False
-    assert (
-        check_metadata_match({}, {"category": None}) is True
-    )  # .get()이 None이므로 매칭
 
-    # 2. 필터가 빈 리스트([])인 경우 -> 절대로 매치될 수 없음 (Restrictive)
+    # 2. 키 자체가 없는 경우 (필터에서 기대하는데 데이터 없음) -> 매칭 실패 (엄격한 존재성 검증)
+    assert check_metadata_match({}, {"category": None}) is False
+
+    # 3. 필터가 빈 리스트([])인 경우 -> 절대로 매치될 수 없음 (Restrictive)
     assert check_metadata_match({"tags": ["AI"]}, {"tags": []}) is False
     assert check_metadata_match({"tags": []}, {"tags": []}) is False
     assert check_metadata_match({}, {"tags": []}) is False


### PR DESCRIPTION
- [backend/utils.py]:
    - [check_metadata_match](backend/utils.py:19:0-56:15)에서 빈 리스트 필터([])를 '불일치'로 처리하여 엄격한 필터링 구현
    - 빈 리스트 필터([])를 '불가항력적 매칭 실패'로 처리하여 필터링 우회 방지
- [backend/utils.py]:
    - `None` 값을 와일드카드가 아닌 실제 데이터 비교 대상으로 취급하여 보안 취약점(Fail-open) 제거
    - `None` 필터를 와일드카드가 아닌 엄격한 동등 비교(Strict None Equality)로 전환
- [tests/unit/test_utils_metadata_filter.py]:
    - 빈 리스트 필터링에 대한 Restrictive matching 테스트 추가
    - 명시적 빈 리스트 필터링에 대한 Restrictive 매칭 테스트 보강
    - `None` 값에 대한 엄격한 동등성 비교(Strict Equality) 테스트 케이스 업데이트

🔗 Related:
- Issue [#507]
- @ai_bot_review (https://github.com/jjaayy2222/flownote-mvp/pull/559#pullrequestreview-3852929227) - 필터링 로직의 모호성 제거 및 가시성•보안성 만족하는 필터링 엔진 완성

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro

## Summary by Sourcery

메타데이터 필터링 방식(시맨틱)을 더 엄격하게 변경하여, 명시적인 `None` 및 빈 리스트 필터를 제한적인 조건으로 처리함으로써 와일드카드처럼 동작하던 동작을 제거하고, 보다 안전하고 값에 정확히 일치하는 매칭을 보장합니다.

Bug Fixes:
- 빈 리스트를 사용하는 메타데이터 필터가 모든 문서에 매칭되지 않도록 방지하여, 잠재적인 필터 우회 경로를 차단했습니다.
- 필터에서 `None`이 엄격한 동등 비교를 요구하는 대신 와일드카드처럼 동작할 수 있던 fail-open 동작을 제거했습니다.

Tests:
- 메타데이터 필터 테스트를 확장하여, `None`에 대한 엄격한 시맨틱과 빈 리스트 필터의 비매칭 동작, 그리고 `None`과 값이 섞여 있는 리스트 케이스까지 모두 포함하도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten metadata filtering semantics to treat explicit None and empty list filters as restrictive, eliminating wildcard-like behavior and ensuring secure, value-precise matching.

Bug Fixes:
- Prevent metadata filters with empty lists from matching any documents, closing a potential filter bypass path.
- Remove fail-open behavior where None in filters could act as a wildcard instead of requiring strict equality.

Tests:
- Extend metadata filter tests to cover strict None semantics and the non-matching behavior of empty-list filters, including mixed None-and-value list cases.

</details>