### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/api/endpoints/__init__.py
+++ b/backend/api/endpoints/__init__.py
@@ -6,5 +6,12 @@ from .classify import router as classify_router
 from .search import router as search_router
 from .metadata import router as metadata_router
 from .automation import router as automation_router
+from .chat import router as chat_router
 
-__all__ = ["classify_router", "search_router", "metadata_router", "automation_router"]
+__all__ = [
+    "classify_router",
+    "search_router",
+    "metadata_router",
+    "automation_router",
+    "chat_router",
+]

--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -1,0 +1,41 @@
+# backend/api/endpoints/chat.py
+
+"""
+스트리밍 기반 AI 채팅 엔드포인트
+"""
+
+import logging
+from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
+
+from backend.api.models import ChatQueryRequest
+from backend.services.chat_service import ChatService, get_chat_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/chat", tags=["chat"])
+
+
+@router.post("/stream", summary="RAG 채팅 결과 스트리밍")
+async def stream_chat(
+    request: ChatQueryRequest, chat_service: ChatService = Depends(get_chat_service)
+):
+    """
+    사용자의 질문을 기반으로 RAG 파이프라인(LangChain + Hybrid Search)을 거쳐
+    LLM의 응답을 Server-Sent Events(SSE) 스트리밍 형식으로 반환합니다.
+    """
+    logger.info(
+        "Chat stream requested by user: %s (query_len=%d)",
+        request.user_id,
+        len(request.query),
+    )
+
+    return StreamingResponse(
+        chat_service.stream_chat(
+            query=request.query,
+            user_id=request.user_id,
+            k=request.k,
+            alpha=request.alpha,
+        ),
+        media_type="text/event-stream",
+    )

--- a/backend/api/models/__init__.py
+++ b/backend/api/models/__init__.py
@@ -177,6 +177,24 @@ class HybridSearchResponse(BaseModel):
     )
 
 
