### PR TITLE
♻️ refactor [#11.5.1]: 10차 개선 - 분석 친화적 로깅 및 라우팅 타겟 메타데이터 구조화

### DIFF
--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -90,16 +90,18 @@ def router_edge(state: AgentState) -> Literal["planner", "responder"]:
     
     # 로그 메타데이터 중복 방지를 위한 공통 속성 딕셔너리 분리
     router_log_extra = {
-        "query_length": len(cleaned_query),
+        "cleaned_query_length": len(cleaned_query),
         "max_greeting_length": _MAX_GREETING_LENGTH
     }
     
     # 인사말 판별기(내부 길이 제한 등 로직 포함)를 통과하면 응답자 모드로 직행
     if is_simple_greeting:
         # 민감 정보(PII) 마스킹 관점과 구조화된 로깅 지침 준수
+        router_log_extra["target"] = "responder"
         logger.info("[Router] 단순 대화 감지 -> responder", extra=router_log_extra)
         return "responder"
         
+    router_log_extra["target"] = "planner"
     logger.info("[Router] 검색/추론 도구 필요 판단 -> planner", extra=router_log_extra)
     return "planner"
 


### PR DESCRIPTION
- **[backend/agent/chat/nodes.py]**:
  - `query_length` 필드명을 `cleaned_query_length`로 명확히 변경하여 향후 데이터 분석 및 디버깅 시 원본 쿼리 길이와의 혼동 방지.
  - 구조화된 로그 딕셔너리(`extra`) 내부에 라우팅 최종 목적지(`"target": "responder" | "planner"`)를 명시적으로 추가 삽입하여 다운스트림 로그 파서(Kibana 등)의 집계 및 필터링 편의성 극대화.

🔗 Related:
- Issue [#714]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/724#pullrequestreview-3950028809)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

더 명확한 분석과 라우팅 추적 가능성을 위해 채팅 라우터 로깅 메타데이터를 개선합니다.

개선 사항:
- 기록되는 쿼리 길이 필드를 `cleaned_query_length`로 이름을 변경하여 정제된 쿼리 텍스트의 길이임을 명확히 합니다.
- 최종 라우팅 대상(planner 또는 responder)을 구조화된 로그 메타데이터에 포함하여 이후 단계의 필터링 및 집계를 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine chat router logging metadata for clearer analysis and routing traceability.

Enhancements:
- Rename the logged query length field to cleaned_query_length to clearly indicate it refers to the cleaned query text.
- Include the final routing target (planner or responder) in structured log metadata to improve downstream filtering and aggregation.

</details>