### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/web_ui/src/app/api/chat/route.ts
+++ b/web_ui/src/app/api/chat/route.ts
@@ -99,12 +99,7 @@ function handleSseEvent(
 function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChunk> {
   return new ReadableStream<UIMessageChunk>({
     async start(controller) {
-      if (!backendRes.body) {
-        finishStream(controller, false, null);
-        return;
-      }
-
-      const reader = backendRes.body.getReader();
+      const reader = backendRes.body?.getReader();
       const decoder = new TextDecoder();
       let buffer = '';
       const textPartId = `text-${generateUniqueId()}`;
@@ -115,13 +110,21 @@ function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChun
         if (isFinished) return;
         isFinished = true;
 
-        reader.cancel().catch((err) => {
-          if (isDebugChatEnabled()) {
-            console.error('Error canceling stream reader:', err);
-          }
-        });
+        if (reader) {
+          reader.cancel().catch((err) => {
+            if (isDebugChatEnabled()) {
+              console.error('Error canceling stream reader:', err);
+            }
+          });
+        }
         finishStream(controller, textStarted, textPartId);
       };
+
+      if (!reader) {
+        done();
+        return;
+      }
+
       const ensureTextStarted = () => {
         if (!textStarted) {
           controller.enqueue({ type: 'text-start', id: textPartId });
@@ -266,6 +269,7 @@ export async function POST(req: Request) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
+        signal: req.signal || undefined,
       });
 
       if (!backendRes.ok) {


### PR DESCRIPTION
♻️ refactor [#11.3.7]: 7차 개선 - 스트림 자원 자가 해제 및 런타임 가드레일 보강 
♻️ refactor [#11.3.7]: 8차 개선 - 정적 타입 정합성 최적화 및 런타임 시그널 가드 보강

## Summary by Sourcery

백엔드 응답 본문이 누락된 경우에 대비해 채팅 스트리밍을 보호하고, 클라이언트의 중단(abort) 신호를 백엔드 요청으로 전달합니다.

Bug Fixes:
- 백엔드 응답에 본문이 없는 경우에도 UI 청크 스트림을 안전하게 종료하도록 처리합니다.
- `cancel()`을 호출하기 전에 스트림 리더의 존재 여부를 확인하여, 스트림 리더 취소 중 발생할 수 있는 오류를 방지합니다.
- 적절한 취소와 리소스 정리를 위해, 들어오는 요청의 abort 신호를 백엔드 `fetch`에 전달합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard chat streaming against missing backend response bodies and propagate client abort signals to the backend request.

Bug Fixes:
- Handle cases where the backend response has no body by safely finalizing the UI chunk stream.
- Avoid errors when canceling the stream reader by checking for its existence before calling cancel().
- Forward the incoming request’s abort signal to the backend fetch to ensure proper cancellation and resource cleanup.

</details>