### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -38,4 +38,9 @@ async def stream_chat(
             alpha=request.alpha,
         ),
         media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
     )

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import asyncio
 from typing import AsyncGenerator, List, Optional
 from functools import lru_cache
 
@@ -49,7 +50,8 @@ class HybridSearchLangChainRetriever(BaseRetriever):
         docs = []
         for res in result.results:
             content = res.get("content", "")
-            metadata = res.get("metadata", {})
+            # 원본 검색 결과의 metadata 훼손을 방지하기 위해 얕은 복사 후 조작
+            metadata = dict(res.get("metadata", {}))
             metadata["id"] = res.get("id", "")
             metadata["score"] = res.get("score", 0.0)
             docs.append(Document(page_content=content, metadata=metadata))
@@ -133,42 +135,61 @@ Context:
         # 4. Langchain Runnable Streaming 실행 (v2 Events API 사용으로 진짜 토큰 단위 스트리밍 달성)
         sources_emitted = False
 
-        async for event in retrieval_chain.astream_events(
-            {"input": query}, version="v2"
-        ):
-            kind = event["event"]
+        try:
+            async for event in retrieval_chain.astream_events(
+                {"input": query}, version="v2"
+            ):
+                kind = event["event"]
 
-            # 검색기 종료 시점 (컨텍스트 로드 완료)에 소스 전송
-            if kind == "on_retriever_end" and not sources_emitted:
-                docs = event["data"].get("output", [])
-                if docs and isinstance(docs, list):
-                    sources = []
-                    for doc in docs:
-                        if hasattr(doc, "metadata"):
-                            sources.append(
-                                {
-                                    "id": doc.metadata.get("id", ""),
-                                    "score": doc.metadata.get("score", 0.0),
-                                }
-                            )
-                    # Source Documents 메타데이터를 클라이언트로 1회만 전송
-                    meta_event = json.dumps(
-                        {"type": "sources", "data": sources}, ensure_ascii=False
-                    )
-                    yield f"data: {meta_event}\n\n"
-                    sources_emitted = True
+                # 검색기 종료 시점 (컨텍스트 로드 완료)에 소스 전송
+                if kind == "on_retriever_end" and not sources_emitted:
+                    docs = event["data"].get("output", [])
+                    if docs and isinstance(docs, list):
+                        sources = []
+                        for doc in docs:
+                            if hasattr(doc, "metadata"):
+                                sources.append(
+                                    {
+                                        "id": doc.metadata.get("id", ""),
+                                        "score": doc.metadata.get("score", 0.0),
+                                    }
+                                )
+                        # Source Documents 메타데이터를 클라이언트로 1회만 전송
+                        meta_event = json.dumps(
+                            {"type": "sources", "data": sources}, ensure_ascii=False
+                        )
+                        yield f"data: {meta_event}\n\n"
+                        sources_emitted = True
 
-            # 채팅 모델에서 스트리밍되는 실제 텍스트 토큰
-            elif kind == "on_chat_model_stream":
-                chunk = event["data"].get("chunk")
-                if chunk and getattr(chunk, "content", None):
-                    data_event = json.dumps(
-                        {"type": "token", "data": chunk.content}, ensure_ascii=False
-                    )
-                    yield f"data: {data_event}\n\n"
+                # 채팅 모델에서 스트리밍되는 실제 텍스트 토큰
+                elif kind == "on_chat_model_stream":
+                    chunk = event["data"].get("chunk")
+                    if chunk and getattr(chunk, "content", None):
+                        data_event = json.dumps(
+                            {"type": "token", "data": chunk.content}, ensure_ascii=False
+                        )
+                        yield f"data: {data_event}\n\n"
 
-        # 스트리밍 완료를 알리는 종료 신호
-        yield "data: [DONE]\n\n"
+        except asyncio.CancelledError:
+            # 클라이언트 연결 끊김/취소 시 조기 종료되도록 처리 (에러로 삼키지 않음)
+            logger.info("Chat stream cancelled by user.")
+            raise
+        except Exception as e:
+            # 서버 측 상세 에러 기록 (내부 로깅)
+            logger.exception("Error during streaming RAG chat")
+            # 클라이언트 측에는 민감한 내부 에러(str(e))가 아닌 일반(Generic) 메시지 전송
+            error_event = json.dumps(
+                {
+                    "type": "error",
+                    "message": "서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+                },
+                ensure_ascii=False,
+            )
+            yield f"data: {error_event}\n\n"
+            yield "data: [DONE]\n\n"
+        else:
+            # 루프 정상 종료 시 완료 신호 전송
+            yield "data: [DONE]\n\n"
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
🐛 fix [#11.3.3]: 1차 개선 - RAG 스트리밍 안정화 및 메모리 오염 버그 수정 
🐛 fix [#11.3.3]: 2차 개선 - RAG 스트리밍 예외 처리 분리 및 보안/출력 안정화

## Summary by Sourcery

채팅 서비스에서 RAG 스트리밍 응답의 안정성과 안전성을 개선합니다.

버그 수정:
- RAG용 LangChain 문서를 구성할 때 원본 검색 메타데이터가 변경되지 않도록 방지합니다.
- 예외 또는 취소가 발생하는 경우를 포함해, 스트리밍 채팅이 항상 올바른 완료 신호 또는 오류 신호를 전송하도록 보장합니다.

개선사항:
- RAG 스트리밍에 대해 구조화된 오류 처리를 추가하여, 클라이언트에는 일반적이고 안전한 오류 메시지를 반환하면서 내부 오류는 로깅합니다.
- 보다 안정적인 실시간 스트리밍을 위해 버퍼링 및 캐싱을 비활성화하도록 SSE 응답 헤더를 설정합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve stability and safety of RAG streaming responses in the chat service.

Bug Fixes:
- Prevent mutation of original retrieval metadata when constructing LangChain documents for RAG.
- Ensure streaming chat always sends a proper completion or error signal, including on exceptions or cancellations.

Enhancements:
- Add structured error handling for RAG streaming to log internal errors while returning a generic, user-safe error message to clients.
- Set SSE response headers to disable buffering and caching for more reliable real-time streaming.

</details>