### PR TITLE
♻️ refactor [#11.3.7]: 7차 개선 - 스트림 자원 자가 해제 및 런타임 가드레일 보강

### DIFF
--- a/web_ui/src/app/api/chat/route.ts
+++ b/web_ui/src/app/api/chat/route.ts
@@ -115,11 +115,13 @@ function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChun
         if (isFinished) return;
         isFinished = true;
 
-        reader.cancel().catch((err) => {
-          if (isDebugChatEnabled()) {
-            console.error('Error canceling stream reader:', err);
-          }
-        });
+        if (reader) {
+          reader.cancel().catch((err) => {
+            if (isDebugChatEnabled()) {
+              console.error('Error canceling stream reader:', err);
+            }
+          });
+        }
         finishStream(controller, textStarted, textPartId);
       };
       const ensureTextStarted = () => {
@@ -266,6 +268,7 @@ export async function POST(req: Request) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
+        signal: req.signal,
       });
 
       if (!backendRes.ok) {


### PR DESCRIPTION
- **[web_ui/src/app/api/chat/route.ts]**:
  - `fetch` 커넥션 최적화: 백엔드 스트림 요청 시 `signal: req.signal`을 명시적으로 전달하여, 사용자가 브라우저 탭을 닫을 경우 좀비 소켓이 남지 않고 즉시 백엔드 연결이 끊어지도록 개선.
  - [done()](web_ui/src/app/api/chat/route.ts:113:6-125:8) 핸들러 안전성 보강: `reader` 초기화 여부 체크 및 `isFinished` 멱등성 가드(Idempotency)를 통해 중복 호출 시의 런타임 오류 방어.
  - 디버그 제어 래퍼 고도화: [isDebugChatEnabled()](web_ui/src/app/api/chat/route.ts:13:0-16:1)가 다양한 진취적 값(`true`, `1`, `yes`)을 정규화하여 처리하도록 유연화.

🔗 Related:
- Issue [#614]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/640#pullrequestreview-3908649366)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1

## Summary by Sourcery

채팅 API에서 스트림 정리 및 취소 로직을 보호하고, 요청 중단(abort) 신호가 백엔드 fetch 호출로 전달되도록 합니다.

버그 수정:
- 스트림 리더가 초기화된 경우에만 취소하도록 하여 런타임 오류를 방지합니다.
- 들어오는 요청의 signal을 fetch 호출에 연결하여, 클라이언트 요청이 취소될 때 백엔드 스트리밍 연결이 중단되도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard stream cleanup and cancelation logic in the chat API and propagate the request abort signal to backend fetch calls.

Bug Fixes:
- Prevent runtime errors by only canceling the stream reader when it has been initialized.
- Ensure backend streaming connections are aborted when the client request is canceled by wiring the incoming request signal into the fetch call.

</details>