### PR TITLE
♻️ refactor [#11.2.11]: 2차 개선 - 임베딩 병렬화(Semaphore) 및 sys.path 의도 명문화

### DIFF
--- a/scripts/bootstrap_index.py
+++ b/scripts/bootstrap_index.py
@@ -61,7 +61,7 @@ async def _generate_embeddings_async(
     async with semaphore:
         try:
             # generate_embeddings는 동기 함수이므로 스레드풀에서 실행
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             emb_result = await loop.run_in_executor(
                 None,
                 service.faiss_retriever.embedding_generator.generate_embeddings,
@@ -78,30 +78,30 @@ async def _generate_embeddings_async(
             return None
 
 
-async def _process_file(
+def _process_file(
     file_path: Path,
     vault_path: Path,
     chunker: TextChunker,
     batch_size: int,
-) -> tuple[list[list[dict]], list[str], int]:
+) -> tuple[list[list[dict]], list[str]]:
     """
-    파일을 읽고 청킹하여 (배치 doc_entries 리스트, 배치 texts 리스트, 스킵 여부)를 반환한다.
-    인덱싱 자체는 수행하지 않으므로 완전히 순수 함수다.
+    파일을 읽고 청킹하여 (배치 doc_entries 리스트, 배치 texts 리스트)를 반환한다.
+    인덱싱 자체는 수행하지 않으므로 완전히 순수 함수다. async I/O 없음.
 
     Returns:
-        (batched_docs, batched_texts, error_flag): 배치 단위 문서·텍스트, 파일 오류 여부(0/1)
+        (batched_docs, batched_texts): 배치 단위 문서·텍스트
     """
     try:
         content = file_path.read_text(encoding="utf-8")
     except UnicodeDecodeError:
         logger.warning("UnicodeDecodeError — 파일 스킵: %s", file_path.name)
-        return [], [], 0
+        return [], []
     except OSError as e:
         logger.warning("파일 읽기 실패 (%s): %s", type(e).__name__, file_path.name)
-        return [], [], 0
+        return [], []
 
     if not content.strip():
-        return [], [], 0
+        return [], []
 
     category = _infer_category(file_path)
     metadata = {
@@ -112,7 +112,7 @@ async def _process_file(
 
     chunks = chunker.chunk_with_metadata(content, metadata)
     if not chunks:
-        return [], [], 0
+        return [], []
 
     # 배치 단위로 분할
     batched_docs = []
@@ -124,7 +124,7 @@ async def _process_file(
         )
         batched_texts.append([c["text"] for c in batch])
 
-    return batched_docs, batched_texts, 0
+    return batched_docs, batched_texts
 
 
 async def main() -> None:
@@ -201,8 +201,8 @@ async def main() -> None:
     logger.info("📖 임베딩 병렬 생성 + 순차 인덱싱 시작...")
 
     for file_idx, file_path in enumerate(md_files):
-        # Phase 1: 파일 읽기/청킹 (순수, 부작용 없음)
-        batched_docs, batched_texts, _ = await _process_file(
+        # Phase 1: 파일 읽기/청킹 (동기, 순수 함수 — async I/O 없음)
+        batched_docs, batched_texts = _process_file(
             file_path=file_path,
             vault_path=vault_path,
             chunker=chunker,


### PR DESCRIPTION
- **[scripts/bootstrap_index.py]**:
  - [병렬 임베딩 생성]: 파일 단위 순차 처리를 투-페이즈 구조로 개선.
    - Phase 2:
      - [_generate_embeddings_async()](scripts/bootstrap_index.py:48:0-77:23) + `asyncio.gather()` + `asyncio.Semaphore`로 배치별 임베딩 생성을 병렬화.
      - I/O 바운드(OpenAI API 호출) 작업만 병렬화하여 처리량 향상.
    - Phase 3: - [add_documents()](backend/faiss_search.py:72:4-103:71) 순차 실행 유지. - BM25/FAISS 리트리버가 thread-safe하지 않으므로 race condition 방지.
  - [--concurrency 인자 추가]:
    - 최대 동시 임베딩 API 요청 수를 외부에서 제어.
    - 기본값 5, API rate limit에 맞게 조절 가능. 하드코딩 제거.
  - [sys.path 주석 명문화]:
    - `sys.path.insert()` 사용 의도를 주석으로 명시
    - 단독 CLI 유틸, pyproject.toml 도입 시 Entry Point로 대체 가능
  - [_process_file() 분리]: 청킹 로직을 부작용 없는 순수 함수로 분리하여 임베딩 병렬화 설계와 역할 분리.

🔗 Related:
- Issue [#566]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/593#pullrequestreview-3872622745)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1

## Summary by Sourcery

인덱스 부트스트랩 스크립트에서 임베딩 생성을 병렬화하면서, 문서 인덱싱은 순차적으로 유지하고 CLI를 통해 설정 가능하도록 합니다.

신규 기능:
- 부트스트랩 인덱싱 스크립트에서 임베딩 API 요청의 동시 실행 최대 개수를 제어하기 위해 `--concurrency` CLI 옵션을 추가했습니다.

개선 사항:
- 파일 처리 로직을 순수한 청크 분할 함수와, `asyncio.Semaphore`로 조율되는 별도의 비동기 임베딩 생성 단계로 리팩터링했습니다.
- 인덱싱 파이프라인을, 동시 임베딩 생성 이후 스레드 안전성을 위한 순차적인 BM25/FAISS 인덱싱이 수행되는 2단계 모델로 변경했습니다.
- 배치 크기와 동시성 설정을 보고하는 기능을 포함하여, 부트스트랩 인덱싱을 위한 로깅과 CLI 도움말 메시지를 개선했습니다.
- 부트스트랩 스크립트에서 `sys.path` 수정의 의도를 명확히 하고, 카테고리 추론 결과에 `Optional`을 사용하도록 타입 힌트를 업데이트했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Parallelize embedding generation in the index bootstrap script while keeping document indexing sequential and configurable via CLI.

New Features:
- Add a --concurrency CLI option to control the maximum number of concurrent embedding API requests in the bootstrap indexing script.

Enhancements:
- Refactor file processing into a pure chunking function and a separate async embedding generation phase coordinated with asyncio.Semaphore.
- Change the indexing pipeline to a two-phase model with concurrent embedding generation followed by sequential BM25/FAISS indexing for thread-safety.
- Improve logging and CLI help messages for bootstrap indexing, including reporting batch size and concurrency settings.
- Clarify the intent of sys.path modification in the bootstrap script and update type hints to use Optional for category inference results.

</details>