### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -415,6 +415,7 @@ If you cannot answer the question using the context, state "주어진 문서 내
 - You MUST use inline citations to indicate the source of your information.
 - Use the format [1], [2], etc., corresponding to the Document number provided in the context.
 - Place the citation at the end of the sentence or paragraph it supports.
+- Citations must be plain `[1]`, `[2]`, etc. tokens with no surrounding markdown links or additional formatting (for example, do NOT output `[1](url)` or `[**1**]`).
 - Do not mention the words "context" or "provided text" explicitly.
 - Do not add a separate "Sources" or "References" section at the end of your answer; the citations [1], [2] within the text are sufficient.
 

--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -73,12 +73,32 @@ export function MessageBubble({ message }: MessageBubbleProps) {
     // 인라인 인용(Citation) 링크 컴포넌트
     a({ children, href, className, ...props }) {
       if (href?.startsWith('cite:')) {
-        const index = parseInt(href.replace('cite:', ''), 10) - 1;
+        const indexStr = href.replace('cite:', '').trim();
+
+        // [Validation] cite 인덱스는 공백을 제외하고 순수한 양의 정수여야 함 (리뷰 반영)
+        if (!/^\d+$/.test(indexStr)) {
+          return (
+            <span className={cn("text-slate-500", className)} title="출처 정보 없음">
+              {children}
+            </span>
+          );
+        }
+
+        const index = parseInt(indexStr, 10) - 1;
         const source = sources[index];
         
+        // [Robustness] 유효하지 않은 인용 지수이거나 소스가 없는 경우 일반 텍스트로 폴백
+        if (!source) {
+          return (
+            <span className={cn("text-slate-500", className)} title="출처 정보 없음">
+              {children}
+            </span>
+          );
+        }
+
         const handleCitationClick = (e: React.MouseEvent | React.KeyboardEvent) => {
           e.preventDefault();
-          if (source) handleBadgeClick(source);
+          handleBadgeClick(source);
         };
 
         return (
@@ -126,10 +146,11 @@ export function MessageBubble({ message }: MessageBubbleProps) {
     .join('');
 
   // AI 답변 내 [1], [2] 패턴을 인라인 인용 링크로 변환 (isUser가 아닐 때만 적용)
-  // [Robustness] 백틱(`)으로 감싸진 코드 블록 내의 매치는 제외하도록 정규식 개선 (리뷰 반영)
+  // [Robustness] 백틱(`)으로 감싸진 코드 블록 내의 매치는 제외하도록 정규식 개선
+  // [Robustness] 기존 마크다운 링크 / 참조 정의([1](/path), [1]: http...)는 변환 대상에서 제외 (리뷰 반영)
   const processedContent = isUser
     ? textContent
-    : textContent.replace(/(`{1,3}[\s\S]*?`{1,3})|\[(\d+)\]/g, (match, code, num) => {
+    : textContent.replace(/(`{1,3}[\s\S]*?`{1,3})|\[(\d+)\](?!\(|:)/g, (match, code, num) => {
         return code ? code : `[${num}](cite:${num})`;
       });
 


### PR DESCRIPTION
♻️ refactor [#11.3.12]: 2차 개선 - 정규식 정교화 및 방어 로직 추가 
♻️ refactor [#11.3.12]: 3차 개선 - 엄격한 인덱스 검증 도입

## Summary by Sourcery

채팅 메시지에서 인라인 인용 처리 방식을 강화하고, RAG 응답을 위한 백엔드 인용 포맷 지침을 명확히 합니다.

Enhancements:
- 채팅 UI에서 인라인 인용 인덱스를 검증하고 정제하여, 인덱스가 잘못되었거나 출처가 누락된 경우 우아하게 일반 텍스트로 대체되도록 합니다.
- 숫자 괄호 패턴을 인용 링크로 변환하는 정규식을 개선하여, 코드 블록과 기존 마크다운 링크 또는 참조 정의를 무시하도록 합니다.
- 시스템 프롬프트 지침을 명확히 하여, 모델이 추가적인 마크다운 포맷팅이나 링크 없이, 단순한 대괄호 숫자 인용만을 출력하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden inline citation handling in chat messages and clarify backend citation formatting instructions for RAG responses.

Enhancements:
- Validate and sanitize inline citation indexes in the chat UI, gracefully falling back to plain text when indexes are invalid or missing sources.
- Refine the regex that converts numeric bracket patterns into citation links to ignore code blocks and existing markdown links or reference definitions.
- Clarify system prompt instructions so the model emits plain bracketed numeric citations without additional markdown formatting or links.

</details>