### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -8,8 +8,12 @@ import logging
 from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
 
-from backend.api.models import ChatQueryRequest
+from backend.api.models import ChatQueryRequest, ChatHistoryResponse
 from backend.services.chat_service import ChatService, get_chat_service
+from backend.services.chat_history_service import (
+    ChatHistoryService,
+    get_chat_history_service,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +38,7 @@ async def stream_chat(
         chat_service.stream_chat(
             query=request.query,
             user_id=request.user_id,
+            session_id=request.session_id,
             k=request.k,
             alpha=request.alpha,
         ),
@@ -44,3 +49,37 @@ async def stream_chat(
             "X-Accel-Buffering": "no",
         },
     )
+
+
+@router.get(
+    "/history/{session_id}",
+    response_model=ChatHistoryResponse,
+    summary="대화 히스토리 조회",
+)
+async def get_chat_history(
+    session_id: str,
+    limit: int = 20,
+    chat_history_service: ChatHistoryService = Depends(get_chat_history_service),
+):
+    """
+    지정된 세션 ID의 최근 대화 내역을 조회합니다.
+    """
+    messages = await chat_history_service.get_history(session_id, limit=limit)
+    return ChatHistoryResponse(
+        status="success", session_id=session_id, messages=messages
+    )
+
+
+@router.delete("/history/{session_id}", summary="대화 히스토리 초기화")
+async def clear_chat_history(
+    session_id: str,
+    chat_history_service: ChatHistoryService = Depends(get_chat_history_service),
+):
+    """
+    지정된 세션 ID의 대화 내역을 모두 삭제합니다.
+    """
+    await chat_history_service.clear_history(session_id)
+    return {
+        "status": "success",
+        "message": f"History for session {session_id} cleared.",
+    }

--- a/backend/api/models/__init__.py
+++ b/backend/api/models/__init__.py
@@ -187,12 +187,31 @@ class ChatQueryRequest(BaseModel):
 
     query: str = Field(..., description="사용자 질의 텍스트")
     user_id: str = Field(..., description="사용자 ID (온보딩 및 세션 식별용)")
+    session_id: Optional[str] = Field(
+        default=None, description="세션 ID (대화 맥락 유지용)"
+    )
     k: int = Field(
         default=5, ge=1, le=20, description="RAG 검색에 사용할 최대 컨텍스트(문서) 수"
     )
     alpha: float = Field(
         default=0.5, ge=0.0, le=1.0, description="하이브리드 검색 FAISS 가중치"
     )
+
+
+class ChatMessage(BaseModel):
+    """채팅 메시지 개별 항목 모델"""
+
+    role: str = Field(..., description="메시지 발신자 역할 (user, assistant, system)")
+    content: str = Field(..., description="메시지 내용")
+    timestamp: Optional[str] = Field(None, description="ISO 형식의 타임스탬프")
+
+
+class ChatHistoryResponse(BaseModel):
+    """채팅 히스토리 응답 모델"""
+
+    status: str = Field(..., description="응답 상태")
+    session_id: str = Field(..., description="세션 ID")
+    messages: List[ChatMessage] = Field(default_factory=list, description="대화 내역 리스트")
 
 
 __all__ = [
@@ -232,4 +251,6 @@ __all__ = [
     "HybridSearchResponse",
     # Chat (Step 7)
     "ChatQueryRequest",
+    "ChatMessage",
+    "ChatHistoryResponse",
 ]

--- a/backend/services/chat_history_service.py
+++ b/backend/services/chat_history_service.py
@@ -1,0 +1,105 @@
+# backend/services/chat_history_service.py
+
+import json
+import logging
+from typing import List, Dict, Any, Optional
+from datetime import datetime
+from backend.services.redis_pubsub import redis_client
+from backend.api.models import ChatMessage
+
+logger = logging.getLogger(__name__)
+
+
+class ChatHistoryService:
+    """Redis 기반 채팅 히스토리 관리 서비스"""
+
+    def __init__(self, ttl: int = 86400 * 7):  # 기본 7일 유지
+        self.ttl = ttl
+
+    def _get_key(self, session_id: str) -> str:
+        return f"chat:history:{session_id}"
+
+    async def add_message(self, session_id: str, role: str, content: str):
+        """메시지를 Redis 리스트에 추가"""
+        if not redis_client.is_connected():
+            try:
+                await redis_client.connect()
+            except Exception as e:
+                logger.error(
+                    "Redis connection failed in ChatHistoryService",
+                    extra={"session_id": session_id, "error": str(e)},
+                )
+                return
+
+        key = self._get_key(session_id)
+        message = {
+            "role": role,
+            "content": content,
+            "timestamp": datetime.now().isoformat(),
+        }
+
+        try:
+            # 리스트 끝에 추가
+            await redis_client.redis.rpush(key, json.dumps(message))
+            # 만료 시간 갱신
+            await redis_client.redis.expire(key, self.ttl)
+        except Exception as e:
+            logger.error(
+                "Failed to add message to history",
+                extra={"session_id": session_id, "error": str(e)},
+            )
+
+    async def get_history(self, session_id: str, limit: int = 20) -> List[ChatMessage]:
+        """최근 대화 내역 조회"""
+        if not redis_client.is_connected():
+            try:
+                await redis_client.connect()
+            except Exception as e:
+                logger.error(
+                    "Redis connection failed in ChatHistoryService",
+                    extra={"session_id": session_id, "error": str(e)},
+                )
+                return []
+
+        key = self._get_key(session_id)
+        if not key:
+            return []
+        try:
+            # 최근 limit개의 메시지 가져오기 (리스트의 끝에서부터)
+            data = await redis_client.redis.lrange(key, -limit, -1)
+            messages = []
+            for item in data:
+                msg_dict = json.loads(item)
+                messages.append(ChatMessage(**msg_dict))
+            return messages
+        except Exception as e:
+            logger.error(
+                "Failed to get history",
+                extra={"session_id": session_id, "error": str(e)},
+            )
+            return []
+
+    async def clear_history(self, session_id: str):
+        """특정 세션의 히스토리 삭제"""
+        if not redis_client.is_connected():
+            try:
+                await redis_client.connect()
+            except Exception as e:
+                logger.error(
+                    "Failed to connect to Redis for clearing history",
+                    extra={"session_id": session_id, "error": str(e)},
+                )
+                return
+
+        key = self._get_key(session_id)
+        try:
+            await redis_client.redis.delete(key)
+        except Exception as e:
+            logger.error(
+                "Failed to clear history",
+                extra={"session_id": session_id, "error": str(e)},
+            )
+
+
+def get_chat_history_service() -> ChatHistoryService:
+    return ChatHistoryService()

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -20,6 +20,11 @@ from backend.services.hybrid_search_service import (
     get_hybrid_search_service,
 )
 from backend.services.onboarding_service import OnboardingService
+from backend.services.chat_history_service import (
+    ChatHistoryService,
+    get_chat_history_service,
+)
+from backend.api.models import ChatMessage
 
 logger = logging.getLogger(__name__)
 
@@ -78,9 +83,11 @@ class ChatService:
         self,
         hybrid_search_service: HybridSearchService,
         onboarding_service: OnboardingService,
+        chat_history_service: ChatHistoryService,
     ):
         self.hybrid_search_service = hybrid_search_service
         self.onboarding_service = onboarding_service
+        self.chat_history_service = chat_history_service
 
         import os
 
@@ -119,6 +126,10 @@ class ChatService:
 
     def _get_streaming_llm(self):
         """스트리밍용 ChatOpenAI 객체 생성"""
+        return self._get_llm(streaming=True)
+
+    def _get_llm(self, streaming: bool = False):
+        """ChatOpenAI 객체 생성 (기본값: non-streaming)"""
         from langchain_openai import ChatOpenAI
         import os
 
@@ -147,7 +158,7 @@ class ChatService:
             api_key=api_key,
             base_url=base_url,
             model=model,
-            streaming=True,
+            streaming=streaming,
             temperature=0.3,
         )
 
