### PR TITLE
Feature/v7 phase3 agent

### DIFF
--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -1,5 +1,6 @@
 # backend/agent/chat/nodes.py
 
+import re
 import logging
 from typing import Dict, Any, Literal
 from langchain_core.messages import AIMessage
@@ -7,6 +8,15 @@ from langchain_core.messages import AIMessage
 from backend.agent.chat.state import AgentState
 
 logger = logging.getLogger(__name__)
+
+# 라우팅 휴리스틱을 위한 상수 (상단 분리 및 하드코딩 제거)
+_SIMPLE_KOREAN_GREETINGS = ["안녕", "반가워", "누구야"]
+_SIMPLE_LATIN_GREETINGS = ["hello", "hi"]
+
+# 정규식 특수 문자 이스케이프 처리 및 모듈 레벨에서 1회만 미리 컴파일 (성능 및 오탐 방지)
+_LATIN_GREETING_RE = re.compile(
+    r"\b(" + "|".join(re.escape(g) for g in _SIMPLE_LATIN_GREETINGS) + r")\b"
+)
 
 def router_edge(state: AgentState) -> Literal["planner", "responder"]:
     """
@@ -36,14 +46,23 @@ def router_edge(state: AgentState) -> Literal["planner", "responder"]:
     # 안전한 문자열 처리 및 소문자 변환
     user_query_str = str(user_query).strip().lower()
     
-    simple_greetings = ["안녕", "hello", "hi", "반가워", "누구야"]
-    # 쿼리의 길이가 짧고 인사말이 포함되어 있으면 단순 채팅 모드로 간주
-    if len(user_query_str) < 15 and any(greet in user_query_str for greet in simple_greetings):
+    # 기본적인 구두점 제거 및 공백 정규화 (오탐률 최소화 및 안정성 확보)
+    cleaned_query = re.sub(r"[^\w가-힣\s]", " ", user_query_str)
+    cleaned_query = re.sub(r"\s+", " ", cleaned_query).strip()
+
+    is_korean_greeting = any(greet in cleaned_query for greet in _SIMPLE_KOREAN_GREETINGS)
+    # 라틴 인사말은 단어 단위 매칭 및 이스케이프가 적용된 사전 컴파일 정규식 사용
+    is_latin_greeting = bool(_LATIN_GREETING_RE.search(cleaned_query))
+
+    is_simple_greeting = is_korean_greeting or is_latin_greeting
+    
+    # 쿼리의 길이가 짧고 인사말로 판단되면 단순 채팅 모드로 간주
+    if len(cleaned_query) < 15 and is_simple_greeting:
         # 민감 정보(PII) 마스킹 관점에서 원본 내용 대신 길이 등 비민감 정보 로깅
-        logger.info(f"[Router] 단순 대화 감지 (길이: {len(user_query_str)}) -> responder")
+        logger.info(f"[Router] 단순 대화 감지 (길이: {len(cleaned_query)}) -> responder")
         return "responder"
         
-    logger.info(f"[Router] 검색/추론 도구 필요 판단 (길이: {len(user_query_str)}) -> planner")
+    logger.info(f"[Router] 검색/추론 도구 필요 판단 (길이: {len(cleaned_query)}) -> planner")
     return "planner"
 
 
@@ -72,6 +91,10 @@ def responder_node(state: AgentState) -> Dict[str, Any]:
     - 대화 이력(messages)과 Planner가 획득한 context를 융합하여 LLM을 호출합니다.
     """
     logger.info("[Responder Node] 실행 중... (최종 응답 생성)")
+    
+    # NotRequired 필드에 대한 안전한 접근 (.get 사용 필수)
+    # Planner에서 넘어온 문맥 정보가 없다면 빈 문자열로 처리
+    context = state.get("search_context", "")
     
     # TODO: ChatService.stream_chat의 로직을 향후 이 노드로 통합하여 SSE 스트리밍 연동
     mock_response = "임시 뼈대 단계에서의 시스템 AI 응답입니다."

--- a/backend/agent/chat/state.py
+++ b/backend/agent/chat/state.py
@@ -1,6 +1,6 @@
 # backend/agent/chat/state.py
 
-from typing import Annotated, TypedDict, Any, Optional
+from typing import Annotated, TypedDict, Any, Optional, NotRequired
 from langchain_core.messages import BaseMessage
 import operator
 
@@ -31,10 +31,10 @@ class AgentState(TypedDict):
 
     # 사용자 식별자 및 세션 정보
     user_id: str
-    session_id: Optional[str]
+    session_id: NotRequired[Optional[str]]
 
     # 검색된 정보나 중간 연산 결과물
-    search_context: Optional[str]
+    search_context: NotRequired[Optional[str]]
 
     # 클라이언트에게 반환할 최종 완성 답변
-    final_answer: Optional[str]
+    final_answer: NotRequired[Optional[str]]


### PR DESCRIPTION
♻️ refactor [#11.5.1]: 2차 개선 - 휴리스틱 정규식 정교화 및 타입 제약 완화 
♻️ refactor [#11.5.1]: 3차 개선 - 정규식 런타임 안정성 및 NotRequired 상태 접근자 방어 코딩

## Summary by Sourcery

채팅 에이전트의 라우팅 휴리스틱을 개선하고, 선택적 필드에 대한 에이전트 상태 타입 요구사항을 완화합니다.

Enhancements:
- 사용자 쿼리를 정규화하고, 한국어/라틴 문자 인사말 처리를 분리하며, 라틴 문자 인사말에 대해 사전에 컴파일되고 이스케이프된 정규식을 사용하여 인사말 기반 라우팅을 개선.
- 라우터 로깅에서 PII를 고려한 로깅을 위해 정제된 쿼리 길이를 사용하고, 모드 선택 메시지를 더 명확하게 조정.
- responder 노드에서 방어적인 `.get` 접근과 기본값을 사용하여 선택적 planner context에 안전하게 접근.

Chores:
- 런타임 상태에서의 선택적 존재 여부를 더 잘 반영하기 위해, `AgentState` `TypedDict`의 `session_id`, `search_context`, `final_answer` 필드를 `NotRequired` 옵션으로 표시하여 필수 요구사항을 완화.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the chat agent’s routing heuristics and relax agent state type requirements for optional fields.

Enhancements:
- Improve greeting-based routing by normalizing user queries, separating Korean/Latin greeting handling, and using a precompiled, escaped regex for Latin greetings.
- Adjust router logging to use sanitized query length for PII-aware logging and clearer mode selection messages.
- Safely access optional planner context in the responder node using defensive .get access with a default value.

Chores:
- Relax AgentState TypedDict field requirements by marking session_id, search_context, and final_answer as NotRequired optionals to better reflect optional presence in runtime state.

</details>