### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/web_ui/src/app/api/chat/route.ts
+++ b/web_ui/src/app/api/chat/route.ts
@@ -16,6 +16,10 @@ function isDebugChatEnabled(): boolean {
   return val === 'true' || val === '1' || val === 'yes';
 }
 
+function isAbortError(err: unknown): boolean {
+  return (err instanceof Error && err.name === 'AbortError') || (err as { name?: string })?.name === 'AbortError';
+}
+
 function getOnlyTextFromMessage(message: UIMessage): string {
   const parts = message.parts ?? [];
   const textParts = parts.filter((p) => p.type === 'text');
@@ -88,10 +92,12 @@ function handleSseEvent(
       } as UIMessageChunk);
     }
   } catch (e) {
-    console.error('Failed to parse SSE data payload as JSON', {
-      dataPayload,
-      error: e,
-    });
+    if (isDebugChatEnabled()) {
+      console.error('Failed to parse SSE data payload as JSON', {
+        dataPayload,
+        error: e,
+      });
+    }
   }
   return false;
 }
@@ -202,11 +208,17 @@ function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChun
             }
           }
         }
-      } catch {
-        controller.enqueue({
-          type: 'error',
-          errorText: '스트림 읽기 중 오류가 발생했습니다.',
-        } as UIMessageChunk);
+      } catch (err) {
+        if (isAbortError(err)) {
+          if (isDebugChatEnabled()) {
+            console.log('[Chat Proxy] Stream reading aborted.');
+          }
+        } else {
+          controller.enqueue({
+            type: 'error',
+            errorText: '스트림 읽기 중 오류가 발생했습니다.',
+          } as UIMessageChunk);
+        }
       }
 
       done();
@@ -277,6 +289,12 @@ export async function POST(req: Request) {
         fallbackRequired = true;
       }
     } catch (e) {
+      if (isAbortError(e)) {
+        if (isDebugChatEnabled()) {
+          console.log('[Chat Proxy] Fetch aborted by client.');
+        }
+        return new Response(null, { status: 499 });
+      }
       console.warn('[Chat Proxy] Backend connection failed, falling back to Gemini...', e);
       fallbackRequired = true;
     }


### PR DESCRIPTION
♻️ refactor [#11.3.7]: 9차 개선 - 클라이언트 중단(Abort) 예외 처리 및 스트림 종료 정교화 
♻️ refactor [#11.3.7]: 10차 개선 - 런타임 예외 처리 및 보안 로깅 최적화

## Summary by Sourcery

웹 UI 채팅 API 라우트에서 채팅 스트리밍 오류 처리 및 중단(Abort) 인식 동작을 개선합니다.

버그 수정:
- 클라이언트가 의도적으로 채팅 스트림을 중단했을 때, 일반적인 사용자용 스트림 오류가 발생하지 않도록 방지합니다.
- 백엔드 fetch 요청을 클라이언트가 중단한 경우, 일반적인 백엔드 장애로 처리하는 대신 특정 HTTP 499 응답을 반환합니다.

개선 사항:
- 일반 동작 시 불필요한 로그를 줄이기 위해, 상세한 SSE JSON 파싱 오류 로그를 디버그 채팅 플래그 뒤로 숨깁니다.
- 채팅 라우트 전반에서 AbortError 인스턴스를 일관되게 식별할 수 있도록, 공유되는 중단 오류 감지 헬퍼를 도입합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve chat streaming error handling and abort-aware behavior in the web UI chat API route.

Bug Fixes:
- Prevent generic user-facing stream errors from being emitted when the client intentionally aborts the chat stream.
- Return a specific HTTP 499 response when the client aborts the backend fetch request instead of treating it as a generic backend failure.

Enhancements:
- Gate detailed SSE JSON parse error logging behind the debug chat flag to reduce noisy logs in normal operation.
- Introduce a shared abort-error detection helper to consistently identify AbortError instances across the chat route.

</details>