### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,18 @@ sys.path.append(str(Path(__file__).parent.parent))
 os.environ["TESTING"] = "true"
 os.environ["GPT4O_MINI_API_KEY"] = "test-key"  # Mocking용
 
+# ────────────────────────────────────────────────────────
+# 공용 테스트 설정 (Centralized Test Config)
+# ────────────────────────────────────────────────────────
+DEFAULT_EMBEDDING_DIM = 1536
+
+
+@pytest.fixture(scope="session")
+def embedding_dim():
+    """테스트용 기본 임베딩 차원"""
+    return DEFAULT_EMBEDDING_DIM
+
+
 from backend.main import app
 from backend.services.onboarding_service import OnboardingService
 from backend.services.classification_service import ClassificationService

--- a/tests/e2e/test_rag_search_quality.py
+++ b/tests/e2e/test_rag_search_quality.py
@@ -42,29 +42,41 @@ SAMPLE_DOCS = [
     },
 ]
 
-# Ground Truth for Evaluation: (Query -> List of Expected Source Files)
+# Ground Truth for Evaluation: (Query -> Dict with Expected Sources and Optional Category)
 GROUND_TRUTH = {
-    "FlowNote RAG": [
-        "Projects/FlowNote/Plan.md",
-        "Projects/FlowNote/Meeting_20240301.md",
-        "Resources/AI/RAG_Basics.md",
-    ],
-    "Health and workout": ["Areas/Health/Workout.md"],
-    "Documentation for FastAPI": ["Resources/Tech/FastAPI.md"],
-    "filter_expansion_factor": ["Projects/FlowNote/Meeting_20240301.md"],
+    "FlowNote RAG": {
+        "sources": [
+            "Projects/FlowNote/Plan.md",
+            "Projects/FlowNote/Meeting_20240301.md",
+            "Resources/AI/RAG_Basics.md",
+        ],
+        "category": PARACategory.PROJECTS,
+    },
+    "Health and workout": {
+        "sources": ["Areas/Health/Workout.md"],
+        "category": PARACategory.AREAS,
+    },
+    "Documentation for FastAPI": {
+        "sources": ["Resources/Tech/FastAPI.md"],
+        "category": PARACategory.RESOURCES,
+    },
+    "filter_expansion_factor": {
+        "sources": ["Projects/FlowNote/Meeting_20240301.md"],
+        "category": PARACategory.PROJECTS,
+    },
 }
 
 
 @pytest.mark.skip(reason="Requires real OpenAI API Credit")
 @pytest.mark.e2e
-def test_rag_quality_and_tuning():
+def test_rag_quality_and_tuning(embedding_dim):
     """
     실제 임베딩을 사용하여 검색 품질(P/R) 측정 및 expansion_factor 튜닝 시뮬레이션
     """
     logger.info("Starting RAG Quality E2E Test with Real Embeddings...")
 
     # 1. Initialize retrievers with real embeddings
-    faiss_ret = FAISSRetriever(dimension=1536)  # text-embedding-3-small uses 1536
+    faiss_ret = FAISSRetriever(dimension=embedding_dim)
     bm25_ret = BM25Retriever()
     embedder = faiss_ret.embedding_generator
 
@@ -91,10 +103,16 @@ def test_rag_quality_and_tuning():
         total_precision = 0.0
         total_recall = 0.0
 
-        for query, expected_sources in GROUND_TRUTH.items():
+        for query, gd in GROUND_TRUTH.items():
+            expected_sources = gd["sources"]
+            target_category = gd.get("category")
+
             # Perform search (k=3 for testing)
             search_result = service.search(
-                query=query, k=3, filter_expansion_factor=factor
+                query=query,
+                k=3,
+                filter_expansion_factor=factor,
+                category=target_category,
             )
 
             retrieved_sources = [


### PR DESCRIPTION
♻️ refactor [#11.2.8]: 2차 개선 - E2E 테스트 시나리오 보강 및 하드코딩 제거 
♻️ refactor [#11.2.8]: 3차 개선 - 테스트 의존성 분리 및 데이터 구조 명시화

## Sourcery에 의한 요약

구조화된 정답 메타데이터와 설정 가능한 임베딩 차원을 사용하도록 RAG E2E 검색 품질 테스트를 개선합니다.

새로운 기능:
- 정답 항목에 카테고리 메타데이터를 추가하여 확장함으로써, PARACategory 기반의 선택적 카테고리 제약 조건을 RAG 검색 품질 평가에 추가합니다.

개선 사항:
- 각 쿼리에 대해 예상 소스와 카테고리를 모두 포함하도록 GROUND_TRUTH 구조를 변경하여, 더 표현력 있는 평가 시나리오를 가능하게 합니다.
- FAISS 인덱스 차원을 하드코딩하는 대신, 임베딩 차원 픽스처를 받도록 RAG 품질 E2E 테스트를 매개변수화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the RAG E2E search quality test to use structured ground truth metadata and configurable embedding dimensions.

New Features:
- Add optional PARACategory-based category constraints to RAG search quality evaluation by extending ground truth entries with category metadata.

Enhancements:
- Change the GROUND_TRUTH structure to include both expected sources and categories for each query, enabling more expressive evaluation scenarios.
- Parameterize the RAG quality E2E test to accept an embedding dimension fixture instead of hardcoding the FAISS index dimension.

</details>