### PR TITLE
♻️ refactor [#11.5.2]: 6차 개선 - Type Contract 복구 및 PII 방어 강화

### DIFF
--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -4,11 +4,11 @@ import re
 import logging
 from itertools import islice
 from typing import Dict, Any, Literal, cast, List, TypedDict
-from langchain_core.messages import AIMessage, SystemMessage, BaseMessage  # type: ignore
+from langchain_core.messages import AIMessage, SystemMessage, BaseMessage  # type: ignore[import, import-untyped, reportMissingImports]
 
-from backend.agent.chat.state import AgentState  # type: ignore
-from backend.agent.chat.tools import search_documents_tool  # type: ignore
-from backend.services.chat_service import get_chat_service  # type: ignore
+from backend.agent.chat.state import AgentState  # type: ignore[import, import-untyped, reportMissingImports]
+from backend.agent.chat.tools import search_documents_tool  # type: ignore[import, import-untyped, reportMissingImports]
+from backend.services.chat_service import get_chat_service  # type: ignore[import, import-untyped, reportMissingImports]
 
 logger = logging.getLogger(__name__)
 
@@ -143,13 +143,13 @@ async def _run_planner_with_tools(
         else:
             logger.info("[Planner] LLM이 도구 없이 자체 판단 가능으로 결론내렸습니다.")
     except Exception as e:
-        # [Comment 3 적용] PII 누출 방지를 위해 str(e) 로깅 제거
+        # [Comment 3 반영] Traceback의 payload가 PII를 노출할 수 있으므로 exc_info=True 제거
         logger.error(
             "[Planner] LLM 추론 중 에러 발생",
             extra={
                 "error_type": type(e).__name__,
+                "security": "Traceback omitted for PII protection",
             },
-            exc_info=True,
         )
         planner_failed = True
         planner_error_message = "Planner 실행 중 오류가 발생했습니다. 검색 결과 없이 직접 응답을 시도합니다."
@@ -230,7 +230,7 @@ def router_edge(state: AgentState) -> Literal["planner", "responder"]:
     return "planner"
 
 
-async def planner_node(state: AgentState) -> Dict[str, Any]:
+async def planner_node(state: AgentState) -> PlannerResult:
     """
     계획자(Planner) 노드 — Thin Orchestrator:
     - 상태를 수집하고 헬퍼를 호출하여 도구 실행 및 컨텍스트를 구성한 후 반환합니다.
@@ -313,13 +313,13 @@ async def responder_node(state: AgentState) -> Dict[str, Any]:
             else str(response)
         )
     except Exception as e:
-        # [Comment 3 적용] PII 누출 방지를 위해 str(e) 로깅 제거
+        # [Comment 3 반영] Traceback의 payload가 PII를 노출할 수 있으므로 exc_info=True 제거
         logger.error(
             "[Responder Node] LLM 응답 생성 실패",
             extra={
                 "error_type": type(e).__name__,
+                "security": "Traceback omitted for PII protection",
             },
-            exc_info=True,
         )
         final_answer = (
             "죄송합니다, 현재 트래픽이 많거나 응답 생성 중에 내부적인 통신 오류가 발생했습니다. "


### PR DESCRIPTION
- **[backend/agent/chat/nodes.py]**:
  - LLM 도구 파라미터 파싱 시 `or {}`의 남용으로 타입 가드가 무력화되던 버그 수정 (`falsy` 값이 dict로 암묵적 캐스팅되는 문제 차단).
  - `planner_node`의 다운스트림 계약 안정성을 위해 [PlannerResult(TypedDict)](backend/agent/chat/nodes.py:38:0-43:30)를 원복하여 명시적 Type Safety 보장.
  - 최상위 범용 `Exception` 로깅 시 `str(e)`를 제거하여 사용자/프로바이더 민감 정보(PII)가 중앙 로그 모니터링 시스템으로 누출되는 보안 취약점 사전 차단.
- **[IDE Configurations]**:
  - [.vscode/settings.json] 및 `pyrightconfig.json`에 파이썬 분석기(`Pyre2` 등)가 `${workspaceFolder}` 및 `site-packages`를 식별할 수 있도록 명시적 `extraPaths` 추가하여 일관된 Import Resolution 환경 구축.
  - 특정 정적 분석기가 환경 경로를 무시하고 뱉는 False-Positive 에러를 강제 억제하기 위해 `# type: ignore` 주석 적용.

🔗 Related:
- Issue [#714]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/732#pullrequestreview-3952173618)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

명시적인 플래너 결과 타입을 복원하고, 오류 로그에서 노출되는 PII를 줄이면서 LLM 도구 인자 처리의 안정성을 강화합니다.

버그 수정:
- 딕셔너리가 아닌 LLM 도구 인자가 도구 디스패치 과정에서 타입 가드를 우회하지 못하도록 방지합니다.

개선 사항:
- `PlannerResult` `TypedDict`를 도입하고 플래너 플로우에서 이를 사용해 플래너와 다운스트림 노드 간의 안정적이고 타입 안전한 계약을 보장합니다.
- 특정 모듈 및 메시지 타입에 대한 임포트 시 타입 체크를 완화하여 불필요한 정적 분석 오류를 방지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore explicit planner result typing and harden LLM tool argument handling while reducing PII exposure in error logs.

Bug Fixes:
- Prevent non-dict LLM tool arguments from bypassing type guards during tool dispatch.

Enhancements:
- Introduce a PlannerResult TypedDict and use it in planner flow to enforce a stable, type-safe contract between planner and downstream nodes.
- Relax import-time type checking for certain modules and message types to avoid spurious static analysis errors.

</details>