### PR TITLE
♻️ refactor [#11.5.2]: 20차 최종 개선 - 주석 무결성 확보 및 헬퍼 함수 안정성 고도화

### DIFF
--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -47,10 +47,17 @@ def _build_e164_exclusion_lookahead(max_digits: int) -> str:
     긴 숫자 시퀀스를 제외하기 위한 부정 룩어헤드 패턴을 생성합니다.
     
     Args:
-        max_digits: 허용되는 최대 숫자 자릿수 (양의 정수 가정)
+        max_digits: 허용되는 최대 숫자 자릿수. (정수형)
+
+    Raises:
+        ValueError: max_digits가 0 이하거나 정수 타입이 아닐 때 발생.
     """
+    # [Engineering Decision] 타입 및 값에 대한 엄격한 방어적 프로그래밍
+    if not isinstance(max_digits, int) or isinstance(max_digits, bool):
+        raise ValueError(f"max_digits must be an integer, but got {type(max_digits).__name__}: {max_digits}")
+    
     if max_digits <= 0:
-        raise ValueError("max_digits must be a positive integer.")
+        raise ValueError(f"max_digits must be a positive integer, but got: {max_digits}")
     return rf"""
     (?!                                         # [Negative Lookahead]
         (?:\D?\d){{{max_digits + 1},}}            # (구분자?\d) 패턴이 상한({max_digits}+1) 이상 반복 검사


### PR DESCRIPTION
- **[Comment Alignment]**: 정규식 인라인 주석 내에 남아있던 하드코딩된 숫자(`16자`)를 상수명(`_E164_MAX_DIGITS`) 참조 방식으로 변경하여 코드와 주석 간의 정보 불일치(Comment Drift) 가능성 원천 차단.
- **[Input Validation]**: `_build_e164_exclusion_lookahead` 헬퍼 함수에 양의 정수 검증 로직(`ValueError`)을 추가하고 Docstring에 명시적 인자 안내를 보강하여 함수의 견고성 향상.
- **[Engineering Integrity]**: 모듈 내 모든 상한선 로직과 기술 문서의 정보를 `_E164_MAX_DIGITS` 상수로 일원화함으로써 완벽한 단일 진실 공급원(SSoT) 원칙 달성.

🔗 Related:
- Issue [#714]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/746#pullrequestreview-3952784505) - (Single Source of Truth, Input Validation 종결)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

전화번호 패턴 헬퍼의 견고성을 강화하고, 인라인 문서를 E.164 숫자 제한 상수와 일치하도록 정렬합니다.

개선 사항:
- 입력 견고성을 높이기 위해 `_build_e164_exclusion_lookahead` 헬퍼에 인자에 대한 문서와 양의 정수 검증을 추가합니다.
- 코드와 문서 간의 불일치를 방지하기 위해 인라인 정규식 주석을 `_E164_MAX_DIGITS` 상수와 일치하도록 정렬합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen phone number pattern helper robustness and align inline documentation with the E.164 digit limit constant.

Enhancements:
- Add argument documentation and positive-integer validation to the _build_e164_exclusion_lookahead helper to improve input robustness.
- Align inline regex comment with the _E164_MAX_DIGITS constant to prevent divergence between code and documentation.

</details>