+# ---------------------------------------------------------
+# Chat Streaming API Models (Step 7: RAG API Integration)
+# ---------------------------------------------------------
+
+
+class ChatQueryRequest(BaseModel):
+    """채팅 질의 요청 스키마"""
+
+    query: str = Field(..., description="사용자 질의 텍스트")
+    user_id: str = Field(..., description="사용자 ID (온보딩 및 세션 식별용)")
+    k: int = Field(
+        default=5, ge=1, le=20, description="RAG 검색에 사용할 최대 컨텍스트(문서) 수"
+    )
+    alpha: float = Field(
+        default=0.5, ge=0.0, le=1.0, description="하이브리드 검색 FAISS 가중치"
+    )
+
+
 __all__ = [
     # Classification (Core)
     "ClassifyRequest",
@@ -212,4 +230,6 @@ __all__ = [
     "HybridSearchRequest",
     "SearchResultItem",
     "HybridSearchResponse",
+    # Chat (Step 7)
+    "ChatQueryRequest",
 ]

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -22,3 +22,4 @@ async def health_check(locale: str = Depends(get_locale)) -> HealthCheckResponse
 router.include_router(endpoints.classify_router)
 router.include_router(endpoints.search_router)
 router.include_router(endpoints.metadata_router)
+router.include_router(endpoints.chat_router)

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -1,0 +1,179 @@
+# backend/services/chat_service.py
+
+import json
+import logging
+from typing import AsyncGenerator, List, Optional
+from functools import lru_cache
+
+from langchain_core.documents import Document
+from langchain_core.prompts import (
+    ChatPromptTemplate,
+    SystemMessagePromptTemplate,
+    HumanMessagePromptTemplate,
+)
+from langchain_core.retrievers import BaseRetriever
+from langchain.chains import create_retrieval_chain
+from langchain.chains.combine_documents import create_stuff_documents_chain
+
+from backend.services.hybrid_search_service import (
+    HybridSearchService,
+    get_hybrid_search_service,
+)
+from backend.services.onboarding_service import OnboardingService
+
+logger = logging.getLogger(__name__)
+
+
+class HybridSearchLangChainRetriever(BaseRetriever):
+    """HybridSearchService를 LangChain Retriever로 래핑"""
+
+    service: HybridSearchService
+    k: int = 5
+    alpha: float = 0.5
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    def _get_relevant_documents(
+        self, query: str, *, run_manager=None
+    ) -> List[Document]:
+        """비동기 호출(aget) 전용으로, 동기 호출은 지원하지 않습니다."""
+        raise NotImplementedError(
+            "This retriever only supports asynchronous execution (_aget_relevant_documents)."
+        )
+
+    async def _aget_relevant_documents(
+        self, query: str, *, run_manager=None
+    ) -> List[Document]:
+        """비동기 하이브리드 검색 실행하여 LangChain Document 객체로 변환"""
+        result = await self.service.search(query=query, k=self.k, alpha=self.alpha)
+        docs = []
+        for res in result.results:
+            content = res.get("content", "")
+            metadata = res.get("metadata", {})
+            metadata["id"] = res.get("id", "")
+            metadata["score"] = res.get("score", 0.0)
+            docs.append(Document(page_content=content, metadata=metadata))
+        return docs
+
+
+class ChatService:
+    def __init__(
+        self,
+        hybrid_search_service: HybridSearchService,
+        onboarding_service: OnboardingService,
+    ):
+        self.hybrid_search_service = hybrid_search_service
+        self.onboarding_service = onboarding_service
+
+    def _get_streaming_llm(self):
+        """스트리밍용 ChatOpenAI 객체 생성"""
+        from langchain_openai import ChatOpenAI
+        import os
+
+        return ChatOpenAI(
+            model=os.getenv("GPT4O_MODEL", "gpt-4o"), streaming=True, temperature=0.3
+        )
+
+    def _get_user_context_prompt_text(self, user_id: str) -> str:
+        """온보딩 데이터를 기반으로 사용자 맞춤형 시스템 프롬프트 문구 생성"""
+        try:
+            status = self.onboarding_service.get_user_status(user_id)
+            if status.get("status") == "success" and status.get("is_completed"):
+                occupation = status.get("occupation", "알 수 없음")
+                areas = ", ".join(status.get("areas", []))
+                return (
+                    f"You are assisting a user who works as a '{occupation}' and is interested in the following areas: {areas}. "
+                    "Tailor your response to be suitable and helpful for someone with this background."
+                )
+        except Exception as e:
+            logger.warning(f"Failed to fetch onboarding status for user {user_id}: {e}")
+
+        return "You are a helpful and expert AI assistant."
+
+    async def stream_chat(
+        self,
+        query: str,
+        user_id: str,
+        k: int = 5,
+        alpha: float = 0.5,
+    ) -> AsyncGenerator[str, None]:
+        """질의를 받아 RAG 체인을 실행하고 SSE 규격에 맞게 결과 청크를 반환하는 비동기 제너레이터"""
+        logger.info(f"Stream chat started for user {user_id}")
+
+        llm = self._get_streaming_llm()
+
+        # 1. Custom Retriever 구성
+        retriever = HybridSearchLangChainRetriever(
+            service=self.hybrid_search_service, k=k, alpha=alpha
+        )
+
+        # 2. 사용자 상황에 맞춘 시스템 프롬프트 템플릿 작성
+        user_context_msg = self._get_user_context_prompt_text(user_id)
+
+        system_template = f"""{user_context_msg}
+
+Answer the user's question clearly and accurately, using ONLY the context provided below.
+If you cannot answer the question using the context, state "주어진 문서 내용에서는 답변을 찾을 수 없습니다." and do not guess.
+Do not mention the words "context" or "provided text" explicitly in your final answer, just answer the question directly.
+
+Context: 
+{{context}}
+"""
+        prompt = ChatPromptTemplate.from_messages(
+            [
+                SystemMessagePromptTemplate.from_template(system_template),
+                HumanMessagePromptTemplate.from_template("{input}"),
+            ]
+        )
+
+        # 3. 문서 결합 체인 및 RAG 검색 체인 생성
+        document_chain = create_stuff_documents_chain(llm, prompt)
+        retrieval_chain = create_retrieval_chain(retriever, document_chain)
+
+        # 4. Langchain Runnable Streaming 실행 (v2 Events API 사용으로 진짜 토큰 단위 스트리밍 달성)
+        sources_emitted = False
+
+        async for event in retrieval_chain.astream_events(
+            {"input": query}, version="v2"
+        ):
+            kind = event["event"]
+
+            # 검색기 종료 시점 (컨텍스트 로드 완료)에 소스 전송
+            if kind == "on_retriever_end" and not sources_emitted:
+                docs = event["data"].get("output", [])
+                if docs and isinstance(docs, list):
+                    sources = []
+                    for doc in docs:
+                        if hasattr(doc, "metadata"):
+                            sources.append(
+                                {
+                                    "id": doc.metadata.get("id", ""),
+                                    "score": doc.metadata.get("score", 0.0),
+                                }
+                            )
+                    # Source Documents 메타데이터를 클라이언트로 1회만 전송
+                    meta_event = json.dumps(
+                        {"type": "sources", "data": sources}, ensure_ascii=False
+                    )
+                    yield f"data: {meta_event}\n\n"
+                    sources_emitted = True
+
+            # 채팅 모델에서 스트리밍되는 실제 텍스트 토큰
+            elif kind == "on_chat_model_stream":
+                chunk = event["data"].get("chunk")
+                if chunk and getattr(chunk, "content", None):
+                    data_event = json.dumps(
+                        {"type": "token", "data": chunk.content}, ensure_ascii=False
+                    )
+                    yield f"data: {data_event}\n\n"
+
+        # 스트리밍 완료를 알리는 종료 신호
+        yield "data: [DONE]\n\n"
+
+
+@lru_cache(maxsize=None)
+def get_chat_service() -> ChatService:
+    return ChatService(
+        hybrid_search_service=get_hybrid_search_service(),
+        onboarding_service=OnboardingService(),
+    )


### PR DESCRIPTION
✨ feat [#11.3.1]: RAG 스트리밍 챗 서비스 핵심 엔진(LangChain) 구현 
✨ feat [#11.3.2]: RAG 스트리밍 채팅 전용 API 엔드포인트 및 라우터 등록 
♻️ refactor [#11.3.3]: RAG 채팅 스트리밍 안정화 및 코드 리뷰 반영

## Summary by Sourcery

LangChain과 기존 하이브리드 검색 서비스를 기반으로 하는 스트리밍 RAG 기반 채팅 API를 추가합니다.

New Features:
- 사용자 컨텍스트와 검색 파라미터를 포함하는 RAG 채팅 쿼리를 위한 `ChatQueryRequest` 모델을 도입합니다.
- LangChain과 `HybridSearchService`를 사용하여 Server-Sent Events를 통해 RAG 채팅 응답을 반환하는 `/chat/stream` 엔드포인트를 제공합니다.

Enhancements:
- 새로운 채팅 라우터를 메인 API 라우팅에 통합하여 기존 서비스와 함께 채팅 엔드포인트를 사용할 수 있도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a streaming RAG-based chat API powered by LangChain and the existing hybrid search service.

New Features:
- Introduce ChatQueryRequest model for RAG chat queries including user context and retrieval parameters.
- Expose a /chat/stream endpoint that returns RAG chat responses via Server-Sent Events using LangChain and HybridSearchService.

Enhancements:
- Integrate the new chat router into the main API routing so chat endpoints are available alongside existing services.

</details>