### PR TITLE
✨ feat [#11.5.1]: 멀티 에이전트 워크플로우 기초 뼈대(State, Node, Graph) 구축

### DIFF
--- a/backend/agent/chat/graph.py
+++ b/backend/agent/chat/graph.py
@@ -13,7 +13,7 @@ from backend.agent.chat.nodes import router_edge, planner_node, responder_node
 from backend.agent.checkpointer import get_checkpointer
 
 
-def create_chat_workflow(checkpointer: Optional[Any] = None) -> Any:
+def create_chat_workflow(checkpointer: Optional["BaseCheckpointSaver"] = None) -> "CompiledStateGraph":
     """
     채팅 에이전트(Multi-Agent) 워크플로우를 구성하고 컴파일합니다.
     기존의 RAG 검색과 일상 대화를 분기하는 시작점 역할을 합니다.

--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -11,26 +11,39 @@ logger = logging.getLogger(__name__)
 def router_edge(state: AgentState) -> Literal["planner", "responder"]:
     """
     조건부 엣지(Conditional Edge):
-    마지막 사용자 메시지의 의도를 간단히 파악하여 복잡한 추론/검색이 필요한지(planner),
-    아니면 단순 인사말/단답형인지 판별하여 다음 노드로 라우팅합니다.
+    가장 마지막 사용자(Human) 메시지의 의도를 파악하여 
+    복잡한 추론/검색이 필요한지(planner), 단순 인사말인지(responder) 판별합니다.
     """
     messages = state.get("messages", [])
     if not messages:
+        logger.debug("[Router] 메시지가 없어 responder로 라우팅")
         return "responder"
         
-    last_message = messages[-1]
-    query = last_message.content if hasattr(last_message, "content") else str(last_message)
-    
+    # 사용자의 마지막 메시지 탐색 (이전 AI 응답에 영향을 받지 않기 위함)
+    user_query = ""
+    for msg in reversed(messages):
+        # LangChain BaseMessage type 속성 확인 (방어적 코딩)
+        if hasattr(msg, "type") and msg.type == "human":
+            user_query = msg.content if hasattr(msg, "content") else str(msg)
+            break
+            
+    if not user_query:
+        logger.debug("[Router] 사용자 메시지를 찾을 수 없어 responder로 라우팅")
+        return "responder"
+        
     # [임시 휴리스틱 모델링]
     # 실제 환경에서는 소형 LLM(분류기)이나 정규식, Intent 판단 모델이 들어갑니다.
-    # 현재는 단순 인사말 등은 응답자(responder)로 직행하고, 그 외 질문은 계획자(planner)를 거친다고 가정합니다.
+    # 안전한 문자열 처리 및 소문자 변환
+    user_query_str = str(user_query).strip().lower()
+    
     simple_greetings = ["안녕", "hello", "hi", "반가워", "누구야"]
     # 쿼리의 길이가 짧고 인사말이 포함되어 있으면 단순 채팅 모드로 간주
-    if len(query) < 15 and any(greet in query.lower() for greet in simple_greetings):
-        logger.info("[Router] 질문 의도: 단순 대화 (-> responder)")
+    if len(user_query_str) < 15 and any(greet in user_query_str for greet in simple_greetings):
+        # 민감 정보(PII) 마스킹 관점에서 원본 내용 대신 길이 등 비민감 정보 로깅
+        logger.info(f"[Router] 단순 대화 감지 (길이: {len(user_query_str)}) -> responder")
         return "responder"
         
-    logger.info("[Router] 질문 의도: 검색/추론 도구 필요 (-> planner)")
+    logger.info(f"[Router] 검색/추론 도구 필요 판단 (길이: {len(user_query_str)}) -> planner")
     return "planner"
 
 
@@ -46,9 +59,9 @@ def planner_node(state: AgentState) -> Dict[str, Any]:
     # 지금은 기초 뼈대(Scaffolding)만 잡아둡니다.
     mock_context = "검색된 임시 컨텍스트 조각입니다 (Scaffolding Data)."
     
+    # 그래프 라우팅은 graph.py에서 명시적인 엣지를 통해 제어되므로 next_step 상태는 반환하지 않습니다.
     return {
         "search_context": mock_context,
-        "next_step": "responder" # Planner가 끝나면 최종 응답을 위해 responder로 이동
     }
 
 

--- a/backend/agent/chat/state.py
+++ b/backend/agent/chat/state.py
@@ -1,6 +1,6 @@
 # backend/agent/chat/state.py
 
-from typing import Annotated, TypedDict, Sequence, Any, Optional
+from typing import Annotated, TypedDict, Any, Optional
 from langchain_core.messages import BaseMessage
 import operator
 
@@ -20,21 +20,18 @@ class AgentState(TypedDict):
         messages: 사용자 질문, 도구 호출, LLM 응답 등의 메시지 이력 (누적형)
         user_id: 대화 중인 사용자 ID (개인화 및 Context 기반 응답용)
         session_id: 현재 대화 세션 ID (로깅 및 히스토리 관리용)
-        next_step: 그래프 라우팅 시 다음으로 이동할 노드의 이름이나 행동 지침
         search_context: RAG 등에서 검색해 온 문맥/문서 데이터 문자열
         final_answer: 클라이언트(프론트)로 내보낼 최종 결정된 답변 문자열 (필요 시)
     """
 
     # 메시지 리스트: 누적 축적을 위해 Annotated와 operator.add를 활용합니다.
     # 이전 배열에 새로운 배열이 들어오면 계속 덧붙여집니다.
-    messages: Annotated[Sequence[BaseMessage], operator.add]
+    # list[BaseMessage]를 사용해 가변 컬렉션임을 명시적으로 표현합니다.
+    messages: Annotated[list[BaseMessage], operator.add]
 
     # 사용자 식별자 및 세션 정보
     user_id: str
     session_id: Optional[str]
-
-    # 라우터의 결정 결과 또는 흐름 제어 변수
-    next_step: Optional[str]
 
     # 검색된 정보나 중간 연산 결과물
     search_context: Optional[str]


### PR DESCRIPTION
- **[backend/agent/chat/state.py]**:
  - 채팅 특화 LangGraph 상태 관리용 `AgentState` 스키마 정의.
  - 대화 유지용 `messages` 컬렉션, 문맥 통합용 `search_context`, 그리고 라우팅 플래그용 `next_step` 구조화.

- **[backend/agent/chat/nodes.py]**:
  - `router_edge`: 사용자 질의 길이나 맥락에 기반해 단순 인사말(`responder`)과 복잡한 도구 호출(`planner`)을 판단하는 초기 라우터 로직 구축.
  - `planner_node` & `responder_node`: 도구 호출부터 최종 답변에 이르는 노드 스캐폴딩(Scaffolding) 함수 생성.

- **[backend/agent/chat/graph.py]**:
  - 앞서 제작한 `AgentState`와 노드들을 `StateGraph`에 주입 및 엣지(Edge) 연결.
  - 조건부 라우팅 및 공용 메모리(`get_checkpointer`) 로직을 포괄하여 완성된 Workflow 컴파일 단계 적용.

🔗 Related: Issue [#714]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

상태, 노드, 그리고 계획 수립과 응답 생성 간 라우팅을 위한 그래프 연결을 포함하는 초기 LangGraph 기반 멀티 에이전트 채팅 워크플로를 도입합니다.

새로운 기능:
- 메시지, 사용자/세션 식별자, 라우팅 힌트, 검색 컨텍스트, 최종 답변을 포괄하는 채팅 지향 멀티 에이전트 워크플로용 `AgentState` 스키마를 정의합니다.
- 워크플로 내에서 사용자 입력을 라우팅하고, 검색 컨텍스트를 준비하며, AI 응답을 조합하는 라우터, 플래너, 리스폰더 노드를 추가합니다.
- 세션 지속성을 위한 체크포인트 상태와 함께 라우터, 플래너, 리스폰더 노드를 연결하는 컴파일된 채팅 워크플로 그래프를 생성합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an initial LangGraph-based multi-agent chat workflow with state, nodes, and graph wiring for routing between planning and response generation.

New Features:
- Define an AgentState schema for chat-oriented multi-agent workflows, covering messages, user/session identifiers, routing hints, search context, and final answers.
- Add router, planner, and responder nodes that route user input, prepare search context, and assemble AI responses within the workflow.
- Create a compiled chat workflow graph that wires the router, planner, and responder nodes with checkpointed state for session persistence.

</details>