### PR TITLE
♻️ refactor [#11.3.7]: 5차 개선 - 스트림 메모리 릭 방지 및 디버그 로깅 쓰로틀링 적용

### DIFF
--- a/web_ui/src/app/api/chat/route.ts
+++ b/web_ui/src/app/api/chat/route.ts
@@ -11,10 +11,15 @@ function generateUniqueId(): string {
     : `uid-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
 }
 
+function isDebugChatEnabled(): boolean {
+  const val = process.env.DEBUG_CHAT?.toLowerCase();
+  return val === 'true' || val === '1' || val === 'yes';
+}
+
 function getOnlyTextFromMessage(message: UIMessage): string {
   const parts = message.parts ?? [];
   const textParts = parts.filter((p) => p.type === 'text');
-  if (parts.length > textParts.length && process.env.DEBUG_CHAT === 'true') {
+  if (parts.length > textParts.length && isDebugChatEnabled()) {
     console.warn('[Chat Proxy] Extracting only text. Ignored non-text parts in message.');
   }
   return textParts
@@ -104,10 +109,14 @@ function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChun
       let buffer = '';
       const textPartId = `text-${generateUniqueId()}`;
       let textStarted = false;
+      let isFinished = false;
 
       const done = () => {
+        if (isFinished) return;
+        isFinished = true;
+
         reader.cancel().catch((err) => {
-          if (process.env.DEBUG_CHAT === 'true') {
+          if (isDebugChatEnabled()) {
             console.error('Error canceling stream reader:', err);
           }
         });


### PR DESCRIPTION
- **[web_ui/src/app/api/chat/route.ts]**:
  - ReadableStream 데이터 해제 보장: SSE의 `[DONE]` 감지 혹은 스트림 조기 끊김(Flush) 시 호출되는 [done()](web_ui/src/app/api/chat/route.ts:107:6-114:8) 로직 내에 `reader.cancel()`을 명시적으로 추가하여, 부모 Fetch 네트워크 커넥션 및 바디 스트림이 안전하게 즉시 해제(메모리 누수/좀비 커넥션 방지)되도록 보강.
  - 가시성 기반 로깅 제어 추가: 프로덕션 환경에서 비 텍스트 이벤트로 인한 무한 로그 스팸을 막기 위해, 노출 위험이 있는 `console.warn` 및 내부 에러 출력을 하드코딩된 환경체크에서 완전히 격리된 독립 환경 스위치(`process.env.DEBUG_CHAT === 'true'`) 뒤로 숨김.

🔗 Related:
- Issue [#614]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/638#pullrequestreview-3908637097)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1

## Summary by Sourcery

리소스 누수를 방지하고 디버그 로깅을 전용 플래그 뒤에 두기 위해 챗 API 스트림 처리 방식을 개선합니다.

개선 사항:
- UI 청크 스트림이 종료될 때 백엔드 응답 리더를 명시적으로 취소하여, 남아 있는 네트워크 연결과 메모리 누수를 방지합니다.
- `NODE_ENV`에 의존하는 대신 `DEBUG_CHAT` 환경 변수 플래그를 통해, 텍스트가 아닌 파트 추출 경고와 스트림 취소 오류를 제어합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine chat API stream handling to prevent resource leaks and gate debug logging behind a dedicated flag.

Enhancements:
- Introduce explicit cancellation of the backend response reader when the UI chunk stream finishes to avoid lingering network connections and memory leaks.
- Guard non-text-part extraction warnings and stream cancellation errors behind a DEBUG_CHAT environment flag instead of relying on NODE_ENV.

</details>