### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/web_ui/src/app/api/chat/route.ts
+++ b/web_ui/src/app/api/chat/route.ts
@@ -4,6 +4,8 @@ import type { UIMessage, UIMessageChunk, ModelMessage } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
+/** Nginx 스타일의 비표준 상태 코드: 클라이언트가 연결을 조기에 닫았음을 나타냄 */
+const HTTP_STATUS_CLIENT_CLOSED_REQUEST = 499;
 
 function generateUniqueId(): string {
   return typeof crypto !== 'undefined' && crypto.randomUUID
@@ -16,8 +18,11 @@ function isDebugChatEnabled(): boolean {
   return val === 'true' || val === '1' || val === 'yes';
 }
 
-function isAbortError(err: unknown): boolean {
-  return (err instanceof Error && err.name === 'AbortError') || (err as { name?: string })?.name === 'AbortError';
+function isAbortError(err: unknown): err is Error & { name: 'AbortError' } {
+  return (
+    (err instanceof Error && err.name === 'AbortError') ||
+    (err as { name?: string })?.name === 'AbortError'
+  );
 }
 
 function getOnlyTextFromMessage(message: UIMessage): string {
@@ -162,20 +167,43 @@ function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChun
           return false;
         };
 
+        const processLine = (rawLine: string): boolean => {
+          const line = rawLine.replace(/\r$/, '');
+
+          if (line === '') {
+            return flushCurrentEvent();
+          }
+
+          if (line.startsWith(':')) return false;
+
+          if (line.startsWith('event:')) {
+            currentEventType = line.slice('event:'.length).trimStart();
+            return false;
+          }
+
+          if (line.startsWith('data:')) {
+            currentEventDataLines.push(line.slice('data:'.length).trimStart());
+          }
+          return false;
+        };
+
         while (true) {
           const { done: streamDone, value } = await reader.read();
           
           if (streamDone) {
-            // Flush any remaining partial multi-line event if stream dropped
-            buffer += decoder.decode(new Uint8Array(0), { stream: false });
-            const trailingLines = buffer.split('\n');
-            for (const trailingLine of trailingLines) {
-              const line = trailingLine.replace(/\r$/, '');
-              if (line.startsWith('data:')) {
-                currentEventDataLines.push(line.slice('data:'.length).trimStart());
+            // [Fixed] Flush any remaining partial multi-line 이벤트 처리 
+            // 스트림이 끊겼을 때 기존 buffer와 마지막 데이터(lastChunk)를 결합하여 데이터 유실을 방지합니다.
+            const lastChunk = decoder.decode(new Uint8Array(0), { stream: false });
+            const finalData = buffer + lastChunk;
+            
+            if (finalData) {
+              const trailingLines = finalData.split('\n');
+              for (const tl of trailingLines) {
+                if (processLine(tl)) return;
               }
             }
 
+            // 루프 종료 전 마지막 미처리 이벤트 플러시
             if (flushCurrentEvent()) {
               return;
             }
@@ -187,25 +215,7 @@ function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChun
           buffer = rawLines.pop() ?? '';
 
           for (const rawLine of rawLines) {
-            const line = rawLine.replace(/\r$/, '');
-
-            if (line === '') {
-              if (flushCurrentEvent()) {
-                return;
-              }
-              continue;
-            }
-
-            if (line.startsWith(':')) continue;
-
-            if (line.startsWith('event:')) {
-              currentEventType = line.slice('event:'.length).trimStart();
-              continue;
-            }
-
-            if (line.startsWith('data:')) {
-              currentEventDataLines.push(line.slice('data:'.length).trimStart());
-            }
+            if (processLine(rawLine)) return;
           }
         }
       } catch (err) {
@@ -213,6 +223,11 @@ function createUIChunkStream(backendRes: Response): ReadableStream<UIMessageChun
           if (isDebugChatEnabled()) {
             console.log('[Chat Proxy] Stream reading aborted.');
           }
+          // [Engineering Decision] 
+          // 사용자 중단(Abort) 시에는 실시간 수신된 부분 데이터까지를 유효한 결과로 간주하고 
+          // 불필요한 에러 팝업 없이 조용히 스트림을 닫는 것이 최상의 UX입니다.
+          done();
+          return;
         } else {
           controller.enqueue({
             type: 'error',
@@ -293,7 +308,7 @@ export async function POST(req: Request) {
         if (isDebugChatEnabled()) {
           console.log('[Chat Proxy] Fetch aborted by client.');
         }
-        return new Response(null, { status: 499 });
+        return new Response(null, { status: HTTP_STATUS_CLIENT_CLOSED_REQUEST });
       }
       console.warn('[Chat Proxy] Backend connection failed, falling back to Gemini...', e);
       fallbackRequired = true;


### PR DESCRIPTION
♻️ refactor [#11.3.7]: 11차 개선 - 엔지니어링 무결성 확보 및 상용 수준 예외 처리 
♻️ refactor [#11.3.7]: 12차 개선 - 데이터 무결성 보강 및 스트림 종료 로직 동기화

## Summary by Sourcery

웹 UI 채팅 API 프록시에서 채팅 스트리밍의 견고성과 클라이언트 중단 처리 기능을 개선합니다.

버그 수정:
- 백엔드 스트림이 끝날 때 남아 있는 다중 라인의 부분 서버 전송 이벤트가 올바르게 플러시되도록 해서 데이터 손실을 방지합니다.
- 채팅 스트리밍 중 사용자가 중단을 수행한 경우, 이를 오류가 아닌 정상 종료로 처리하여 UI에 불필요한 오류가 표시되지 않도록 합니다.

개선 사항:
- 서버 전송 이벤트 라인 파싱 로직을 재사용 가능한 헬퍼로 리팩터링하여 스트림 처리 로직을 더 명확하고 유지 보수하기 쉽게 합니다.
- 클라이언트 중단 응답에서의 사용을 문서화하고 표준화하기 위해 HTTP 상태 코드 499(client-closed-request)에 대한 명명된 상수를 도입합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve chat streaming robustness and client abort handling in the web UI chat API proxy.

Bug Fixes:
- Ensure remaining partial multi-line server-sent events are flushed correctly when the backend stream ends to avoid data loss.
- Treat user-initiated aborts during chat streaming as a normal, non-error termination to prevent unnecessary error surfacing in the UI.

Enhancements:
- Refactor server-sent event line parsing into a reusable helper for clearer and more maintainable stream processing logic.
- Introduce a named constant for the 499 client-closed-request HTTP status code to document and standardize its use in client abort responses.

</details>