@@ -167,6 +178,46 @@ class ChatService:
 
         return "You are a helpful and expert AI assistant."
 
+    async def _rephrase_query(self, query: str, history: List[ChatMessage]) -> str:
+        """이전 대화 맥락을 기반으로 질의 재구성 (Query Rewriting)"""
+        if not history:
+            return query
+
+        from langchain_core.output_parsers import StringOutputParser
+
+        # 최근 5개 정도의 대화만 맥락으로 사용
+        context_history = "\n".join([f"{m.role}: {m.content}" for m in history[-5:]])
+
+        rephrase_template = """Given the following conversation history and a follow-up question, rephrase the follow-up question to be a standalone question that can be understood without the conversation history.
+If the follow-up question is already standalone, return it exactly as is.
+
+Chat History:
+{history}
+
+Follow-up Question: {query}
+Standalone Question:"""
+
+        rephrase_prompt = ChatPromptTemplate.from_template(rephrase_template)
+        # 쿼리 재구성 작업은 스트리밍이 필요 없으므로 일반 LLM 사용
+        llm = self._get_llm(streaming=False)
+
+        chain = rephrase_prompt | llm | StringOutputParser()
+
+        try:
+            standalone_query = await chain.ainvoke(
+                {"history": context_history, "query": query}
+            )
+            logger.info(
+                "Rephrased query",
+                extra={"original": query, "rephrased": standalone_query},
+            )
+            return standalone_query.strip()
+        except Exception as e:
+            logger.warning(
+                "Query rephrasing failed", extra={"query": query, "error": str(e)}
+            )
+            return query
+
     @staticmethod
     def _format_sse_event(event_type: str, **kwargs) -> str:
         """SSE 규격에 맞게 이벤트를 포맷팅하는 헬퍼 함수"""
