### PR TITLE
🐛 fix [#11.3.4]: 4차 개선 - RAG 설정 Fail-Fast 규정 준수 및 Retriever 하위 호환성 래퍼 복구

### DIFF
--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -59,7 +59,10 @@ class HybridSearchLangChainRetriever(BaseRetriever):
         self, query: str, *, run_manager=None
     ) -> List[Document]:
         """Provides backward-compatibility for traditional BaseRetriever interface."""
-        return await self.ainvoke(query)
+        kwargs = {}
+        if run_manager:
+            kwargs["config"] = {"callbacks": run_manager.get_child()}
+        return await self.ainvoke(query, **kwargs)
 
 
 class ChatService:
@@ -75,9 +78,13 @@ class ChatService:
 
         # 런타임마다 읽지 않고 서비스 초기화 시점에 한 번만 읽고 검증(Fail Fast)
         try:
-            self.rag_max_docs = int(os.getenv("RAG_MAX_DOCS", "10"))
-            self.rag_max_doc_chars = int(os.getenv("RAG_MAX_DOC_CHARS", "2000"))
-            self.rag_max_total_chars = int(os.getenv("RAG_MAX_TOTAL_CHARS", "16000"))
+            raw_docs = os.getenv("RAG_MAX_DOCS", "10")
+            raw_chars = os.getenv("RAG_MAX_DOC_CHARS", "2000")
+            raw_total = os.getenv("RAG_MAX_TOTAL_CHARS", "16000")
+
+            self.rag_max_docs = int(raw_docs)
+            self.rag_max_doc_chars = int(raw_chars)
+            self.rag_max_total_chars = int(raw_total)
 
             if any(
                 val < 0
@@ -87,10 +94,18 @@ class ChatService:
                     self.rag_max_total_chars,
                 )
             ):
-                raise ValueError("RAG bounds must be non-negative.")
+                raise ValueError(
+                    f"RAG bounds must be non-negative. "
+                    f"Parsed values: docs={self.rag_max_docs}, chars={self.rag_max_doc_chars}, total={self.rag_max_total_chars}"
+                )
         except ValueError as e:
+            # 설정 무결성을 위반했으므로 구체적인 값을 로그에 담아 명확히 에러 전파(Fail-Fast)
             logger.error(
-                f"Invalid RAG configuration detected: {e}. Raising exception to fail fast."
+                f"Invalid RAG configuration detected. "
+                f"Env values were -> RAG_MAX_DOCS='{os.getenv('RAG_MAX_DOCS')}', "
+                f"RAG_MAX_DOC_CHARS='{os.getenv('RAG_MAX_DOC_CHARS')}', "
+                f"RAG_MAX_TOTAL_CHARS='{os.getenv('RAG_MAX_TOTAL_CHARS')}'. "
+                f"Detail: {e}. Raising exception to fail fast."
             )
             raise
 


### PR DESCRIPTION
- **[backend/services/chat_service.py]**:
  - `ChatService.__init__` 내 환경변수 파싱 중 설정값 오류(ValueError 또는 음수값) 발생 시, 조용히 기본값으로 덮지 않고 즉각 `raise` 처리하여 서버 초기화 단계에서 문제를 표출시키도록 Fail-Fast 원칙 전면 도입.
  - LangChain `BaseRetriever`의 오래된 호환성을 요구하는 다른 컴포넌트와의 충돌을 막기 위해, [HybridSearchLangChainRetriever](backend/services/chat_service.py:25:0-61:40) 객체에 [aget_relevant_documents](backend/services/chat_service.py:57:4-61:40) 래퍼 메서드 명시적 구현.
  - RAG 스트리밍 본문 코드 영역에 `ainvoke` 로직을 폐기하고 공식 지적받은 [aget_relevant_documents](backend/services/chat_service.py:57:4-61:40)로 완전 롤백 및 안정성 복구.

🔗 Related:
- Issue [#614]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/627#pullrequestreview-3902400325)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1

## Summary by Sourcery

잘못된 RAG 구성에 대해 fail-fast 동작을 강제하고, 챗 서비스에서 리트리버의 하위 호환성을 복원합니다.

버그 수정:
- 잘못된 RAG 환경 구성을 기본값으로 조용히 되돌리는 대신, 시작 시점에 노출합니다.
- `BaseRetriever`의 `aget_relevant_documents` 인터페이스를 기대하는 컴포넌트들과의 호환성을 복원합니다.

개선 사항:
- 더 안정적이고 예측 가능한 동작을 위해 RAG 검색 호출을 `aget_relevant_documents`에 표준화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce fail-fast behavior for invalid RAG configuration and restore retriever backward compatibility in the chat service.

Bug Fixes:
- Surface invalid RAG environment configuration at startup instead of silently falling back to defaults.
- Restore compatibility with components expecting the BaseRetriever aget_relevant_documents interface.

Enhancements:
- Standardize RAG retrieval calls on aget_relevant_documents for more stable and predictable behavior.

</details>