### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/services/chat_history_service.py
+++ b/backend/services/chat_history_service.py
@@ -21,8 +21,9 @@ class ChatHistoryService:
 
     async def add_message(self, session_id: str, role: str, content: str):
         """메시지를 Redis 리스트에 추가"""
-        if not session_id:
-            return
+        if not session_id or not session_id.strip():
+            logger.error("Operation failed: session_id is missing or empty.")
+            raise ValueError("session_id is required to add messages to history.")
 
         if not redis_client.is_connected():
             try:
@@ -54,8 +55,9 @@ class ChatHistoryService:
 
     async def get_history(self, session_id: str, limit: int = 20) -> List[ChatMessage]:
         """최근 대화 내역 조회"""
-        if not session_id:
-            return []
+        if not session_id or not session_id.strip():
+            logger.error("Operation failed: session_id is missing or empty.")
+            raise ValueError("session_id is required to get chat history.")
 
         if not redis_client.is_connected():
             try:
@@ -85,8 +87,9 @@ class ChatHistoryService:
 
     async def clear_history(self, session_id: str):
         """특정 세션의 히스토리 삭제"""
-        if not session_id:
-            return
+        if not session_id or not session_id.strip():
+            logger.error("Operation failed: session_id is missing or empty.")
+            raise ValueError("session_id is required to clear history.")
 
         if not redis_client.is_connected():
             try:

--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -81,6 +81,10 @@ export function ChatWindow() {
     if (!sessionId) return;
     let ignore = false;
 
+    // 세션이 변경되면 먼저 메시지 창을 비우고 환영 메시지만 남깁니다.
+    // 이를 통해 이전 세션의 잔여 메시지가 섞이는 현상을 방지합니다.
+    setMessages([WELCOME_MESSAGE]);
+
     const loadHistory = async () => {
       setIsHistoryLoading(true);
       try {
@@ -101,11 +105,7 @@ export function ChatWindow() {
             }));
 
             setMessages(prev => {
-              // 현재 세션의 히스토리가 이미 포함되어 있는지 정밀 체크 (ID와 세션 매칭)
-              const alreadyHasCurrentHistory = prev.some(m => m.id.endsWith(`-${sessionId}`));
-              if (alreadyHasCurrentHistory) return prev;
-
-              // welcome 메시지는 최상단 고정을 위해 제외하고 히스토리 뒤에 대화 재결합
+              // 환영 메시지와 로딩 중 이미 발생했을 수 있는 신규 메시지는 보존
               const currentMessages = prev.filter(m => m.id !== 'welcome');
               return [WELCOME_MESSAGE, ...historyMessages, ...currentMessages];
             });
@@ -125,7 +125,7 @@ export function ChatWindow() {
     loadHistory();
     return () => {
       ignore = true;
-      setIsHistoryLoading(false); // 세션 전환 시 로딩 상태 강제 초기화 (Stuck 방지)
+      setIsHistoryLoading(false); // Cleanup 시 로딩 상태 해제 보장
     };
   }, [sessionId, setMessages]);
 


### PR DESCRIPTION
♻️ refactor [#11.3.8]: 5차 개선 - 세션 결합도 해제 및 에러 가시성 확보 
♻️ refactor [#11.3.8]: 6차 개선 - 히스토리 서비스 인터페이스 계약 정렬

## Summary by Sourcery

채팅 내역 세션 처리 방식을 더욱 엄격하게 하고, 프론트엔드의 메시지 로딩 동작을 백엔드의 더 엄격해진 세션 계약과 일치하도록 조정했습니다.

Bug Fixes:
- 세션이 변경될 때마다 채팅 창을 초기화해 환영 메시지만 보이도록 하여, 서로 다른 세션의 메시지가 섞이는 문제를 방지합니다.
- 효과(cleanup) 단계에서 히스토리 로딩 상태가 확실히 초기화되도록 하여, 로딩 인디케이터가 계속 표시되는 문제를 방지합니다.

Enhancements:
- 채팅 히스토리 서비스에서 세션 식별자를 검증하고, 세션 ID가 없거나 비어 있는 경우 조용히 아무 작업도 하지 않는 대신 명시적인 오류로 노출합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten chat history session handling and align frontend message loading with the backend’s stricter session contract.

Bug Fixes:
- Prevent mixing messages between sessions by clearing the chat window to only the welcome message whenever the session changes.
- Ensure history loading state is reliably reset during effect cleanup to avoid stuck loading indicators.

Enhancements:
- Validate session identifiers in the chat history service and surface missing or empty session IDs as explicit errors instead of silently no-oping.

</details>