### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/web_ui/src/app/api/chat/route.ts
+++ b/web_ui/src/app/api/chat/route.ts
@@ -11,10 +11,15 @@ function generateUniqueId(): string {
     : `uid-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
 }
 
+function isDebugChatEnabled(): boolean {
+  const val = process.env.DEBUG_CHAT?.toLowerCase();
+  return val === 'true' || val === '1' || val === 'yes';
+}
+
 function getOnlyTextFromMessage(message: UIMessage): string {
   const parts = message.parts ?? [];
   const textParts = parts.filter((p) => p.type === 'text');
-  if (parts.length > textParts.length && process.env.NODE_ENV !== 'production') {
+  if (parts.length > textParts.length && isDebugChatEnabled()) {
     console.warn('[Chat Proxy] Extracting only text. Ignored non-text parts in message.');
   }
   return textParts
@@ -104,8 +109,19 @@ function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChun
       let buffer = '';
       const textPartId = `text-${generateUniqueId()}`;
       let textStarted = false;
+      let isFinished = false;
 
-      const done = () => finishStream(controller, textStarted, textPartId);
+      const done = () => {
+        if (isFinished) return;
+        isFinished = true;
+
+        reader.cancel().catch((err) => {
+          if (isDebugChatEnabled()) {
+            console.error('Error canceling stream reader:', err);
+          }
+        });
+        finishStream(controller, textStarted, textPartId);
+      };
       const ensureTextStarted = () => {
         if (!textStarted) {
           controller.enqueue({ type: 'text-start', id: textPartId });


### PR DESCRIPTION
♻️ refactor [#11.3.7]: 5차 개선 - 스트림 메모리 릭 방지 및 디버그 로깅 쓰로틀링 적용 
♻️ refactor [#11.3.7]: 6차 개선 - 스트림 종료 로직 멱등성 확보 및 설정 중앙화

## Summary by Sourcery

채팅 스트리밍 안정성을 개선하고 디버그 로깅 설정을 중앙집중화합니다.

버그 수정:
- 잠재적인 스트림 누수 또는 이중 종료를 방지하기 위해, 채팅 UI 청크 스트림 종료가 멱등성(idempotent)을 갖도록 보장합니다.

개선 사항:
- `NODE_ENV`와 독립적으로 채팅 관련 디버그 로깅을 제어할 수 있는 `DEBUG_CHAT` 환경 토글을 도입합니다.
- UI 청크 스트림을 종료할 때 백엔드 스트림 리더를 취소하고, 취소 오류에 대해 선택적으로 디버그 로깅을 수행합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve chat streaming stability and centralize debug logging configuration.

Bug Fixes:
- Ensure chat UI chunk stream termination is idempotent to avoid potential stream leaks or double-finalization.

Enhancements:
- Introduce a DEBUG_CHAT environment toggle to control chat-related debug logging independently of NODE_ENV.
- Cancel the backend stream reader when finishing the UI chunk stream, with optional debug logging on cancellation errors.

</details>