### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/services/chat_history_service.py
+++ b/backend/services/chat_history_service.py
@@ -21,6 +21,9 @@ class ChatHistoryService:
 
     async def add_message(self, session_id: str, role: str, content: str):
         """메시지를 Redis 리스트에 추가"""
+        if not session_id:
+            return
+
         if not redis_client.is_connected():
             try:
                 await redis_client.connect()
@@ -51,6 +54,9 @@ class ChatHistoryService:
 
     async def get_history(self, session_id: str, limit: int = 20) -> List[ChatMessage]:
         """최근 대화 내역 조회"""
+        if not session_id:
+            return []
+
         if not redis_client.is_connected():
             try:
                 await redis_client.connect()
@@ -62,8 +68,6 @@ class ChatHistoryService:
                 return []
 
         key = self._get_key(session_id)
-        if not key:
-            return []
         try:
             # 최근 limit개의 메시지 가져오기 (리스트의 끝에서부터)
             data = await redis_client.redis.lrange(key, -limit, -1)
@@ -81,6 +85,9 @@ class ChatHistoryService:
 
     async def clear_history(self, session_id: str):
         """특정 세션의 히스토리 삭제"""
+        if not session_id:
+            return
+
         if not redis_client.is_connected():
             try:
                 await redis_client.connect()

--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -66,7 +66,7 @@ export function ChatWindow() {
     },
   });
 
-  // 세션 관리 및 히스토리 로딩
+  // 1. 초기 세션 복원/생성 (마운트 시 1회)
   useEffect(() => {
     let sid = localStorage.getItem('flownote_chat_session_id');
     if (!sid) {
@@ -74,33 +74,60 @@ export function ChatWindow() {
       localStorage.setItem('flownote_chat_session_id', sid);
     }
     setSessionId(sid);
+  }, []);
+
+  // 2. 세션 변경 시 히스토리 로드 (sessionId 의존성 추가)
+  useEffect(() => {
+    if (!sessionId) return;
+    let ignore = false;
 
     const loadHistory = async () => {
       setIsHistoryLoading(true);
       try {
-        const res = await fetch(`/api/chat?session_id=${sid}`);
+        const res = await fetch(`/api/chat?session_id=${sessionId}`);
+        if (ignore) return;
+
         if (res.ok) {
           const data = await res.json();
+          if (ignore) return;
+
           if (data.messages && data.messages.length > 0) {
             // 백엔드 메시지를 UIMessage 형식으로 변환
             const historyMessages: UIMessage[] = data.messages.map((m: { role: string; content: string; timestamp?: string }, index: number) => ({
-              id: `hist-${index}`,
+              id: `hist-${index}-${sessionId}`,
               role: m.role as 'user' | 'assistant' | 'system' | 'data',
               parts: [{ type: 'text', text: m.content }],
               createdAt: m.timestamp ? new Date(m.timestamp) : undefined,
             }));
-            setMessages([WELCOME_MESSAGE, ...historyMessages]);
+
+            setMessages(prev => {
+              // 현재 세션의 히스토리가 이미 포함되어 있는지 정밀 체크 (ID와 세션 매칭)
+              const alreadyHasCurrentHistory = prev.some(m => m.id.endsWith(`-${sessionId}`));
+              if (alreadyHasCurrentHistory) return prev;
+
+              // welcome 메시지는 최상단 고정을 위해 제외하고 히스토리 뒤에 대화 재결합
+              const currentMessages = prev.filter(m => m.id !== 'welcome');
+              return [WELCOME_MESSAGE, ...historyMessages, ...currentMessages];
+            });
           }
         }
       } catch (err) {
-        console.error('Failed to load chat history:', err);
+        if (!ignore) {
+          console.error('Failed to load chat history:', err);
+        }
       } finally {
-        setIsHistoryLoading(false);
+        if (!ignore) {
+          setIsHistoryLoading(false);
+        }
       }
     };
 
     loadHistory();
-  }, [setMessages]);
+    return () => {
+      ignore = true;
+      setIsHistoryLoading(false); // 세션 전환 시 로딩 상태 강제 초기화 (Stuck 방지)
+    };
+  }, [sessionId, setMessages]);
 
   const handleClearHistory = async () => {
     if (!sessionId) return;


### PR DESCRIPTION
♻️ refactor [#11.3.8]: 3차 개선 - 비동기 정합성 강화 및 세션 관리 로직 정교화 
♻️ refactor [#11.3.8]: 4차 개선 - 대화 히스토리 로직 안정화

## Summary by Sourcery

비동기 상태 변경과 누락된 세션 ID 상황에서도 더 견고하게 동작하도록 채팅 세션 처리와 히스토리 로딩을 개선했습니다.

Bug Fixes:
- 빈 세션 ID로 백엔드 채팅 히스토리 작업이 실행되지 않도록 하여, 에러 및 무의미한(no-op) 동작을 방지합니다.
- 세션이 변경될 때 UI에 중복되거나 오래된 채팅 히스토리가 표시되지 않도록 하여, 환영 메시지가 고정된 상태를 유지하고 로딩 상태가 멈춰버리지 않도록 합니다.

Enhancements:
- 채팅 창에서 초기 세션 복원 과정과 히스토리 로딩을 분리하여, 히스토리가 현재 세션 ID에 명시적으로 연결되도록 하고 세션 전환 시에도 안전하게 동작하도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve chat session handling and history loading to be more robust to asynchronous state changes and missing session IDs.

Bug Fixes:
- Prevent backend chat history operations from running with empty session IDs, avoiding errors and no-op behavior.
- Avoid duplicate or stale chat history in the UI when sessions change, ensuring welcome message remains pinned and loading state does not get stuck.

Enhancements:
- Separate initial session restoration from history loading in the chat window, making history explicitly tied to the current session ID and safe across session switches.

</details>