### PR TITLE
♻️ refactor [#11.3.7]: 11차 개선 - 엔지니어링 무결성 확보 및 상용 수준 예외 처리

### DIFF
--- a/web_ui/src/app/api/chat/route.ts
+++ b/web_ui/src/app/api/chat/route.ts
@@ -191,16 +191,22 @@ function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChun
           const { done: streamDone, value } = await reader.read();
           
           if (streamDone) {
-            // Flush any remaining partial multi-line 이벤트 처리 
-            // 스트림이 끊겼을 때 마지막 행이 줄바꿈 없이 끝난 경우를 대비해 decoder를 닫으며 남은 데이터를 긁어옵니다.
+            // [Fixed] Flush any remaining partial multi-line 이벤트 처리 
+            // 스트림이 끊겼을 때 기존 buffer와 마지막 데이터(lastChunk)를 결합하여 데이터 유실을 방지합니다.
             const lastChunk = decoder.decode(new Uint8Array(0), { stream: false });
-            if (lastChunk) {
-              const trailingLines = lastChunk.split('\n');
+            const finalData = buffer + lastChunk;
+            
+            if (finalData) {
+              const trailingLines = finalData.split('\n');
               for (const tl of trailingLines) {
                 if (processLine(tl)) return;
               }
             }
-            flushCurrentEvent();
+
+            // 루프 종료 전 마지막 미처리 이벤트 플러시
+            if (flushCurrentEvent()) {
+              return;
+            }
             break;
           }
 


### PR DESCRIPTION
- **[web_ui/src/app/api/chat/route.ts]**:
  - `HTTP_STATUS_CLIENT_CLOSED_REQUEST`(499) 상수화: 매직 넘버를 제거하고 주석을 통해 의도된 비정상 종료(Silent Close) 설계 결정을 명시함.
  - `isAbortError` 타입 프레디킷 고도화: TypeScript 고유 기능을 활용한 타입 추론 최적화로 런타임 가드 정확도 향상.
  - SSE 처리 로직 완전 통합: 스트림 내부와 종료 직후 잔여 데이터 처리를 `processLine` 내부 함수로 단일화하여 엣지 케이스별 파싱 드리프트(Drift) 원천 차단.
  - 자원 해제 가드 강화: [done()](web_ui/src/app/api/chat/route.ts:119:6-131:8) 핸들러 내 멱등성 보장 및 `reader` 존재 여부를 2중 체크하여 상용 환경에서의 안정성 극대화.

🔗 Related:
- Issue [#614]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/645#pullrequestreview-3908668766)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1

## Summary by Sourcery

더 견고한 SSE 처리와 더 명확한 클라이언트 중단(Abort) 의미 체계를 위해 채팅 API 스트리밍과 중단 처리 로직을 개선합니다.

개선 사항:
- 클라이언트가 연결을 닫았을 때 사용할 HTTP 상태 코드 499에 대해 이름이 있는 상수를 도입해, 클라이언트 중단 응답을 문서화하고 표준화합니다.
- TypeScript 타입 내로잉을 활용할 수 있도록 `AbortError` 타입 가드를 강화하여, 더 안전한 에러 처리를 가능하게 합니다.
- 공유 헬퍼를 통해 SSE 라인 파싱과 말단(trailing) 데이터 플러시를 통합하여, 스트림 종료 시점과 일반 읽기 과정 모두에서 일관된 이벤트 처리가 이루어지도록 합니다.
- 사용자가 중단을 요청했을 때 UI 청크 스트림이 조용하고(idempotent) 우아하게 종료되도록 보장하여, 부분 결과는 유지하면서도 불필요한 에러 로그가 발생하지 않도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine chat API streaming and abort handling for more robust SSE processing and clearer client-abort semantics.

Enhancements:
- Introduce a named constant for the 499 client-closed HTTP status code to document and standardize client abort responses.
- Strengthen the AbortError type guard to leverage TypeScript type narrowing for safer error handling.
- Unify SSE line parsing and trailing data flushing through a shared helper to ensure consistent event processing at stream end and during normal reads.
- Ensure graceful, idempotent completion of the UI chunk stream on user-initiated aborts to avoid noisy error reporting while preserving partial results.

</details>