### PR TITLE
♻️ refactor [#11.3.7]: 3차 개선 - SSE 스트림 파생 로직 병합 및 식별자 안정성 보강

### DIFF
--- a/web_ui/src/app/api/chat/route.ts
+++ b/web_ui/src/app/api/chat/route.ts
@@ -5,11 +5,17 @@ import { createOpenAI } from '@ai-sdk/openai';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
 
+function generateUniqueId(): string {
+  return typeof crypto !== 'undefined' && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `uid-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+}
+
 function getOnlyTextFromMessage(message: UIMessage): string {
   const parts = message.parts ?? [];
   const textParts = parts.filter((p) => p.type === 'text');
-  if (parts.length > textParts.length) {
-    console.warn(`[Chat Proxy] Extracting only text. Ignored non-text parts in message: ${message.id}`);
+  if (parts.length > textParts.length && process.env.NODE_ENV !== 'production') {
+    console.warn('[Chat Proxy] Extracting only text. Ignored non-text parts in message.');
   }
   return textParts
     .map((p) => (p as { type: 'text'; text: string }).text)
@@ -96,7 +102,7 @@ function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChun
       const reader = backendRes.body.getReader();
       const decoder = new TextDecoder();
       let buffer = '';
-      const textPartId = `text-${crypto.randomUUID()}`;
+      const textPartId = `text-${generateUniqueId()}`;
       let textStarted = false;
 
       const done = () => finishStream(controller, textStarted, textPartId);
@@ -123,6 +129,9 @@ function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChun
             );
             currentEventDataLines = [];
             currentEventType = null;
+            if (isDone) {
+              done();
+            }
             return isDone;
           }
           return false;
@@ -143,7 +152,6 @@ function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChun
             }
 
             if (flushCurrentEvent()) {
-              done();
               return;
             }
             break;
@@ -158,7 +166,6 @@ function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChun
 
             if (line === '') {
               if (flushCurrentEvent()) {
-                done();
                 return;
               }
               continue;


### PR DESCRIPTION
- **[web_ui/src/app/api/chat/route.ts]**:
  - SSE 이벤트 청크 누적 플러시 로직(`flushCurrentEvent`)을 단일 헬퍼 함수로 추출하여 루프 중간과 스트림 종료 시점의 데이터 처리 정합성을 구조적으로 일치시킴.
  - `getOnlyTextFromMessage`, `mapUiMessagesToTextOnlyModel`로 함수명을 변경하여 명시성을 확보하고, 텍스트가 아닌 UIPart 무시 시 개발 환경에 경고 로그가 남도록 가드레일 추가.
  - `textPartId` 발급 기준을 `Date.now()`에서 `crypto.randomUUID()`로 교체하여 높은 동시성 부하 환경에서도 식별자 충돌(Collision)이 나지 않도록 고유성 방어.

🔗 Related:
- Issue [#614]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/636#pullrequestreview-3908608696)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1

## Summary by Sourcery

채팅 API SSE 스트리밍 및 텍스트 추출을 개선하여 견고성과 식별자 안정성을 향상합니다.

버그 수정:
- 스트리밍 중과 스트림 종료 시 모두 SSE 이벤트 청크가 일관되게 flush되도록 하여 이벤트가 누락되거나 중복되는 문제를 방지합니다.

개선 사항:
- 누적된 이벤트 데이터를 일관되게 처리하기 위해 SSE 이벤트 flush 로직을 공용 헬퍼로 분리합니다.
- 헬퍼 이름을 변경하고, 비텍스트 부분이 무시될 때 이를 로깅하여 UI 메시지에 대한 텍스트 전용 매핑을 강화합니다.
- 높은 동시성 환경에서의 충돌을 방지하기 위해 SSE 텍스트 파트 식별자를 타임스탬프 기반 ID에서 `crypto.randomUUID` 기반 ID로 전환합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine chat API SSE streaming and text-extraction to improve robustness and identifier stability.

Bug Fixes:
- Ensure SSE event chunks are flushed consistently both during streaming and at stream termination to avoid dropped or duplicated events.

Enhancements:
- Extract SSE event flush logic into a shared helper to unify handling of accumulated event data.
- Strengthen text-only mapping for UI messages by renaming helpers and logging when non-text parts are ignored.
- Switch SSE text part identifiers from timestamp-based IDs to crypto.randomUUID-based IDs to prevent collisions under high concurrency.

</details>