### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/api/endpoints/search.py
+++ b/backend/api/endpoints/search.py
@@ -9,7 +9,7 @@
 """
 
 import logging
-from typing import Optional
+from typing import Optional, Dict, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.concurrency import run_in_threadpool
@@ -134,7 +134,7 @@ async def _run_hybrid_search(
     k: int,
     alpha: float,
     category: Optional[PARACategory],
-    metadata_filter: Optional[dict],
+    metadata_filter: Optional[Dict[str, Any]],
 ) -> HybridSearchResponse:
     """POST/GET 공통 검색 실행 로직."""
     try:

--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -76,6 +76,12 @@ class HybridSearchService:
         참고: 이 메서드는 CPU/IO bound 작업을 포함하므로
         FastAPI 엔드포인트에서 run_in_threadpool 등을 통해 비동기적으로 실행해야 합니다.
         """
+        # 0. 서비스 레벨 파라미터 검증 (방어적 프로그래밍)
+        if not (0.0 <= alpha <= 1.0):
+            raise ValueError(f"alpha must be between 0.0 and 1.0, got {alpha}")
+        if k < 1:
+            raise ValueError(f"k must be greater than or equal to 1, got {k}")
+
         # 1. PARA 카테고리 검증 및 필터 병합
         effective_filter = self._build_metadata_filter(category, metadata_filter)
 
@@ -114,6 +120,9 @@ class HybridSearchService:
     ) -> Optional[Dict[str, Any]]:
         """
         PARA 카테고리와 추가 필터를 하나의 메타데이터 필터 딕셔너리로 병합.
+
+        Raises:
+            ValueError: extra_filter에 이미 다른 'category'가 존재하는 경우
         """
         merged: Dict[str, Any] = {}
 
@@ -123,7 +132,12 @@ class HybridSearchService:
 
         # PARACategory Enum 값 삽입
         if category is not None:
-            # Enum 멤버가 전달되었는지 확인 (FastAPI가 이미 검증하지만 서비스 레이어에서도 안전하게 처리)
+            # [Review 반영] extra_filter에 이미 category가 존재하고 값이 다른 경우 충돌로 간주
+            if "category" in merged and merged["category"] != category.value:
+                raise ValueError(
+                    f"Category conflict: extra_filter has '{merged['category']}' "
+                    f"but explicit category is '{category.value}'."
+                )
             merged["category"] = category.value
 
         return merged if merged else None

--- a/tests/unit/test_search_endpoint.py
+++ b/tests/unit/test_search_endpoint.py
@@ -135,24 +135,89 @@ def test_hybrid_search_get_basic(client: TestClient, mock_service: MagicMock):
     assert data["count"] == 1
 
 
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━
-# HybridSearchService 단위 테스트 (빌드 필터)
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# HybridSearchService 단위 테스트 (빌드 필터 & 파라미터 검증)
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 
-class TestHybridSearchServiceBuildFilter:
-    """HybridSearchService._build_metadata_filter 단위 검증."""
+class TestHybridSearchServiceValidation:
+    """HybridSearchService의 파라미터 검증 및 필터 빌드 로직 단위 검증."""
 