@@ -182,21 +233,40 @@ class ChatService:
         self,
         query: str,
         user_id: str,
+        session_id: Optional[str] = None,
         k: int = 5,
         alpha: float = 0.5,
     ) -> AsyncGenerator[str, None]:
         """질의를 받아 RAG 체인을 실행하고 SSE 규격에 맞게 결과 청크를 반환하는 비동기 제너레이터"""
         logger.info(f"Stream chat started for user {user_id}")
 
+        # 0. 히스토리 로드 및 질의 재구성
+        history: List[ChatMessage] = []
+        effective_query = query
+        if session_id:
+            history = await self.chat_history_service.get_history(session_id)
+            if history:
+                effective_query = await self._rephrase_query(query, history)
+
         # 1. Custom Retriever 구성
         retriever = HybridSearchLangChainRetriever(
             service=self.hybrid_search_service, k=k, alpha=alpha
         )
 
-        # 2. 사용자 상황에 맞춘 시스템 프롬프트 템플릿 작성
-        user_context_msg = self._get_user_context_prompt_text(user_id)
+        # 4. Streaming 실행 (astream_events v2 사용)
+        is_cancelled = False
+        full_content = ""
 
-        system_template = f"""{user_context_msg}
+        try:
+            # 1.5. 검색 실행 (재구성된 쿼리 사용) - 예외 발생 시 SSE error로 보고하기 위해 try 내부로 이동
+            source_docs: List[Document] = await retriever.aget_relevant_documents(
+                effective_query
+            )
+
+            # 2. 사용자 상황에 맞춘 시스템 프롬프트 템플릿 작성
+            user_context_msg = self._get_user_context_prompt_text(user_id)
+
+            system_template = f"""{user_context_msg}
 
 Answer the user's question clearly and accurately, using ONLY the context provided below.
 If you cannot answer the question using the context, state "주어진 문서 내용에서는 답변을 찾을 수 없습니다." and do not guess.
