### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -25,6 +25,7 @@ from backend.api.endpoints.sync import router as sync_router
 from backend.api.endpoints.automation import router as automation_router
 from backend.api.endpoints.graph import router as graph_router
 from backend.api.endpoints.search import router as search_router
+from backend.api.endpoints.chat import router as chat_router
 
 
 # 로깅 설정
@@ -146,6 +147,10 @@ logger.info("✅ automation_router 등록 완료 (Celery Automation)")
 
 app.include_router(graph_router, prefix="/api")
 logger.info("✅ graph_router 등록 완료 (Visualization)")
+
+# chat_router (Issue #614: RAG 스트리밍 채팅)
+app.include_router(chat_router, prefix="/api")
+logger.info("✅ chat_router 등록 완료 (RAG Streaming Chat)")
 
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -13,8 +13,6 @@ from langchain_core.prompts import (
     HumanMessagePromptTemplate,
 )
 from langchain_core.retrievers import BaseRetriever
-from langchain.chains import create_retrieval_chain
-from langchain.chains.combine_documents import create_stuff_documents_chain
 
 from backend.services.hybrid_search_service import (
     HybridSearchService,
@@ -72,8 +70,33 @@ class ChatService:
         from langchain_openai import ChatOpenAI
         import os
 
+        # 기본 OPENAI_API_KEY가 없는 환경이므로 .env의 커스텀 환경변수를 명시적으로 주입
+        # GPT-4o-mini를 1순위로, GPT-4o 등 다른 모델을 fallback으로 사용
+        api_key = (
+            os.getenv("GPT4O_MINI_API_KEY")
+            or os.getenv("GPT4O_API_KEY")
+            or os.getenv("OPENAI_API_KEY")
+        )
+        if not api_key:
+            raise ValueError(
+                "OpenAI API key is missing. Please set GPT4O_MINI_API_KEY, GPT4O_API_KEY, or OPENAI_API_KEY in your environment variables."
+            )
+
+        base_url = (
+            os.getenv("GPT4O_MINI_BASE_URL")
+            or os.getenv("GPT4O_BASE_URL")
+            or os.getenv("OPENAI_BASE_URL")
+        )
+        model = (
+            os.getenv("GPT4O_MINI_MODEL") or os.getenv("GPT4O_MODEL") or "gpt-4o-mini"
+        )
+
         return ChatOpenAI(
-            model=os.getenv("GPT4O_MODEL", "gpt-4o"), streaming=True, temperature=0.3
+            api_key=api_key,
+            base_url=base_url,
+            model=model,
+            streaming=True,
+            temperature=0.3,
         )
 
     def _get_user_context_prompt_text(self, user_id: str) -> str:
@@ -139,39 +162,44 @@ Context:
             ]
         )
 
-        # 3. 문서 결합 체인 및 RAG 검색 체인 생성
-        document_chain = create_stuff_documents_chain(llm, prompt)
-        retrieval_chain = create_retrieval_chain(retriever, document_chain)
+        # 3. 단일 책임 RAG 파이프라인: 수동 retrieval + 단순 LLM 체인
+        def format_docs(docs: List[Document]) -> str:
+            return "\n\n".join(doc.page_content for doc in docs)
 
-        # 4. Langchain Runnable Streaming 실행 (v2 Events API 사용으로 진짜 토큰 단위 스트리밍 달성)
+        rag_chain = prompt | llm
+
+        # 4. Streaming 실행 (astream_events v2 사용)
         sources_emitted = False
         is_cancelled = False
 
         try:
-            async for event in retrieval_chain.astream_events(
-                {"input": query}, version="v2"
-            ):
+            # 1) 단일 위치에서 public API를 통해 retrieval 수행 (중복 조회 방지)
+            source_docs: List[Document] = await retriever.aget_relevant_documents(query)
+
+            sources = [
+                {
+                    "id": doc.metadata.get("id", ""),
+                    "score": doc.metadata.get("score", 0.0),
+                }
+                for doc in source_docs
+                if hasattr(doc, "metadata")
+            ]
+
+            # 2) sources가 있으면 스트리밍 시작 전 먼저 전송
+            if sources:
+                yield self._format_sse_event("sources", data=sources)
+                sources_emitted = True
+
+            # 3) 컨텍스트를 직접 만들어 체인에 주입 (LCEL Runnable 의존성 최소화)
+            context_str = format_docs(source_docs)
+            chain_input = {"input": query, "context": context_str}
+
+            # 4) LLM 스트리밍
+            async for event in rag_chain.astream_events(chain_input, version="v2"):
                 kind = event["event"]
 
-                # 검색기 종료 시점 (컨텍스트 로드 완료)에 소스 전송
-                if kind == "on_retriever_end" and not sources_emitted:
-                    docs = event["data"].get("output", [])
-                    if docs and isinstance(docs, list):
-                        sources = []
-                        for doc in docs:
-                            if hasattr(doc, "metadata"):
-                                sources.append(
-                                    {
-                                        "id": doc.metadata.get("id", ""),
-                                        "score": doc.metadata.get("score", 0.0),
-                                    }
-                                )
-                        # Source Documents 메타데이터를 클라이언트로 1회만 전송
-                        yield self._format_sse_event("sources", data=sources)
-                        sources_emitted = True
-
                 # 채팅 모델에서 스트리밍되는 실제 텍스트 토큰
-                elif kind == "on_chat_model_stream":
+                if kind == "on_chat_model_stream":
                     chunk = event["data"].get("chunk")
                     if chunk and getattr(chunk, "content", None):
                         yield self._format_sse_event("token", data=chunk.content)

