### PR TITLE
♻️ refactor [#11.3.11]: 8차 개선 - 로그 가독성 최적화 및 연산 비용 효율화

### DIFF
--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -233,13 +233,16 @@ class ChatService:
             raw_source = (
                 doc.metadata.get("source") or doc.metadata.get("id") or "unknown"
             )
+            # [Optimization] 문자열 변환은 한 번만 수행하여 재사용 (리뷰 반영)
+            source_path = str(raw_source)
 
             # [Observability] 비정상적인 메타데이터 타입 감지 및 경고 (리뷰 반영)
-            if not isinstance(raw_source, str) and raw_source != "unknown":
-                # [Security] 로그 비대화 방지 및 보안을 위해 출력 값 제한 (리뷰 반영)
-                raw_source_str = str(raw_source)
-                safe_val = raw_source_str[:100]
-                if len(raw_source_str) > 100:
+            # sentinel("unknown")이 아닌데 문자열이 아닌 경우에만 경고 발생
+            if not isinstance(raw_source, str) and source_path != "unknown":
+                # [Security] 로그 비대화 방지 및 보안을 위해 출력 값 제한
+                # 이미 source_path로 변환되었으므로 추가 str() 호출 없이 재사용
+                safe_val = source_path[:100]
+                if len(source_path) > 100:
                     safe_val += "..."
 
                 logger.warning(
@@ -247,8 +250,6 @@ class ChatService:
                     f"Doc ID: {doc.metadata.get('id', 'N/A')}. "
                     f"Coercing to string. Value(truncated): {safe_val}"
                 )
-
-            source_path = str(raw_source)
             if source_path in seen_sources:
                 continue
 


### PR DESCRIPTION
- **[backend/services/chat_service.py]**:
  - [str(raw_source)](backend/services/chat_service.py:356:4-519:48) 중복 호출을 제거하고 변수 할당을 통해 연산 비용 최적화.
  - 의도된 센티널 값("unknown")에 대한 불필요한 경고 로깅 방지 (Log Hygiene).
  - 경고 로그 내 값 제한 로직을 재사용 가능한 구조로 정제.
  - 보안 가드레일(PII 마스킹, Truncation) 및 타입 안정성 무결성 최종 검증 완료.

🔗 Related:
- Issue [#614]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/675#pullrequestreview-3919836548)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1

## Summary by Sourcery

소스 중복 제거 과정에서 비정상 메타데이터 값 처리 시, 채팅 서비스 로깅의 효율성과 위생을 개선합니다.

버그 수정:
- 메타데이터 타입 검사 중, 의도된 센티널 소스 값인 `"unknown"`에 대해 경고 로그를 출력하지 않도록 합니다.

개선 사항:
- 경고 로그에서 문자열이 아닌 메타데이터 소스 값을 기록할 때, 불필요한 문자열 변환을 줄이고, 잘린(truncated) 값 계산을 재사용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve chat service logging efficiency and hygiene when handling abnormal metadata values in source deduplication.

Bug Fixes:
- Avoid emitting warning logs for the intended sentinel source value "unknown" during metadata type checks.

Enhancements:
- Reduce redundant string conversion and reuse truncated value computation when logging non-string metadata sources in warnings.

</details>