### PR TITLE
Feature/v7 phase3 agent

### DIFF
--- a/backend/agent/chat/graph.py
+++ b/backend/agent/chat/graph.py
@@ -1,0 +1,60 @@
+# backend/agent/chat/graph.py
+
+from typing import Optional, Any
+from langgraph.graph import StateGraph, END, START
+# TYPE_CHECKING
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from langgraph.checkpoint.base import BaseCheckpointSaver
+    from langgraph.graph.state import CompiledStateGraph
+
+from backend.agent.chat.state import AgentState
+from backend.agent.chat.nodes import router_edge, planner_node, responder_node
+from backend.agent.checkpointer import get_checkpointer
+
+
+def create_chat_workflow(checkpointer: Optional["BaseCheckpointSaver"] = None) -> "CompiledStateGraph":
+    """
+    채팅 에이전트(Multi-Agent) 워크플로우를 구성하고 컴파일합니다.
+    기존의 RAG 검색과 일상 대화를 분기하는 시작점 역할을 합니다.
+    
+    Returns:
+        CompiledStateGraph: 실행 가능한 채팅 그래프 객체
+    """
+    # 1. 상태(State) 스키마를 가진 그래프 초기화
+    workflow = StateGraph(AgentState)
+    
+    # 2. 노드(Nodes) 추가
+    # 각 노드는 AgentState를 입력받아, 변동될 속성의 딕셔너리를 반환합니다.
+    workflow.add_node("planner", planner_node)
+    workflow.add_node("responder", responder_node)
+    
+    # 3. 라우팅 (조건부 진입점)
+    # 시작점(START)에서 사용자의 메시지를 받아, 조건부 엣지(router_edge)를 통해 
+    # 복잡한 검색이 필요한 planner를 거칠지, 단순 인사말인 responder로 직행할지 결정합니다.
+    workflow.add_conditional_edges(
+        START,
+        router_edge,
+        {
+            "planner": "planner",
+            "responder": "responder"
+        }
+    )
+    
+    # 4. 방향 엣지(Edges) 연결
+    # Planner 작업(검색 및 도구 호출)이 끝나면 무조건 Responder로 넘어와서 최종 텍스트 답변을 구성합니다.
+    workflow.add_edge("planner", "responder")
+    
+    # Responder가 최종 응답을 생성하면 에이전트 그래프 모방을 종료(END)합니다.
+    workflow.add_edge("responder", END)
+    
+    # 5. 체크포인터 확보 (메모리 및 세션 유지를 위함)
+    if checkpointer is None:
+        checkpointer = get_checkpointer()
+        
+    # 6. 컴파일 (실행 준비)
+    compiled_workflow = workflow.compile(
+        checkpointer=checkpointer
+    )
+    
+    return compiled_workflow

--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -1,0 +1,83 @@
+# backend/agent/chat/nodes.py
+
+import logging
+from typing import Dict, Any, Literal
+from langchain_core.messages import AIMessage
+
+from backend.agent.chat.state import AgentState
+
+logger = logging.getLogger(__name__)
+
+def router_edge(state: AgentState) -> Literal["planner", "responder"]:
+    """
+    조건부 엣지(Conditional Edge):
+    가장 마지막 사용자(Human) 메시지의 의도를 파악하여 
+    복잡한 추론/검색이 필요한지(planner), 단순 인사말인지(responder) 판별합니다.
+    """
+    messages = state.get("messages", [])
+    if not messages:
+        logger.debug("[Router] 메시지가 없어 responder로 라우팅")
+        return "responder"
+        
+    # 사용자의 마지막 메시지 탐색 (이전 AI 응답에 영향을 받지 않기 위함)
+    user_query = ""
+    for msg in reversed(messages):
+        # LangChain BaseMessage type 속성 확인 (방어적 코딩)
+        if hasattr(msg, "type") and msg.type == "human":
+            user_query = msg.content if hasattr(msg, "content") else str(msg)
+            break
+            
+    if not user_query:
+        logger.debug("[Router] 사용자 메시지를 찾을 수 없어 responder로 라우팅")
+        return "responder"
+        
+    # [임시 휴리스틱 모델링]
+    # 실제 환경에서는 소형 LLM(분류기)이나 정규식, Intent 판단 모델이 들어갑니다.
+    # 안전한 문자열 처리 및 소문자 변환
+    user_query_str = str(user_query).strip().lower()
+    
+    simple_greetings = ["안녕", "hello", "hi", "반가워", "누구야"]
+    # 쿼리의 길이가 짧고 인사말이 포함되어 있으면 단순 채팅 모드로 간주
+    if len(user_query_str) < 15 and any(greet in user_query_str for greet in simple_greetings):
+        # 민감 정보(PII) 마스킹 관점에서 원본 내용 대신 길이 등 비민감 정보 로깅
+        logger.info(f"[Router] 단순 대화 감지 (길이: {len(user_query_str)}) -> responder")
+        return "responder"
+        
+    logger.info(f"[Router] 검색/추론 도구 필요 판단 (길이: {len(user_query_str)}) -> planner")
+    return "planner"
+
+
+def planner_node(state: AgentState) -> Dict[str, Any]:
+    """
+    계획자(Planner) 노드:
+    - 외부 도구(Tool) 호출 및 복잡한 추론을 담당합니다.
+    - 예: HybridSearchService를 호출하여 관련 문서(RAG)를 찾아냅니다.
+    """
+    logger.info("[Planner Node] 실행 중... (도구 호출 및 검색 활용 계획)")
+    
+    # 추후 'tools.py' 파트에서 RAG 검색 도구를 구현하고 여기서 호출 결과를 search_context 에 담을 예정입니다.
+    # 지금은 기초 뼈대(Scaffolding)만 잡아둡니다.
+    mock_context = "검색된 임시 컨텍스트 조각입니다 (Scaffolding Data)."
+    
+    # 그래프 라우팅은 graph.py에서 명시적인 엣지를 통해 제어되므로 next_step 상태는 반환하지 않습니다.
+    return {
+        "search_context": mock_context,
+    }
+
+
+def responder_node(state: AgentState) -> Dict[str, Any]:
+    """
+    응답 생성자(Responder) 노드:
+    - 최종적으로 사용자에게 전달될 메시지를 스트리밍하거나 반환하기 전 조립합니다.
+    - 대화 이력(messages)과 Planner가 획득한 context를 융합하여 LLM을 호출합니다.
+    """
+    logger.info("[Responder Node] 실행 중... (최종 응답 생성)")
+    
+    # TODO: ChatService.stream_chat의 로직을 향후 이 노드로 통합하여 SSE 스트리밍 연동
+    mock_response = "임시 뼈대 단계에서의 시스템 AI 응답입니다."
+    
+    # 기존 메시지에 AI 답변을 누적시키기 위해 리스트로 반환 (Annotated[operator.add]에 의해 기존 배열에 병합됨)
+    return {
+        "messages": [AIMessage(content=mock_response)],
+        "final_answer": mock_response
+    }

