### PR TITLE
♻️ refactor [#11.3.9]: 6차 개선 - HTTP 규격 준수 및 데이터 무결성 보강

### DIFF
--- a/web_ui/src/app/api/chat/history/route.ts
+++ b/web_ui/src/app/api/chat/history/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
+const NO_BODY_STATUSES = [204, 205, 304] as const;
 
 /**
  * 백엔드 히스토리 응답 데이터를 문자열 에러 메시지로 정규화하는 헬퍼
@@ -13,8 +14,8 @@ function normalizeErrorMessage(data: unknown): string | null {
   const detail = record.detail ?? record.message;
   if (detail == null) return null;
 
-  // 1. 단순 문자열인 경우
-  if (typeof detail === 'string') return detail || null;
+  // 1. 단순 문자열인 경우 (빈 문자열 포함 그대로 반환)
+  if (typeof detail === 'string') return detail;
 
   // 2. FastAPI validation error 형태인 경우: [{ msg, loc, type }, ...]
   if (Array.isArray(detail)) {
@@ -38,6 +39,30 @@ function normalizeErrorMessage(data: unknown): string | null {
 }
 
 /**
+ * 백엔드 결과를 Next.js Response/NextResponse로 변환하는 공통 직렬화 헬퍼
+ */
+function toNextResponse({
+  data,
+  error,
+  status,
+}: {
+  data?: unknown;
+  error?: string;
+  status: number;
+}) {
+  if (error) {
+    return NextResponse.json({ error }, { status });
+  }
+
+  // RFC 7231 규격 준수: 바디가 없어야 하는 상태 코드인 경우 빈 응답 반환
+  if ((NO_BODY_STATUSES as ReadonlyArray<number>).includes(status)) {
+    return new Response(null, { status });
+  }
+
+  return NextResponse.json(data, { status });
+}
+
+/**
  * 백엔드 히스토리 API 호출을 처리하는 공통 헬퍼 함수
  */
 async function callBackendHistory(method: 'GET' | 'DELETE', sessionId: string) {
@@ -49,13 +74,11 @@ async function callBackendHistory(method: 'GET' | 'DELETE', sessionId: string) {
 
   try {
     const response = await fetch(url, options);
-
-    // [Engineering Decision] 바디가 없어야 하는 HTTP 상태 코드들 (RFC 규격 준수)
-    // 204 No Content, 205 Reset Content, 304 Not Modified
-    const isNoContentStatus = [204, 205, 304].includes(response.status);
+    const isNoBodyStatus = (NO_BODY_STATUSES as ReadonlyArray<number>).includes(response.status);
+    
     let data: unknown = null;
 
-    if (!isNoContentStatus) {
+    if (!isNoBodyStatus) {
       // 텍스트로 먼저 읽어 바디 존재 확인 후 JSON 파싱 (가장 견고한 방법)
       const text = await response.text();
       if (text.trim()) {
@@ -68,36 +91,21 @@ async function callBackendHistory(method: 'GET' | 'DELETE', sessionId: string) {
       }
     }
 
-    // 성공 또는 캐시 히트(304) 시 처리
-    // response.ok는 200~299 사이임을 보장함. 304는 개별 체크.
+    // 성공 또는 304 상태 시 처리
     if (response.ok || response.status === 304) {
-      // [Review 반영] falsy 값이지만 유효한 데이터(0, '', false)가 덮어씌워지지 않도록 개선
       if (data == null) data = { status: 'success' };
-      
-      return { 
-        data, 
-        status: response.status, 
-        isNoContent: isNoContentStatus 
-      };
+      return { data, status: response.status };
     }
 
-    // 에러 발생(status >= 400 등) 시 처리
+    // 에러 발생(status >= 400) 시 처리
     const errorMessage =
       normalizeErrorMessage(data) ||
       `Failed to ${method.toLowerCase()} history from backend (Status: ${response.status})`;
 
-    return { 
-      error: errorMessage, 
-      status: response.status, 
-      isNoContent: false 
-    };
+    return { error: errorMessage, status: response.status };
   } catch (error) {
     console.error(`[Chat History ${method} Proxy Error]`, error);
-    return { 
-      error: 'Internal Server Error', 
-      status: 500, 
-      isNoContent: false 
-    };
+    return { error: 'Internal Server Error', status: 500 };
   }
 }
 
@@ -109,18 +117,8 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: 'session_id is required' }, { status: 400 });
   }
 
-  const { data, error, status, isNoContent } = await callBackendHistory('GET', sessionId);
-  
-  if (error) {
-    return NextResponse.json({ error }, { status });
-  }
-
-  // [Review 반영] 204/205/304 규격 준수: 바디가 없어야 하는 상태 코드는 empty response 반환
-  if (isNoContent) {
-    return new Response(null, { status });
-  }
-
-  return NextResponse.json(data, { status });
+  const result = await callBackendHistory('GET', sessionId);
+  return toNextResponse(result);
 }
 
 export async function DELETE(req: Request) {
@@ -131,15 +129,6 @@ export async function DELETE(req: Request) {
     return NextResponse.json({ error: 'session_id is required' }, { status: 400 });
   }
 
-  const { data, error, status, isNoContent } = await callBackendHistory('DELETE', sessionId);
-  
-  if (error) {
-    return NextResponse.json({ error }, { status });
-  }
-
-  if (isNoContent) {
-    return new Response(null, { status });
-  }
-
-  return NextResponse.json(data, { status });
+  const result = await callBackendHistory('DELETE', sessionId);
+  return toNextResponse(result);
 }


