### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -39,23 +39,45 @@ class HybridSearchService:
 
     def __init__(
         self,
+        faiss_retriever: Optional[FAISSRetriever] = None,
+        bm25_retriever: Optional[BM25Retriever] = None,
         rrf_k: int = 60,
         faiss_dimension: int = 1536,
     ) -> None:
         """
+        의존성 주입(DI)을 지원하는 생성자.
+
         Args:
+            faiss_retriever: 외부에서 주입할 FAISS 리트리버 (없으면 신규 생성)
+            bm25_retriever: 외부에서 주입할 BM25 리트리버 (없으면 신규 생성)
             rrf_k: RRF 페널티 상수
             faiss_dimension: FAISS 임베딩 벡터 차원
         """
-        self.faiss_retriever = FAISSRetriever(dimension=faiss_dimension)
-        self.bm25_retriever = BM25Retriever()
+        # 의존성 주입 또는 기본 생성 (None 여부를 명시적으로 확인하여 falsy 객체도 허용)
+        self.faiss_retriever = (
+            faiss_retriever
+            if faiss_retriever is not None
+            else FAISSRetriever(dimension=faiss_dimension)
+        )
+        self.bm25_retriever = (
+            bm25_retriever if bm25_retriever is not None else BM25Retriever()
+        )
+
+        # 통합 검색기 초기화
         self.searcher = HybridSearcher(
             faiss_retriever=self.faiss_retriever,
             bm25_retriever=self.bm25_retriever,
             rrf_k=rrf_k,
         )
         logger.info(
-            "HybridSearchService initialized (rrf_k=%d, dim=%d)", rrf_k, faiss_dimension
+            "HybridSearchService initialized (rrf_k=%d, dim=%d, DI=%s)",
+            rrf_k,
+            faiss_dimension,
+            (
+                "Yes"
+                if (faiss_retriever is not None or bm25_retriever is not None)
+                else "No"
+            ),
         )
 
     # ------------------------------------------------------------------

--- a/tests/unit/test_search_endpoint.py
+++ b/tests/unit/test_search_endpoint.py
@@ -1,20 +1,21 @@
 # tests/unit/test_search_endpoint.py
 
 """
-Step 6: /search/hybrid 엔드포인트 단위 테스트 (리팩토링 반영)
+Step 6: /search/hybrid 엔드포인트 단위 테스트 (리팩토링 최종 반영)
 
-1. 레거시 GET /search/ 엔드포인트 하위 호환성 테스트 추가
-2. PARACategory Enum 및 HybridSearchResult DTO 반영
+리뷰 피드백 반영:
+1. 의존성 주입(DI)을 활용하여 Mock 리트리버를 서비스에 직접 주입 (patch 의존성 제거)
+2. Fixture를 활용하여 테스트 중복 코드 제거 및 유지보수성 향상
 """
 
 from typing import Any, Dict, List, Optional
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
 
 from backend.main import app