--- a/backend/agent/chat/state.py
+++ b/backend/agent/chat/state.py
@@ -1,0 +1,40 @@
+# backend/agent/chat/state.py
+
+from typing import Annotated, TypedDict, Any, Optional
+from langchain_core.messages import BaseMessage
+import operator
+
+# =================================================================
+# Type Definitions
+# =================================================================
+
+
+class AgentState(TypedDict):
+    """
+    채팅 특화 멀티 에이전트를 위한 상태(State) 스키마
+
+    이 상태 객체는 LangGraph 워크플로우를 통과하면서 각 노드별로 업데이트됩니다.
+    'messages' 콜렉션은 기존 메시지에 새 메시지를 누적(append)하는 역할을 합니다.
+
+    Attributes:
+        messages: 사용자 질문, 도구 호출, LLM 응답 등의 메시지 이력 (누적형)
+        user_id: 대화 중인 사용자 ID (개인화 및 Context 기반 응답용)
+        session_id: 현재 대화 세션 ID (로깅 및 히스토리 관리용)
+        search_context: RAG 등에서 검색해 온 문맥/문서 데이터 문자열
+        final_answer: 클라이언트(프론트)로 내보낼 최종 결정된 답변 문자열 (필요 시)
+    """
+
+    # 메시지 리스트: 누적 축적을 위해 Annotated와 operator.add를 활용합니다.
+    # 이전 배열에 새로운 배열이 들어오면 계속 덧붙여집니다.
+    # list[BaseMessage]를 사용해 가변 컬렉션임을 명시적으로 표현합니다.
+    messages: Annotated[list[BaseMessage], operator.add]
+
+    # 사용자 식별자 및 세션 정보
+    user_id: str
+    session_id: Optional[str]
+
+    # 검색된 정보나 중간 연산 결과물
+    search_context: Optional[str]
+
+    # 클라이언트에게 반환할 최종 완성 답변
+    final_answer: Optional[str]


### PR DESCRIPTION
✨ feat [#11.5.1]: 멀티 에이전트 워크플로우 기초 뼈대(State, Node, Graph) 구축 
♻️ refactor [#11.5.1]: 1차 개선 - 라우팅 안정성 강화 및 PII 보호 로깅 적용

## Summary by Sourcery

사용자 의도에 따라 계획(플래닝) 노드와 응답 노드 간 라우팅이 가능한 LangGraph 기반 멀티 에이전트 챗 워크플로를 도입합니다.

New Features:
- 멀티 에이전트 워크플로를 위해 채팅 세션 상태, 메시지, 검색 컨텍스트, 최종 답변을 모델링하는 `AgentState` 스키마를 추가합니다.
- 초기 골조로서 모의 검색 컨텍스트와 AI 응답으로 `AgentState`를 업데이트하는 플래너(planner) 노드와 리스폰더(responder) 노드를 추가합니다.
- 사용자 메시지를 간단한 인사와 복잡한 질의로 분류하여 플래너와 리스폰더 사이를 라우팅하는 라우터 엣지를 추가합니다.
- START에서 라우터를 거쳐 플래너/리스폰더 노드까지 연결하고 체크포인트 기반 세션 지속성을 제공하는 컴파일된 채팅 워크플로 그래프를 추가합니다.

Enhancements:
- 방어적 체크를 통해 로깅 및 라우팅의 견고성을 개선하고, 사용자 입력의 원본 내용 대신 특성만을 로깅하여 PII(개인 식별 정보)를 보호합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a LangGraph-based multi-agent chat workflow with routing between planning and response nodes based on user intent.

New Features:
- Add an AgentState schema to model chat session state, messages, search context, and final answers for the multi-agent workflow.
- Add planner and responder nodes that update AgentState with mock search context and AI responses as initial scaffolding.
- Add a router edge that classifies user messages into simple greetings vs. complex queries to route between planner and responder.
- Add a compiled chat workflow graph wiring START through the router to planner/responder nodes with checkpoint-based session persistence.

Enhancements:
- Improve logging and routing robustness with defensive checks and PII-safe logging of user input characteristics rather than raw content.

</details>