### PR TITLE
♻️ refactor [#11.2.7]: 10차 개선 - 상수 도입 및 명시적 타입 체크를 통한 생성자 견고화

### DIFF
--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -11,7 +11,7 @@
 import logging
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, Protocol, runtime_checkable
 
 from backend.faiss_search import FAISSRetriever
 from backend.bm25_search import BM25Retriever
@@ -19,6 +19,15 @@ from backend.hybrid_search import HybridSearcher
 from backend.api.models import PARACategory
 
 logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class Retriever(Protocol):
+    """리트리버 오리 타이핑(Duck Typing)을 위한 프로토콜."""
+
+    def search(
+        self, query: str, k: int = 3, metadata_filter: Optional[Dict] = None
+    ) -> List[Dict]: ...
 
 
 @dataclass
@@ -44,6 +53,15 @@ class HybridSearchService:
     # 하위 호환성 및 테스트 정합성을 위한 기본값 상수
     DEFAULT_RRF_K = 60
     DEFAULT_FAISS_DIMENSION = 1536
+
+    # 위치 인수 매핑 규칙 (리뷰 제안: 테이블 기반 접근)
+    # 인덱스별로 (타입, 타겟 키) 리스트 정의
+    _POSITION_RULES = {
+        0: [(int, "rrf_k"), (Retriever, "faiss_ret")],
+        1: [(int, "faiss_dim"), (Retriever, "bm25_ret")],
+        2: [(int, "rrf_k"), (Retriever, "faiss_ret")],
+        3: [(int, "faiss_dim"), (Retriever, "bm25_ret")],
+    }
 
     def __init__(
         self,
@@ -97,12 +115,11 @@ class HybridSearchService:
         kwargs: Dict[str, Any],
         rrf_k: int,
         faiss_dim: int,
-        faiss_ret: Optional[FAISSRetriever],
-        bm25_ret: Optional[BM25Retriever],
+        faiss_ret: Optional[Retriever],
+        bm25_ret: Optional[Retriever],
     ) -> Dict[str, Any]:
         """위치 인수와 키워드 인수를 병합하고 우선순위를 결정하는 헬퍼."""
         # 1. 시그니처에 의해 자동으로 바인딩된 값들로 시작
-        # (호출 시 rrf_k=... 등을 사용했다면 이미 이 값들이 채워져 들어옴)
         res = {
             "rrf_k": rrf_k,
             "faiss_dim": faiss_dim,
@@ -111,46 +128,25 @@ class HybridSearchService:
         }
 
         # 2. **kwargs에 별칭이나 명시되지 않은 키워드가 있는 경우 처리
-        # (리뷰 지적대로 named arg는 args/kwargs가 아닌 개별 변수로 이미 전달됨)
-        if "rrf_k_alias" in kwargs:  # 미래의 확장성을 위한 kwargs 예시
+        if "rrf_k_alias" in kwargs:
             res["rrf_k"] = kwargs["rrf_k_alias"]
 
-        # 3. 위치 인수(*args) 처리
-        # 우선순위 확립: 위치 인수로 명시적 값을 채웠다면, 해당 값을 우선하되
-        # 이미 기본값(Default)이 아닌 다른 '의도적인' 키워드 값이 있다면 경고 후 키워드 우선
+        # 3. 위치 인수(*args) 처리 (테스트 및 레거시 대응)
         for i, arg in enumerate(args):
+            rules = self._POSITION_RULES.get(i)
+            if not rules:
+                continue
+
             target_key = None
-
-            # 타입 체크 강화
-            is_faiss = isinstance(arg, FAISSRetriever)
-            is_bm25 = isinstance(arg, BM25Retriever)
-            is_int = isinstance(arg, int)
-
-            if i == 0:
-                target_key = "rrf_k" if is_int else "faiss_ret" if is_faiss else None
-            elif i == 1:
-                target_key = "faiss_dim" if is_int else "bm25_ret" if is_bm25 else None
-            elif i == 2:
-                target_key = "rrf_k" if is_int else "faiss_ret" if is_faiss else None
-            elif i == 3:
-                target_key = "faiss_dim" if is_int else "bm25_ret" if is_bm25 else None
+            for expected_type, key in rules:
+                if isinstance(arg, expected_type):
+                    target_key = key
+                    break
 
             if target_key:
                 current_val = res[target_key]
-                # 기본값과 다른지(사용자가 키워드로 명명했는지) 체크
-                is_modified_by_kw = (
-                    (target_key == "rrf_k" and current_val != self.DEFAULT_RRF_K)
-                    or (
-                        target_key == "faiss_dim"
-                        and current_val != self.DEFAULT_FAISS_DIMENSION
-                    )
-                    or (
-                        target_key in ["faiss_ret", "bm25_ret"]
-                        and current_val is not None
-                    )
-                )
-
-                if is_modified_by_kw and current_val != arg:
+                # 명시적 키워드 우선순위 체크 (헬퍼 메서드 분리)
+                if self._is_overridden_by_keyword(target_key, current_val, arg):
                     logger.warning(
                         "Positional argument at index %d ignored in favor of explicit keyword argument",
                         i,
@@ -174,6 +170,19 @@ class HybridSearchService:
             "bm25_ret": final_bm25,
             "is_di": (res["faiss_ret"] is not None or res["bm25_ret"] is not None),
         }
+
+    def _is_overridden_by_keyword(
+        self, key: str, current_val: Any, new_val: Any
+    ) -> bool:
+        """키워드 인수가 기본값이 아닌 명시적인 값인지 판별하는 헬퍼."""
+        if key == "rrf_k":
+            is_explicit = current_val != self.DEFAULT_RRF_K
+        elif key == "faiss_dim":
+            is_explicit = current_val != self.DEFAULT_FAISS_DIMENSION
+        else:  # "faiss_ret" or "bm25_ret"
+            is_explicit = current_val is not None
+
+        return is_explicit and current_val != new_val
 
     # ------------------------------------------------------------------
     # 퍼블릭 메서드

--- a/tests/unit/test_search_endpoint.py
+++ b/tests/unit/test_search_endpoint.py
@@ -48,6 +48,10 @@ def mock_retrievers():
 
     faiss = MagicMock(spec=FAISSRetriever)
     bm25 = MagicMock(spec=BM25Retriever)
+
+    # HybridSearchService가 기대하는 기본 차원을 설정하여 AttributeError 방지
+    faiss.dimension = HybridSearchService.DEFAULT_FAISS_DIMENSION
+
     faiss.search.return_value = []
     bm25.search.return_value = []
     return (faiss, bm25)
@@ -152,13 +156,10 @@ class TestHybridSearchServiceInitialization:
     def test_init_with_mixed_args_full_case_b(self, mock_retrievers):
         """Case B (ret1, ret2, rrf_k, dim) 위치 인수 호출 확인."""
         faiss, bm25 = mock_retrievers
-        # Mock 객체에 dimension 속성이 없는 경우를 대비해 미리 설정 (AttributeError 방지)
-        faiss.dimension = 1536
-
         svc = HybridSearchService(faiss, bm25, 45, 1024)
         assert svc.faiss_retriever is faiss
         assert svc.bm25_retriever is bm25
-        # 내부에 전달된 파라미터 해석 결과가 올바른지 확인 (DI 상황이므로 Mock의 속성이 변하진 않음)
+        # 내부에 전달된 파라미터 해석 결과가 올바른지 확인
         assert svc._resolved_params["rrf_k"] == 45
         assert svc._resolved_params["faiss_dim"] == 1024
         assert svc.searcher.rrf_k == 45


### PR DESCRIPTION
- **[backend/services/hybrid_search_service.py]**:
  - `DEFAULT_RRF_K`, `DEFAULT_FAISS_DIMENSION` 클래스 상수 도입으로 하드코딩 제거 및 기본값 동기화 보장.
  - 리트리버 감지 로직을 `hasattr`에서 `isinstance` 기반의 엄격한 타입 체크로 전환.
  - `is_di` 퍼블릭 속성 추가로 의존성 주입 여부 모니터링 지원.
  - `**kwargs`의 인자 바인딩 특성을 고려하여 [_resolve_init_args](backend/services/hybrid_search_service.py:93:4-175:9) 시그니처 및 처리 로직 최적화.

- **[tests/unit/test_search_endpoint.py]**:
  - 생성자 호출 전수 테스트(인자 없음, 키워드 우선, DI 활성화 등) 케이스 보강.
  - Mock 객체를 활용한 혼합 인수 패턴 검증 시 발생하던 AttributeError 수정 및 속성 검증 정교화.
  - 전체 13개 테스트 시나리오 PASS 확인.

🔗 Related:
- Issue [#566]
- @ai-ai_bot_review (https://github.com/jjaayy2222/flownote-mvp/pull/577#pullrequestreview-3867253943)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1 Pro

## Summary by Sourcery

HybridSearchService 생성자의 기본값 및 인자 해석 방식을 다듬고, retriever 타입 처리 강화 및 초기화 테스트를 확장합니다.

Enhancements:
- HybridSearchService에서 기본 RRF weight와 FAISS dimension에 대한 클래스 상수(클래스 레벨 상수)를 도입하고, 이들의 사용 위치를 중앙집중화합니다.
- 명시적인 FAISS/BM25 retriever 타입 체크와 더 명확한 위치 인자 vs 키워드 인자 우선순위를 통해 HybridSearchService 생성자의 인자 해석을 엄격하게 만들고, 공개 DI 플래그를 노출합니다.
- HybridSearchService 내부의 로깅과 최종적으로 해석된 파라미터 처리 방식을 단순화하고 명료하게 개선합니다.

Tests:
- 타입이 지정된 mocks를 사용하여, 인자 없는(no-arg), 위치 인자(positional), 키워드 인자(keyword), DI 기반 생성 경로를 모두 포괄하도록 HybridSearchService 초기화 테스트 매트릭스를 확장합니다.
- 더 엄격해진 retriever 타입 처리와 새로운 DI 플래그 동작에 맞추어 테스트 픽스처와 기대값을 조정하고, 중복되는 경계(boundary) 테스트를 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine HybridSearchService constructor defaults and argument resolution while strengthening retriever type handling and expanding initialization tests.

Enhancements:
- Introduce class-level constants for default RRF weight and FAISS dimension and centralize their usage in HybridSearchService.
- Tighten HybridSearchService constructor argument resolution with explicit FAISS/BM25 retriever type checks and clearer positional vs keyword precedence, exposing a public DI flag.
- Simplify and clarify internal logging and resolved-parameter handling in HybridSearchService.

Tests:
- Expand HybridSearchService initialization test matrix to cover no-arg, positional, keyword, and DI-based construction paths using typed mocks.
- Adjust test fixtures and expectations to align with stricter retriever typing and new DI flag behavior, removing redundant boundary tests.

</details>