### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -26,6 +26,8 @@ def check_metadata_match(
     Args:
         doc_metadata: 문서에서 추출한 메타데이터 딕셔너리
         metadata_filter: 적용할 필터 조건 (예: {"category": "Projects", "tags": ["AI", "Tech"]})
+            * 정책: 필터 값이 빈 리스트([])인 경우, 유효한 매칭 후보가 없는 것으로 간주하여
+              해당 조건에 대해 즉시 False를 반환합니다.
 
     Returns:
         bool: 모든 필터 조건을 만족하면 True, 하나라도 불일치하면 False.
@@ -39,20 +41,23 @@ def check_metadata_match(
         return False
 
     for filter_key, filter_value in metadata_filter.items():
-        doc_value = doc_metadata.get(filter_key)
+        # 1. 존재성 확인: 필터에서 요구하는 키가 문서에 아예 없는 경우 실패
+        if filter_key not in doc_metadata:
+            return False
 
-        # 양쪽 값을 모두 리스트로 정규화하여 처리하되, None은 유효 값 매칭에서 제외
+        doc_value = doc_metadata[filter_key]
+
+        # 2. 빈 리스트 필터([]) 처리: 어떤 값과도 매칭될 수 없으므로 False (보안 정책)
+        if isinstance(filter_value, list) and not filter_value:
+            return False
+
+        # 3. 리스트 정규화 및 교집합 검사 (None 포함)
         filter_raw = filter_value if isinstance(filter_value, list) else [filter_value]
         doc_raw = doc_value if isinstance(doc_value, list) else [doc_value]
 
-        # None이 아닌 실제 값들만 추출하여 비교 (필터링의 의도는 '실제 값'의 일치여야 함)
-        filter_values = [v for v in filter_raw if v is not None]
-        doc_values = [v for v in doc_raw if v is not None]
-
-        # 만약 필터에 유효한 값이 명시되었는데 문서 값이 없거나 불일치하면 False
-        if filter_values:
-            if not doc_values or not any(v in filter_values for v in doc_values):
-                return False
+        # OR 세만틱: 문서 값 중 하나라도 필터 후보군에 포함되는지 확인
+        if not any(v in filter_raw for v in doc_raw):
+            return False
 
     return True
 

--- a/tests/unit/test_utils_metadata_filter.py
+++ b/tests/unit/test_utils_metadata_filter.py
@@ -54,19 +54,24 @@ def test_check_metadata_match_edge_cases():
 
 
 def test_check_metadata_match_none_semantics():
-    """None 값에 대한 매칭 세만틱 검증 (엄격한 가치 기반 필터링)."""
-    # 1. 필터가 스칼라 None인 경우 -> 모든 값에 대해 매칭 (와일드카드성 동작 유지)
-    assert check_metadata_match({"category": "A"}, {"category": None}) is True
-    assert check_metadata_match({}, {"category": None}) is True
+    """None 값 및 빈 리스트에 대한 매칭 세만틱 검증 (엄격한 필터링 모델)."""
+    # 1. 필터가 명시적인 None인 경우 -> 문서 값이 실제로 None인 경우만 매칭
+    assert check_metadata_match({"category": None}, {"category": None}) is True
+    assert check_metadata_match({"category": "A"}, {"category": None}) is False
 
-    # 2. 필터에 명시적 값이 있는데 문서가 None/누락인 경우 -> 매칭 실패 (방어적)
-    assert check_metadata_match({"category": None}, {"category": "A"}) is False
-    assert check_metadata_match({}, {"category": "A"}) is False
+    # 2. 키 자체가 없는 경우 (필터에서 기대하는데 데이터 없음) -> 매칭 실패 (엄격한 존재성 검증)
+    assert check_metadata_match({}, {"category": None}) is False
 
-    # 3. 필터 리스트에 None과 유효 값이 섞인 경우 -> 유효 값 기준으로만 판정
+    # 3. 필터가 빈 리스트([])인 경우 -> 절대로 매치될 수 없음 (Restrictive)
+    assert check_metadata_match({"tags": ["AI"]}, {"tags": []}) is False
+    assert check_metadata_match({"tags": []}, {"tags": []}) is False
+    assert check_metadata_match({}, {"tags": []}) is False
+
+    # 3. 리스트 내에 None과 값이 섞인 경우 -> 일반적인 교집합 논리 작동 (None 포함)
     doc_none = {"tags": None}
     doc_val = {"tags": ["AI"]}
-    filter_mix = {"tags": ["AI", None]}  # None은 무시되고 "AI"만 필터로 작동
+    filter_mix = {"tags": ["AI", None]}
 
-    assert check_metadata_match(doc_none, filter_mix) is False
-    assert check_metadata_match(doc_val, filter_mix) is True
+    assert check_metadata_match(doc_none, filter_mix) is True  # None끼리 매칭
+    assert check_metadata_match(doc_val, filter_mix) is True  # "AI"끼리 매칭
+    assert check_metadata_match({"tags": ["CV"]}, filter_mix) is False


### PR DESCRIPTION
♻️ refactor [#11.2.5]: 6차 개선 - 필터링 시맨틱 엄격화 및 보안성 강화 
♻️ refactor [#11.2.5]: 7차 개선 - 데이터 존재성 검증 및 필터링 정책 명세

## Summary by Sourcery

`None`, 빈 리스트, 그리고 누락된 키에 대한 메타데이터 필터링 의미론을 더 엄격하고 예측 가능하게 만들어, 매칭 조건을 강화합니다.

버그 수정:
- 문서 메타데이터에 키가 없을 때, 해당 키를 기대하는 필터가 이를 매치로 처리하지 않고 실패하도록 보장합니다.
- 빈 리스트 필터 값을 어떤 문서에도 매치되지 않는 조건으로 취급하여, 필터링의 보안성을 향상합니다.
- `None` 처리 방식을 정렬하여, 필터에 명시된 `None`이 문서 메타데이터의 명시된 `None`에만 매치되도록 하고, 리스트 기반 매칭 의미론에도 올바르게 참여하도록 합니다.

테스트:
- 보다 엄격해진 `None`, 빈 리스트, 키 존재 여부 의미론과 교집합 동작을 다루도록 메타데이터 필터 단위 테스트를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten metadata filtering semantics around None, empty lists, and missing keys to enforce stricter and more predictable matching.

Bug Fixes:
- Ensure filters expecting a key fail when the key is missing in document metadata instead of treating it as a match.
- Treat empty list filter values as non-matchable conditions so no documents satisfy them, improving security of filtering.
- Align None handling so explicit None in filters only matches explicit None in document metadata and participates correctly in list-based matching semantics.

Tests:
- Update metadata filter unit tests to cover stricter None, empty list, and key-existence semantics and intersection behavior.

</details>