### PR TITLE
♻️ refactor [#11.3.7]: 7차 개선 - 스트림 자원 자가 해제 및 런타임 가드레일 보강

### DIFF
--- a/web_ui/src/app/api/chat/route.ts
+++ b/web_ui/src/app/api/chat/route.ts
@@ -99,12 +99,7 @@ function handleSseEvent(
 function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChunk> {
   return new ReadableStream<UIMessageChunk>({
     async start(controller) {
-      if (!backendRes.body) {
-        finishStream(controller, false, null);
-        return;
-      }
-
-      const reader = backendRes.body.getReader();
+      const reader = backendRes.body?.getReader();
       const decoder = new TextDecoder();
       let buffer = '';
       const textPartId = `text-${generateUniqueId()}`;
@@ -124,6 +119,12 @@ function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChun
         }
         finishStream(controller, textStarted, textPartId);
       };
+
+      if (!reader) {
+        done();
+        return;
+      }
+
       const ensureTextStarted = () => {
         if (!textStarted) {
           controller.enqueue({ type: 'text-start', id: textPartId });
@@ -268,7 +269,7 @@ export async function POST(req: Request) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
-        signal: req.signal,
+        signal: req.signal || undefined,
       });
 
       if (!backendRes.ok) {


### PR DESCRIPTION
- **[web_ui/src/app/api/chat/route.ts]**:
  - `fetch` 커넥션 최적화: 백엔드 스트림 요청 시 `signal: req.signal`을 명시적으로 전달하여, 사용자가 브라우저 탭을 닫을 경우 좀비 소켓이 남지 않고 즉시 백엔드 연결이 끊어지도록 개선.
  - [done()](web_ui/src/app/api/chat/route.ts:113:6-125:8) 핸들러 안전성 보강: `reader` 초기화 여부 체크 및 `isFinished` 멱등성 가드(Idempotency)를 통해 중복 호출 시의 런타임 오류 방어.
  - 디버그 제어 래퍼 고도화: [isDebugChatEnabled()](web_ui/src/app/api/chat/route.ts:13:0-16:1)가 다양한 진취적 값(`true`, `1`, `yes`)을 정규화하여 처리하도록 유연화.

🔗 Related:
- Issue [#614]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/640#pullrequestreview-3908649366)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1

## Summary by Sourcery

채팅 스트리밍 정리 로직의 견고성을 향상시키고, 백엔드 스트림의 라이프사이클을 클라이언트 요청 취소 동작과 정렬합니다.

버그 수정:
- 채팅 API에서 스트림 리더가 초기화되지 않았거나 이미 해제된 상태에서도 오류가 발생하지 않도록, 스트림 리더 취소 로직에 가드를 추가했습니다.

개선 사항:
- 클라이언트가 연결을 끊으면 백엔드 스트리밍이 중단되도록, 들어오는 요청의 signal을 백엔드 채팅 fetch 호출에 전달합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve robustness of chat streaming cleanup and align backend stream lifecycle with client request cancellation.

Bug Fixes:
- Guard stream reader cancellation in the chat API to avoid errors when the reader is not initialized or already released.

Enhancements:
- Propagate the incoming request signal to the backend chat fetch call so backend streaming is aborted when the client disconnects.

</details>