### PR TITLE
♻️ refactor [#11.3.7]: 2차 개선 - 아키텍처 고도화 및 의존성 이슈 대응

### DIFF
--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -11,6 +11,7 @@
         "@ai-sdk/openai": "^3.0.41",
         "@ai-sdk/react": "^3.0.118",
         "@monaco-editor/react": "^4.7.0",
+        "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-progress": "^1.1.8",
         "@radix-ui/react-scroll-area": "^1.2.10",
@@ -2639,16 +2640,54 @@
       }
     },
     "node_modules/@radix-ui/react-avatar": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
-      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.11.tgz",
+      "integrity": "sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-context": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.4",
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-is-hydrated": "0.1.0",
         "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-context": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
+      "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -11770,6 +11809,33 @@
         "@radix-ui/react-use-layout-effect": "1.1.1",
         "@radix-ui/react-use-size": "1.1.1",
         "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
+      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/web_ui/package.json
+++ b/web_ui/package.json
@@ -13,6 +13,7 @@
     "@ai-sdk/openai": "^3.0.41",
     "@ai-sdk/react": "^3.0.118",
     "@monaco-editor/react": "^4.7.0",
+    "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-scroll-area": "^1.2.10",

--- a/web_ui/src/app/api/chat/route.ts
+++ b/web_ui/src/app/api/chat/route.ts
@@ -2,20 +2,196 @@ import { NextResponse } from 'next/server';
 import { createUIMessageStreamResponse, streamText } from 'ai';
 import type { UIMessage, UIMessageChunk, ModelMessage } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
-import dotenv from 'dotenv';
-import path from 'path';
-import fs from 'fs';
-
-// 모듈 진입 시 1회만 한 곳에서 일관되게 환경변수(root .env) 로드
-const envPath = path.resolve(process.cwd(), '../.env');
-if (fs.existsSync(envPath)) {
-  dotenv.config({ path: envPath });
-}
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
 
