### PR TITLE
Feature/issue 614 rag chat

### DIFF
--- a/web_ui/src/app/api/chat/history/route.ts
+++ b/web_ui/src/app/api/chat/history/route.ts
@@ -7,31 +7,34 @@ const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
  */
 function normalizeErrorMessage(data: unknown): string | null {
   if (!data || typeof data !== 'object') return null;
-  
+
   const record = data as Record<string, unknown>;
-  const detail = record.detail || record.message;
+  // Nullish coalescing 사용: 빈 문자열('') 등 falsy 하지만 유효한 값을 보존
+  const detail = record.detail ?? record.message;
   if (!detail) return null;
 
+  // 1. 단순 문자열인 경우
   if (typeof detail === 'string') return detail;
-  
+
+  // 2. FastAPI validation error 형태인 경우: [{ msg, loc, type }, ...]
   if (Array.isArray(detail)) {
-    // FastAPI validation error(422)는 [{msg, loc, type}, ...] 형태를 가집니다.
     return detail
-      .map((d: unknown) => {
+      .map((d) => {
         if (typeof d === 'string') return d;
-        if (d && typeof d === 'object') {
-          return (d as Record<string, unknown>).msg || JSON.stringify(d);
+        if (d && typeof d === 'object' && 'msg' in d) {
+          return String((d as { msg: unknown }).msg);
         }
         return JSON.stringify(d);
       })
       .join(', ');
   }
 
-  if (typeof detail === 'object') {
-     return JSON.stringify(detail);
+  // 3. 단일 객체이면서 msg 필드가 있는 경우
+  if (typeof detail === 'object' && detail !== null && 'msg' in detail) {
+    return String((detail as { msg: unknown }).msg);
   }
 
-  return String(detail);
+  return JSON.stringify(detail);
 }
 
 /**
@@ -47,35 +50,36 @@ async function callBackendHistory(method: 'GET' | 'DELETE', sessionId: string) {
   try {
     const response = await fetch(url, options);
 
-    // [Refactor] 204 No Content 또는 빈 바디 응답 시 Safe Handling
-    // JSON 필드가 없는 경우 response.json() 호출 시 발생하는 예외를 방지합니다.
-    if (response.status === 204) {
-      return { data: { status: 'success' }, status: 204 };
+    // 바디가 없는 상태 코드 확인 (204 No Content, 205, 304 등)
+    const isNoContent = [204, 205, 304].includes(response.status);
+    let data: unknown = null;
+
+    if (!isNoContent) {
+      // 텍스트로 먼저 읽어 바디 존재 확인 후 JSON 파싱 (가장 견고한 방법)
+      const text = await response.text();
+      if (text.trim()) {
+        try {
+          data = JSON.parse(text);
+        } catch (e) {
+          console.warn(`[Chat History ${method}] Failed to parse JSON body`, e);
+          data = { message: text };
+        }
+      }
     }
 
-    const responseText = await response.text();
-    const hasBody = responseText.trim().length > 0;
-    let data;
-    
-    try {
-      data = hasBody ? JSON.parse(responseText) : (method === 'DELETE' ? { status: 'success' } : {});
-    } catch (e) {
-      console.warn(`[Chat History ${method}] Failed to parse JSON body`, e);
-      data = { message: responseText || 'No clear message' };
+    // 성공 시 기본 데이터 설정
+    if (response.ok) {
+      if (!data) data = { status: 'success' };
+      // [Refactor] 성공 상태 노멀라이즈 해제: 원본 상태 코드를 전파하여 투명성 유지
+      return { data, status: response.status };
     }
 
-    // [Refactor] FastAPI는 기본적으로 에러 정보를 'detail' 필드에 담아 반환함
-    if (!response.ok) {
-      // detail 우선 순위로 에러 메시지 추출
-      const errorMessage = data.detail || data.message || `Failed to ${method.toLowerCase()} history from backend`;
-      
-      return {
-        error: errorMessage,
-        status: response.status,
-      };
-    }
+    // 에러 발생(status >= 400) 시 처리
+    const errorMessage =
+      normalizeErrorMessage(data) ||
+      `Failed to ${method.toLowerCase()} history from backend (Status: ${response.status})`;
 
-    return { data, status: 200 };
+    return { error: errorMessage, status: response.status };
   } catch (error) {
     console.error(`[Chat History ${method} Proxy Error]`, error);
     return { error: 'Internal Server Error', status: 500 };
@@ -91,12 +95,7 @@ export async function GET(req: Request) {
   }
 
   const { data, error, status } = await callBackendHistory('GET', sessionId);
-
-  if (error) {
-    return NextResponse.json({ error }, { status });
-  }
-
-  return NextResponse.json(data);
+  return error ? NextResponse.json({ error }, { status }) : NextResponse.json(data, { status });
 }
 
 export async function DELETE(req: Request) {
@@ -108,10 +107,5 @@ export async function DELETE(req: Request) {
   }
 
   const { data, error, status } = await callBackendHistory('DELETE', sessionId);
-
-  if (error) {
-    return NextResponse.json({ error }, { status });
-  }
-
-  return NextResponse.json(data);
+  return error ? NextResponse.json({ error }, { status }) : NextResponse.json(data, { status });
 }


### PR DESCRIPTION
## Summary by Sourcery

채팅 히스토리 백엔드 프록시 처리의 견고성과 일관성을 개선합니다.

버그 수정:
- 백엔드로부터의 204 No Content 및 비어 있는 응답 본문을 JSON 파싱 오류 없이 처리합니다.
- FastAPI 검증 오류를 포함한 백엔드 오류 응답을 클라이언트가 읽기 쉬운 문자열 메시지로 정규화합니다.

개선 사항:
- 백엔드 상태 코드와 관계없이 프록시에서 성공적인 채팅 히스토리 응답은 항상 HTTP 200 상태 코드를 반환하도록 표준화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve robustness and consistency of the chat history backend proxy handling.

Bug Fixes:
- Handle 204 No Content and empty response bodies from the backend without throwing JSON parsing errors.
- Normalize backend error responses, including FastAPI validation errors, into readable string messages for clients.

Enhancements:
- Standardize successful chat history responses to always return HTTP 200 status from the proxy regardless of backend status codes.

</details>