-from backend.api.models import PARACategory, HybridSearchResponse
+from backend.api.models import PARACategory
 from backend.services.hybrid_search_service import (
     HybridSearchService,
     get_hybrid_search_service,
@@ -22,9 +23,9 @@ from backend.services.hybrid_search_service import (
 )
 
 
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━
-# 픽스처
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# 픽스처 (Fixtures)
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 
 def _make_mock_doc(
@@ -39,186 +40,107 @@ def _make_mock_doc(
     }
 
 
-@pytest.fixture()
-def mock_service() -> MagicMock:
-    """HybridSearchService 모킹 픽스처."""
-    svc = MagicMock(spec=HybridSearchService)
-    # DTO 객체를 반환하도록 설정
-    svc.search.return_value = HybridSearchResult(
-        results=[_make_mock_doc()],
-        applied_filter={"category": "Projects"},
-    )
+@pytest.fixture
+def mock_retrievers():
+    """리트리버 Mock 객체 쌍을 생성하는 Fixture."""
+    return (MagicMock(name="FAISS"), MagicMock(name="BM25"))
+
+
+@pytest.fixture
+def hybrid_service(mock_retrievers):
+    """의존성이 주입된 HybridSearchService 인스턴스를 생성하는 Fixture."""
+    faiss, bm25 = mock_retrievers
+    # 실제 FAISSRetriever/BM25Retriever 클래스 대신 Mock을 주입 (DI)
+    svc = HybridSearchService(faiss_retriever=faiss, bm25_retriever=bm25)
+    # searcher.search 메서드를 기본적으로 가짜 결과 반환하도록 설정
+    svc.searcher.search = MagicMock(return_value=[_make_mock_doc()])
     return svc
 
 
-@pytest.fixture()
-def client(mock_service: MagicMock) -> TestClient:
+@pytest.fixture
+def client(hybrid_service):
     """모킹된 서비스를 DI로 주입한 TestClient."""
-    app.dependency_overrides[get_hybrid_search_service] = lambda: mock_service
+    app.dependency_overrides[get_hybrid_search_service] = lambda: hybrid_service
     with TestClient(app) as c:
         yield c
     app.dependency_overrides.clear()
 
 
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━
-# 레거시 /search/ 테스트 (하위 호환성)
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# 엔드포인트 테스트 (API Routing & Schema)
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 
 def test_legacy_search_get_compatibility(client: TestClient):
-    """레거시 GET /search/ 엔드포인트가 정상 작동하고 필수 필드를 포함해야 한다."""
+    """레거시 GET /search/ 엔드포인트 하위 호환성 확인."""
     response = client.get("/search/?q=legacy-query")
-
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "success"
-    assert "message" in data
     assert data["query"] == "legacy-query"
     assert data["results"] == []
-    assert data["count"] == 0
 
 
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━
-# POST /search/hybrid 테스트
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-
-def test_hybrid_search_post_basic(client: TestClient, mock_service: MagicMock):
-    """기본 POST 요청이 성공적으로 처리되어야 한다."""
-    payload = {"query": "프로젝트 일정", "k": 3, "alpha": 0.5, "category": "Projects"}
+def test_hybrid_search_post_basic(client: TestClient, hybrid_service):
+    """기본 POST 요청 및 DTO 변환 확인."""
+    payload = {"query": "프로젝트", "k": 3, "category": "Projects"}
     response = client.post("/search/hybrid", json=payload)
 
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "success"
-    assert data["query"] == "프로젝트 일정"
-    assert data["count"] == 1
     assert len(data["results"]) == 1
     assert data["results"][0]["content"] == "테스트 문서 내용"
-    assert data["alpha"] == 0.5
 
 
-def test_hybrid_search_post_no_category(client: TestClient, mock_service: MagicMock):
-    """category 없이 POST 요청도 성공해야 한다."""
-    mock_service.search.return_value = HybridSearchResult(
-        results=[_make_mock_doc()],
-        applied_filter=None,
-    )
-    payload = {"query": "파이썬 비동기"}
-    response = client.post("/search/hybrid", json=payload)
-
+def test_hybrid_search_get_basic(client: TestClient):
+    """기본 GET 요청 확인."""
+    response = client.get("/search/hybrid?q=검색&category=Areas")
     assert response.status_code == 200
-    assert response.json()["applied_filter"] is None
+    assert response.json()["query"] == "검색"
 
 
-def test_hybrid_search_post_invalid_enum_value(client: TestClient):
-    """잘못된 카테고리 Enum 값 요청 시 422 에러가 발생해야 한다."""
-    response = client.post(
-        "/search/hybrid", json={"query": "테스트", "category": "Invalid"}
-    )
+def test_hybrid_search_invalid_category(client: TestClient):
+    """잘못된 카테고리 입력 시 Schema 에러 확인."""
+    response = client.post("/search/hybrid", json={"query": "x", "category": "Invalid"})
     assert response.status_code == 422
 
 
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━
-# GET /search/hybrid 테스트
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-
-def test_hybrid_search_get_basic(client: TestClient, mock_service: MagicMock):
-    """기본 GET 요청이 성공적으로 처리되어야 한다."""
-    response = client.get("/search/hybrid?q=검색+테스트&k=5&category=Areas")
-
-    assert response.status_code == 200
-    data = response.json()
-    assert data["status"] == "success"
-    assert data["query"] == "검색 테스트"
-    assert data["count"] == 1
-
-
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# HybridSearchService 단위 테스트 (빌드 필터 & 파라미터 검증)
+# 서비스 레이어 단위 테스트 (Validation & Filter)
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 
-class TestHybridSearchServiceValidation:
-    """HybridSearchService의 파라미터 검증 및 필터 빌드 로직 단위 검증."""
+class TestHybridSearchServiceLogic:
+    """HybridSearchService 내부 로직 단위 검증."""
 
-    def test_search_alpha_out_of_range_raises_value_error(self):
-        """alpha가 [0.0, 1.0] 범위를 벗어날 때 ValueError 발생 확인."""
-        with patch("backend.services.hybrid_search_service.FAISSRetriever"), patch(
-            "backend.services.hybrid_search_service.BM25Retriever"
-        ):
-            svc = HybridSearchService()
-            with pytest.raises(ValueError, match="alpha must be between 0.0 and 1.0"):
-                svc.search(query="test", alpha=1.1)
-            with pytest.raises(ValueError, match="alpha must be between 0.0 and 1.0"):
-                svc.search(query="test", alpha=-0.1)
+    def test_search_alpha_out_of_range(self, hybrid_service):
+        """alpha 범위 검증."""
+        with pytest.raises(ValueError, match="alpha must be between 0.0 and 1.0"):
+            hybrid_service.search(query="t", alpha=1.1)
 
-    def test_search_k_min_validation(self):
-        """k가 1 미만일 때 ValueError 발생 확인."""
-        with patch("backend.services.hybrid_search_service.FAISSRetriever"), patch(
-            "backend.services.hybrid_search_service.BM25Retriever"
-        ):
-            svc = HybridSearchService()
-            with pytest.raises(
-                ValueError, match="k must be greater than or equal to 1"
-            ):
-                svc.search(query="test", k=0)
+    def test_search_k_min_validation(self, hybrid_service):
+        """k 최소값 검증."""
+        with pytest.raises(ValueError, match="k must be greater than or equal to 1"):
+            hybrid_service.search(query="t", k=0)
 
-    def test_search_k_boundary_accepts_valid_values(self):
-        """k의 유효 경계값(1, 50)이 정상적으로 허용되는지 확인."""
-        with patch("backend.services.hybrid_search_service.FAISSRetriever"), patch(
-            "backend.services.hybrid_search_service.BM25Retriever"
-        ):
-            svc = HybridSearchService()
-            # 검색 엔진 호출을 모킹하여 실제 임베딩/검색 방지
-            svc.searcher.search = MagicMock(return_value=[])
+    def test_search_boundary_accepts_valid_values(self, hybrid_service):
+        """파라미터 경계값 허용 확인 (DI 기반 테스트)."""
+        # DI 덕분에 patch 없이 직접 mock 호출 여부 확인 가능
+        hybrid_service.search(query="test", k=1, alpha=0.0)
+        hybrid_service.search(query="test", k=50, alpha=1.0)
+        assert hybrid_service.searcher.search.call_count == 2
 
-            # 범위를 벗어나지 않으므로 예외 없이 실행되어야 함
-            svc.search(query="test", k=1)
-            svc.search(query="test", k=50)
-
-            assert svc.searcher.search.call_count == 2
-
-    def test_search_alpha_boundary_accepts_valid_values(self):
-        """alpha의 유효 경계값(0.0, 1.0)이 정상적으로 허용되는지 확인."""
-        with patch("backend.services.hybrid_search_service.FAISSRetriever"), patch(
-            "backend.services.hybrid_search_service.BM25Retriever"
-        ):
-            svc = HybridSearchService()
-            svc.searcher.search = MagicMock(return_value=[])
-
-            # 범위를 벗어나지 않으므로 예외 없이 실행되어야 함
-            svc.search(query="test", alpha=0.0)
-            svc.search(query="test", alpha=1.0)
-
-            assert svc.searcher.search.call_count == 2
-
-    def test_build_filter_no_args_returns_none(self):
-        result = HybridSearchService._build_metadata_filter(None, None)
-        assert result is None
-
-    def test_build_filter_category_enum_conversion(self):
-        """Enum이 문자열 값으로 올바르게 변환되는지 확인."""
-        result = HybridSearchService._build_metadata_filter(PARACategory.PROJECTS, None)
-        assert result == {"category": "Projects"}
-
-    def test_build_filter_category_conflict_raises_value_error(self):
-        """extra_filter의 category와 명시적 category가 다르면 ValueError 발생."""
+    def test_build_filter_category_conflict(self):
+        """카테고리 충돌 방지 로직 확인."""
         with pytest.raises(ValueError, match="Category conflict"):
             HybridSearchService._build_metadata_filter(
                 PARACategory.PROJECTS, {"category": "Areas"}
             )
 
-    def test_build_filter_category_match_is_ok(self):
-        """extra_filter의 category와 명시적 category가 같으면 허용."""
+    def test_build_filter_success(self):
+        """필터 빌드 성공 케이스 확인."""
         result = HybridSearchService._build_metadata_filter(
-            PARACategory.PROJECTS, {"category": "Projects", "other": "val"}
+            PARACategory.RESOURCES, {"other": "val"}
         )
-        assert result == {"category": "Projects", "other": "val"}
-
-    def test_build_filter_merged(self):
-        result = HybridSearchService._build_metadata_filter(
-            PARACategory.AREAS, {"source": "b.md"}
-        )
-        assert result == {"category": "Areas", "source": "b.md"}
+        assert result == {"category": "Resources", "other": "val"}


### PR DESCRIPTION
♻️ refactor [#11.2.7]: 4차 개선 - 의존성 주입(DI) 도입 및 테스트 아키텍처 리팩토링 
♻️ refactor [#11.2.7]: 5차 개선 - 의존성 주입 로직의 명시적 None 체크 적용

## Summary by Sourcery

HybridSearchService의 retriever에 대한 의존성 주입을 도입하고, 검색 테스트를 주입된 서비스와 구조화된 서비스 수준 검증 테스트를 사용하도록 리팩터링합니다.

Enhancements:
- HybridSearchService가 기본 인스턴스 생성을 유지하면서, 생성자를 통해 선택적인 FAISS 및 BM25 retriever 인스턴스를 받을 수 있도록 허용합니다.
- 서비스 초기화 로깅을 확장하여 retriever가 의존성 주입을 통해 제공되었는지 여부를 나타내도록 합니다.

Tests:
- API 엔드포인트 테스트를 리팩터링하여, 주입된 mock retriever로 HybridSearchService를 생성하고 요청/응답 단언을 단순화합니다.
- HybridSearchService 단위 테스트를 통합 및 정리하여, 내부 retriever 클래스를 patch하지 않고도 파라미터 경계와 메타데이터 필터 동작을 검증하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dependency injection for HybridSearchService retrievers and refactor search tests to use injected services and structured service-level validation tests.

Enhancements:
- Allow HybridSearchService to accept optional FAISS and BM25 retriever instances via its constructor while preserving default instantiation.
- Extend service initialization logging to indicate whether retrievers were provided via dependency injection.

Tests:
- Refactor API endpoint tests to construct HybridSearchService with injected mock retrievers and simplify request/response assertions.
- Consolidate and streamline HybridSearchService unit tests to validate parameter boundaries and metadata filter behavior without patching internal retriever classes.

</details>