-async function fallbackToGemini(messages: UIMessage[]) {
+function getTextFromMessage(message: UIMessage): string {
+  return (message.parts ?? [])
+    .filter((p) => p.type === 'text')
+    .map((p) => (p as { type: 'text'; text: string }).text)
+    .join('');
+}
 
+function mapUiMessagesToModel(messages: UIMessage[]): ModelMessage[] {
+  return messages
+    .filter((m) => ['system', 'user', 'assistant'].includes(m.role))
+    .map((m) => ({
+      role: m.role as 'user' | 'assistant' | 'system',
+      content: getTextFromMessage(m),
+    }));
+}
+
+function finishStream(
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  textStarted: boolean,
+  textPartId: string | null,
+) {
+  if (textStarted && textPartId) {
+    controller.enqueue({ type: 'text-end', id: textPartId });
+  }
+  controller.enqueue({ type: 'finish-step' });
+  controller.enqueue({ type: 'finish' });
+  controller.close();
+}
+
+function handleSseEvent(
+  currentEventType: string | null,
+  dataPayload: string,
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  ensureTextStarted: () => void,
+  textPartId: string,
+): boolean {
+  if (dataPayload === '[DONE]') {
+    return true; // signals stream is done
+  }
+
+  try {
+    const parsed = JSON.parse(dataPayload) as {
+      type: string;
+      data?: unknown;
+      message?: string;
+    };
+    
+    const eventType = parsed.type ?? currentEventType ?? 'message';
+
+    if (eventType === 'sources') {
+      controller.enqueue({
+        type: 'message-metadata',
+        messageMetadata: { sources: parsed.data },
+      } as UIMessageChunk);
+    } else if (eventType === 'token') {
+      ensureTextStarted();
+      controller.enqueue({
+        type: 'text-delta',
+        id: textPartId,
+        delta: String(parsed.data ?? ''),
+      });
+    } else if (eventType === 'error') {
+      controller.enqueue({
+        type: 'error',
+        errorText: parsed.message ?? '서버 오류가 발생했습니다.',
+      } as UIMessageChunk);
+    }
+  } catch (e) {
+    console.error('Failed to parse SSE data payload as JSON', {
+      dataPayload,
+      error: e,
+    });
+  }
+  return false;
+}
+
+function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChunk> {
+  return new ReadableStream<UIMessageChunk>({
+    async start(controller) {
+      if (!backendRes.body) {
+        finishStream(controller, false, null);
+        return;
+      }
+
+      const reader = backendRes.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      const textPartId = `text-${Date.now()}`;
+      let textStarted = false;
+
+      const done = () => finishStream(controller, textStarted, textPartId);
+      const ensureTextStarted = () => {
+        if (!textStarted) {
+          controller.enqueue({ type: 'text-start', id: textPartId });
+          textStarted = true;
+        }
+      };
+
+      try {
+        let currentEventType: string | null = null;
+        let currentEventDataLines: string[] = [];
+
+        while (true) {
+          const { done: streamDone, value } = await reader.read();
+          
+          if (streamDone) {
+            // Flush any remaining partial multi-line event if stream dropped
+            buffer += decoder.decode(new Uint8Array(0), { stream: false });
+            const trailingLines = buffer.split('\n');
+            for (const trailingLine of trailingLines) {
+              const line = trailingLine.replace(/\r$/, '');
+              if (line.startsWith('data:')) {
+                currentEventDataLines.push(line.slice('data:'.length).trimStart());
+              }
+            }
+
+            if (currentEventDataLines.length > 0) {
+              const dataPayload = currentEventDataLines.join('\n');
+              const isDone = handleSseEvent(
+                currentEventType,
+                dataPayload,
+                controller,
+                ensureTextStarted,
+                textPartId
+              );
+              if (isDone) {
+                done();
+                return;
+              }
+            }
+            break;
+          }
+
+          buffer += decoder.decode(value, { stream: true });
+          const rawLines = buffer.split('\n');
+          buffer = rawLines.pop() ?? '';
+
+          for (const rawLine of rawLines) {
+            const line = rawLine.replace(/\r$/, '');
+
+            if (line === '') {
+              if (currentEventDataLines.length > 0) {
+                const dataPayload = currentEventDataLines.join('\n');
+                const isDone = handleSseEvent(
+                  currentEventType,
+                  dataPayload,
+                  controller,
+                  ensureTextStarted,
+                  textPartId
+                );
+
+                if (isDone) {
+                  done();
+                  return;
+                }
+
+                currentEventDataLines = [];
+                currentEventType = null;
+              }
+              continue;
+            }
+
+            if (line.startsWith(':')) continue;
+
+            if (line.startsWith('event:')) {
+              currentEventType = line.slice('event:'.length).trimStart();
+              continue;
+            }
+
+            if (line.startsWith('data:')) {
+              currentEventDataLines.push(line.slice('data:'.length).trimStart());
+            }
+          }
+        }
+      } catch {
+        controller.enqueue({
+          type: 'error',
+          errorText: '스트림 읽기 중 오류가 발생했습니다.',
+        } as UIMessageChunk);
+      }
+
+      done();
+    },
+  });
+}
+
+async function fallbackToGemini(messages: UIMessage[]) {
   const apiKey = process.env.GEMINI_3_PRO_API_KEY;
   const baseURL = process.env.GEMINI_3_PRO_BASE_URL;
   const modelId = process.env.GEMINI_3_PRO_MODEL;
@@ -27,34 +203,15 @@ async function fallbackToGemini(messages: UIMessage[]) {
     );
   }
 
-  const customOpenAI = createOpenAI({
-    apiKey,
-    baseURL,
-  });
-
+  const customOpenAI = createOpenAI({ apiKey, baseURL });
   const model = customOpenAI(modelId);
-
-  // UIMessage -> ModelMessage 변환 (지원하지 않는 role 필터링 가능, 예: system/user/assistant만)
-  const coreMessages: ModelMessage[] = messages
-    .filter((m) => ['system', 'user', 'assistant'].includes(m.role))
-    .map((m) => {
-      const textContent = (m.parts ?? [])
-        .filter((p) => p.type === 'text')
-        .map((p) => (p as { type: 'text'; text: string }).text)
-        .join('');
-      return {
-        role: m.role as 'user' | 'assistant' | 'system',
-        content: textContent,
-      };
-    });
+  const coreMessages = mapUiMessagesToModel(messages);
 
   try {
     const result = streamText({
       model,
       messages: coreMessages,
     });
-    
-    // ai SDK v6 - UIMessage 스트림 형태로 응답
     return result.toUIMessageStreamResponse();
   } catch (e: unknown) {
     const errMsg = e instanceof Error ? e.message : 'Unknown error during Gemini fallback';
@@ -65,8 +222,6 @@ async function fallbackToGemini(messages: UIMessage[]) {
 export async function POST(req: Request) {
   try {
     const body = await req.json();
-
-    // ai v6 DefaultChatTransport는 { messages } 형태로 전송
     const messages: UIMessage[] = body.messages ?? [];
     const lastMessage = messages[messages.length - 1];
 
@@ -74,11 +229,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'No messages provided' }, { status: 400 });
     }
 
-    // TextUIPart에서 텍스트 추출
-    const queryText = (lastMessage.parts ?? [])
-      .filter((p) => p.type === 'text')
-      .map((p) => (p as { type: 'text'; text: string }).text)
-      .join('');
+    const queryText = getTextFromMessage(lastMessage);
 
     const payload = {
       query: queryText,
@@ -90,7 +241,6 @@ export async function POST(req: Request) {
     let backendRes: Response | null = null;
     let fallbackRequired = false;
 
-    // 백엔드 SSE 스트리밍 요청 시도
     try {
       backendRes = await fetch(`${BACKEND_URL}/api/chat/stream`, {
         method: 'POST',
@@ -111,138 +261,7 @@ export async function POST(req: Request) {
       return fallbackToGemini(messages);
     }
 
-    /**
-     * UIMessageChunk 오브젝트 스트림을 생성합니다.
-     * 백엔드 SSE(sources/token/error/[DONE]) → UIMessageChunk 변환:
-     *  - sources 이벤트 → metadata 청크
-     *  - token  이벤트 → text-start + text-delta 청크
-     *  - error  이벤트 → error 청크  
-     *  - [DONE]        → finish-step + finish 청크
-     */
-    const chunkStream = new ReadableStream<UIMessageChunk>({
-      async start(controller) {
-        if (!backendRes?.body) {
-          controller.enqueue({ type: 'finish-step' });
-          controller.enqueue({ type: 'finish' });
-          controller.close();
-          return;
-        }
-
-        const reader = backendRes.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = '';
-        const textPartId = `text-${Date.now()}`;
-        let textStarted = false;
-
-        const done = () => {
-          if (textStarted) {
-            controller.enqueue({ type: 'text-end', id: textPartId });
-          }
-          controller.enqueue({ type: 'finish-step' });
-          controller.enqueue({ type: 'finish' });
-          controller.close();
-        };
-
-        try {
-          // SSE parsing state for accumulating multiline data fields
-          let currentEventType: string | null = null;
-          let currentEventDataLines: string[] = [];
-
-          while (true) {
-            const { done: streamDone, value } = await reader.read();
-            if (streamDone) break;
-
-            // Decode the incoming chunk and append to the rolling buffer
-            buffer += decoder.decode(value, { stream: true });
-
-            // Split into lines; keep the last partial line in the buffer
-            const rawLines = buffer.split('\n');
-            buffer = rawLines.pop() ?? '';
-
-            for (const rawLine of rawLines) {
-              // Trim trailing CR for CRLF endings
-              const line = rawLine.replace(/\r$/, '');
-
-              // Empty line indicates end of one SSE event
-              if (line === '') {
-                if (currentEventDataLines.length > 0) {
-                  const dataPayload = currentEventDataLines.join('\n');
-
-                  if (dataPayload === '[DONE]') {
-                    done();
-                    return;
-                  }
-
-                  // Hand off the aggregated payload for further handling
-                  try {
-                    const parsed = JSON.parse(dataPayload) as {
-                      type: string;
-                      data?: unknown;
-                      message?: string;
-                    };
-                    
-                    const eventType = parsed.type ?? currentEventType ?? 'message';
-
-                    if (eventType === 'sources') {
-                      controller.enqueue({
-                        type: 'message-metadata',
-                        messageMetadata: { sources: parsed.data },
-                      } as UIMessageChunk);
-                    } else if (eventType === 'token') {
-                      if (!textStarted) {
-                        controller.enqueue({ type: 'text-start', id: textPartId });
-                        textStarted = true;
-                      }
-                      controller.enqueue({
-                        type: 'text-delta',
-                        id: textPartId,
-                        delta: String(parsed.data ?? ''),
-                      });
-                    } else if (eventType === 'error') {
-                      controller.enqueue({
-                        type: 'error',
-                        errorText: parsed.message ?? '서버 오류가 발생했습니다.',
-                      } as UIMessageChunk);
-                    }
-                  } catch (e) {
-                    console.error('Failed to parse SSE data payload as JSON', {
-                      dataPayload,
-                      error: e,
-                    });
-                  }
-
-                  currentEventDataLines = [];
-                  currentEventType = null;
-                }
-                continue;
-              }
-
-              // Comment line (ignored)
-              if (line.startsWith(':')) continue;
-
-              // Explicit event type (optional; default is "message")
-              if (line.startsWith('event:')) {
-                currentEventType = line.slice('event:'.length).trimStart();
-                continue;
-              }
-
-              // Data line (may be repeated; concatenate with newlines)
-              if (line.startsWith('data:')) {
-                currentEventDataLines.push(line.slice('data:'.length).trimStart());
-              }
-            }
-          }
-        } catch {
-          controller.enqueue({
-            type: 'error',
-            errorText: '스트림 읽기 중 오류가 발생했습니다.',
-          } as UIMessageChunk);
-        }
-
-        done();
-      },
-    });
-
+    const chunkStream = createUIChunkStream(backendRes);
     return createUIMessageStreamResponse({ stream: chunkStream });
   } catch (error) {
     console.error('[Chat Proxy Error]', error);

--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -23,6 +23,8 @@ const WELCOME_MESSAGE: UIMessage = {
   ],
 };
 
+const defaultChatTransport = new DefaultChatTransport({ api: '/api/chat' });
+
 export function ChatWindow() {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [input, setInput] = useState('');
@@ -40,7 +42,7 @@ export function ChatWindow() {
 
   const { messages, sendMessage, status, error } = useChat({
     messages: [WELCOME_MESSAGE],
-    transport: new DefaultChatTransport({ api: '/api/chat' }),
+    transport: defaultChatTransport,
     onError: (err: Error) => {
       toast.error('메시지 전송 중 에러가 발생했습니다.', {
         description: err.message || '서버와의 연결을 확인해주세요.',

--- a/web_ui/src/components/ui/avatar.tsx
+++ b/web_ui/src/components/ui/avatar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Avatar as AvatarPrimitive } from "radix-ui"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
 
 import { cn } from "@/lib/utils"
 


### PR DESCRIPTION
- **[web_ui/src/app/api/chat/route.ts]**:
  - Serverless/Edge 런타임 호환성을 위해 `fs`, `dotenv` 모듈 직접 로드 패턴을 폐기하고 런타임(Next.js) `process.env`로 통일.
  - SSE 데이터 유실(Drop) 버그를 막기 위해 `while` 루프 종료 시 잔여 버퍼를 반드시 Flush하도록 수정
  - `getTextFromMessage`, `createUIChunkStream`, `handleSseEvent` 등 단일 책임 헬퍼 함수 5종을 추출해내어 체감 복잡도를 극소화하고 직관적 파이프라인 형성

- **[web_ui/src/components/ui/avatar.tsx]**:
  - `radix-ui` 루트 임포트로 인한 잠재적 오류를 방지하고자, 올바른 개별 패키지인 `@radix-ui/react-avatar` 모듈 설치 및 경로 스코프 수정 반영.
- **[web_ui/src/components/chat/ChatWindow.tsx]**:
  - `DefaultChatTransport` 렌더링 병목 방지를 위해 인스턴스 할당 위치를 컴포넌트 생명주기 바깥으로 격리 최적화. 초기 환영 메시지는 올바른 v6 ChatInit 속성(`messages`)을 유지하여 Type 안전성 방어.

🔗 Related:
- Issue [#614]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/633#pullrequestreview-3908545260)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1

## Summary by Sourcery

런타임 호환성, 안정성, 성능을 개선하기 위해 chat API 스트리밍 파이프라인과 웹 UI 의존성을 정제했습니다.

버그 수정:
- 백엔드 스트림이 종료될 때 버퍼링된 남은 데이터를 모두 flush 하여 마지막 SSE 이벤트가 유실되지 않도록 방지했습니다.
- 서버리스/엣지 환경에서의 비호환성을 피하기 위해 Next.js 런타임의 `process.env` 에 의존해 환경 설정이 이루어지도록 보장했습니다.

개선 사항:
- 메시지 텍스트 추출, 메시지 매핑, SSE 처리, 스트림 종료 처리를 위한 재사용 가능한 헬퍼들을 추출하여 chat API 라우트를 단순화했습니다.
- SSE 를 UIMessageChunk 로 변환하는 로직을 전용 스트림 팩토리로 캡슐화하여 chat 라우트 핸들러의 복잡성을 줄였습니다.
- 렌더링 시점의 재생성 오버헤드를 피하기 위해 ChatWindow 컴포넌트 라이프사이클 외부에서 단일 DefaultChatTransport 인스턴스를 재사용하도록 했습니다.

빌드:
- 아바타 컴포넌트의 올바른 import 및 사용을 위해 `@radix-ui/react-avatar` 의존성을 추가했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the chat API streaming pipeline and web UI dependencies for better runtime compatibility, reliability, and performance.

Bug Fixes:
- Prevent loss of trailing SSE events by flushing any remaining buffered data when the backend stream ends.
- Ensure environment configuration relies on Next.js runtime `process.env` to avoid serverless/edge incompatibilities.

Enhancements:
- Extract reusable helpers for message text extraction, message mapping, SSE handling, and stream finalization to simplify the chat API route.
- Encapsulate SSE-to-UIMessageChunk conversion in a dedicated stream factory to reduce complexity in the chat route handler.
- Reuse a single DefaultChatTransport instance outside the ChatWindow component lifecycle to avoid render-time re-instantiation overhead.

Build:
- Add the `@radix-ui/react-avatar` dependency for proper avatar component imports and usage.

</details>