@@ -205,63 +275,55 @@ Do not mention the words "context" or "provided text" explicitly in your final a
 Context: 
 {{context}}
 """
-        prompt = ChatPromptTemplate.from_messages(
-            [
+            prompt_messages = [
                 SystemMessagePromptTemplate.from_template(system_template),
-                HumanMessagePromptTemplate.from_template("{input}"),
             ]
-        )
+            prompt_messages.append(HumanMessagePromptTemplate.from_template("{input}"))
+            prompt = ChatPromptTemplate.from_messages(prompt_messages)
 
-        # 3. 단일 책임 RAG 파이프라인: 수동 retrieval + 단순 LLM 체인
-        def format_docs(docs: List[Document]) -> str:
-            """Format retrieved documents securely into a bounded-length context string."""
-            limited_docs = docs[: self.rag_max_docs]
-            contents: List[str] = []
-            total_length = 0
+            # 3. 단일 책임 RAG 파이프라인: 수동 retrieval + 단순 LLM 체인
+            def format_docs(docs: List[Document]) -> str:
+                """Format retrieved documents securely into a bounded-length context string."""
+                limited_docs = docs[: self.rag_max_docs]
+                contents: List[str] = []
+                total_length = 0
 
-            for i, doc in enumerate(limited_docs, 1):
-                content = doc.page_content or ""
-                # 문서 경계를 모델이 구분하기 쉽도록 가벼운 구분자 추가
-                header = f"--- Document {i} ---"
+                for i, doc in enumerate(limited_docs, 1):
+                    content = doc.page_content or ""
+                    # 문서 경계를 모델이 구분하기 쉽도록 가벼운 구분자 추가
+                    header = f"--- Document {i} ---"
 
-                doc_suffix = "...(truncated)"
-                if len(content) > self.rag_max_doc_chars:
-                    # 잘림 표시 접미사의 길이까지 고려해서 엄격하게 자름
-                    safe_len = max(0, self.rag_max_doc_chars - len(doc_suffix))
-                    content = content[:safe_len] + doc_suffix
+                    doc_suffix = "...(truncated)"
+                    if len(content) > self.rag_max_doc_chars:
+                        # 잘림 표시 접미사의 길이까지 고려해서 엄격하게 자름
+                        safe_len = max(0, self.rag_max_doc_chars - len(doc_suffix))
+                        content = content[:safe_len] + doc_suffix
 
-                doc_text = f"{header}\n{content}\n"
+                    doc_text = f"{header}\n{content}\n"
 
-                # 전체 문자열 길이 제한
-                remaining = self.rag_max_total_chars - total_length
-                if remaining <= 0:
-                    break
+                    # 전체 문자열 길이 제한
+                    remaining = self.rag_max_total_chars - total_length
+                    if remaining <= 0:
+                        break
 
-                if len(doc_text) > remaining:
-                    total_limit_suffix = " ...(truncated due to total length limit)"
-                    if remaining > len(total_limit_suffix):
-                        doc_text = (
-                            doc_text[: remaining - len(total_limit_suffix)]
-                            + total_limit_suffix
-                        )
-                    else:
-                        doc_text = doc_text[:remaining]
+                    if len(doc_text) > remaining:
+                        total_limit_suffix = " ...(truncated due to total length limit)"
+                        if remaining > len(total_limit_suffix):
+                            doc_text = (
+                                doc_text[: remaining - len(total_limit_suffix)]
+                                + total_limit_suffix
+                            )
+                        else:
+                            doc_text = doc_text[:remaining]
 
-                contents.append(doc_text)
-                total_length += len(doc_text)
+                    contents.append(doc_text)
+                    total_length += len(doc_text)
 
-            return "\n\n".join(contents)
+                return "\n\n".join(contents)
 
-        # 4. Streaming 실행 (astream_events v2 사용)
-        is_cancelled = False
-
-        try:
-            # 1) LLM 초기화 및 파이프라인 구성 (예외 발생 시 클라이언트에 error SSE로 전달되도록 try 블록 안으로 이동)
+            # 1) LLM 초기화 및 파이프라인 구성
             llm = self._get_streaming_llm()
             rag_chain = prompt | llm
-
-            # 2) 단일 위치에서 public API를 통해 retrieval 수행 (중복 조회 방지)
-            source_docs: List[Document] = await retriever.aget_relevant_documents(query)
 
             sources = [
                 {
@@ -278,7 +340,10 @@ Context:
 
             # 3) 컨텍스트를 직접 만들어 체인에 주입 (LCEL Runnable 의존성 최소화)
             context_str = format_docs(source_docs)
-            chain_input = {"input": query, "context": context_str}
+            chain_input = {
+                "input": query,
+                "context": context_str,
+            }  # 유저는 원본 질문을 보고 싶어하므로 query 사용
 
             # 4) LLM 스트리밍
             async for event in rag_chain.astream_events(chain_input, version="v2"):
@@ -288,6 +353,7 @@ Context:
                 if kind == "on_chat_model_stream":
                     chunk = event["data"].get("chunk")
                     if chunk and getattr(chunk, "content", None):
+                        full_content += chunk.content
                         yield self._format_sse_event("token", data=chunk.content)
 
         except asyncio.CancelledError:
@@ -297,7 +363,10 @@ Context:
             raise
         except Exception as e:
             # 서버 측 상세 에러 기록 (내부 로깅)
-            logger.exception("Error during streaming RAG chat")
+            logger.exception(
+                "Error during streaming RAG chat",
+                extra={"user_id": user_id, "session_id": session_id},
+            )
             # 클라이언트 측에는 일반(Generic) 메시지 전송
             yield self._format_sse_event(
                 "error",
@@ -306,6 +375,13 @@ Context:
 
         # GeneratorExit/CancelledError 중에는 yield를 호출하면 안되므로 정상/내부오류 발생 시에만 DONE 방출
         if not is_cancelled:
+            # 성공적으로 마쳤다면 히스토리에 저장
+            if session_id and full_content:
+                await self.chat_history_service.add_message(session_id, "user", query)
+                await self.chat_history_service.add_message(
+                    session_id, "assistant", full_content
+                )
+
             yield self._format_sse_event("done")
 
 
@@ -314,4 +390,5 @@ def get_chat_service() -> ChatService:
     return ChatService(
         hybrid_search_service=get_hybrid_search_service(),
         onboarding_service=OnboardingService(),
+        chat_history_service=get_chat_history_service(),
     )

--- a/web_ui/src/app/api/chat/route.ts
+++ b/web_ui/src/app/api/chat/route.ts
@@ -283,9 +283,10 @@ export async function POST(req: Request) {
 
     const payload = {
       query: queryText,
-      user_id: 'test_user_123', // TODO: 인증 연동 시 세션 사용자 ID로 교체
-      k: 3,
-      alpha: 0.5,
+      user_id: body.user_id ?? 'test_user_123',
+      session_id: body.session_id,
+      k: body.k ?? 3,
+      alpha: body.alpha ?? 0.5,
     };
 
     let backendRes: Response | null = null;
@@ -322,6 +323,64 @@ export async function POST(req: Request) {
     return createUIMessageStreamResponse({ stream: chunkStream });
   } catch (error) {
     console.error('[Chat Proxy Error]', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const sessionId = searchParams.get('session_id');
+
+    if (!sessionId) {
+      return NextResponse.json({ error: 'session_id is required' }, { status: 400 });
+    }
+
+    const backendRes = await fetch(`${BACKEND_URL}/api/chat/history/${sessionId}`, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    if (!backendRes.ok) {
+      const errorData = await backendRes.json().catch(() => ({}));
+      return NextResponse.json(
+        { error: errorData.message || 'Failed to fetch history from backend' },
+        { status: backendRes.status }
+      );
+    }
+
+    const data = await backendRes.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('[Chat History Proxy Error]', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const sessionId = searchParams.get('session_id');
+
+    if (!sessionId) {
+      return NextResponse.json({ error: 'session_id is required' }, { status: 400 });
+    }
+
+    const backendRes = await fetch(`${BACKEND_URL}/api/chat/history/${sessionId}`, {
+      method: 'DELETE',
+    });
+
+    if (!backendRes.ok) {
+      const errorData = await backendRes.json().catch(() => ({}));
+      return NextResponse.json(
+        { error: errorData.message || 'Failed to clear history from backend' },
+        { status: backendRes.status }
+      );
+    }
+
+    return NextResponse.json({ status: 'success' });
+  } catch (error) {
+    console.error('[Chat History Delete Error]', error);
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
   }
 }

--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -25,9 +25,16 @@ const WELCOME_MESSAGE: UIMessage = {
 
 const defaultChatTransport = new DefaultChatTransport({ api: '/api/chat' });
 
+function generateSessionId(): string {
+  return `sess-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+}
+
 export function ChatWindow() {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [input, setInput] = useState('');
+  const [sessionId, setSessionId] = useState<string>('');
+  const [isHistoryLoading, setIsHistoryLoading] = useState(false);
+  const [alpha, setAlpha] = useState(0.5);
 
   const scrollToBottom = useCallback(() => {
     if (scrollContainerRef.current) {
@@ -40,9 +47,14 @@ export function ChatWindow() {
     }
   }, []);
 
-  const { messages, sendMessage, status, error } = useChat({
+  const { messages, sendMessage, status, error, setMessages } = useChat({
     messages: [WELCOME_MESSAGE],
     transport: defaultChatTransport,
+    // @ts-expect-error - body is supported at runtime but may have type conflicts with custom transport
+    body: {
+      session_id: sessionId,
+      alpha: alpha,
+    },
     onError: (err: Error) => {
       toast.error('메시지 전송 중 에러가 발생했습니다.', {
         description: err.message || '서버와의 연결을 확인해주세요.',
@@ -53,6 +65,62 @@ export function ChatWindow() {
       scrollToBottom();
     },
   });
+
+  // 세션 관리 및 히스토리 로딩
+  useEffect(() => {
+    let sid = localStorage.getItem('flownote_chat_session_id');
+    if (!sid) {
+      sid = generateSessionId();
+      localStorage.setItem('flownote_chat_session_id', sid);
+    }
+    setSessionId(sid);
+
+    const loadHistory = async () => {
+      setIsHistoryLoading(true);
+      try {
+        const res = await fetch(`/api/chat?session_id=${sid}`);
+        if (res.ok) {
+          const data = await res.json();
+          if (data.messages && data.messages.length > 0) {
+            // 백엔드 메시지를 UIMessage 형식으로 변환
+            const historyMessages: UIMessage[] = data.messages.map((m: { role: string; content: string; timestamp?: string }, index: number) => ({
+              id: `hist-${index}`,
+              role: m.role as 'user' | 'assistant' | 'system' | 'data',
+              parts: [{ type: 'text', text: m.content }],
+              createdAt: m.timestamp ? new Date(m.timestamp) : undefined,
+            }));
+            setMessages([WELCOME_MESSAGE, ...historyMessages]);
+          }
+        }
+      } catch (err) {
+        console.error('Failed to load chat history:', err);
+      } finally {
+        setIsHistoryLoading(false);
+      }
+    };
+
+    loadHistory();
+  }, [setMessages]);
+
+  const handleClearHistory = async () => {
+    if (!sessionId) return;
+    if (!confirm('대화 내용을 모두 초기화하시겠습니까?')) return;
+
+    try {
+      await fetch(`/api/chat/history?session_id=${sessionId}`, {
+        method: 'DELETE',
+      });
+      // Clear local state and localStorage to get a new session
+      const newSid = generateSessionId();
+      localStorage.setItem('flownote_chat_session_id', newSid);
+      setSessionId(newSid);
+      setMessages([WELCOME_MESSAGE]);
+      toast.success('대화가 초기화되었습니다.');
+    } catch (err) {
+      console.error('Clear history error:', err);
+      toast.error('초기화 중 오류가 발생했습니다.');
+    }
+  };
 
   const isLoading = status === 'streaming' || status === 'submitted';
 
@@ -88,13 +156,41 @@ export function ChatWindow() {
           <h2 className="text-lg font-bold text-slate-800 tracking-tight">Flownote AI</h2>
           <p className="text-xs text-slate-500 font-medium">사용자 데이터 기반 RAG 에이전트</p>
         </div>
-        {/* 상태 표시 */}
-        {isLoading && (
-          <div className="flex items-center gap-1.5 text-xs text-blue-500">
-            <Loader2 className="w-3.5 h-3.5 animate-spin" />
-            <span>응답 생성 중...</span>
+        <div className="flex items-center gap-3">
+          {/* 하이브리드 가중치 조절 (간이) */}
+          <div className="hidden md:flex flex-col items-end mr-2">
+            <span className="text-[10px] text-slate-400 uppercase font-bold tracking-wider">Alpha (Dense/FAISS)</span>
+            <select 
+              value={alpha} 
+              aria-label="Alpha weighting for hybrid search"
+              onChange={(e) => setAlpha(parseFloat(e.target.value))}
+              className="text-xs bg-transparent border-none focus:ring-0 text-slate-600 font-medium cursor-pointer"
+            >
+              <option value="0.0">0.0 (Keyword Only)</option>
+              <option value="0.3">0.3 (Keyword Heavy)</option>
+              <option value="0.5">0.5 (Balanced)</option>
+              <option value="0.7">0.7 (Semantic Heavy)</option>
+              <option value="1.0">1.0 (Semantic Only)</option>
+            </select>
           </div>
-        )}
+
+          <Button 
+            variant="ghost" 
+            size="sm" 
+            onClick={handleClearHistory}
+            className="text-slate-400 hover:text-red-500 hover:bg-red-50 text-xs h-8"
+          >
+            초기화
+          </Button>
+
+          {/* 상태 표시 */}
+          {(isLoading || isHistoryLoading) && (
+            <div className="flex items-center gap-1.5 text-xs text-blue-500 bg-blue-50 px-2.5 py-1 rounded-full border border-blue-100">
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              <span>{isHistoryLoading ? '이전 대화 로드 중...' : '응답 생성 중...'}</span>
+            </div>
+          )}
+        </div>
       </div>
 
       {/* 메시지 목록 */}


### PR DESCRIPTION
✨ feat [#11.3.8]: 대화 맥락(Context) 유지 및 하이브리드 검색 가중치 파라미터화 
♻️ refactor [#11.3.8]: 1차 개선 - 안정성 강화 및 RAG 파이프라인 무결성 확보

## Summary by Sourcery

Redis 기반 채팅 히스토리를 사용한 세션 기반 대화 컨텍스트를 추가하고, RAG 채팅 플로우의 견고성과 설정 가능성을 향상합니다.

New Features:
- Redis를 사용한 세션 범위(chat session 단위)의 채팅 히스토리 저장을 도입하고, 대화 히스토리를 가져오고 초기화할 수 있는 API를 제공합니다.
- 최근 채팅 히스토리를 바탕으로 사용자 질의를 재구성(rephrasing)하여 RAG 파이프라인에서 대화 컨텍스트를 유지합니다.
- 클라이언트가 하이브리드 검색 가중치(alpha)를 제어하고, 세션 메타데이터를 채팅 API를 통해 전달할 수 있도록 합니다.
- `localStorage`에 저장된 세션 ID를 사용해 웹 UI에서 채팅 히스토리를 저장하고 복원합니다.

Enhancements:
- RAG 파이프라인의 다양한 단계에서 스트리밍/비스트리밍 모드를 모두 지원할 수 있도록 LLM 생성 로직을 리팩터링했습니다.
- 쿼리 재구성(rephrasing) 또는 Redis 연산 실패 시 더 풍부한 컨텍스트와 안전한 폴백을 제공하도록 스트리밍 채팅 서비스의 로깅 및 에러 처리 기능을 개선했습니다.
- 채팅 UI 헤더를 업데이트하여 alpha 제어, 히스토리 초기화, 더 이해하기 쉬운 로딩 상태를 노출합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add session-based conversational context with Redis-backed chat history and enhance the RAG chat flow for robustness and configurability.

New Features:
- Introduce session-scoped chat history storage using Redis and expose APIs to fetch and clear conversation history.
- Maintain conversational context in the RAG pipeline by rephrasing user queries based on recent chat history.
- Allow clients to control hybrid search weighting (alpha) and pass session metadata through the chat API.
- Persist and restore chat history in the web UI using a session ID stored in localStorage.

Enhancements:
- Refactor LLM creation to support both streaming and non-streaming modes for different stages of the RAG pipeline.
- Improve logging and error handling in the streaming chat service with richer context and safer fallbacks when query rephrasing or Redis operations fail.
- Update the chat UI header to surface alpha controls, history reset, and more informative loading states.

</details>