### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/api/endpoints/search.py
+++ b/backend/api/endpoints/search.py
@@ -168,12 +168,12 @@ async def _run_hybrid_search(
     # 결과 직렬화 (SearchResultItem)
     items = [
         SearchResultItem(
-            id=doc.get("id", f"unknown-{i}"),
+            id=doc["id"],  # 검색 엔진에서 보증하는 고유 ID 사용
             content=doc.get("content", ""),
             metadata=doc.get("metadata", {}),
             score=doc.get("score", 0.0),
         )
-        for i, doc in enumerate(raw_results)
+        for doc in raw_results
     ]
 
     logger.info(

--- a/backend/api/models/__init__.py
+++ b/backend/api/models/__init__.py
@@ -150,14 +150,11 @@ class HybridSearchRequest(BaseModel):
 class SearchResultItem(BaseModel):
     """개별 검색 결과 항목.
 
-    주의: `id` 필드는 모델 생성 시 하위 호환성을 위해 `Optional`로 정의되어 있으나,
-    API 엔드포인트 응답 시에는 항상 구체적인 식별자(String)가 포함됨을 보장합니다.
+    API 응답 규격으로서, 프론트엔드 React key로 활용되는 `id`가 필수이며
+    백엔드 하이브리드 검색 레이어에서 보장하는 고유 식별자가 포함됩니다.
     """
 
-    id: Optional[str] = Field(
-        None,
-        description="문서 고유 식별자. 내부 생성 시에는 생략 가능하나 외부 응답 시에는 항상 값이 포함됨.",
-    )
+    id: str = Field(..., description="문서 고유 식별자 (파일명-청크인덱스 등)")
     content: str = Field(..., description="문서 내용")
     metadata: Dict[str, Any] = Field(
         default_factory=dict, description="문서 메타데이터"

--- a/backend/hybrid_search.py
+++ b/backend/hybrid_search.py
@@ -186,6 +186,7 @@ class HybridSearcher:
         final_results = []
         for doc_key in sorted_keys[:k]:
             doc_info = merged_docs[doc_key].copy()
+            doc_info["id"] = doc_key  # 고유 식별자 포함
             doc_info["score"] = rrf_scores[doc_key]
             final_results.append(doc_info)
 


### PR DESCRIPTION
♻️ refactor [#11.2.12]: 6차 개선 - 모델 수준의 ID 타입 강제 및 런타임 안정성 보장 
♻️ refactor [#11.2.12]: 7차 개선 - 매직 문자열 제거 및 데이터 기반 고유 ID 체계 완성

## Summary by Sourcery

하이브리드 검색 결과에 대해 백엔드에서 생성한 안정적인 고유 ID를 강제하고, 검색 결과 모델과 파이프라인 전반에서 `id`를 필수 문자열 식별자로 일관되게 처리하도록 합니다.

Enhancements:
- `SearchResultItem.id`를 선택적 값이 아닌 필수 문자열 필드로 변경하여, API 응답에서의 보장 사항과 프론트엔드에서의 key 사용 방식에 맞춥니다.
- 하이브리드 검색이 병합된 문서 키에서 결정론적인 고유 `id`를 각 결과에 채워 넣고, 검색 엔드포인트 전체에서 대체용 placeholder ID 없이 그대로 전파되도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce stable, backend-generated unique IDs for hybrid search results and make the search result model and pipeline consistently treat `id` as a required string identifier.

Enhancements:
- Make `SearchResultItem.id` a required string field instead of an optional value to align with API response guarantees and frontend key usage.
- Ensure hybrid search populates each result with a deterministic unique `id` from the merged document key and propagates it through the search endpoint without fallback placeholder IDs.

</details>