-    def test_no_args_returns_none(self):
+    def test_search_alpha_out_of_range_raises_value_error(self):
+        """alpha가 [0.0, 1.0] 범위를 벗어날 때 ValueError 발생 확인."""
+        with patch("backend.services.hybrid_search_service.FAISSRetriever"), patch(
+            "backend.services.hybrid_search_service.BM25Retriever"
+        ):
+            svc = HybridSearchService()
+            with pytest.raises(ValueError, match="alpha must be between 0.0 and 1.0"):
+                svc.search(query="test", alpha=1.1)
+            with pytest.raises(ValueError, match="alpha must be between 0.0 and 1.0"):
+                svc.search(query="test", alpha=-0.1)
+
+    def test_search_k_min_validation(self):
+        """k가 1 미만일 때 ValueError 발생 확인."""
+        with patch("backend.services.hybrid_search_service.FAISSRetriever"), patch(
+            "backend.services.hybrid_search_service.BM25Retriever"
+        ):
+            svc = HybridSearchService()
+            with pytest.raises(
+                ValueError, match="k must be greater than or equal to 1"
+            ):
+                svc.search(query="test", k=0)
+
+    def test_search_k_boundary_accepts_valid_values(self):
+        """k의 유효 경계값(1, 50)이 정상적으로 허용되는지 확인."""
+        with patch("backend.services.hybrid_search_service.FAISSRetriever"), patch(
+            "backend.services.hybrid_search_service.BM25Retriever"
+        ):
+            svc = HybridSearchService()
+            # 검색 엔진 호출을 모킹하여 실제 임베딩/검색 방지
+            svc.searcher.search = MagicMock(return_value=[])
+
+            # 범위를 벗어나지 않으므로 예외 없이 실행되어야 함
+            svc.search(query="test", k=1)
+            svc.search(query="test", k=50)
+
+            assert svc.searcher.search.call_count == 2
+
+    def test_search_alpha_boundary_accepts_valid_values(self):
+        """alpha의 유효 경계값(0.0, 1.0)이 정상적으로 허용되는지 확인."""
+        with patch("backend.services.hybrid_search_service.FAISSRetriever"), patch(
+            "backend.services.hybrid_search_service.BM25Retriever"
+        ):
+            svc = HybridSearchService()
+            svc.searcher.search = MagicMock(return_value=[])
+
+            # 범위를 벗어나지 않으므로 예외 없이 실행되어야 함
+            svc.search(query="test", alpha=0.0)
+            svc.search(query="test", alpha=1.0)
+
+            assert svc.searcher.search.call_count == 2
+
+    def test_build_filter_no_args_returns_none(self):
         result = HybridSearchService._build_metadata_filter(None, None)
         assert result is None
 
-    def test_category_enum_conversion(self):
+    def test_build_filter_category_enum_conversion(self):
         """Enum이 문자열 값으로 올바르게 변환되는지 확인."""
         result = HybridSearchService._build_metadata_filter(PARACategory.PROJECTS, None)
         assert result == {"category": "Projects"}
 
-    def test_category_and_extra_filter_merged(self):
+    def test_build_filter_category_conflict_raises_value_error(self):
+        """extra_filter의 category와 명시적 category가 다르면 ValueError 발생."""
+        with pytest.raises(ValueError, match="Category conflict"):
+            HybridSearchService._build_metadata_filter(
+                PARACategory.PROJECTS, {"category": "Areas"}
+            )
+
+    def test_build_filter_category_match_is_ok(self):
+        """extra_filter의 category와 명시적 category가 같으면 허용."""
+        result = HybridSearchService._build_metadata_filter(
+            PARACategory.PROJECTS, {"category": "Projects", "other": "val"}
+        )
+        assert result == {"category": "Projects", "other": "val"}
+
+    def test_build_filter_merged(self):
         result = HybridSearchService._build_metadata_filter(
             PARACategory.AREAS, {"source": "b.md"}
         )


### PR DESCRIPTION
♻️ refactor [#11.2.7]: 2차 개선 - 서비스 레이어 검증 강화 및 필터 충돌 정책 수립 
♻️ refactor [#11.2.7]: 3차 개선 - 서비스 레이어 파라미터 경계값 테스트 보강 및 격리성 개선

## Summary by Sourcery

HybridSearchService의 파라미터 검증과 메타데이터 필터 충돌 처리 로직을 강화하고, 이에 맞춰 단위 테스트 커버리지를 업데이트합니다.

Enhancements:
- HybridSearchService.search에서 alpha 및 k 파라미터에 대한 서비스 레벨 검증을 추가하여, 범위를 벗어나는 값에 대해 명확한 에러와 함께 요청을 거부합니다.
- _build_metadata_filter에서 명시적인 PARA category와 추가적인 metadata_filter.category 값이 서로 다를 경우 충돌을 감지하도록 강제하고, metadata_filter에 대한 API 타입 정의를 약간 개선했습니다.

Tests:
- HybridSearchService 단위 테스트를 확장하여 파라미터 경계값 검증, alpha/k 에러 케이스, 그리고 category 필터 충돌/병합 동작을 모두 커버하도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen HybridSearchService parameter validation and metadata filter conflict handling, with corresponding unit test coverage updates.

Enhancements:
- Add service-level validation for alpha and k parameters in HybridSearchService.search, rejecting out-of-range values with clear errors.
- Enforce conflict detection when explicit PARA category and extra metadata_filter.category differ in _build_metadata_filter, and slightly refine API typing for metadata_filter.

Tests:
- Expand HybridSearchService unit tests to cover parameter boundary validation, alpha/k error cases, and category filter conflict/merge behavior.

</details>