### PR TITLE
♻️ refactor [#11.3.7]: 9차 개선 - 클라이언트 중단(Abort) 예외 처리 및 스트림 종료 정교화

### DIFF
--- a/web_ui/src/app/api/chat/route.ts
+++ b/web_ui/src/app/api/chat/route.ts
@@ -16,6 +16,10 @@ function isDebugChatEnabled(): boolean {
   return val === 'true' || val === '1' || val === 'yes';
 }
 
+function isAbortError(err: unknown): boolean {
+  return (err instanceof Error && err.name === 'AbortError') || (err as { name?: string })?.name === 'AbortError';
+}
+
 function getOnlyTextFromMessage(message: UIMessage): string {
   const parts = message.parts ?? [];
   const textParts = parts.filter((p) => p.type === 'text');
@@ -88,10 +92,12 @@ function handleSseEvent(
       } as UIMessageChunk);
     }
   } catch (e) {
-    console.error('Failed to parse SSE data payload as JSON', {
-      dataPayload,
-      error: e,
-    });
+    if (isDebugChatEnabled()) {
+      console.error('Failed to parse SSE data payload as JSON', {
+        dataPayload,
+        error: e,
+      });
+    }
   }
   return false;
 }
@@ -121,7 +127,7 @@ function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChun
       };
 
       if (!reader) {
-        finishStream(controller, false, null);
+        done();
         return;
       }
 
@@ -203,7 +209,7 @@ function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChun
           }
         }
       } catch (err) {
-        if (err instanceof Error && err.name === 'AbortError') {
+        if (isAbortError(err)) {
           if (isDebugChatEnabled()) {
             console.log('[Chat Proxy] Stream reading aborted.');
           }
@@ -283,7 +289,7 @@ export async function POST(req: Request) {
         fallbackRequired = true;
       }
     } catch (e) {
-      if (e instanceof Error && e.name === 'AbortError') {
+      if (isAbortError(e)) {
         if (isDebugChatEnabled()) {
           console.log('[Chat Proxy] Fetch aborted by client.');
         }


### PR DESCRIPTION
- **[web_ui/src/app/api/chat/route.ts]**:
  - AbortError 고도화 대응: 사용자가 브라우저 탭을 닫거나 요청을 취소할 때 발생하는 `AbortError`를 에러가 아닌 정상적 중단으로 인식하도록 가드 추가. (Gemini 폴백 방지 및 499 상태 코드 반환)
  - 스트림 자원 정밀 해제: `reader.read()` 단계에서 중단 신호 감지 시, 불필요한 에러 청크 전송 없이 조용히 종료되도록 예외 처리 보강.
  - 엣지 케이스 정합성 확보: `backendRes.body`가 없는 누락 상황에서 명시적으로 `null` 파트 ID를 전달하여 다운스트림 소비자의 오동작 위험을 원천 차단.

🔗 Related:
- Issue [#614]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/643#pullrequestreview-3908660355)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1

## Summary by Sourcery

클라이언트가 시작한 중단을 채팅 프록시 스트림 및 백엔드 fetch 흐름에서 우아한 종료로 처리합니다.

버그 수정:
- 클라이언트가 스트리밍 채팅 요청을 중단했을 때 잘못된 오류 청크와 Gemini 폴백이 발생하지 않도록 방지합니다.
- 채팅 POST 처리 중 클라이언트 측 중단을 백엔드 오류로 취급하지 않고, HTTP 499를 반환하도록 합니다.
- 백엔드 응답 리더를 사용할 수 없는 경우에도 스트림 종료(finalization)가 반드시 호출되도록 보장합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle client-initiated aborts as graceful terminations in the chat proxy stream and backend fetch flow.

Bug Fixes:
- Prevent erroneous error chunks and Gemini fallback when the client aborts a streaming chat request.
- Return HTTP 499 and avoid treating client-side aborts as backend failures during chat POST handling.
- Ensure stream finalization is invoked even when the backend response reader is unavailable.

</details>