### PR TITLE
♻️ refactor [#11.3.10]: user_id 인증 세션 연동 및 하드코딩 제거

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -4,7 +4,7 @@ import React, { useRef, useEffect, useState, useCallback } from 'react';
 import { useChat } from '@ai-sdk/react';
 import type { UIMessage } from 'ai';
 import { DefaultChatTransport } from 'ai';
-import { CHAT_CONFIG } from '@/lib/constants';
+import { CHAT_CONFIG, STORAGE_KEYS } from '@/lib/constants';
 import { MessageBubble } from './MessageBubble';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Textarea } from '@/components/ui/textarea';
@@ -27,22 +27,40 @@ const WELCOME_MESSAGE: UIMessage = {
 
 
 const defaultChatTransport = new DefaultChatTransport({ api: '/api/chat' });
-function generateSessionId(): string {
-  return `sess-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
-}
 
 /**
- * 무작위 사용자 ID 생성 헬퍼
+ * 범용 ID 생성 헬퍼 (prefix 기반)
  */
-function generateUserId(): string {
-  return `user-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+function generateId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
 }
 
 export function ChatWindow() {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [input, setInput] = useState('');
-  const [sessionId, setSessionId] = useState<string>('');
-  const [userId, setUserId] = useState<string>('');
+
+  // 0. ID 상태 지연 초기화 (Lazy Initializer)
+  // 초기 렌더링 시점에 localStorage에서 직접 복원하거나 새로 생성하여 불필요한 재렌더링 및 하드코딩 폴백 방지
+  const [sessionId, setSessionId] = useState<string>(() => {
+    if (typeof window === 'undefined') return '';
+    let sid = localStorage.getItem(STORAGE_KEYS.CHAT_SESSION_ID);
+    if (!sid) {
+      sid = generateId('sess');
+      localStorage.setItem(STORAGE_KEYS.CHAT_SESSION_ID, sid);
+    }
+    return sid;
+  });
+
+  const [userId, setUserId] = useState<string>(() => {
+    if (typeof window === 'undefined') return '';
+    let uid = localStorage.getItem(STORAGE_KEYS.USER_ID);
+    if (!uid) {
+      uid = generateId('user');
+      localStorage.setItem(STORAGE_KEYS.USER_ID, uid);
+    }
+    return uid;
+  });
+
   const [isHistoryLoading, setIsHistoryLoading] = useState(false);
   const [alpha, setAlpha] = useState<number>(CHAT_CONFIG.DEFAULT_ALPHA);
 
@@ -78,24 +96,6 @@ export function ChatWindow() {
     },
   });
 
-  // 1. 초기 세션 및 사용자 ID 복원/생성 (마운트 시 1회)
-  useEffect(() => {
-    // 세션 ID 처리
-    let sid = localStorage.getItem('flownote_chat_session_id');
-    if (!sid) {
-      sid = generateSessionId();
-      localStorage.setItem('flownote_chat_session_id', sid);
-    }
-    setSessionId(sid);
-
-    // 사용자 ID 처리 (온보딩 연동 대비)
-    let uid = localStorage.getItem('flownote_user_id');
-    if (!uid) {
-      uid = generateUserId();
-      localStorage.setItem('flownote_user_id', uid);
-    }
-    setUserId(uid);
-  }, []);
 
   // 2. 세션 변경 시 히스토리 로드 (sessionId 의존성 추가)
   useEffect(() => {
@@ -172,8 +172,8 @@ export function ChatWindow() {
       }
 
       // Clear local state and localStorage to get a new session
-      const newSid = generateSessionId();
-      localStorage.setItem('flownote_chat_session_id', newSid);
+      const newSid = generateId('sess');
+      localStorage.setItem(STORAGE_KEYS.CHAT_SESSION_ID, newSid);
       setSessionId(newSid);
       setMessages([WELCOME_MESSAGE]);
       toast.success('대화가 초기화되었습니다.');


### PR DESCRIPTION
- **[web_ui/src/components/chat/ChatWindow.tsx]**:
  - `localStorage`를 활용하여 `user_id`를 생성 및 보존(`flownote_user_id`)하는 로직 도입.
  - 마운트 시 기존 ID가 없을 경우 무작위 ID(`user-xxxx`)를 생성하여 세션 식별성 확보.
  - `useChat` hook의 `body` 파라미터에 `user_id`를 추가하여 백엔드(`api/chat/stream`)로 실시간 동적 전달.
- **[web_ui/src/lib/constants.ts]**:
  - 기존 하드코딩된 `DEFAULT_USER_ID`('test_user_123')는 동적 ID가 유실되었을 경우의 최후 보루(Fallback)로만 활용되도록 역할 조정.

🔗 Related: Issue [#614]

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1

## Summary by Sourcery

하드코딩된 기본값에만 의존하지 않고, 채팅 세션을 위해 사용자별로 생성된 식별자를 유지하고 활용합니다.

새 기능:
- `localStorage`에 저장되는 지속적인 랜덤 사용자 ID를 도입하고, 이를 채팅 세션과 연동합니다.
- 채팅 API 요청 시 세션 파라미터와 함께 현재 사용자 ID를 전송합니다.

개선 사항:
- 기본 사용자 ID 상수를, 저장된 사용자 ID가 없을 때만 사용하는 폴백 용도로 재활용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Persist and use a generated per-user identifier for chat sessions instead of relying solely on a hardcoded default.

New Features:
- Introduce persistent random user IDs stored in localStorage and associated with chat sessions.
- Send the current user ID alongside session parameters in chat API requests.

Enhancements:
- Repurpose the default user ID constant as a fallback only when no stored user ID is available.

</details>