### PR TITLE
♻️ refactor [#11.3.12]: 4차 개선 - 파싱 정교화 및 코드 구조 최적화

### DIFF
--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -152,10 +152,11 @@ export function MessageBubble({ message }: MessageBubbleProps) {
   // AI 답변 내 [1], [2] 패턴을 인라인 인용 링크로 변환 (isUser가 아닐 때만 적용)
   // [Robustness] 백틱(`)으로 감싸진 코드 블록 내의 매치는 제외하도록 정규식 개선
   // [Robustness] 기존 마크다운 링크 / 참조 정의([1](/path), [1]: http...)는 변환 대상에서 제외
-  // [Refinement] 룩어헤드에 공백을 허용하여 [1] (url) 같은 케이스도 보호 (리뷰 반영)
+  // [Refinement] 룩어헤드에 공백을 허용하여 [1] (url) 같은 케이스도 보호
+  // [Synchronization] 검증 로직과 일치하도록 유효한 인덱스([1-9]\d*)만 매칭 (리뷰 반영)
   const processedContent = isUser
     ? textContent
-    : textContent.replace(/(`{1,3}[\s\S]*?`{1,3})|\[(\d+)\](?!\s*[\(:])/g, (match, code, num) => {
+    : textContent.replace(/(`{1,3}[\s\S]*?`{1,3})|\[([1-9]\d*)\](?!\s*[\(:])/g, (match, code, num) => {
         return code ? code : `[${num}](cite:${num})`;
       });
 


### PR DESCRIPTION
- **[web_ui/src/components/chat/MessageBubble.tsx]**:
  - 인덱스 검증용 정규식을 `/^[1-9]\d*$/`로 강화하여 '0' 및 비정상 인덱스 차단.
  - 중복된 폴백 렌더링 로직을 [FallbackCitation](web_ui/src/components/chat/MessageBubble.tsx:23:0-33:1) 헬퍼 컴포넌트로 일원화 (Refactoring).
  - 변환 정규식의 룩어헤드에 공백 허용(?!\s*[\(:]) 패턴을 추가하여 마크다운 구조 보호.
  - LLM 출력 가이드라인(backend)과의 논리적 동기화 최종 검증 완료.

🔗 Related:
- Issue [#614]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/683#pullrequestreview-3927517616)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1

## Summary by Sourcery

채팅 메시지 말풍선에서 인용구 파싱 및 폴백 렌더링을 정교하게 다듬어 견고성과 일관성을 개선합니다.

버그 수정:
- 잘못된 인용 인덱스나 0 인덱스가 AI 메시지에서 유효한 참조로 처리되지 않도록 방지합니다.

개선 사항:
- 인용 소스가 없거나 잘못된 경우에도 일관된 렌더링을 위해 재사용 가능한 `FallbackCitation` 헬퍼 컴포넌트를 도입합니다.
- AI 출력에서 숫자 인용구를 변환하는 동안 기존 마크다운 링크 및 참조 정의를 더 잘 보존할 수 있도록 마크다운 변환용 정규식의 룩어헤드를 완화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine citation parsing and fallback rendering in chat message bubbles to improve robustness and consistency.

Bug Fixes:
- Prevent invalid or zero citation indices from being treated as valid references in AI messages.

Enhancements:
- Introduce a reusable FallbackCitation helper component for consistent rendering when citation sources are missing or invalid.
- Relax the markdown conversion regex lookahead to better preserve existing markdown links and reference definitions while converting numeric citations in AI outputs.

</details>