### PR TITLE
♻️ refactor [#11.3.12]: 6차 개선 - 상수 중앙 관리 및 컴포넌트 유연성 확보

### DIFF
--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -23,8 +23,12 @@ type CodeProps = React.ComponentPropsWithoutRef<'code'> & {
 
 // [Constants] 인용 관련 공용 패턴 및 기본 텍스트
 // 중앙 집중화를 통해 정규식 불일치 가능성을 원천 차단했습니다.
-const CITATION_ID_PATTERN = '[1-9]\\d*';
-const CITATION_VALIDATION_REGEX = new RegExp(`^${CITATION_ID_PATTERN}$`);
+const CITATION_ID_FRAGMENT = '[1-9]\\d*';
+const CITATION_VALIDATION_REGEX = new RegExp(`^${CITATION_ID_FRAGMENT}$`);
+const INLINE_CITATION_REGEX = new RegExp(
+  `(\`{1,3}[\\s\\S]*?\`{1,3})|\\[(${CITATION_ID_FRAGMENT})\\](?!\\s*[\\(:])`,
+  'g'
+);
 const DEFAULT_FALLBACK_TITLE = "출처 정보 없음";
 
 /**
@@ -164,10 +168,10 @@ export function MessageBubble({ message }: MessageBubbleProps) {
     .join('');
 
   // AI 답변 내 [1], [2] 패턴을 인라인 인용 링크로 변환 (isUser가 아닐 때만 적용)
-  // [Synchronization] 중앙 관리되는 패턴(CITATION_ID_PATTERN)을 사용하여 일관성 유지
+  // [Optimization] 호이스팅된 INLINE_CITATION_REGEX를 사용하여 성능을 최적화하고 일관성을 유지합니다.
   const processedContent = isUser
     ? textContent
-    : textContent.replace(new RegExp(`(\`{1,3}[\\s\\S]*?\`{1,3})|\\[(${CITATION_ID_PATTERN})\\](?!\\s*[\\(:])`, 'g'), (match, code, num) => {
+    : textContent.replace(INLINE_CITATION_REGEX, (match, code, num) => {
         return code ? code : `[${num}](cite:${num})`;
       });
 


### PR DESCRIPTION
- **[web_ui/src/components/chat/MessageBubble.tsx]**:
  - 인용 식별 패턴(`[1-9]\d*`)을 상수로 추출하여 변환 및 검증 로직 간의 동기화 보장.
  - [FallbackCitation](cci:1://file:///Users/jay/ICT-projects/flownote-mvp/web_ui/src/components/chat/MessageBubble.tsx:29:0-47:1) 컴포넌트가 툴팁 텍스트를 prop으로 받도록 개선하여 하드코딩 제거.
  - 동적 RegExp 생성을 통해 중앙 관리되는 패턴을 텍스트 파이프라인에 안전하게 통합.
  - 마크다운 파싱 견고함 및 접근성 표준 준수 상태 최종 점검 완료.

🔗 Related:
- Issue [#614]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/685#pullrequestreview-3927562010)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1

## Summary by Sourcery

인용(citation) 관련 패턴을 중앙화하고, 채팅 메시지 인용 폴백 렌더링의 유연성을 개선했습니다.

Enhancements:
- 인용 ID 패턴과 검증용 정규식을 공용 상수로 분리하여, 일관된 파싱 및 검증이 가능하도록 했습니다.
- `FallbackCitation`이 하드코딩된 텍스트 대신 커스터마이즈 가능한 툴팁 제목 prop을 받을 수 있도록 수정하여 재사용성을 향상했습니다.
- 인라인 인용 링크 변환 로직을 중앙화된 인용 패턴과 정렬시켜, 파싱 동작이 일관되도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize citation-related patterns and improve flexibility of the chat message citation fallback rendering.

Enhancements:
- Extract citation ID pattern and validation regex into shared constants for consistent parsing and validation.
- Update FallbackCitation to accept a customizable tooltip title prop instead of hardcoded text, improving reusability.
- Align inline citation link transformation logic with the centralized citation pattern to keep parsing behavior consistent.

</details>