### PR TITLE
🩹 fix [#11.5.2]: 8차 개선 - Arg-less 도구 누락 버그 해결 및 로그 디버깅 기능 복원

### DIFF
--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -83,6 +83,14 @@ def _truncate_context(raw_context: str) -> str:
     return head + suffix
 
 
+def _safe_truncate_error_msg(e: Exception, max_chars: int = 200) -> str:
+    """
+    Exception 객체의 PII 유출을 방지하기 위해 예외 메시지의 앞부분만 안전하게 잘라 반환합니다.
+    (Pyre2 String Slicing TypeError 우회를 위해 islice 사용)
+    """
+    return "".join(islice(str(e), max_chars))
+
+
 async def _run_planner_with_tools(
     plan_messages: List[BaseMessage],
     base_context: str,
@@ -112,6 +120,10 @@ async def _run_planner_with_tools(
                 raw_args = tool_call.get("args")
 
                 if raw_args is None:
+                    logger.debug(
+                        "[Tool Dispatch] 전달된 args가 없어 빈 dict로 초기화합니다.",
+                        extra={"tool_name": tool_name},
+                    )
                     tool_args = {}
                 elif not isinstance(raw_args, dict):
                     logger.warning(
@@ -150,7 +162,7 @@ async def _run_planner_with_tools(
             extra={
                 "error_type": type(e).__name__,
                 # PII 노출 방지를 위해 전체 메시지 대신 앞부분만 저장 (Pyre2 우회)
-                "error_msg": "".join(islice(str(e), 200)),
+                "error_msg": _safe_truncate_error_msg(e),
                 "security": "Traceback omitted for PII protection; error_msg truncated",
             },
         )
@@ -322,7 +334,7 @@ async def responder_node(state: AgentState) -> Dict[str, Any]:
             extra={
                 "error_type": type(e).__name__,
                 # PII 노출 방지를 위해 전체 메시지 대신 앞부분만 저장 (Pyre2 우회)
-                "error_msg": "".join(islice(str(e), 200)),
+                "error_msg": _safe_truncate_error_msg(e),
                 "security": "Traceback omitted for PII protection; error_msg truncated",
             },
         )


### PR DESCRIPTION
- **[Bug Fix]**: LLM이 인자 없는(Arg-less) 도구 호출 시 payload에 `null`을 반환할 때, `isinstance(..., dict)`가 동작하여 도구가 스킵(Skip)되는 버그 수정. `null` 반환 시 빈 dict(`{}`)로 치환하여 정상 동작을 보장하고 실질적 이상 타입(리스트, 정수 등)만 거르도록 개선.
- **[Debugging & PII]**:
  - Traceback 노출로 몽땅 제거했던 에러 로깅 기능(`str(e)`)을, 운영 환경의 최소한의 디버깅 가능성(Operational Debuggability) 확보를 위해 제한적 복구(`error_msg truncated`).
  - 에러 원문을 최대 200자까지만 자른 후 로깅에 남겨 PII 노출 보안성과 디버깅의 트레이드오프(Trade-off) 전략을 수용함.
- **[Static Analysis]**:
  - 문자열 슬라이싱에 대한 Pyre2의 오탐지(False Positive) 에러를 방지하기 위해, `[:200]` 대신 `"".join(islice(..., 200))`의 안전한 표준 함수형 포맷을 적용.

🔗 Related:
- Issue [#714]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/734#pullrequestreview-3952255185) - (Bug Risk, Suggestion 최종 반영)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

인수 없는 도구 디스패치 처리 문제를 수정하고, PII 보호가 적용된 안전한 오류 메시지 로깅을 복원합니다.

버그 수정:
- `null` 인수를 가진 인수 없는 도구 호출이, 예기치 않은 페이로드 타입 처리로 인해 건너뛰어지는 대신 빈 인수 호출로 처리되도록 보장합니다.

개선 사항:
- 운영상의 디버깅 가능성과 PII 보호 간의 균형을 맞추기 위해, 플래너와 리스폰더 오류에 대해 잘린 예외 메시지(안전한 접두사 길이까지)를 로깅합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix arg-less tool dispatch handling and restore safe error message logging with PII protection.

Bug Fixes:
- Ensure arg-less tool calls with null args are treated as empty-arg invocations instead of being skipped due to unexpected payload type handling.

Enhancements:
- Log truncated exception messages (up to a safe prefix) for planner and responder errors to balance operational debuggability with PII protection.

</details>