--- a/scripts/debug_chat.py
+++ b/scripts/debug_chat.py
@@ -1,0 +1,24 @@
+import asyncio
+import logging
+from backend.services.chat_service import get_chat_service
+
+logging.basicConfig(level=logging.ERROR)
+
+
+async def main():
+    service = get_chat_service()
+    try:
+        gen = service.stream_chat(
+            query="지금까지의 메모를 바탕으로 내 직업과 주요 관심사가 뭔지 요약해줘.",
+            user_id="test_user_123",
+            k=3,
+            alpha=0.5,
+        )
+        async for chunk in gen:
+            pass  # just consume to catch error logger
+    except Exception as e:
+        logging.exception(f"Unhandled exception during chat streaming: {e}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/test_chat_stream.py
+++ b/scripts/test_chat_stream.py
@@ -1,0 +1,78 @@
+# scripts/test_chat_stream.py
+
+import json
+import httpx
+import asyncio
+
+
+async def test_streaming_chat():
+    url = "http://localhost:8000/api/chat/stream"
+
+    # 미리 준비된 데모 사용자 (온보딩이 완료된 유저 ID 가정)
+    payload = {
+        "query": "지금까지의 메모를 바탕으로 내 직업과 주요 관심사가 뭔지, 그리고 관련 문서가 있는지 요약해줘.",
+        "user_id": "test_user_123",
+        "k": 3,
+        "alpha": 0.5,
+    }
+
+    print("🚀 스트리밍 챗봇 테스트 시작...")
+    print("-" * 50)
+
+    # httpx를 사용하여 SSE 스트림 연결
+    async with httpx.AsyncClient() as client:
+        try:
+            async with client.stream(
+                "POST", url, json=payload, timeout=30.0
+            ) as response:
+                response.raise_for_status()
+
+                async for line in response.aiter_lines():
+                    # SSE 규격의 빈 줄은 무시
+                    if not line.strip():
+                        continue
+
+                    # "data: " 프리픽스 제거
+                    if line.startswith("data: "):
+                        data_str = line[6:]
+
+                        # 종료 시그널
+                        if data_str == "[DONE]":
+                            print("\n\n✅ [스트리밍 종료 (DONE)]")
+                            break
+
+                        try:
+                            event = json.loads(data_str)
+                            event_type = event.get("type")
+
+                            if event_type == "token":
+                                # 토큰을 화면에 줄바꿈 없이 즉각 출력하여 타이핑 효과 확인
+                                print(event.get("data", ""), end="", flush=True)
+
+                            elif event_type == "sources":
+                                # RAG 검색 출처 데이터 확인
+                                print("\n\n📚 [검색된 문서 출처 메타데이터]")
+                                print(
+                                    json.dumps(
+                                        event.get("data", []),
+                                        indent=2,
+                                        ensure_ascii=False,
+                                    )
+                                )
+                                print("-" * 50)
+                                print("💡 챗봇 응답: ", end="")
+
+                            elif event_type == "error":
+                                print(f"\n\n❌ [스트리밍 에러]: {event.get('message')}")
+
+                        except json.JSONDecodeError:
+                            print(f"[알 수 없는 데이터 수신]: {data_str}")
+
+        except httpx.ConnectError:
+            print(
+                "🚨 서버 연결 실패! FastAPI 백엔드가 켜져 있는지(localhost:8000) 확인하세요."
+            )
+
+
+if __name__ == "__main__":
+    asyncio.run(test_streaming_chat())


### PR DESCRIPTION
🐛 fix [#11.3.4]: LangChain 1.x 호환 및 chat_router 누락 등록 수정 
♻️ refactor [#11.3.4]: 1차 개선 - RAG 파이프라인 일원화 및 에러 핸들링 강화

## Summary by Sourcery

라우터 등록 및 OpenAI 설정을 수정하면서 RAG 스트리밍 채팅 파이프라인을 통합합니다.

New Features:
- SSE를 통해 RAG 스트리밍 채팅 엔드포인트를 테스트하고 디버깅하기 위한 독립 실행 스크립트를 추가했습니다.

Bug Fixes:
- 기본 `OPENAI_API_KEY` 없이도 동작하도록 OpenAI Chat 클라이언트 구성을 수정하고, 필요한 API 키들이 검증되도록 했습니다.
- FastAPI 앱에 `chat_router`를 등록하여 RAG 스트리밍 채팅 엔드포인트를 노출했습니다.

Enhancements:
- RAG 파이프라인을 단일 검색 + LLM 프롬프트 체인으로 단순화하고, 스트리밍 토큰 방출을 간소화했습니다.

Tests:
- SSE를 사용해 `/api/chat/stream` 엔드포인트를 엔드 투 엔드로 테스트하고, 토큰 및 소스 이벤트를 검증하는 스크립트를 추가했습니다.
- `chat_service` 스트리밍 제너레이터를 소비하고 처리되지 않은 예외를 드러내기 위한 디버그 헬퍼 스크립트를 추가했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify the RAG streaming chat pipeline while fixing router registration and OpenAI configuration for the chat service.

New Features:
- Add standalone scripts for testing and debugging the RAG streaming chat endpoint via SSE.

Bug Fixes:
- Correct OpenAI Chat client configuration to work without a default OPENAI_API_KEY and ensure required API keys are validated.
- Register the chat_router with the FastAPI app to expose the RAG streaming chat endpoint.

Enhancements:
- Simplify the RAG pipeline to a single retrieval plus LLM prompt chain and streamline streaming token emission.

Tests:
- Introduce a script to exercise the /api/chat/stream endpoint end-to-end using SSE and verify token and source events.
- Add a debug helper script to consume the chat_service streaming generator and surface unhandled exceptions.

</details>