### PR TITLE
✨ feat [#11.2.7]: RAG API 엔드포인트 연동 - HybridSearcher API 통합 및 PARA 카테고리 필터 노출

### DIFF
--- a/backend/api/endpoints/search.py
+++ b/backend/api/endpoints/search.py
@@ -1,23 +1,187 @@
 # backend/api/endpoints/search.py
 
-"""Search Endpoint"""
+"""
+하이브리드 검색 엔드포인트 (Step 6: RAG API Integration)
 
-from fastapi import APIRouter, Depends
-from ...api.deps import get_locale
-from ...api.models import SearchResponse
-from ...services.i18n_service import get_message
+GET  /search/          - 기존 단순 검색 (하위 호환)
+POST /search/hybrid    - HybridSearcher를 활용한 RAG 검색 (신규)
+GET  /search/hybrid    - 쿼리 파라미터 기반 RAG 검색 (신규, 간편 호출)
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from backend.api.deps import get_locale
+from backend.api.models import (
+    SearchResponse,
+    HybridSearchRequest,
+    HybridSearchResponse,
+    SearchResultItem,
+    PARA_CATEGORIES,
+)
+from backend.services.hybrid_search_service import (
+    HybridSearchService,
+    get_hybrid_search_service,
+)
+from backend.services.i18n_service import get_message
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/search", tags=["search"])
 
 
-@router.get("/", response_model=SearchResponse)
-async def search_files(q: str, locale: str = Depends(get_locale)) -> SearchResponse:
-    """검색 엔드포인트 (다국어 지원)"""
-    results = []  # TODO: Implement actual search logic
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# 기존 엔드포인트 (하위 호환 유지)
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+@router.get("/", response_model=SearchResponse, summary="기본 검색 (하위 호환)")
+async def search_files(
+    q: str,
+    locale: str = Depends(get_locale),
+) -> SearchResponse:
+    """기존 검색 엔드포인트 (하위 호환 유지).
+
+    현재는 빈 결과를 반환합니다. RAG 검색은 /search/hybrid를 사용하세요.
+    """
+    results = []
     return SearchResponse(
         status="success",
         message=get_message("search_results", locale, count=len(results)),
         query=q,
         results=results,
         count=len(results),
+    )
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# 하이브리드 RAG 검색 엔드포인트 (신규)
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+@router.post(
+    "/hybrid",
+    response_model=HybridSearchResponse,
+    summary="하이브리드 RAG 검색 (POST)",
+    description=(
+        "FAISS(Dense) + BM25(Sparse) 하이브리드 검색을 수행하고 "
+        "RRF(Reciprocal Rank Fusion) 알고리즘으로 결과를 병합합니다.\n\n"
+        "**PARA 카테고리 필터**: `category` 필드로 Projects / Areas / Resources / Archives 중 하나를 지정할 수 있습니다."
+    ),
+)
+async def hybrid_search_post(
+    request: HybridSearchRequest,
+    service: HybridSearchService = Depends(get_hybrid_search_service),
+) -> HybridSearchResponse:
+    """JSON Body로 검색 요청을 전달하는 하이브리드 RAG 검색."""
+    return await _run_hybrid_search(
+        service=service,
+        query=request.query,
+        k=request.k,
+        alpha=request.alpha,
+        category=request.category,
+        metadata_filter=request.metadata_filter,
+    )
+
+
+@router.get(
+    "/hybrid",
+    response_model=HybridSearchResponse,
+    summary="하이브리드 RAG 검색 (GET)",
+    description=(
+        "쿼리 파라미터를 사용하는 간편 하이브리드 RAG 검색.\n\n"
+        "예: `GET /search/hybrid?q=프로젝트+일정&k=5&category=Projects`"
+    ),
+)
+async def hybrid_search_get(
+    q: str = Query(..., min_length=1, description="검색 질의"),
+    k: int = Query(default=5, ge=1, le=50, description="반환할 결과 수 (1~50)"),
+    alpha: float = Query(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description="Dense 검색 가중치 (0.0=BM25 전용, 1.0=FAISS 전용)",
+    ),
+    category: Optional[str] = Query(
+        default=None,
+        description=f"PARA 카테고리 필터 ({', '.join(PARA_CATEGORIES)})",
+    ),
+    service: HybridSearchService = Depends(get_hybrid_search_service),
+) -> HybridSearchResponse:
+    """쿼리 파라미터를 사용하는 간편 하이브리드 RAG 검색."""
+    return await _run_hybrid_search(
+        service=service,
+        query=q,
+        k=k,
+        alpha=alpha,
+        category=category,
+        metadata_filter=None,
+    )
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# 내부 헬퍼
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+async def _run_hybrid_search(
+    service: HybridSearchService,
+    query: str,
+    k: int,
+    alpha: float,
+    category: Optional[str],
+    metadata_filter: Optional[dict],
+) -> HybridSearchResponse:
+    """POST/GET 공통 검색 실행 로직."""
+    try:
+        result = service.search(
+            query=query,
+            k=k,
+            alpha=alpha,
+            category=category,
+            metadata_filter=metadata_filter,
+        )
+    except ValueError as exc:
+        # PARA 카테고리 유효성 오류 등
+        logger.warning("Hybrid search validation error: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+    except Exception as exc:
+        logger.exception("Hybrid search unexpected error: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="검색 중 내부 오류가 발생했습니다.",
+        ) from exc
+
+    raw_results = result["results"]
+    applied_filter = result["applied_filter"]
+
+    # 결과 직렬화 (SearchResultItem)
+    items = [
+        SearchResultItem(
+            content=doc.get("content", ""),
+            metadata=doc.get("metadata", {}),
+            score=doc.get("score", 0.0),
+        )
+        for doc in raw_results
+    ]
+
+    logger.info(
+        "Hybrid search completed: query_len=%d, returned=%d, filter=%s",
+        len(query),
+        len(items),
+        applied_filter,
+    )
+
+    return HybridSearchResponse(
+        status="success",
+        query=query,
+        results=items,
+        count=len(items),
+        alpha=alpha,
+        applied_filter=applied_filter,
     )

--- a/backend/api/models/__init__.py
+++ b/backend/api/models/__init__.py
@@ -73,6 +73,85 @@ class MetadataResponse(BaseResponse):
     pass
 
 
+# ---------------------------------------------------------
+# Hybrid Search API Models (Step 6: RAG API Integration)
+# ---------------------------------------------------------
+
+PARA_CATEGORIES = ["Projects", "Areas", "Resources", "Archives"]
+
+
+class HybridSearchRequest(BaseModel):
+    """하이브리드 검색 요청 스키마
+
+    Attributes:
+        query: 검색 질의 문자열
+        k: 반환할 최종 결과 수 (1 이상)
+        alpha: Dense(FAISS) 검색 가중치 [0.0, 1.0] (기본값 0.5 = 균형)
+        category: PARA 카테고리 필터 (선택). 단일 카테고리 문자열.
+        metadata_filter: 추가 메타데이터 필터 조건 (카테고리 외 필드 필터링)
+    """
+
+    query: str = Field(..., min_length=1, description="검색 질의")
+    k: int = Field(default=5, ge=1, le=50, description="반환할 결과 수 (1~50)")
+    alpha: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description="Dense 검색 가중치 (0.0=BM25 전용, 1.0=FAISS 전용, 0.5=균형)",
+    )
+    category: Optional[str] = Field(
+        default=None,
+        description=f"PARA 카테고리 필터. 허용값: {PARA_CATEGORIES}",
+    )
+    metadata_filter: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description='추가 메타데이터 필터 (예: {"source": "my_notes.md"})',
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "query": "프로젝트 일정 관리",
+                    "k": 5,
+                    "alpha": 0.5,
+                    "category": "Projects",
+                },
+                {
+                    "query": "Python 비동기 처리",
+                    "k": 3,
+                    "alpha": 0.7,
+                    "category": None,
+                    "metadata_filter": {"source": "dev_notes.md"},
+                },
+            ]
+        }
+    }
+
+
+class SearchResultItem(BaseModel):
+    """개별 검색 결과 항목"""
+
+    content: str = Field(..., description="문서 내용")
+    metadata: Dict[str, Any] = Field(default_factory=dict, description="문서 메타데이터")
+    score: float = Field(..., description="RRF 병합 점수")
+
+
+class HybridSearchResponse(BaseModel):
+    """하이브리드 검색 응답 스키마"""
+
+    status: str = Field(..., description="응답 상태 ('success' 또는 'error')")
+    query: str = Field(..., description="원본 검색 질의")
+    results: List[SearchResultItem] = Field(
+        default_factory=list, description="RRF 점수 기준 정렬된 검색 결과"
+    )
+    count: int = Field(..., description="반환된 결과 수")
+    alpha: float = Field(..., description="사용된 Dense 검색 가중치")
+    applied_filter: Optional[Dict[str, Any]] = Field(
+        default=None, description="실제 적용된 메타데이터 필터"
+    )
+
+
 __all__ = [
     # Classification (Core)
     "ClassifyRequest",
@@ -102,4 +181,9 @@ __all__ = [
     "FileProcessingResponse",
     "SearchResponse",
     "MetadataResponse",
+    # Hybrid Search (Step 6)
+    "PARA_CATEGORIES",
+    "HybridSearchRequest",
+    "SearchResultItem",
+    "HybridSearchResponse",
 ]

--- a/backend/main.py
+++ b/backend/main.py
@@ -24,6 +24,7 @@ from backend.routes.onboarding_routes import router as onboarding_router
 from backend.api.endpoints.sync import router as sync_router
 from backend.api.endpoints.automation import router as automation_router
 from backend.api.endpoints.graph import router as graph_router
+from backend.api.endpoints.search import router as search_router
 
 
 # 로깅 설정
@@ -61,6 +62,7 @@ app = FastAPI(
     * `/classifier` - 파일 및 텍스트 분류
     * `/onboarding` - 사용자 온보딩
     * `/conflict` - 충돌 해결
+    * `/search/hybrid` - FAISS+BM25 하이브리드 RAG 검색 (PARA 카테고리 필터 지원)
     * `/health` - 서버 상태 확인
     
     ### 테스트 커버리지
@@ -131,6 +133,10 @@ app.include_router(sync_router)
 # websocket_router (Phase 1: Real-time Updates)
 app.include_router(websocket_router)
 logger.info("✅ sync_router 등록 완료 (MCP Sync & Conflict Resolution)")
+
+# search_router (Phase 2-②: RAG API Integration)
+app.include_router(search_router)
+logger.info("✅ search_router 등록 완료 (Hybrid RAG Search)")
 
 # automation_router (Phase 4: Celery Automation)
 

--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -1,0 +1,164 @@
+# backend/services/hybrid_search_service.py
+
+"""
+하이브리드 검색 서비스 (Step 6: RAG API Integration)
+
+FAISSRetriever와 BM25Retriever를 HybridSearcher와 연결하는
+싱글톤 서비스 레이어. API 엔드포인트와 검색 엔진 사이의 의존성을 관리합니다.
+"""
+
+import logging
+from typing import Dict, Any, List, Optional
+
+from backend.faiss_search import FAISSRetriever
+from backend.bm25_search import BM25Retriever
+from backend.hybrid_search import HybridSearcher
+from backend.api.models import PARA_CATEGORIES
+
+logger = logging.getLogger(__name__)
+
+
+class HybridSearchService:
+    """
+    HybridSearcher를 감싸는 서비스 클래스.
+
+    - FAISSRetriever / BM25Retriever를 초기화하여 HybridSearcher에 주입합니다.
+    - PARA 카테고리 검증 및 메타데이터 필터 병합 로직을 담당합니다.
+    - 호출 측(엔드포인트)은 이 클래스만 알면 됩니다.
+    """
+
+    def __init__(
+        self,
+        rrf_k: int = 60,
+        faiss_dimension: int = 1536,
+    ) -> None:
+        """
+        Args:
+            rrf_k: RRF 페널티 상수 (기본값: 60)
+            faiss_dimension: FAISS 임베딩 벡터 차원
+        """
+        self.faiss_retriever = FAISSRetriever(dimension=faiss_dimension)
+        self.bm25_retriever = BM25Retriever()
+        self.searcher = HybridSearcher(
+            faiss_retriever=self.faiss_retriever,
+            bm25_retriever=self.bm25_retriever,
+            rrf_k=rrf_k,
+        )
+        logger.info(
+            "HybridSearchService initialized (rrf_k=%d, dim=%d)", rrf_k, faiss_dimension
+        )
+
+    # ------------------------------------------------------------------
+    # 퍼블릭 메서드
+    # ------------------------------------------------------------------
+
+    def search(
+        self,
+        query: str,
+        k: int = 5,
+        alpha: float = 0.5,
+        category: Optional[str] = None,
+        metadata_filter: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        하이브리드 검색 수행 후 API 응답 형식으로 반환.
+
+        Args:
+            query: 검색 질의
+            k: 반환할 결과 수
+            alpha: Dense(FAISS) 가중치 [0.0, 1.0]
+            category: PARA 카테고리 필터 (문자열, 선택)
+            metadata_filter: 추가 메타데이터 필터 (선택)
+
+        Returns:
+            dict with keys: results, applied_filter
+        """
+        # 1. PARA 카테고리 검증 및 필터 병합
+        effective_filter = self._build_metadata_filter(category, metadata_filter)
+
+        logger.info(
+            "Hybrid search request: query_len=%d, k=%d, alpha=%.2f, filter=%s",
+            len(query),
+            k,
+            alpha,
+            effective_filter,
+        )
+
+        # 2. 검색 실행
+        raw_results = self.searcher.search(
+            query=query,
+            k=k,
+            alpha=alpha,
+            metadata_filter=effective_filter,
+        )
+
+        return {
+            "results": raw_results,
+            "applied_filter": effective_filter,
+        }
+
+    def is_ready(self) -> bool:
+        """인덱스에 문서가 있으면 True."""
+        faiss_ready = self.faiss_retriever.size() > 0
+        bm25_ready = len(self.bm25_retriever.documents) > 0
+        return faiss_ready and bm25_ready
+
+    # ------------------------------------------------------------------
+    # 내부 헬퍼
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_metadata_filter(
+        category: Optional[str],
+        extra_filter: Optional[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        """
+        PARA 카테고리와 추가 필터를 하나의 메타데이터 필터 딕셔너리로 병합.
+
+        Args:
+            category: PARA 카테고리 문자열 (검증 후 필터에 추가)
+            extra_filter: 사용자 제공 추가 메타데이터 필터
+
+        Returns:
+            병합된 필터 딕셔너리 또는 None (필터 없음)
+
+        Raises:
+            ValueError: 지원하지 않는 PARA 카테고리가 전달된 경우
+        """
+        merged: Dict[str, Any] = {}
+
+        # 추가 필터 먼저 삽입
+        if extra_filter:
+            merged.update(extra_filter)
+
+        # PARA 카테고리 검증 및 삽입
+        if category is not None:
+            if category not in PARA_CATEGORIES:
+                raise ValueError(
+                    f"지원하지 않는 카테고리: '{category}'. "
+                    f"허용값: {PARA_CATEGORIES}"
+                )
+            merged["category"] = category
+
+        return merged if merged else None
+
+
+# ------------------------------------------------------------------
+# 싱글톤 인스턴스 (애플리케이션 전체에서 공유)
+# ------------------------------------------------------------------
+
+_service_instance: Optional[HybridSearchService] = None
+
+
+def get_hybrid_search_service() -> HybridSearchService:
+    """
+    FastAPI Dependency Injection용 싱글톤 팩토리.
+
+    Returns:
+        HybridSearchService 인스턴스
+    """
+    global _service_instance
+    if _service_instance is None:
+        _service_instance = HybridSearchService()
+        logger.info("HybridSearchService singleton created.")
+    return _service_instance

--- a/tests/unit/test_search_endpoint.py
+++ b/tests/unit/test_search_endpoint.py
@@ -1,0 +1,194 @@
+# tests/unit/test_search_endpoint.py
+
+"""
+Step 6: /search/hybrid 엔드포인트 단위 테스트
+
+HybridSearchService를 모킹하여 엔드포인트의 라우팅/검증/직렬화 로직만 검증합니다.
+"""
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.services.hybrid_search_service import (
+    HybridSearchService,
+    get_hybrid_search_service,
+)
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━
+# 픽스처
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+def _make_mock_result(
+    content: str = "테스트 문서 내용",
+    category: str = "Projects",
+    score: float = 0.05,
+) -> Dict[str, Any]:
+    return {
+        "content": content,
+        "metadata": {"category": category, "source": "test.md"},
+        "score": score,
+    }
+
+
+@pytest.fixture()
+def mock_service() -> MagicMock:
+    """HybridSearchService 모킹 픽스처."""
+    svc = MagicMock(spec=HybridSearchService)
+    svc.search.return_value = {
+        "results": [_make_mock_result()],
+        "applied_filter": {"category": "Projects"},
+    }
+    return svc
+
+
+@pytest.fixture()
+def client(mock_service: MagicMock) -> TestClient:
+    """모킹된 서비스를 DI로 주입한 TestClient."""
+    app.dependency_overrides[get_hybrid_search_service] = lambda: mock_service
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━
+# POST /search/hybrid 테스트
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+def test_hybrid_search_post_basic(client: TestClient, mock_service: MagicMock):
+    """기본 POST 요청이 성공적으로 처리되어야 한다."""
+    payload = {"query": "프로젝트 일정", "k": 3, "alpha": 0.5, "category": "Projects"}
+    response = client.post("/search/hybrid", json=payload)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["query"] == "프로젝트 일정"
+    assert data["count"] == 1
+    assert len(data["results"]) == 1
+    assert data["results"][0]["content"] == "테스트 문서 내용"
+    assert data["alpha"] == 0.5
+
+
+def test_hybrid_search_post_no_category(client: TestClient, mock_service: MagicMock):
+    """category 없이 POST 요청도 성공해야 한다."""
+    mock_service.search.return_value = {
+        "results": [_make_mock_result()],
+        "applied_filter": None,
+    }
+    payload = {"query": "파이썬 비동기"}
+    response = client.post("/search/hybrid", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["applied_filter"] is None
+
+
+def test_hybrid_search_post_empty_query_returns_422(client: TestClient):
+    """빈 쿼리는 422 Unprocessable Entity를 반환해야 한다."""
+    response = client.post("/search/hybrid", json={"query": ""})
+    assert response.status_code == 422
+
+
+def test_hybrid_search_post_alpha_out_of_range_returns_422(client: TestClient):
+    """alpha가 [0, 1] 범위를 벗어나면 422를 반환해야 한다."""
+    response = client.post("/search/hybrid", json={"query": "테스트", "alpha": 1.5})
+    assert response.status_code == 422
+
+
+def test_hybrid_search_post_k_out_of_range_returns_422(client: TestClient):
+    """k가 1 미만이거나 50 초과이면 422를 반환해야 한다."""
+    response = client.post("/search/hybrid", json={"query": "테스트", "k": 0})
+    assert response.status_code == 422
+
+    response = client.post("/search/hybrid", json={"query": "테스트", "k": 51})
+    assert response.status_code == 422
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━
+# GET /search/hybrid 테스트
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+def test_hybrid_search_get_basic(client: TestClient, mock_service: MagicMock):
+    """기본 GET 요청이 성공적으로 처리되어야 한다."""
+    response = client.get("/search/hybrid?q=검색+테스트&k=5&category=Areas")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["query"] == "검색 테스트"
+    assert data["count"] == 1
+
+
+def test_hybrid_search_get_missing_query_returns_422(client: TestClient):
+    """q 파라미터가 없으면 422를 반환해야 한다."""
+    response = client.get("/search/hybrid")
+    assert response.status_code == 422
+
+
+def test_hybrid_search_get_invalid_category_propagates(
+    client: TestClient, mock_service: MagicMock
+):
+    """서비스에서 ValueError 발생 시 422로 변환되어야 한다."""
+    mock_service.search.side_effect = ValueError("지원하지 않는 카테고리: 'InvalidCat'")
+    response = client.get("/search/hybrid?q=테스트&category=InvalidCat")
+    assert response.status_code == 422
+
+
+def test_hybrid_search_get_service_error_returns_500(
+    client: TestClient, mock_service: MagicMock
+):
+    """서비스에서 예기치 않은 예외 발생 시 500을 반환해야 한다."""
+    mock_service.search.side_effect = RuntimeError("Unexpected error")
+    response = client.get("/search/hybrid?q=테스트")
+    assert response.status_code == 500
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━
+# HybridSearchService 단위 테스트
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestHybridSearchServiceBuildFilter:
+    """HybridSearchService._build_metadata_filter 단위 검증."""
+
+    def test_no_args_returns_none(self):
+        result = HybridSearchService._build_metadata_filter(None, None)
+        assert result is None
+
+    def test_category_only(self):
+        result = HybridSearchService._build_metadata_filter("Projects", None)
+        assert result == {"category": "Projects"}
+
+    def test_extra_filter_only(self):
+        result = HybridSearchService._build_metadata_filter(None, {"source": "a.md"})
+        assert result == {"source": "a.md"}
+
+    def test_category_and_extra_filter_merged(self):
+        result = HybridSearchService._build_metadata_filter("Areas", {"source": "b.md"})
+        assert result == {"category": "Areas", "source": "b.md"}
+
+    def test_invalid_category_raises_value_error(self):
+        with pytest.raises(ValueError, match="지원하지 않는 카테고리"):
+            HybridSearchService._build_metadata_filter("InvalidCat", None)
+
+    def test_all_para_categories_accepted(self):
+        from backend.api.models import PARA_CATEGORIES
+
+        for cat in PARA_CATEGORIES:
+            result = HybridSearchService._build_metadata_filter(cat, None)
+            assert result == {"category": cat}
+
+    def test_extra_filter_does_not_override_category(self):
+        """extra_filter에 'category' 키가 있어도 명시적 category 인자로 덮어써야 한다."""
+        result = HybridSearchService._build_metadata_filter(
+            "Projects", {"category": "Areas", "source": "c.md"}
+        )
+        assert result["category"] == "Projects"
+        assert result["source"] == "c.md"


### PR DESCRIPTION
- **[backend/services/hybrid_search_service.py]** (신규):
  - FAISSRetriever + BM25Retriever를 HybridSearcher에 주입하는 서비스 레이어 구현
  - PARA 카테고리 유효성 검증 및 메타데이터 필터 병합 로직 캡슐화
  - FastAPI DI 호환 싱글톤 팩토리 [get_hybrid_search_service](backend/services/hybrid_search_service.py:152:0-163:28) 제공
- **[backend/api/models/__init__.py]**:
  - HybridSearchRequest, SearchResultItem, HybridSearchResponse Pydantic 스키마 정의
  - k(1~50), alpha(0.0~1.0), category(PARA), metadata_filter 파라미터 검증 포함
- **[backend/api/endpoints/search.py]**:
  - POST /search/hybrid (JSON Body 기반 RAG 검색) 구현
  - GET  /search/hybrid (쿼리 파라미터 기반 간편 검색) 구현
  - 기존 GET /search/ 하위 호환 유지
- **[backend/main.py]**: search_router 등록
- **[tests/unit/test_search_endpoint.py]** (신규):
  - 엔드포인트 라우팅/검증/직렬화 및 서비스 단위 테스트 총 16개 PASS

🔗 Related: Issue [#566]

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro

## Summary by Sourcery

전용 서비스 레이어에 기반한 하이브리드 RAG 검색 API를 추가하고 FastAPI 앱에 통합합니다.

새 기능:
- PARA 카테고리 및 메타데이터 필터를 지원하는 FAISS+BM25 하이브리드 RAG 검색을 위해 POST 및 GET `/search/hybrid` 엔드포인트를 노출합니다.
- PARA 카테고리 열거형과 결과 아이템 구조를 포함하여 하이브리드 검색 요청과 응답을 위한 Pydantic 스키마를 도입합니다.
- FAISS 및 BM25 리트리버를 `HybridSearcher`에 연결하고 싱글톤 의존성 주입(DI)을 지원하는 `HybridSearchService`를 추가합니다.

개선 사항:
- 기존 `/search` 엔드포인트는 하위 호환성을 위해 유지하면서, 앱 설명에 권장 엔드포인트로 `/search/hybrid` 사용을 문서화합니다.

테스트:
- `/search/hybrid` 엔드포인트와 `HybridSearchService`의 필터 구성 로직에 대한 단위 테스트를 추가하여 검증, 오류 처리, 직렬화를 포괄합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a hybrid RAG search API backed by a dedicated service layer and integrate it into the FastAPI app.

New Features:
- Expose POST and GET /search/hybrid endpoints for FAISS+BM25 hybrid RAG search with PARA category and metadata filters.
- Introduce Pydantic schemas for hybrid search requests and responses, including PARA category enumeration and result item structure.
- Add a HybridSearchService that wires FAISS and BM25 retrievers into a HybridSearcher with singleton DI support.

Enhancements:
- Retain the existing /search endpoint for backward compatibility while documenting the preferred /search/hybrid usage in the app description.

Tests:
- Add unit tests for /search/hybrid endpoints and HybridSearchService filter-building logic, covering validation, error handling, and serialization.

</details>