### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/web_ui/src/app/api/chat/history/route.ts
+++ b/web_ui/src/app/api/chat/history/route.ts
@@ -15,19 +15,34 @@ async function callBackendHistory(method: 'GET' | 'DELETE', sessionId: string) {
   try {
     const response = await fetch(url, options);
 
+    // [Refactor] 204 No Content 또는 빈 바디 응답 시 Safe Handling
+    // JSON 필드가 없는 경우 response.json() 호출 시 발생하는 예외를 방지합니다.
+    if (response.status === 204) {
+      return { data: { status: 'success' }, status: 204 };
+    }
+
+    const responseText = await response.text();
+    const hasBody = responseText.trim().length > 0;
+    let data;
+    
+    try {
+      data = hasBody ? JSON.parse(responseText) : (method === 'DELETE' ? { status: 'success' } : {});
+    } catch (e) {
+      console.warn(`[Chat History ${method}] Failed to parse JSON body`, e);
+      data = { message: responseText || 'No clear message' };
+    }
+
+    // [Refactor] FastAPI는 기본적으로 에러 정보를 'detail' 필드에 담아 반환함
     if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
+      // detail 우선 순위로 에러 메시지 추출
+      const errorMessage = data.detail || data.message || `Failed to ${method.toLowerCase()} history from backend`;
+      
       return {
-        error: errorData.message || `Failed to ${method.toLowerCase()} history from backend`,
+        error: errorMessage,
         status: response.status,
       };
     }
 
-    if (method === 'DELETE') {
-      return { data: { status: 'success' }, status: 200 };
-    }
-
-    const data = await response.json();
     return { data, status: 200 };
   } catch (error) {
     console.error(`[Chat History ${method} Proxy Error]`, error);

--- a/web_ui/src/app/api/chat/route.ts
+++ b/web_ui/src/app/api/chat/route.ts
@@ -2,14 +2,12 @@ import { NextResponse } from 'next/server';
 import { createUIMessageStreamResponse, streamText } from 'ai';
 import type { UIMessage, UIMessageChunk, ModelMessage } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
+import { CHAT_CONFIG } from '@/lib/constants';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
 /** Nginx 스타일의 비표준 상태 코드: 클라이언트가 연결을 조기에 닫았음을 나타냄 */
 const HTTP_STATUS_CLIENT_CLOSED_REQUEST = 499;
 
-const DEFAULT_K = 3;
-const DEFAULT_ALPHA = 0.5;
-const DEFAULT_USER_ID = 'test_user_123';
 
 function generateUniqueId(): string {
   return typeof crypto !== 'undefined' && crypto.randomUUID
@@ -287,10 +285,10 @@ export async function POST(req: Request) {
 
     const payload = {
       query: queryText,
-      user_id: body.user_id ?? DEFAULT_USER_ID,
+      user_id: body.user_id ?? CHAT_CONFIG.DEFAULT_USER_ID,
       session_id: body.session_id,
-      k: body.k ?? DEFAULT_K,
-      alpha: body.alpha ?? DEFAULT_ALPHA,
+      k: body.k ?? CHAT_CONFIG.DEFAULT_K,
+      alpha: body.alpha ?? CHAT_CONFIG.DEFAULT_ALPHA,
     };
 
     let backendRes: Response | null = null;

--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -4,6 +4,7 @@ import React, { useRef, useEffect, useState, useCallback } from 'react';
 import { useChat } from '@ai-sdk/react';
 import type { UIMessage } from 'ai';
 import { DefaultChatTransport } from 'ai';
+import { CHAT_CONFIG } from '@/lib/constants';
 import { MessageBubble } from './MessageBubble';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Textarea } from '@/components/ui/textarea';
@@ -23,8 +24,6 @@ const WELCOME_MESSAGE: UIMessage = {
   ],
 };
 
-const DEFAULT_CHAT_K = 3;
-const DEFAULT_CHAT_ALPHA = 0.5;
 
 
 const defaultChatTransport = new DefaultChatTransport({ api: '/api/chat' });
@@ -37,7 +36,7 @@ export function ChatWindow() {
   const [input, setInput] = useState('');
   const [sessionId, setSessionId] = useState<string>('');
   const [isHistoryLoading, setIsHistoryLoading] = useState(false);
-  const [alpha, setAlpha] = useState(DEFAULT_CHAT_ALPHA);
+  const [alpha, setAlpha] = useState<number>(CHAT_CONFIG.DEFAULT_ALPHA);
 
   const scrollToBottom = useCallback(() => {
     if (scrollContainerRef.current) {
@@ -57,7 +56,7 @@ export function ChatWindow() {
     body: {
       session_id: sessionId,
       alpha: alpha,
-      k: DEFAULT_CHAT_K,
+      k: CHAT_CONFIG.DEFAULT_K,
     },
     onError: (err: Error) => {
       toast.error('메시지 전송 중 에러가 발생했습니다.', {


### PR DESCRIPTION
♻️ refactor [#11.3.9]: 2차 개선 - 설정 중앙화 및 백엔드 에러 정합성 강화 
♻️ refactor [#11.3.9]: 3차 개선 - 빈 응답 바디(204) 처리 안정화 및 파싱 가드 도입

## Summary by Sourcery

채팅 기본 설정을 중앙에서 관리하고, 비어 있는 응답 및 FastAPI 오류 포맷 처리 시 백엔드 채팅/히스토리 API의 안정성을 강화합니다.

Bug Fixes:
- 채팅 히스토리 API 프록시에서 204 No Content 및 빈 응답 본문을 안전하게 처리하여 JSON 파싱 오류를 방지합니다.
- 프론트엔드 오류 처리 방식을 FastAPI의 `detail` 오류 필드와 정렬하여, 백엔드 오류 메시지가 일관되게 노출되도록 합니다.

Enhancements:
- 공용 `CHAT_CONFIG`를 통해 기본 RAG/채팅 파라미터(k, alpha, 기본 사용자 ID)를 중앙에서 관리하고, 이를 채팅 API와 `ChatWindow` 전반에 적용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize chat configuration defaults and harden backend chat/history API handling for empty responses and FastAPI error formats.

Bug Fixes:
- Handle 204 No Content and empty response bodies safely in chat history API proxy to avoid JSON parsing errors.
- Align frontend error handling with FastAPI's `detail` error field to surface consistent backend error messages.

Enhancements:
- Centralize default RAG/chat parameters (k, alpha, default user ID) via shared CHAT_CONFIG and apply across chat API and ChatWindow.

</details>