### PR TITLE
♻️ refactor [#11.4.1]: 4차 개선 - LLM 미호출 계약 검증 강화

### DIFF
--- a/tests/unit/services/test_chat_service.py
+++ b/tests/unit/services/test_chat_service.py
@@ -275,10 +275,22 @@ async def test_rephrase_query_with_history(chat_service):
 @pytest.mark.asyncio
 async def test_rephrase_query_no_history_returns_original(chat_service):
     """
-    [Phase 1] 히스토리가 없으면 LLM 호출 없이 원본 쿼리를 반환하는지 검증
+    [Phase 1] 히스토리가 없으면 LLM 호출 없이 원본 쿼리를 그대로 반환하는지 검증.
+
+    [Review Comment 2 반영]
+    반환값 검증뿐 아니라, `_invoke_rephrase_chain`이 실제로 호출되지 않음을
+    `assert_not_awaited()`로 단언합니다. docstring의 "LLM 호출 없음" 계약이
+    향후 코드 변경에도 유지되는지 보장하는 회귀 방어 장치입니다.
     """
     query = "파이썬에서 비동기 처리 방법은?"
-    result = await chat_service._rephrase_query(query, history=[])
+
+    with patch.object(
+        chat_service, "_invoke_rephrase_chain", new_callable=AsyncMock
+    ) as mock_invoke:
+        result = await chat_service._rephrase_query(query, history=[])
+
+    # 히스토리가 없을 때 LLM chain이 절대 호출되지 않아야 함
+    mock_invoke.assert_not_awaited()
     assert result == query
 
 


### PR DESCRIPTION
- **[tests/unit/services/test_chat_service.py]**:
  - test_rephrase_query_no_history_returns_original: 반환값 검증(`assert result == query`)에서 더 나아가 `_invoke_rephrase_chain.assert_not_awaited()`로 LLM 미호출 계약을 명시적으로 단언. 향후 조기 반환 로직이 변경되어 LLM이 호출되는 회귀를 방지

🔗 Related:
- Issue [#614]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/703#pullrequestreview-3944193617)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Tests:
- 기록(history)가 없을 때의 리프레이즈(rephrase) 테스트를 강화하여, 원래 쿼리를 그대로 반환하면서도 LLM 리프레이즈 체인이 한 번도 `await`되지 않는다는 점을 단언(assert)하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Tighten the no-history rephrase test to assert that the LLM rephrase chain is never awaited while still returning the original query.

</details>