### PR TITLE
♻️ refactor [#11.4.4]: 6차 개선 - 로그 상수화 및 에러 트레이스백 로깅 최적화

### DIFF
--- a/tests/performance/benchmark_rag.py
+++ b/tests/performance/benchmark_rag.py
@@ -33,6 +33,10 @@ logger = logging.getLogger(__name__)
 _LOG_MSG_TRUNCATE_LEN = 100
 _LOG_REPR_TRUNCATE_LEN = 50
 
+def _truncate(text: str, limit: int) -> str:
+    """텍스트가 제한 길이를 넘으면 자르고 '...'을 붙입니다."""
+    return (text[:limit] + "...") if len(text) > limit else text
+
 
 
 
@@ -96,10 +100,11 @@ async def run_load_test(chat_service: ChatService, queries: List[str], concurren
         )
         if errors:
             first_err = errors[0]
-            err_msg = str(first_err)
-            # [Performance] 요약 로그는 간결하게 유지 (상수 사용)
-            truncated_msg = (err_msg[:_LOG_MSG_TRUNCATE_LEN] + '...') if len(err_msg) > _LOG_MSG_TRUNCATE_LEN else err_msg
-            logger.error(f"First error summary: {repr(first_err)[:_LOG_REPR_TRUNCATE_LEN]}... msg={truncated_msg}")
+            # [Performance] 요약 로그는 헬퍼를 통해 간결하게 유지 (Review 반영)
+            repr_summary = _truncate(repr(first_err), _LOG_REPR_TRUNCATE_LEN)
+            msg_summary = _truncate(str(first_err), _LOG_MSG_TRUNCATE_LEN)
+            
+            logger.error(f"First error summary: {repr_summary} msg={msg_summary}")
             
             # [Robustness] exc_info에 예외 객체를 직접 전달하여 상세 트레이스백 확보 (v3.10+ 지원)
             logger.debug("Full error details for debugging", exc_info=first_err)

--- a/tests/performance/benchmark_rag.py
+++ b/tests/performance/benchmark_rag.py
@@ -29,6 +29,10 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+# [Performance] 로그 요약 및 가독성을 위한 상수 (Review 반영)
+_LOG_MSG_TRUNCATE_LEN = 100
+_LOG_REPR_TRUNCATE_LEN = 50
+
 
 
 
@@ -93,10 +97,12 @@ async def run_load_test(chat_service: ChatService, queries: List[str], concurren
         if errors:
             first_err = errors[0]
             err_msg = str(first_err)
-            # [Performance] 요약 로그는 간결하게 유지 (100자 제한)
-            truncated_msg = (err_msg[:100] + '...') if len(err_msg) > 100 else err_msg
-            logger.error(f"First error summary: {repr(first_err)[:50]}... msg={truncated_msg}")
-            logger.debug("Full error traceback", exc_info=first_err)
+            # [Performance] 요약 로그는 간결하게 유지 (상수 사용)
+            truncated_msg = (err_msg[:_LOG_MSG_TRUNCATE_LEN] + '...') if len(err_msg) > _LOG_MSG_TRUNCATE_LEN else err_msg
+            logger.error(f"First error summary: {repr(first_err)[:_LOG_REPR_TRUNCATE_LEN]}... msg={truncated_msg}")
+            
+            # [Robustness] exc_info에 예외 객체를 직접 전달하여 상세 트레이스백 확보 (v3.10+ 지원)
+            logger.debug("Full error details for debugging", exc_info=first_err)
             
     logger.info("=" * 50)
 


### PR DESCRIPTION
- **[tests/performance/benchmark_rag.py]**:
  - 로그 메시지 절삭 길이를 상수로 정의 (`_LOG_MSG_TRUNCATE_LEN`, `_LOG_REPR_TRUNCATE_LEN`).
  - `exc_info`에 예외 객체를 직접 전달하여 상세 트레이스백 확보 로직 고도화.
  - 요약 로그 출력 시 `repr`과 절삭된 메시지를 조합하여 간결한 가독성 확보.

🔗 Related:
- Issue [#614]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/711#pullrequestreview-3944947177)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

성능 테스트 중 더 명확하고 일관된 오류 요약과 향상된 traceback 세부 정보를 제공하도록 RAG 벤치마크 로깅을 정제했습니다.

개선 사항:
- 오류 요약 형식을 표준화하기 위해 로그 메시지 및 표현식(truncation) 길이에 대한 상수들을 도입했습니다.
- 예외 객체를 직접 전달하여 전체 traceback 세부 정보를 캡처함으로써 디버그 수준의 오류 로깅을 개선했습니다.

테스트:
- 표준화된 잘림(truncation) 설정과 더 자세한 디버그 오류 출력을 사용하도록 성능 벤치마크 RAG 테스트의 로깅 동작을 조정했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine RAG benchmark logging for clearer, more consistent error summaries and improved traceback detail during performance tests.

Enhancements:
- Introduce constants for log message and representation truncation lengths to standardize error summary formatting.
- Improve debug-level error logging by passing the exception object directly to capture full traceback details.

Tests:
- Adjust performance benchmark RAG test logging behavior to use standardized truncation and more detailed debug error output.

</details>