### PR TITLE
Feature/v7 phase2 rag

### DIFF
--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -1,3 +1,5 @@
+# backend/services/chat_service.py
+
 import json
 import logging
 import asyncio
@@ -8,6 +10,7 @@ from functools import lru_cache
 
 from langchain_core.callbacks.manager import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
+from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import (
     ChatPromptTemplate,
     SystemMessagePromptTemplate,
@@ -33,6 +36,11 @@ MAX_SOURCE_PAGE_CONTENT_LEN = 500
 
 # [Engineering Excellence] 메타데이터 폴백을 안전하게 식별하기 위한 내부 센티널 (리뷰 반영)
 _METADATA_SENTINEL = object()
+
+# [Contract] 질의 재구성(Query Rephrasing) 시 사용할 최근 대화 히스토리 윈도우 크기.
+# 이 값을 변경하면 test_rephrase_query_truncates_history 테스트가 실패합니다.
+# 테스트에서 이 상수를 직접 import하여 단일 진실 공급원(SSOT)으로 유지하세요.
+REPHRASE_HISTORY_WINDOW = 5
 
 
 class SourceDocumentPayload(TypedDict):
@@ -306,16 +314,16 @@ class ChatService:
         )
         return ttft
 
-    async def _rephrase_query(self, query: str, history: List[ChatMessage]) -> str:
-        """이전 대화 맥락을 기반으로 질의 재구성 (Query Rewriting)"""
-        if not history:
-            return query
+    async def _invoke_rephrase_chain(self, context_history: str, query: str) -> str:
+        """
+        재구성 체인(prompt | llm | StrOutputParser)을 빌드하고 실행합니다.
 
-        from langchain_core.output_parsers import StrOutputParser
-
-        # 최근 5개 정도의 대화만 맥락으로 사용
-        context_history = "\n".join([f"{m.role}: {m.content}" for m in history[-5:]])
-
+        [Engineering Decision - Testability]
+        LangChain 체인 빌드 및 실행 로직을 별도 메서드로 추출하여 테스트 시
+        LangChain 내부 경로(RunnableSequence 등)에 의존하지 않고
+        `chat_service._invoke_rephrase_chain`을 직접 패치할 수 있도록 합니다.
+        이는 LangChain 버전 업그레이드에 대한 취약성을 제거합니다.
+        """
         rephrase_template = """Given the following conversation history and a follow-up question, rephrase the follow-up question to be a standalone question that can be understood without the conversation history.
 If the follow-up question is already standalone, return it exactly as is.
 
@@ -326,15 +334,23 @@ Follow-up Question: {query}
 Standalone Question:"""
 
         rephrase_prompt = ChatPromptTemplate.from_template(rephrase_template)
-        # 쿼리 재구성 작업은 스트리밍이 필요 없으므로 일반 LLM 사용
         llm = self._get_llm(streaming=False)
-
         chain = rephrase_prompt | llm | StrOutputParser()
+        return await chain.ainvoke({"history": context_history, "query": query})
+
+    async def _rephrase_query(self, query: str, history: List[ChatMessage]) -> str:
+        """이전 대화 맥락을 기반으로 질의 재구성 (Query Rewriting)"""
+        if not history:
+            return query
+
+        # [Contract] 모듈 상수 REPHRASE_HISTORY_WINDOW를 사용하여 히스토리 잘라내기.
+        # 테스트(test_rephrase_query_truncates_history)가 이 상수를 import하여 동기화됩니다.
+        context_history = "\n".join(
+            [f"{m.role}: {m.content}" for m in history[-REPHRASE_HISTORY_WINDOW:]]
+        )
 
         try:
