### PR TITLE
♻️ refactor [#11.3.12]: 8차 개선 - 정규식 캡처 구조 안정성 강화 (Non-capturing Group)

### DIFF
--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -23,7 +23,7 @@ type CodeProps = React.ComponentPropsWithoutRef<'code'> & {
 
 // [Constants] 인용 관련 공용 패턴 및 기본 텍스트
 // 중앙 집중화를 통해 정규식 불일치 가능성을 원천 차단했습니다.
-const CITATION_ID_FRAGMENT = '[1-9]\\d*';
+const CITATION_ID_FRAGMENT = '(?:[1-9]\\d*)';
 const CITATION_VALIDATION_REGEX = new RegExp(`^${CITATION_ID_FRAGMENT}$`);
 const INLINE_CITATION_REGEX = new RegExp(
   `(\`{1,3}[\\s\\S]*?\`{1,3})|\\[(${CITATION_ID_FRAGMENT})\\](?!\\s*[\\(:])`,


### PR DESCRIPTION
- **[web_ui/src/components/chat/MessageBubble.tsx]**:
  - `CITATION_ID_FRAGMENT`를 비포착 그룹([(?:...)](web_ui/src/components/chat/MessageBubble.tsx:102:4-161:5))으로 정의하여 정규식 캡처 인덱스 오염 방지.
  - `replace` 콜백 내에서 `num` 인자가 항상 프래그먼트 전체를 안전하게 매핑하도록 로직 견고화 (Bug Risk 해소).
  - 프래그먼트 변경 시에도 `INLINE_CITATION_REGEX`의 캡처 구조가 깨지지 않도록 방어적 설계 적용.
  - 중앙 집중화된 상수의 독립성과 유지보수 안정성 최상위 단계로 격상.

🔗 Related:
- Issue [#614]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/687#pullrequestreview-3927686910)

Co-authored-by: Claude-4.6-sonnet, Gemini 3.1

## Summary by Sourcery

Enhancements:
- 공유 인용 ID 프래그먼트를 비캡처 그룹(non-capturing group)을 사용하도록 개선하여, 프래그먼트의 변경이 전체 인라인 인용 정규식의 캡처 구조에 영향을 주지 않도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Refine the shared citation ID fragment to use a non-capturing group so changes to the fragment do not affect the overall inline citation regex capture structure.

</details>