### PR TITLE
🐛 fix [#11.3.4]: 6차 개선 - RAG 환경설정 드리프트 버그 방지 및 Retriever 완전 하위 호환성 적용

### DIFF
--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -65,7 +65,11 @@ class HybridSearchLangChainRetriever(BaseRetriever):
     ) -> List[Document]:
         """Provides backward-compatibility for traditional BaseRetriever interface."""
         if run_manager:
-            kwargs["config"] = {"callbacks": run_manager.get_child()}
+            # 기존 제공된 config 딕셔너리를 무조건 덮어쓰지 않고 추출(Merge)
+            config = kwargs.pop("config", {}) or {}
+            # run_manager 콜백을 병합하면서, 다른 config 키(태그, 메타데이터 등)를 보존
+            config["callbacks"] = run_manager.get_child()
+            kwargs["config"] = config
         return await self.ainvoke(query, **kwargs)
 
 


### PR DESCRIPTION
- **[backend/services/chat_service.py]**:
  - RAG 환경 변수 예외 로깅 시, `os.getenv`를 중복 호출하지 않고 캐싱된 `raw_*` 로컬 변수를 그대로 재사용하여 파싱과 에러 기록 시점 간의 잠재적 값 변이(Drift) 가능성 원천 차단.
  - [aget_relevant_documents](backend/services/chat_service.py:58:4-68:50) 하위 호환 래퍼에 `CallbackManagerForRetrieverRun` 명시적 타입 힌트 부여 및 `**kwargs` 패스스루(pass-through) 구현을 통해 LangChain 1.x 생태계 도구들과의 타입 시스템 통합 및 유연한 파라미터 확장 지원.

🔗 Related:
- Issue [#614]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/629#pullrequestreview-3902466455)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1

## Summary by Sourcery

RAG 검색기의 하위 호환성을 개선하고, RAG 환경 구성 로깅이 값 드리프트에 영향을 덜 받도록 강화했습니다.

버그 수정:
- 환경 변수를 다시 읽지 않고 이미 읽어온 원시 값을 재사용하여, RAG 환경 변수 오류 로그에서 구성 값 드리프트가 발생하지 않도록 방지했습니다.

개선 사항:
- LangChain 1.x와의 통합을 개선하기 위해, 하위 호환 가능한 검색기 래퍼가 타입이 지정된 `run_manager`와 임의의 키워드 인수들을 받을 수 있도록 확장했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve RAG retriever backward compatibility and harden RAG environment configuration logging against value drift.

Bug Fixes:
- Prevent configuration drift in RAG environment variable error logs by reusing already-read raw values instead of re-reading from the environment.

Enhancements:
- Extend the backward-compatible retriever wrapper to accept typed run_manager and arbitrary keyword arguments for better LangChain 1.x integration.

</details>