### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -410,7 +410,13 @@ Standalone Question:"""
 
 Answer the user's question clearly and accurately, using ONLY the context provided below.
 If you cannot answer the question using the context, state "주어진 문서 내용에서는 답변을 찾을 수 없습니다." and do not guess.
-Do not mention the words "context" or "provided text" explicitly in your final answer, just answer the question directly.
+
+[Important Rule: Citations]
+- You MUST use inline citations to indicate the source of your information.
+- Use the format [1], [2], etc., corresponding to the Document number provided in the context.
+- Place the citation at the end of the sentence or paragraph it supports.
+- Do not mention the words "context" or "provided text" explicitly.
+- Do not add a separate "Sources" or "References" section at the end of your answer; the citations [1], [2] within the text are sufficient.
 
 Context: 
 {{context}}

--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -7,6 +7,7 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
 import type { UIMessage } from 'ai';
 import { SourcePanel, SourceItem } from './SourcePanel';
 import type { Components } from 'react-markdown';
@@ -69,13 +70,68 @@ export function MessageBubble({ message }: MessageBubbleProps) {
         </code>
       );
     },
+    // 인라인 인용(Citation) 링크 컴포넌트
+    a({ children, href, className, ...props }) {
+      if (href?.startsWith('cite:')) {
+        const index = parseInt(href.replace('cite:', ''), 10) - 1;
+        const source = sources[index];
+        
+        const handleCitationClick = (e: React.MouseEvent | React.KeyboardEvent) => {
+          e.preventDefault();
+          if (source) handleBadgeClick(source);
+        };
+
+        return (
+          <sup
+            role="button"
+            tabIndex={0}
+            onClick={handleCitationClick}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                handleCitationClick(e as unknown as React.MouseEvent);
+              }
+            }}
+            className="
+              inline-flex items-center justify-center
+              mx-0.5 px-1 min-w-[1rem] h-4
+              bg-blue-50 text-blue-700 font-bold text-[9px]
+              rounded border border-blue-200
+              cursor-pointer hover:bg-blue-100 hover:border-blue-300
+              transition-colors align-top mt-0.5
+              select-none focus:outline-none focus:ring-1 focus:ring-blue-400
+            "
+            title={source ? `출처: ${source.title || source.id}` : '출처 정보 없음'}
+          >
+            {children}
+          </sup>
+        );
+      }
+      return (
+        <a 
+          href={href} 
+          className={cn("text-blue-600 underline", className)} 
+          target="_blank" 
+          rel="noopener noreferrer" 
+          {...props}
+        >
+          {children}
+        </a>
+      );
+    },
   };
 
-  // ai v6: UIMessage.parts에서 TextUIPart만 추출해 텍스트 결합
   const textContent = (message.parts ?? [])
     .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
     .map((p) => p.text)
     .join('');
+
+  // AI 답변 내 [1], [2] 패턴을 인라인 인용 링크로 변환 (isUser가 아닐 때만 적용)
+  // [Robustness] 백틱(`)으로 감싸진 코드 블록 내의 매치는 제외하도록 정규식 개선 (리뷰 반영)
+  const processedContent = isUser
+    ? textContent
+    : textContent.replace(/(`{1,3}[\s\S]*?`{1,3})|\[(\d+)\]/g, (match, code, num) => {
+        return code ? code : `[${num}](cite:${num})`;
+      });
 
   return (
     <>
@@ -100,7 +156,7 @@ export function MessageBubble({ message }: MessageBubbleProps) {
               remarkPlugins={[remarkGfm]}
               components={markdownComponents}
             >
-              {textContent}
+              {processedContent}
             </ReactMarkdown>
           </div>
 


### PR DESCRIPTION
✨ feat [#11.3.12]: 인라인 인용(Inline Citations) 구현 및 UX 고도화 
♻️ refactor [#11.3.12]: 1차 개선 - 접근성 보강 및 정규식 오탐지 수정

## Summary by Sourcery

AI 응답에 대한 인라인 인용 렌더링을 구현하고, 코드 블록과 접근성을 유지하면서 인용 패턴 처리 방식을 개선합니다.

새로운 기능:
- AI 메시지 내 숫자 인용 마커를 클릭 가능한 인라인 배지로 렌더링하여, 해당 소스 상세 정보를 여는 기능을 추가합니다.

개선 사항:
- 마크다운 링크 처리 방식을 개선하여 인용 링크와 일반 외부 링크를 구분하고, 각각에 적절한 스타일과 동작을 적용합니다.
- 코드 블록 내부의 매치를 건너뛰도록 하는 더 안전한 정규식을 사용해 인용 패턴 처리 로직을 정교화합니다.
- 키보드 상호작용과 포커스 스타일을 통해 인라인 인용 요소의 접근성을 강화합니다.
- 백엔드 답변 지침을 업데이트하여 AI 응답에서 인라인 인용 형식을 필수로 요구하고 표준화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement inline citation rendering for AI responses and improve handling of citation patterns while preserving code blocks and accessibility.

New Features:
- Render numeric citation markers in AI messages as clickable inline badges that open the corresponding source detail.

Enhancements:
- Improve markdown link handling to distinguish between citation links and regular external links with appropriate styling and behavior.
- Refine citation pattern processing with a safer regular expression that skips matches inside code blocks.
- Strengthen accessibility of inline citation elements with keyboard interaction and focus styles.
- Update backend answer instructions to require and standardize inline citation formatting in AI responses.

</details>