### PR TITLE
♻️ refactor [#11.3.10]: 2차 개선 - ChatWindow 아키텍처 고도화 및 린트 경고 해결

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -37,14 +37,34 @@ function generateId(prefix: string): string {
 
 /**
  * Storage에서 ID를 가져오거나 없으면 새로 생성하여 저장하는 유틸리티
+ * 
+ * [Refinement] localStorage 접근 시 보안 설정이나 시크릿 모드 등으로 인한
+ * 런타임 에러를 방지하기 위해 try/catch 가드를 적용했습니다.
  */
 function getOrCreateStoredId(storageKey: string, prefix: string): string {
+  // 서버 사이드 렌더링 시에는 빈 문자열 반환 (hydration mismatch 방지)
   if (typeof window === 'undefined') return '';
-  let id = localStorage.getItem(storageKey);
+
+  let id: string | null = null;
+  
+  // 1. 기존 ID 로드 시도
+  try {
+    id = localStorage.getItem(storageKey);
+  } catch (err) {
+    console.warn(`[Storage] Failed to read ${storageKey} from localStorage:`, err);
+  }
+
+  // 2. ID가 없으면 생성 후 저장 시도
   if (!id) {
     id = generateId(prefix);
-    localStorage.setItem(storageKey, id);
+    try {
+      localStorage.setItem(storageKey, id);
+    } catch (err) {
+      // 저장이 실패하더라도 현재 세션에서는 생성된 ID를 사용함
+      console.warn(`[Storage] Failed to save ${storageKey} to localStorage:`, err);
+    }
   }
+  
   return id;
 }
 
@@ -176,7 +196,11 @@ export function ChatWindow() {
 
       // Clear local state and localStorage to get a new session
       const newSid = generateId('sess');
-      localStorage.setItem(STORAGE_KEYS.CHAT_SESSION_ID, newSid);
+      try {
+        localStorage.setItem(STORAGE_KEYS.CHAT_SESSION_ID, newSid);
+      } catch (err) {
+        console.warn('[Storage] Failed to update session_id in localStorage:', err);
+      }
       setSessionId(newSid);
       setMessages([WELCOME_MESSAGE]);
       toast.success('대화가 초기화되었습니다.');


### PR DESCRIPTION
- **[web_ui/src/components/chat/ChatWindow.tsx]**:
  - [getOrCreateStoredId](web_ui/src/components/chat/ChatWindow.tsx:37:0-48:1) 유틸리티 추출을 통한 ID 관리 로직 중복 제거.
  - `useChat` 설정 객체에 `useMemo`를 적용하여 불필요한 내부 연산 방지 및 성능 최적화.
  - 사용하지 않는 `setUserId` 제거로 ESLint 경고('setUserId' is assigned a value but never used) 해결.
  - `useMemo` 의존성 배열에 `scrollToBottom` 등 필수 참조값 포함하여 안정성 확보.
  - ID 생성 및 스토리지 접근 로직을 헬퍼 함수로 캡슐화하여 가독성 개선.

🔗 Related:
- Issue [#614]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/665#pullrequestreview-3919668108)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1

## Summary by Sourcery

ChatWindow 상태 초기화와 채팅 훅 설정 방식을 다듬어 중복을 줄이고, 성능을 개선하며, 린트 경고를 해결합니다.

버그 수정:
- 사용되지 않는 `userId` 상태 setter를 제거하여 ESLint 경고를 해결합니다.

개선 사항:
- 공유 헬퍼를 도입해 저장된 ID를 읽거나 생성하도록 하여, ChatWindow 내에서 중복되었던 `localStorage` 로직을 제거합니다.
- `useChat` 설정 옵션을 메모이제이션하여 불필요한 재계산과 이펙트를 방지하고, 필요한 의존성이 모두 포함되도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine ChatWindow state initialization and chat hook configuration to reduce duplication, improve performance, and address lint warnings.

Bug Fixes:
- Eliminate the unused userId state setter to resolve ESLint warnings.

Enhancements:
- Introduce a shared helper to read or create persisted IDs, removing duplicated localStorage logic in ChatWindow.
- Memoize useChat configuration options to avoid unnecessary recomputation and effects, while ensuring required dependencies are included.

</details>