### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -5,7 +5,7 @@
 """
 
 import logging
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 
 from backend.api.models import ChatQueryRequest, ChatHistoryResponse
@@ -64,10 +64,13 @@ async def get_chat_history(
     """
     지정된 세션 ID의 최근 대화 내역을 조회합니다.
     """
-    messages = await chat_history_service.get_history(session_id, limit=limit)
-    return ChatHistoryResponse(
-        status="success", session_id=session_id, messages=messages
-    )
+    try:
+        messages = await chat_history_service.get_history(session_id, limit=limit)
+        return ChatHistoryResponse(
+            status="success", session_id=session_id, messages=messages
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 @router.delete("/history/{session_id}", summary="대화 히스토리 초기화")
@@ -78,8 +81,11 @@ async def clear_chat_history(
     """
     지정된 세션 ID의 대화 내역을 모두 삭제합니다.
     """
-    await chat_history_service.clear_history(session_id)
-    return {
-        "status": "success",
-        "message": f"History for session {session_id} cleared.",
-    }
+    try:
+        await chat_history_service.clear_history(session_id)
+        return {
+            "status": "success",
+            "message": f"History for session {session_id} cleared.",
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/web_ui/src/app/api/chat/history/route.ts
+++ b/web_ui/src/app/api/chat/history/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
+
+/**
+ * 백엔드 히스토리 API 호출을 처리하는 공통 헬퍼 함수
+ */
+async function callBackendHistory(method: 'GET' | 'DELETE', sessionId: string) {
+  const url = `${BACKEND_URL}/api/chat/history/${sessionId}`;
+  const options: RequestInit = {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+  };
+
+  try {
+    const response = await fetch(url, options);
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      return {
+        error: errorData.message || `Failed to ${method.toLowerCase()} history from backend`,
+        status: response.status,
+      };
+    }
+
+    if (method === 'DELETE') {
+      return { data: { status: 'success' }, status: 200 };
+    }
+
+    const data = await response.json();
+    return { data, status: 200 };
+  } catch (error) {
+    console.error(`[Chat History ${method} Proxy Error]`, error);
+    return { error: 'Internal Server Error', status: 500 };
+  }
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const sessionId = searchParams.get('session_id');
+
+  if (!sessionId) {
+    return NextResponse.json({ error: 'session_id is required' }, { status: 400 });
+  }
+
+  const { data, error, status } = await callBackendHistory('GET', sessionId);
+
+  if (error) {
+    return NextResponse.json({ error }, { status });
+  }
+
+  return NextResponse.json(data);
+}
+
+export async function DELETE(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const sessionId = searchParams.get('session_id');
+
+  if (!sessionId) {
+    return NextResponse.json({ error: 'session_id is required' }, { status: 400 });
+  }
+
+  const { data, error, status } = await callBackendHistory('DELETE', sessionId);
+
+  if (error) {
+    return NextResponse.json({ error }, { status });
+  }
+
+  return NextResponse.json(data);
+}

--- a/web_ui/src/app/api/chat/route.ts
+++ b/web_ui/src/app/api/chat/route.ts
@@ -7,6 +7,10 @@ const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
 /** Nginx 스타일의 비표준 상태 코드: 클라이언트가 연결을 조기에 닫았음을 나타냄 */
 const HTTP_STATUS_CLIENT_CLOSED_REQUEST = 499;
 
+const DEFAULT_K = 3;
+const DEFAULT_ALPHA = 0.5;
+const DEFAULT_USER_ID = 'test_user_123';
+
 function generateUniqueId(): string {
   return typeof crypto !== 'undefined' && crypto.randomUUID
     ? crypto.randomUUID()
@@ -283,10 +287,10 @@ export async function POST(req: Request) {
 
     const payload = {
       query: queryText,
-      user_id: body.user_id ?? 'test_user_123',
+      user_id: body.user_id ?? DEFAULT_USER_ID,
       session_id: body.session_id,
-      k: body.k ?? 3,
-      alpha: body.alpha ?? 0.5,
+      k: body.k ?? DEFAULT_K,
+      alpha: body.alpha ?? DEFAULT_ALPHA,
     };
 
     let backendRes: Response | null = null;
@@ -327,60 +331,3 @@ export async function POST(req: Request) {
   }
 }
 
-export async function GET(req: Request) {
-  try {
-    const { searchParams } = new URL(req.url);
-    const sessionId = searchParams.get('session_id');
-
-    if (!sessionId) {
-      return NextResponse.json({ error: 'session_id is required' }, { status: 400 });
-    }
-
-    const backendRes = await fetch(`${BACKEND_URL}/api/chat/history/${sessionId}`, {
-      method: 'GET',
-      headers: { 'Content-Type': 'application/json' },
-    });
-
-    if (!backendRes.ok) {
-      const errorData = await backendRes.json().catch(() => ({}));
-      return NextResponse.json(
-        { error: errorData.message || 'Failed to fetch history from backend' },
-        { status: backendRes.status }
-      );
-    }
-
-    const data = await backendRes.json();
-    return NextResponse.json(data);
-  } catch (error) {
-    console.error('[Chat History Proxy Error]', error);
-    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
-  }
-}
-
-export async function DELETE(req: Request) {
-  try {
-    const { searchParams } = new URL(req.url);
-    const sessionId = searchParams.get('session_id');
-
-    if (!sessionId) {
-      return NextResponse.json({ error: 'session_id is required' }, { status: 400 });
-    }
-
-    const backendRes = await fetch(`${BACKEND_URL}/api/chat/history/${sessionId}`, {
-      method: 'DELETE',
-    });
-
-    if (!backendRes.ok) {
-      const errorData = await backendRes.json().catch(() => ({}));
-      return NextResponse.json(
-        { error: errorData.message || 'Failed to clear history from backend' },
-        { status: backendRes.status }
-      );
-    }
-
-    return NextResponse.json({ status: 'success' });
-  } catch (error) {
-    console.error('[Chat History Delete Error]', error);
-    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
-  }
-}

--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -23,8 +23,11 @@ const WELCOME_MESSAGE: UIMessage = {
   ],
 };
 
-const defaultChatTransport = new DefaultChatTransport({ api: '/api/chat' });
+const DEFAULT_CHAT_K = 3;
+const DEFAULT_CHAT_ALPHA = 0.5;
 
+
+const defaultChatTransport = new DefaultChatTransport({ api: '/api/chat' });
 function generateSessionId(): string {
   return `sess-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
 }
@@ -34,7 +37,7 @@ export function ChatWindow() {
   const [input, setInput] = useState('');
   const [sessionId, setSessionId] = useState<string>('');
   const [isHistoryLoading, setIsHistoryLoading] = useState(false);
-  const [alpha, setAlpha] = useState(0.5);
+  const [alpha, setAlpha] = useState(DEFAULT_CHAT_ALPHA);
 
   const scrollToBottom = useCallback(() => {
     if (scrollContainerRef.current) {
@@ -54,6 +57,7 @@ export function ChatWindow() {
     body: {
       session_id: sessionId,
       alpha: alpha,
+      k: DEFAULT_CHAT_K,
     },
     onError: (err: Error) => {
       toast.error('메시지 전송 중 에러가 발생했습니다.', {
@@ -88,7 +92,7 @@ export function ChatWindow() {
     const loadHistory = async () => {
       setIsHistoryLoading(true);
       try {
-        const res = await fetch(`/api/chat?session_id=${sessionId}`);
+        const res = await fetch(`/api/chat/history?session_id=${sessionId}`);
         if (ignore) return;
 
         if (res.ok) {
@@ -110,10 +114,17 @@ export function ChatWindow() {
               return [WELCOME_MESSAGE, ...historyMessages, ...currentMessages];
             });
           }
+        } else {
+          const errorData = await res.json().catch(() => ({}));
+          throw new Error(errorData.error || 'Failed to load history');
         }
-      } catch (err) {
+      } catch (err: unknown) {
         if (!ignore) {
+          const errMsg = err instanceof Error ? err.message : 'Unknown error';
           console.error('Failed to load chat history:', err);
+          toast.error('대화 내역을 불러오는데 실패했습니다.', {
+            description: errMsg,
+          });
         }
       } finally {
         if (!ignore) {
@@ -134,18 +145,27 @@ export function ChatWindow() {
     if (!confirm('대화 내용을 모두 초기화하시겠습니까?')) return;
 
     try {
-      await fetch(`/api/chat/history?session_id=${sessionId}`, {
+      const res = await fetch(`/api/chat/history?session_id=${sessionId}`, {
         method: 'DELETE',
       });
+      
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({}));
+        throw new Error(errorData.error || 'Failed to clear history');
+      }
+
       // Clear local state and localStorage to get a new session
       const newSid = generateSessionId();
       localStorage.setItem('flownote_chat_session_id', newSid);
       setSessionId(newSid);
       setMessages([WELCOME_MESSAGE]);
       toast.success('대화가 초기화되었습니다.');
-    } catch (err) {
+    } catch (err: unknown) {
       console.error('Clear history error:', err);
-      toast.error('초기화 중 오류가 발생했습니다.');
+      const errMsg = err instanceof Error ? err.message : 'Unknown error';
+      toast.error('초기화 중 오류가 발생했습니다.', {
+        description: errMsg,
+      });
     }
   };
 


### PR DESCRIPTION
♻️ refactor [#11.3.9]: 시스템 정합성 복구 및 안정화 - 히스토리 API 분리 및 페이로드 복구 
♻️ refactor [#11.3.9]: 1차 개선 - 히스토리 헬퍼 도입 및 파라미터 상수화

## Summary by Sourcery

채팅 히스토리 처리를 리팩터링하여 히스토리 엔드포인트를 전용 API 라우트로 분리하고, RAG 쿼리의 기본 파라미터 관리를 개선하며, 프론트엔드와 백엔드 전반의 히스토리 플로우에서 에러 처리 안정성을 강화합니다.

Enhancements:
- 채팅 API와 UI에서 기본 RAG 파라미터 및 사용자 ID에 대한 공용 상수를 도입해 설정을 중앙집중화합니다.
- 메인 채팅 라우트에서 채팅 히스토리 프록시 로직을 분리하여, 재사용 가능한 백엔드 호출 헬퍼를 갖춘 전용 `/api/chat/history` 엔드포인트로 추출합니다.
- 프론트엔드 채팅 히스토리 로드 및 삭제 플로우에 명시적인 에러 처리와 사용자에게 표시되는 토스트 알림을 추가하여 개선합니다.
- 백엔드 채팅 히스토리 조회 및 삭제 로직을 에러 처리로 감싸, 잘못된 세션 ID가 주어졌을 때 적절한 400 응답을 반환하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor chat history handling by extracting history endpoints into a dedicated API route, improving default parameter management for RAG queries, and hardening error handling across frontend and backend history flows.

Enhancements:
- Introduce shared constants for default RAG parameters and user ID in the chat API and UI to centralize configuration.
- Extract chat history proxy logic from the main chat route into a dedicated /api/chat/history endpoint with a reusable backend-call helper.
- Improve frontend chat history load and clear flows with explicit error handling and user-facing toast notifications.
- Wrap backend chat history retrieval and clearing in error handling that returns proper 400 responses when given invalid session IDs.

</details>