### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -65,6 +65,21 @@ class ChatService:
         self.hybrid_search_service = hybrid_search_service
         self.onboarding_service = onboarding_service
 
+        import os
+
+        # 런타임마다 읽지 않고 서비스 초기화 시점에 한 번만 읽고 검증(Fail Fast)
+        try:
+            self.rag_max_docs = int(os.getenv("RAG_MAX_DOCS", "10"))
+            self.rag_max_doc_chars = int(os.getenv("RAG_MAX_DOC_CHARS", "2000"))
+            self.rag_max_total_chars = int(os.getenv("RAG_MAX_TOTAL_CHARS", "16000"))
+        except ValueError as e:
+            logger.error(f"Invalid RAG configuration detected: {e}")
+            self.rag_max_docs, self.rag_max_doc_chars, self.rag_max_total_chars = (
+                10,
+                2000,
+                16000,
+            )
+
     def _get_streaming_llm(self):
         """스트리밍용 ChatOpenAI 객체 생성"""
         from langchain_openai import ChatOpenAI
@@ -136,8 +151,6 @@ class ChatService:
         """질의를 받아 RAG 체인을 실행하고 SSE 규격에 맞게 결과 청크를 반환하는 비동기 제너레이터"""
         logger.info(f"Stream chat started for user {user_id}")
 
-        llm = self._get_streaming_llm()
-
         # 1. Custom Retriever 구성
         retriever = HybridSearchLangChainRetriever(
             service=self.hybrid_search_service, k=k, alpha=alpha
@@ -164,17 +177,54 @@ Context:
 
         # 3. 단일 책임 RAG 파이프라인: 수동 retrieval + 단순 LLM 체인
         def format_docs(docs: List[Document]) -> str:
-            return "\n\n".join(doc.page_content for doc in docs)
+            """Format retrieved documents securely into a bounded-length context string."""
+            limited_docs = docs[: self.rag_max_docs]
+            contents: List[str] = []
+            total_length = 0
 
-        rag_chain = prompt | llm
+            for i, doc in enumerate(limited_docs, 1):
+                content = doc.page_content or ""
+                # 문서 경계를 모델이 구분하기 쉽도록 가벼운 구분자 추가
+                header = f"--- Document {i} ---"
+
+                doc_suffix = "...(truncated)"
+                if len(content) > self.rag_max_doc_chars:
+                    # 잘림 표시 접미사의 길이까지 고려해서 엄격하게 자름
+                    safe_len = max(0, self.rag_max_doc_chars - len(doc_suffix))
+                    content = content[:safe_len] + doc_suffix
+
+                doc_text = f"{header}\n{content}\n"
+
+                # 전체 문자열 길이 제한
+                remaining = self.rag_max_total_chars - total_length
+                if remaining <= 0:
+                    break
+
+                if len(doc_text) > remaining:
+                    total_limit_suffix = " ...(truncated due to total length limit)"
+                    if remaining > len(total_limit_suffix):
+                        doc_text = (
+                            doc_text[: remaining - len(total_limit_suffix)]
+                            + total_limit_suffix
+                        )
+                    else:
+                        doc_text = doc_text[:remaining]
+
+                contents.append(doc_text)
+                total_length += len(doc_text)
+
+            return "\n\n".join(contents)
 
         # 4. Streaming 실행 (astream_events v2 사용)
-        sources_emitted = False
         is_cancelled = False
 
         try:
-            # 1) 단일 위치에서 public API를 통해 retrieval 수행 (중복 조회 방지)
-            source_docs: List[Document] = await retriever.aget_relevant_documents(query)
+            # 1) LLM 초기화 및 파이프라인 구성 (예외 발생 시 클라이언트에 error SSE로 전달되도록 try 블록 안으로 이동)
+            llm = self._get_streaming_llm()
+            rag_chain = prompt | llm
+
+            # 2) 단일 위치에서 public API를 통해 retrieval 수행 (중복 조회 방지)
+            source_docs: List[Document] = await retriever.ainvoke(query)
 
             sources = [
                 {
@@ -185,10 +235,9 @@ Context:
                 if hasattr(doc, "metadata")
             ]
 
-            # 2) sources가 있으면 스트리밍 시작 전 먼저 전송
+            # 3) sources가 있으면 스트리밍 시작 전 먼저 전송
             if sources:
                 yield self._format_sse_event("sources", data=sources)
-                sources_emitted = True
 
             # 3) 컨텍스트를 직접 만들어 체인에 주입 (LCEL Runnable 의존성 최소화)
             context_str = format_docs(source_docs)

--- a/scripts/debug_chat.py
+++ b/scripts/debug_chat.py
@@ -4,21 +4,14 @@ from backend.services.chat_service import get_chat_service
 
 logging.basicConfig(level=logging.ERROR)
 
-
 async def main():
     service = get_chat_service()
     try:
-        gen = service.stream_chat(
-            query="지금까지의 메모를 바탕으로 내 직업과 주요 관심사가 뭔지 요약해줘.",
-            user_id="test_user_123",
-            k=3,
-            alpha=0.5,
-        )
+        gen = service.stream_chat(query="hi", user_id="test_user_123", k=3, alpha=0.5)
         async for chunk in gen:
-            pass  # just consume to catch error logger
+            print(chunk, end="")
     except Exception as e:
         logging.exception(f"Unhandled exception during chat streaming: {e}")
-
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
♻️ refactor [#11.3.4]: 2차 개선 - RAG 컨텍스트 안전장치 추가 및 예외 캡슐화 
♻️ refactor [#11.3.4]: 3차 개선 - RAG 컨텍스트 성능 최적화 및 Fail-Fast 설정 분리

## Summary by Sourcery

컨텍스트 크기에 상한을 두고 설정을 중앙집중화하여 RAG 채팅 스트리밍의 안전성과 성능을 개선하고, 수동 테스트를 더 쉽게 할 수 있도록 디버그 스크립트를 업데이트합니다.

버그 수정:
- LLM 초기화 및 RAG 파이프라인 설정 오류가 스트리밍 에러 경로를 통해 포착되고 노출되도록 보장합니다.

개선 사항:
- 과도하게 큰 프롬프트를 방지하기 위해 RAG 문서 개수와 전체/컨텍스트 길이에 대한 설정 가능한 제한을 추가하고, 안전한 절단(truncation)을 적용합니다.
- 요청마다 발생하는 오버헤드를 피하고 빠른 실패(fail-fast) 동작을 지원하기 위해 서비스 시작 시 한 번만 RAG 구성을 초기화 및 검증합니다.
- 모델이 인식하기 쉽도록 RAG 응답에서 문서 사이를 명확히 구분하는 구분자를 포함하도록 문서 포맷팅을 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve RAG chat streaming safety and performance by bounding context size and centralizing configuration, while updating the debug script for easier manual testing.

Bug Fixes:
- Ensure LLM initialization and RAG pipeline setup errors are captured and surfaced via the streaming error path.

Enhancements:
- Add configurable limits for RAG document count and total/context length with safe truncation to prevent oversized prompts.
- Initialize and validate RAG configuration once at service startup to avoid per-request overhead and support fail-fast behavior.
- Refine document formatting in RAG responses to include clear per-document separators for the model.

</details>