### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/web_ui/src/app/[locale]/search/page.tsx
+++ b/web_ui/src/app/[locale]/search/page.tsx
@@ -1,0 +1,27 @@
+// web_ui/src/app/[locale]/search/page.tsx
+
+import { getTranslations } from 'next-intl/server';
+import { HybridSearch } from '@/components/search/HybridSearch';
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'search' });
+  return {
+    title: t('title'),
+    description: t('description'),
+  };
+}
+
+export default async function SearchPage() {
+  const t = await getTranslations('search');
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
+        <p className="text-muted-foreground mt-1">{t('description')}</p>
+      </div>
+      <HybridSearch />
+    </div>
+  );
+}

--- a/web_ui/src/components/search/HybridSearch.tsx
+++ b/web_ui/src/components/search/HybridSearch.tsx
@@ -1,0 +1,398 @@
+// web_ui/src/components/search/HybridSearch.tsx
+'use client';
+
+import React, { useState, useRef, useCallback } from 'react';
+import { useTranslations } from 'next-intl';
+import {
+  hybridSearch,
+  SearchApiError,
+  SearchResultItem,
+  PARACategory,
+  PARA_CATEGORIES,
+} from '@/lib/searchApi';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Search, Loader2, AlertCircle, FileSearch, Clock, ChevronDown, ChevronUp } from 'lucide-react';
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Constants
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+const DEFAULT_K = 5;
+const DEFAULT_ALPHA = 0.5;
+const LATENCY_WARN_MS = 2000; // 2초 이상이면 "느림" 표시
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Sub-components
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+function LatencyBadge({ ms }: { ms: number }) {
+  const isWarn = ms >= LATENCY_WARN_MS;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-xs font-mono px-2 py-0.5 rounded-full ${
+        isWarn
+          ? 'bg-amber-50 text-amber-700 border border-amber-200'
+          : 'bg-green-50 text-green-700 border border-green-200'
+      }`}
+    >
+      <Clock className="h-3 w-3" />
+      {ms.toLocaleString()}ms {isWarn && '⚠️'}
+    </span>
+  );
+}
+
+function ScoreBadge({ score }: { score: number }) {
+  const pct = Math.round(score * 100);
+  const color =
+    pct >= 70
+      ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
+      : pct >= 40
+      ? 'bg-blue-50 text-blue-700 border-blue-200'
+      : 'bg-slate-50 text-slate-500 border-slate-200';
+  return (
+    <Badge variant="outline" className={`text-xs font-mono ${color}`}>
+      {pct}%
+    </Badge>
+  );
+}
+
+function ResultCard({ item, index }: { item: SearchResultItem; index: number }) {
+  const t = useTranslations('search.result');
+  const [expanded, setExpanded] = useState(false);
+  const source = typeof item.metadata?.source === 'string' ? item.metadata.source : null;
+  const category = typeof item.metadata?.category === 'string' ? item.metadata.category : null;
+  const isLong = item.content.length > 300;
+  const displayContent = isLong && !expanded ? item.content.slice(0, 300) + '...' : item.content;
+
+  return (
+    <div
+      className="group relative border rounded-xl p-4 bg-white hover:shadow-md transition-all duration-200 hover:border-blue-200"
+      data-testid={`search-result-${index}`}
+    >
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3 mb-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="flex-shrink-0 w-6 h-6 rounded-full bg-slate-100 text-slate-500 text-xs font-bold flex items-center justify-center">
+            {index + 1}
+          </span>
+          {source && (
+            <span className="text-xs font-mono text-muted-foreground truncate" title={source}>
+              {source}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {category && (
+            <Badge variant="secondary" className="text-xs">
+              {category}
+            </Badge>
+          )}
+          <ScoreBadge score={item.score} />
+        </div>
+      </div>
+
+      {/* Content */}
+      <p className="text-sm text-slate-700 leading-relaxed whitespace-pre-wrap break-words">
+        {displayContent}
+      </p>
+
+      {isLong && (
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className="mt-2 text-xs text-blue-600 hover:text-blue-800 flex items-center gap-1 transition-colors"
+        >
+          {expanded ? (
+            <>
+              <ChevronUp className="h-3 w-3" /> {t('collapse')}
+            </>
+          ) : (
+            <>
+              <ChevronDown className="h-3 w-3" /> {t('expand')}
+            </>
+          )}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Main Component
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+export function HybridSearch() {
+  const t = useTranslations('search');
+  
+  // Form state
+  const [query, setQuery] = useState('');
+  const [k, setK] = useState(DEFAULT_K);
+  const [alpha, setAlpha] = useState(DEFAULT_ALPHA);
+  const [category, setCategory] = useState<PARACategory | ''>('');
+
+  // UI state
+  const [loading, setLoading] = useState(false);
+  const [results, setResults] = useState<SearchResultItem[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [latencyMs, setLatencyMs] = useState<number | null>(null);
+  const [lastQuery, setLastQuery] = useState<string>('');
+
+  const abortRef = useRef<AbortController | null>(null);
+
+  const handleSearch = useCallback(async () => {
+    const trimmed = query.trim();
+    if (!trimmed) return;
+
+    // 이전 요청 취소
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoading(true);
+    setError(null);
+    setResults(null);
+    setLatencyMs(null);
+    setLastQuery(trimmed);
+
+    const startAt = performance.now();
+
+    try {
+      const data = await hybridSearch(
+        {
+          query: trimmed,
+          k,
+          alpha,
+          category: category || null,
+        },
+        controller.signal,
+      );
+
+      const elapsed = Math.round(performance.now() - startAt);
+      setLatencyMs(elapsed);
+      setResults(data.results);
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        // 사용자가 취소한 경우 — 에러 표시 불필요
+        return;
+      }
+      if (err instanceof SearchApiError) {
+        if (err.statusCode === 422) {
+          setError(err.message); // 상세 메시지(파라미터 오류 등)
+        } else if (err.statusCode >= 500) {
+          setError(t('status.error_server'));
+        } else {
+          setError(err.message);
+        }
+      } else if (err instanceof TypeError) {
+        // fetch 실패 (네트워크 오류, 서버 미실행 등)
+        setError(t('status.error_network'));
+      } else {
+        setError(t('status.error_unexpected'));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [query, k, alpha, category, t]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !loading) {
+      handleSearch();
+    }
+  };
+
+  const handleCancel = () => {
+    abortRef.current?.abort();
+    setLoading(false);
+  };
+
+  // ── Render ──────────────────────────────────────────
+
+  return (
+    <div className="space-y-6">
+      {/* Search Form */}
+      <Card>
+        <CardHeader className="pb-4">
+          <CardTitle className="flex items-center gap-2">
+            <FileSearch className="h-5 w-5 text-blue-600" />
+            {t('title')}
+          </CardTitle>
+          <CardDescription>
+            {t('description')}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Query Input */}
+          <div className="flex gap-2">
+            <input
+              id="search-query-input"
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={t('placeholder')}
+              disabled={loading}
+              aria-label={t('title')}
+              className="flex-1 px-3 py-2 text-sm border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:opacity-50 disabled:bg-slate-50"
+            />
+            {loading ? (
+              <Button
+                id="search-cancel-btn"
+                variant="outline"
+                onClick={handleCancel}
+                className="gap-2 min-w-[80px]"
+              >
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {t('cancel')}
+              </Button>
+            ) : (
+              <Button
+                id="search-submit-btn"
+                onClick={handleSearch}
+                disabled={!query.trim()}
+                className="gap-2 min-w-[80px] bg-blue-600 hover:bg-blue-700"
+              >
+                <Search className="h-4 w-4" />
+                {t('submit')}
+              </Button>
+            )}
+          </div>
+
+          {/* Filters */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            {/* 결과 수 */}
+            <div className="space-y-1">
+              <label htmlFor="search-k-input" className="text-xs text-muted-foreground font-medium">
+                {t('filters.k_label')}: <span className="text-blue-600 font-bold">{k}</span>
+              </label>
+              <input
+                id="search-k-input"
+                type="range"
+                min={1}
+                max={20}
+                value={k}
+                onChange={(e) => setK(Number(e.target.value))}
+                disabled={loading}
+                className="w-full accent-blue-600"
+              />
+            </div>
+
+            {/* Alpha (Dense 가중치) */}
+            <div className="space-y-1">
+              <label htmlFor="search-alpha-input" className="text-xs text-muted-foreground font-medium">
+                {t('filters.alpha_label')}: <span className="text-blue-600 font-bold">{alpha.toFixed(1)}</span>
+              </label>
+              <input
+                id="search-alpha-input"
+                type="range"
+                min={0}
+                max={1}
+                step={0.1}
+                value={alpha}
+                onChange={(e) => setAlpha(parseFloat(e.target.value))}
+                disabled={loading}
+                className="w-full accent-blue-600"
+              />
+              <div className="flex justify-between text-[10px] text-muted-foreground uppercase font-bold tracking-tighter">
+                <span>{t('filters.alpha_hint_sparse')}</span>
+                <span className="font-normal lowercase">{t('filters.alpha_hint_mid')}</span>
+                <span>{t('filters.alpha_hint_dense')}</span>
+              </div>
+            </div>
+
+            {/* PARA 카테고리 필터 */}
+            <div className="space-y-1">
+              <label htmlFor="search-category-select" className="text-xs text-muted-foreground font-medium">
+                {t('filters.category_label')}
+              </label>
+              <select
+                id="search-category-select"
+                value={category}
+                onChange={(e) => setCategory(e.target.value as PARACategory | '')}
+                disabled={loading}
+                className="w-full px-3 py-2 text-sm border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:opacity-50"
+              >
+                <option value="">{t('filters.category_all')}</option>
+                {PARA_CATEGORIES.map((cat) => (
+                  <option key={cat} value={cat}>
+                    {cat}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Loading Skeleton */}
+      {loading && (
+        <div className="space-y-3" aria-live="polite" aria-label={t('status.searching')}>
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="border rounded-xl p-4 bg-white animate-pulse">
+              <div className="h-3 bg-slate-200 rounded w-1/3 mb-3" />
+              <div className="space-y-2">
+                <div className="h-2.5 bg-slate-100 rounded w-full" />
+                <div className="h-2.5 bg-slate-100 rounded w-4/5" />
+                <div className="h-2.5 bg-slate-100 rounded w-2/3" />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Error State */}
+      {!loading && error && (
+        <div
+          role="alert"
+          className="flex items-start gap-3 p-4 border border-red-200 rounded-xl bg-red-50 text-red-700"
+        >
+          <AlertCircle className="h-5 w-5 flex-shrink-0 mt-0.5" />
+          <div className="space-y-1">
+            <p className="font-semibold text-sm">{t('status.error_title')}</p>
+            <p className="text-sm">{error}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Results */}
+      {!loading && results !== null && !error && (
+        <div className="space-y-3">
+          {/* Results Header */}
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-muted-foreground">
+              {t('status.results_count', { query: lastQuery, count: results.length })}
+            </p>
+            {latencyMs !== null && <LatencyBadge ms={latencyMs} />}
+          </div>
+
+          {/* Empty State */}
+          {results.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 text-center text-muted-foreground border rounded-xl bg-white">
+              <Search className="h-12 w-12 mb-3 opacity-20" />
+              <p className="font-medium">{t('status.no_results')}</p>
+              <p className="text-sm mt-1">
+                {t('status.no_results_hint')}
+              </p>
+              {category && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="mt-3 text-blue-600"
+                  onClick={() => setCategory('')}
+                >
+                  {t('status.clear_filter')}
+                </Button>
+              )}
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {results.map((item, i) => (
+                <ResultCard key={i} item={item} index={i} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web_ui/src/config/navigation.ts
+++ b/web_ui/src/config/navigation.ts
@@ -1,9 +1,9 @@
 // web_ui/src/config/navigation.ts
 
-import { LayoutDashboard, Network, BarChart3, Settings, Github } from "lucide-react";
+import { LayoutDashboard, Network, BarChart3, Search, Settings, Github } from "lucide-react";
 
 // Translation keys defined in en.json/ko.json under "navigation" namespace
-export type TranslationKey = "dashboard" | "graph" | "stats" | "preferences" | "github";
+export type TranslationKey = "dashboard" | "graph" | "stats" | "search" | "preferences" | "github";
 
 export interface NavigationItem {
   href: string;
@@ -14,6 +14,7 @@ export interface NavigationItem {
 
 export const mainNavItems: NavigationItem[] = [
   { href: "/", label: "dashboard", icon: LayoutDashboard },
+  { href: "/search", label: "search", icon: Search },
   { href: "/graph", label: "graph", icon: Network },
   { href: "/stats", label: "stats", icon: BarChart3 },
 ];

--- a/web_ui/src/locales/en.json
+++ b/web_ui/src/locales/en.json
@@ -19,6 +19,7 @@
     "dashboard": "Dashboard",
     "graph": "Graph View",
     "stats": "Statistics",
+    "search": "Hybrid Search",
     "preferences": "Preferences",
     "github": "GitHub"
   },
@@ -84,5 +85,36 @@
   "metadata": {
     "title": "FlowNote - AI Knowledge System",
     "description": "AI-powered Knowledge Management System based on PARA method."
+  },
+  "search": {
+    "title": "Hybrid RAG Search",
+    "description": "Find relevant notes from your Obsidian Vault using FAISS + BM25 hybrid vector search.",
+    "placeholder": "Enter search terms...",
+    "submit": "Search",
+    "cancel": "Cancel",
+    "filters": {
+      "k_label": "Number of results (k)",
+      "alpha_label": "Dense weight (α)",
+      "alpha_hint_dense": "FAISS",
+      "alpha_hint_sparse": "BM25",
+      "alpha_hint_mid": "Balanced",
+      "category_label": "PARA Category",
+      "category_all": "All (No filter)"
+    },
+    "status": {
+      "searching": "Searching",
+      "results_count": "{count} results for \"{query}\"",
+      "no_results": "No results found",
+      "no_results_hint": "Try different search terms or change the category filter.",
+      "clear_filter": "Clear category filter",
+      "error_title": "Search Error",
+      "error_server": "A server error occurred. Please try again later.",
+      "error_network": "Cannot connect to API server. Please check if the backend is running.",
+      "error_unexpected": "An unexpected error occurred."
+    },
+    "result": {
+      "expand": "Expand",
+      "collapse": "Collapse"
+    }
   }
 }

--- a/web_ui/src/locales/ko.json
+++ b/web_ui/src/locales/ko.json
@@ -19,6 +19,7 @@
     "dashboard": "대시보드",
     "graph": "그래프 뷰",
     "stats": "통계",
+    "search": "하이브리드 검색",
     "preferences": "설정",
     "github": "GitHub"
   },
@@ -84,5 +85,36 @@
   "metadata": {
     "title": "FlowNote - AI 지식 관리 시스템",
     "description": "PARA 방법론 기반의 AI 지식 관리 시스템. 당신의 제2의 두뇌를 자동화하세요."
+  },
+  "search": {
+    "title": "하이브리드 RAG 검색",
+    "description": "FAISS + BM25 하이브리드 벡터 검색으로 Obsidian Vault에서 관련 노트를 찾아보세요.",
+    "placeholder": "검색어를 입력하세요...",
+    "submit": "검색",
+    "cancel": "취소",
+    "filters": {
+      "k_label": "결과 수 (k)",
+      "alpha_label": "Dense 가중치 (α)",
+      "alpha_hint_dense": "FAISS",
+      "alpha_hint_sparse": "BM25",
+      "alpha_hint_mid": "균형",
+      "category_label": "PARA 카테고리",
+      "category_all": "전체 (필터 없음)"
+    },
+    "status": {
+      "searching": "검색 중",
+      "results_count": "\"{query}\" 검색 결과 {count}건",
+      "no_results": "검색 결과가 없습니다",
+      "no_results_hint": "다른 검색어를 사용하거나 카테고리 필터를 변경해 보세요.",
+      "clear_filter": "카테고리 필터 해제",
+      "error_title": "검색 오류",
+      "error_server": "서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+      "error_network": "API 서버에 연결할 수 없습니다. 백엔드가 실행 중인지 확인해 주세요.",
+      "error_unexpected": "예상치 못한 오류가 발생했습니다."
+    },
+    "result": {
+      "expand": "더 보기",
+      "collapse": "접기"
+    }
   }
 }


### PR DESCRIPTION
✨ feat [#11.2.12]: 하이브리드 RAG 검색 프론트엔드 연동 및 Search UI 구현 
♻️ refactor [#11.2.12]: 1차 개선 - 검색 UI i18n 완전 적용 및 하드코딩 제거

## Summary by Sourcery

로컬라이즈된 하이브리드 RAG 검색 페이지를 추가하고 메인 내비게이션에 연결합니다.

새 기능:
- 조정 가능한 파라미터와 PARA 카테고리 필터를 사용해 백엔드 RAG 검색 API를 조회하는 하이브리드 검색 UI 컴포넌트를 도입합니다.
- 메타데이터와 레이아웃을 포함해 하이브리드 검색 경험을 제공하는 전용 로컬라이즈된 검색 페이지를 추가합니다.
- 아이콘과 i18n을 고려한 레이블을 사용해 메인 내비게이션을 통해 새로운 검색 페이지를 노출합니다.

개선 사항:
- 상태 메시지와 필터 레이블을 포함한 새로운 검색 플로우의 문구를 완전히 i18n 기반으로 구현하여 검색 UI에서 하드코딩된 문자열을 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a localized hybrid RAG search page and link it into the main navigation.

New Features:
- Introduce a hybrid search UI component that queries the backend RAG search API with tunable parameters and PARA category filters.
- Add a dedicated, localized search page that exposes the hybrid search experience, including metadata and layout.
- Expose the new search page through the main navigation with an icon and i18n-aware label.

Enhancements:
- Implement fully i18n-driven copy for the new search flow, including status messages and filter labels, removing hardcoded strings from the search UI.

</details>