### PR TITLE
♻️ refactor [#11.3.3]: 5차 개선 - SSE 헬퍼 통일성 및 JSON 직렬화 안전망 적용

### DIFF
--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -95,9 +95,13 @@ class ChatService:
     @staticmethod
     def _format_sse_event(event_type: str, **kwargs) -> str:
         """SSE 규격에 맞게 이벤트를 포맷팅하는 헬퍼 함수"""
+        if event_type == "done":
+            return "data: [DONE]\n\n"
+
         payload = {"type": event_type}
         payload.update(kwargs)
-        return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
+        # JSON 직렬화 불가 객체(UUID, datetime 등) 방어를 위해 default=str 파라미터 적용
+        return f"data: {json.dumps(payload, ensure_ascii=False, default=str)}\n\n"
 
     async def stream_chat(
         self,
@@ -188,7 +192,7 @@ Context:
 
         # GeneratorExit/CancelledError 중에는 yield를 호출하면 안되므로 정상/내부오류 발생 시에만 DONE 방출
         if not is_cancelled:
-            yield "data: [DONE]\n\n"
+            yield self._format_sse_event("done")
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
- **[backend/services/chat_service.py]**:
  - `[DONE]` 종료 시그널도 `_format_sse_event` 헬퍼 함수를 통과하도록 개선하여, 소스 코드 내 모든 SSE 응답 페이로드가 단일 창구(Single Source of Truth)에서 포맷팅되도록 일관성 대폭 향상.
  - `json.dumps` 호출 시 `default=str` 옵션을 추가하여, 향후 UUID, Datetime, Pydantic 객체 등이 포함되더라도 직렬화 오류(TypeError)로 인해 스트리밍이 중단되지 않도록 강력한 방어 코드(Defensive Programming) 구축.

🔗 Related:
- Issue [#614]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/620#pullrequestreview-3891550859)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1

## Summary by Sourcery

공유 헬퍼를 통해 SSE 응답 포맷을 통일하고, SSE 이벤트에 대한 JSON 직렬화를 강화하여 런타임 스트리밍 실패를 방지합니다.

개선 사항:
- 일관된 이벤트 생성을 위해 SSE 스트림 완료 신호를 공유 SSE 포맷팅 헬퍼를 통해 라우팅합니다.
- 스트림이 중단되지 않도록, 직렬화할 수 없는 객체가 포함되어도 허용하는 더 안전한 SSE 페이로드용 JSON 직렬화 전략을 적용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify SSE response formatting through the shared helper and harden JSON serialization for SSE events to prevent runtime streaming failures.

Enhancements:
- Route the SSE stream completion signal through the shared SSE formatting helper for consistent event generation.
- Apply a safer JSON serialization strategy for SSE payloads to tolerate non-serializable objects without breaking the stream.

</details>