### PR DESCRIPTION
- **[web_ui/src/app/api/chat/history/route.ts]**:
  - `data == null` 체크를 통해 `0`, `""` 등 유효한 falsy 데이터 보존 로드맵 구축.
  - 204, 205, 304 등 바디가 없어야 하는 상태 코드 발생 시 빈 응답(Empty Response) 반환 처리.
  - 304 Not Modified를 성공 분기로 추가 포함하여 캐싱 프로토콜 대응력 확보.
  - [normalizeErrorMessage](web_ui/src/app/api/chat/history/route.ts:4:0-37:1) 헬퍼의 Nullish Safety를 강화하여 에러 메시지 유실 방지.

🔗 Related:
- Issue [#614]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/659/#pullrequestreview-3913199275)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1

## Summary by Sourcery

채팅 히스토리 API 프록시를 HTTP no-body 상태 코드 의미론과 정렬하고, 응답 메타데이터를 보강하면서 유효한 falsy 페이로드는 그대로 유지합니다.

Bug Fixes:
- 백엔드 오류 세부 정보를 정규화할 때 0, 빈 문자열과 같은 유효한 falsy 값을 보존하여 우발적인 데이터 손실을 방지합니다.
- HTTP 의미론을 준수하기 위해, 백엔드에서 오는 204, 205, 304 응답을 JSON 본문 없이 비어 있는 응답으로 반환하도록 보장합니다.
- 상위 레벨에서 정확히 처리될 수 있도록, 채팅 히스토리 프록시의 성공 및 오류 응답을 정규화하여 항상 명시적인 no-content 표시 플래그를 포함하도록 합니다.

Enhancements:
- 채팅 히스토리 프록시에서 304 Not Modified를 캐시 히트 성공 사례로 처리하도록 성공 처리 범위를 확장합니다.
- 라우트 핸들러에 백엔드 no-body 상태 정보를 노출하기 위해, 채팅 히스토리 API 응답에 `isNoContent` 플래그를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align chat history API proxy with HTTP no-body status semantics and preserve valid falsy payloads while enriching response metadata.

Bug Fixes:
- Preserve valid falsy values (e.g., 0, empty string) when normalizing backend error details to avoid accidental data loss.
- Ensure 204, 205, and 304 responses from the backend are returned as empty responses without JSON bodies to comply with HTTP semantics.
- Normalize successful and error responses from the chat history proxy to always include an explicit no-content indicator flag for accurate upstream handling.

Enhancements:
- Extend success handling to treat 304 Not Modified as a cache-hit success case in the chat history proxy.
- Augment chat history API responses with an isNoContent flag to surface backend no-body status information to route handlers.

</details>