-            standalone_query = await chain.ainvoke(
-                {"history": context_history, "query": query}
-            )
+            standalone_query = await self._invoke_rephrase_chain(context_history, query)
             logger.info(
                 "Rephrased query",
                 extra={

--- a/tests/unit/services/test_chat_service.py
+++ b/tests/unit/services/test_chat_service.py
@@ -1,17 +1,22 @@
 # tests/unit/services/test_chat_service.py
 #
 # [Engineering Decisions]
-# - 헬퍼 메서드(_mask_pii, _dedupe_and_build_sources)는 외부 의존성(Redis, OpenAI) 없이
-#   독립적으로 검증하는 것이 실용적이므로 직접 단위 테스트를 유지합니다.
-# - LangChain 버전 변경에 대한 취약성을 줄이기 위해 chain 내부 경로 대신
-#   _get_llm 레이어에서 추상화하여 모킹합니다.
-# - 위치(인덱스) 기반 assert 대신 ID/내용 기반 assert를 사용하여 구현 변경에 강건하게 합니다.
+# 1. _mask_pii, _dedupe_and_build_sources는 외부 의존성(Redis, OpenAI) 없이
+#    독립적으로 검증하는 것이 실용적이므로 직접 단위 테스트를 유지합니다.
+#    공개 인터페이스를 통한 테스트는 검색 엔진·LLM·Redis를 모두 모킹해야 해서
+#    오히려 테스트 신뢰도가 낮아집니다. (pragmatic test boundary 원칙)
+#
+# 2. _rephrase_query 테스트는 ChatService 자체 메서드인 `_invoke_rephrase_chain`을
+#    패치하므로, LangChain 내부 구현(RunnableSequence 경로)에 의존하지 않습니다.
+#    이 메서드는 이 목적을 위해 chat_service.py에서 명시적으로 추출되었습니다.
+#
+# 3. 위치(인덱스) 기반 assert 대신 ID/내용 기반 assert를 사용합니다.
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 from langchain_core.documents import Document
 
-from backend.services.chat_service import ChatService
+from backend.services.chat_service import ChatService, REPHRASE_HISTORY_WINDOW
 from backend.services.hybrid_search_service import HybridSearchService
 from backend.services.onboarding_service import OnboardingService
 from backend.services.chat_history_service import ChatHistoryService
@@ -38,7 +43,9 @@ def mock_chat_history_service():
 
 
 @pytest.fixture
-def chat_service(mock_hybrid_search_service, mock_onboarding_service, mock_chat_history_service):
+def chat_service(
+    mock_hybrid_search_service, mock_onboarding_service, mock_chat_history_service
+):
     with patch("os.getenv") as mock_getenv:
 
         def mock_getenv_side_effect(key, default=None):
@@ -63,8 +70,6 @@ def chat_service(mock_hybrid_search_service, mock_onboarding_service, mock_chat_
 
 # ─────────────────────────────────────────────────────────────
 # TEST 1: PII 마스킹 정확도
-# [Review] Comment 1 반영:
-#   - 비PII 일반 텍스트가 잘못 마스킹되지 않는지(오버-마스킹) 검증 케이스 추가
 # ─────────────────────────────────────────────────────────────
 
 def test_mask_pii_masks_sensitive_data(chat_service):
@@ -77,15 +82,12 @@ def test_mask_pii_masks_sensitive_data(chat_service):
     )
     masked_text = chat_service._mask_pii(original_text)
 
-    # 이메일 마스킹 확인
     assert "t***@example.com" in masked_text
     assert "test@example.com" not in masked_text
 
-    # 휴대폰 번호 마스킹 확인
     assert "010-****-5678" in masked_text
     assert "010-1234-5678" not in masked_text
 
-    # 유선 번호 마스킹 확인
     assert "02-****-4567" in masked_text
     assert "02-123-4567" not in masked_text
 
@@ -100,7 +102,6 @@ def test_mask_pii_handles_edge_cases(chat_service):
 
 def test_mask_pii_does_not_over_mask_normal_text(chat_service):
     """
-    [Review] Comment 1 반영:
     PII가 없는 일반 텍스트가 마스킹 함수를 통과해도 변경되지 않아야 합니다.
     정규식 변경으로 인한 오버-마스킹(과잉 필터링) 버그를 방지합니다.
     """
@@ -108,7 +109,7 @@ def test_mask_pii_does_not_over_mask_normal_text(chat_service):
         "단순한 일반 텍스트입니다.",
         "FlowNote는 AI 기반 노트 관리 앱입니다.",
         "버전 v7.0 Phase 2 완료.",
-        "https://github.com/jjaayy2222/flownote-mvp",  # URL (이메일 패턴과 유사하지 않음)
+        "https://github.com/jjaayy2222/flownote-mvp",
     ]
     for text in normal_texts:
         assert chat_service._mask_pii(text) == text, (
@@ -118,37 +119,78 @@ def test_mask_pii_does_not_over_mask_normal_text(chat_service):
 
 # ─────────────────────────────────────────────────────────────
 # TEST 2: 소스 중복 제거 및 페이로드 빌드
-# [Review] Comment 2 반영:
-#   - 인덱스 대신 ID/내용 기반 검증으로 변경
-#   - 메타데이터 누락 엣지케이스 (id/source 없음) 추가
-#   - 빈 docs 리스트 처리 케이스 추가
+# [Review] Comment 1 반영:
+#   - 테스트명과 독스트링이 검증 내용과 일치하도록 수정 (by_id vs by_source 명확화)
+#   - source 기준 중복 제거 케이스 별도 추가
 # ─────────────────────────────────────────────────────────────
 
-def test_dedupe_and_build_sources_deduplicates_by_source(chat_service):
+def test_dedupe_and_build_sources_deduplicates_by_id(chat_service):
     """
-    [Phase 1] 동일한 source를 가진 문서가 중복 제거되는지 검증 (ID 기반 assert)
+    [Phase 1] 동일한 ID(key: 'id')를 가진 문서가 중복 제거되는지 검증.
+
+    [Review Comment 1 반영]
+    이전 테스트명은 'by_source'였으나 실제로는 'id' 기준 dedup을 검증하고 있었습니다.
+    테스트명과 독스트링을 검증 내용과 일치하도록 수정했습니다.
     """
     docs = [
         Document(page_content="Content A", metadata={"id": "doc1", "score": 0.9}),
-        # 동일 id → 중복 제거 대상
+        # 동일 id → 중복 제거 대상 (source 키는 없으므로 id가 dedup key로 사용됨)
         Document(page_content="Content B", metadata={"id": "doc1", "score": 0.8}),
         Document(page_content="Content C", metadata={"id": "doc2", "score": 0.7}),
     ]
 
     deduped_docs, payload = chat_service._dedupe_and_build_sources(docs)
 
-    # 중복 제거 후 2개만 남아야 함
     assert len(deduped_docs) == 2
     assert len(payload) == 2
 
-    # [Review 반영] 인덱스 대신 ID 기반으로 검증
+    # ID 기반 검증 (위치 독립적)
     payload_ids = {p["id"] for p in payload}
     assert "doc1" in payload_ids
     assert "doc2" in payload_ids
 
-    # 첫 번째 등장한 doc1의 content가 선택되었는지 확인
+    # 첫 번째로 등장한 doc1(Content A)이 선택되었는지 확인
     doc1_payload = next(p for p in payload if p["id"] == "doc1")
     assert doc1_payload["source"] == "doc1"
+
+
+def test_dedupe_and_build_sources_deduplicates_by_source(chat_service):
+    """
+    [Review Comment 1 반영] source 키를 기준으로 중복 제거가 이루어지는지 검증.
+
+    _dedupe_and_build_sources의 dedup key 우선 순위는 source > id 입니다.
+    source 값이 같은 두 문서는 id가 달라도 중복으로 처리됩니다.
+    """
+    docs = [
+        Document(
+            page_content="First occurrence",
+            metadata={"source": "shared/path.md", "id": "id_a", "score": 0.9},
+        ),
+        # 동일한 source를 가진 다른 문서 → 중복 제거 대상
+        Document(
+            page_content="Second occurrence",
+            metadata={"source": "shared/path.md", "id": "id_b", "score": 0.7},
+        ),
+        Document(
+            page_content="Unique document",
+            metadata={"source": "unique/path.md", "id": "id_c", "score": 0.5},
+        ),
+    ]
+
+    deduped_docs, payload = chat_service._dedupe_and_build_sources(docs)
+
+    # source가 같으면 중복으로 처리되어 2개만 남아야 함
+    assert len(deduped_docs) == 2
+    assert len(payload) == 2
+
+    # source 기반 검증
+    payload_sources = {p["source"] for p in payload}
+    assert "shared/path.md" in payload_sources
+    assert "unique/path.md" in payload_sources
+
+    # 첫 번째 등장한 문서(id_a)가 선택되어야 함
+    shared_doc = next(p for p in payload if p["source"] == "shared/path.md")
+    assert shared_doc["id"] == "id_a"
 
 
 def test_dedupe_and_build_sources_pii_masking_in_payload(chat_service):
@@ -164,14 +206,12 @@ def test_dedupe_and_build_sources_pii_masking_in_payload(chat_service):
     _, payload = chat_service._dedupe_and_build_sources(docs)
 
     assert len(payload) == 1
-    # 이메일이 마스킹되어 있어야 함
     assert "u***@secret.com" in payload[0]["page_content"]
     assert "user@secret.com" not in payload[0]["page_content"]
 
 
 def test_dedupe_and_build_sources_missing_metadata(chat_service):
     """
-    [Review] Comment 2 반영:
     id와 source가 모두 없는 문서의 경우 'unknown'으로 처리되는지 검증.
     이 계약이 변경되면 테스트가 실패하여 리그레션을 방어합니다.
     """
@@ -187,7 +227,7 @@ def test_dedupe_and_build_sources_missing_metadata(chat_service):
 
 def test_dedupe_and_build_sources_empty_input(chat_service):
     """
-    [Review] Comment 2 반영: 빈 리스트 입력 시 정상 처리 검증
+    빈 리스트 입력 시 정상 처리 검증
     """
     deduped_docs, payload = chat_service._dedupe_and_build_sources([])
     assert deduped_docs == []
@@ -196,9 +236,11 @@ def test_dedupe_and_build_sources_empty_input(chat_service):
 
 # ─────────────────────────────────────────────────────────────
 # TEST 3: 질의 재구성 (Query Rephrasing)
-# [Review] Overall Comment 반영:
-#   - RunnableSequence 내부 경로 대신 _get_llm 레이어에서 추상화하여 모킹
-#   - LangChain 버전 변경에 취약하지 않도록 개선
+# [Review] Overall Comment 1 반영:
+#   - `_invoke_rephrase_chain`(ChatService 자체 메서드)을 패치하여
+#     LangChain 내부 경로(RunnableSequence) 의존성 완전 제거
+# [Review] Comment 2 반영:
+#   - history 최근 5개 잘라내기(truncation) 계약 검증 테스트 추가
 # ─────────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio
@@ -207,12 +249,9 @@ async def test_rephrase_query_with_history(chat_service):
     [Phase 1] 대화 히스토리가 있을 때 재구성된 쿼리가 반환되는지 검증.
 
     [Engineering Decision - Mock 전략]
-    LangChain의 `prompt | llm | StrOutputParser()` 파이프라인은 최종적으로
-    `RunnableSequence.ainvoke`를 호출합니다. 이 경로를 직접 패치하는 것이
-    복잡한 중간 __or__ 체인 모킹보다 훨씬 안정적이며, 실제 실행 경로와
-    일치하는 것이 검증을 통해 확인되었습니다.
-    ChatPromptTemplate 중간 레이어 모킹은 StrOutputParser가 개입하면서
-    체인 연결이 끊어지는 문제가 있어 채택하지 않았습니다.
+    `_invoke_rephrase_chain`은 LangChain 체인 실행을 담당하는 ChatService 자체 메서드입니다.
+    이 메서드를 패치하면 LangChain 내부 구현(RunnableSequence 등)에 전혀 의존하지 않으므로
+    LangChain 버전 업그레이드에도 테스트가 깨지지 않습니다.
     """
     history = [
         ChatMessage(role="user", content="맥북 프로에 대해 알려주세요."),
@@ -221,13 +260,14 @@ async def test_rephrase_query_with_history(chat_service):
     query = "그럼 배터리 타임은 얼마나 되나요?"
     expected_rephrased = "맥북 프로의 배터리 타임은 얼마나 되나요?"
 
-    with patch(
-        "langchain_core.runnables.base.RunnableSequence.ainvoke",
+    # LangChain 내부가 아닌 ChatService 자체 메서드를 패치합니다.
+    with patch.object(
+        chat_service,
+        "_invoke_rephrase_chain",
         new_callable=AsyncMock,
         return_value=expected_rephrased,
     ):
-        with patch.object(chat_service, "_get_llm", return_value=MagicMock()):
-            result = await chat_service._rephrase_query(query, history)
+        result = await chat_service._rephrase_query(query, history)
 
     assert result == expected_rephrased
 
@@ -235,7 +275,7 @@ async def test_rephrase_query_with_history(chat_service):
 @pytest.mark.asyncio
 async def test_rephrase_query_no_history_returns_original(chat_service):
     """
-    [Phase 1] 히스토리가 없으면 LLM 호출 없이 원본 쿼리를 그대로 반환하는지 검증
+    [Phase 1] 히스토리가 없으면 LLM 호출 없이 원본 쿼리를 반환하는지 검증
     """
     query = "파이썬에서 비동기 처리 방법은?"
     result = await chat_service._rephrase_query(query, history=[])
@@ -243,28 +283,66 @@ async def test_rephrase_query_no_history_returns_original(chat_service):
 
 
 @pytest.mark.asyncio
-async def test_rephrase_query_falls_back_on_llm_error(chat_service):
+async def test_rephrase_query_truncates_history_to_last_five(chat_service):
     """
-    [Phase 1] chain.ainvoke 실패 시 원본 쿼리로 폴백하는지 검증 (회복 탄력성).
+    [Review] Comment 2 반영:
+    _rephrase_query가 전체 history 대신 최근 5개 메시지만 맥락으로 사용하는지 검증.
+
+    chat_service.py의 HISTORY_WINDOW = 5 계약이 실수로 변경되는 것을 방지합니다.
+    _invoke_rephrase_chain에 전달된 context_history 인수를 캡쳐하여 검증합니다.
+    """
+    # REPHRASE_HISTORY_WINDOW * 2 개의 히스토리를 구성하여 잘라내기 동작 검증
+    # [Engineering Decision] 하드코딩된 숫자 대신 모듈 상수를 import하여 SSOT를 유지합니다.
+    # chat_service.py의 REPHRASE_HISTORY_WINDOW 값이 바뀌면 이 테스트도 자동으로 연동됩니다.
+    total = REPHRASE_HISTORY_WINDOW * 2  # 10개
+    # [주의] 부분 문자열 충돌이 없는 고유한 문자열을 사용합니다. (예: 'msg-A'~'msg-J')
+    messages = [f"msg-{chr(ord('A') + i)}" for i in range(total)]
+    history = [
+        ChatMessage(role="user", content=msg) for msg in messages
+    ]
+    query = "최신 질문입니다."
+
+    captured_calls = []
+
+    async def capture_invoke(context_history: str, query: str) -> str:
+        captured_calls.append(context_history)
+        return "재구성된 쿼리"
+
+    with patch.object(chat_service, "_invoke_rephrase_chain", side_effect=capture_invoke):
+        await chat_service._rephrase_query(query, history)
+
+    assert len(captured_calls) == 1, "chain이 정확히 1회 호출되어야 합니다."
+    captured_context = captured_calls[0]
+
+    # 최근 REPHRASE_HISTORY_WINDOW 개만 포함되어야 함
+    for msg in messages[-REPHRASE_HISTORY_WINDOW:]:
+        assert msg in captured_context, f"'{msg}'가 context에 포함되어야 합니다."
+
+    # 그보다 오래된 메시지들은 포함되지 않아야 함
+    for msg in messages[:-REPHRASE_HISTORY_WINDOW]:
+        assert msg not in captured_context, f"'{msg}'는 context에서 제외되어야 합니다."
+
+
+@pytest.mark.asyncio
+async def test_rephrase_query_falls_back_on_invoke_error(chat_service):
+    """
+    [Phase 1] _invoke_rephrase_chain 실패 시 원본 쿼리로 폴백하는지 검증 (회복 탄력성).
 
     [코드 설계 확인]
-    _rephrase_query의 try/except는 chain.ainvoke() 호출만 감쌉니다.
-    _get_llm() 자체의 실패는 try 블록 밖이므로 폴백 대상이 아닙니다.
-    따라서 `chain.ainvoke`가 예외를 던지는 시나리오를 테스트합니다.
+    _rephrase_query의 try/except는 _invoke_rephrase_chain() 호출을 감쌉니다.
+    예외 발생 시 경고 로그를 남기고 원본 query를 반환하는 것이 계약입니다.
     """
     history = [
         ChatMessage(role="user", content="이전 질문입니다."),
     ]
     query = "후속 질문입니다."
 
-    # chain.ainvoke가 예외를 던지면 → except 블록에서 원본 query 반환
-    with patch(
-        "langchain_core.runnables.base.RunnableSequence.ainvoke",
+    with patch.object(
+        chat_service,
+        "_invoke_rephrase_chain",
         new_callable=AsyncMock,
         side_effect=Exception("chain 실행 실패"),
     ):
-        with patch.object(chat_service, "_get_llm", return_value=MagicMock()):
-            result = await chat_service._rephrase_query(query, history)
+        result = await chat_service._rephrase_query(query, history)
 
-    # except 블록에서 원본 쿼리로 안전하게 폴백해야 함
     assert result == query


### PR DESCRIPTION
♻️ refactor [#11.4.1]: 2차 개선 - 테스트 LangChain 의존성 완전 제거 및 계약 강화 
♻️ refactor [#11.4.1]: 3차 개선 - 매직 넘버 제거 및 모듈 의존성 명확화

## Summary by Sourcery

채팅 쿼리 재작성(contract)을 강화하면서 LangChain 내부 구현에 대한 테스트의 직접 의존성을 제거하고, 채팅 서비스 테스트에서 PII 마스킹 및 소스 중복 제거 동작을 개선합니다.

Bug Fixes:
- 공유 모듈 상수를 통해, 쿼리 재작성 시 가장 최근의 설정된 개수만큼의 히스토리 메시지만 사용하도록 보장합니다.

Enhancements:
- LangChain의 프롬프트/LLM 체인 실행을 캡슐화하고 향후 라이브러리 변경에 대한 테스트 가능성을 개선하기 위해 전용 `_invoke_rephrase_chain` 메서드를 도입합니다.
- PII 마스킹 동작과, 문서를 id 기준 vs. source 기준으로 중복 제거하는 테스트를 더 엄격하고 명확하게 다듬고, 누락된 메타데이터 및 빈 입력에 대한 처리를 포함합니다.

Tests:
- LangChain 내부 대신 채팅 서비스 자체의 체인 호출 메서드를 모킹하도록 쿼리 재작성 테스트를 리팩터링하고, 히스토리 윈도우 절단(truncation)에 대한 커버리지를 추가하며, 체인 오류 발생 시 원본 쿼리로 우아하게 폴백하는 동작을 검증합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen chat query rephrasing contracts while removing direct test dependencies on LangChain internals, and refine PII masking and source deduplication behaviors in chat service tests.

Bug Fixes:
- Ensure query rephrasing uses only the most recent configured number of history messages via a shared module constant.

Enhancements:
- Introduce a dedicated _invoke_rephrase_chain method to encapsulate LangChain prompt/LLM chain execution and improve testability against future library changes.
- Tighten and clarify tests around PII masking behavior and document deduplication by id versus source, including handling of missing metadata and empty inputs.

Tests:
- Refactor rephrase query tests to mock the chat service’s own chain invocation method instead of LangChain internals, add coverage for history window truncation, and verify graceful fallback to the original query on chain errors.

</details>