### PR TITLE
🩹 fix [#11.5.3]: 6차 개선 - cast(SerializedDoc) 적용 및 관찰성 강화

### DIFF
--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -61,7 +61,7 @@ def _normalize_doc(doc: Any) -> SerializedDoc:
     else:
         # 업스트림 스키마 변경이나 오류를 조기에 탐지하기 위해 경고 로깅
         logger.warning(
-            "[Tool] metadata가 dict가 아닌 타입. {}로 폴백",
+            "[Tool] metadata가 dict가 아닌 타입. 빈 dict로 폴백",
             extra={"metadata_type": type(raw_metadata).__name__},
         )
         metadata = {}


### PR DESCRIPTION
- **[backend/agent/chat/tools.py]**:
  - _normalize_doc 반환값에 cast(SerializedDoc, {...}) 명시 → 정적 타입 체커가 TypedDict 계약을 실제로 강제하도록 개선.
  - raw_metadata가 dict가 아닌 경우 조용히 {}로 대체하던 로직에 경고 로그 추가 → 업스트림 스키마 문제 조기 탐지 가능.
  - 경고 로그는 metadata_type(타입명)만 기록하여 PII 비노출 원칙 완전 준수.
  - 미사용 List 임포트 제거, cast 임포트 추가.

🔗 Related:
- Issue [#714]
- ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/760#pullrequestreview-3958089543)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.7 Pro

## Summary by Sourcery

도구 메타데이터 처리와 관련된 문서 정규화의 타입 안전성과 관측 가능성을 강화합니다.

버그 수정:
- 정적 타입 안전성을 높이기 위해 `_normalize_doc` 이 항상 `SerializedDoc` 규격을 따르는 값을 반환하도록 보장합니다.
- 상위 스키마 문제를 드러내기 위해 메타데이터가 dict 가 아닐 경우, 빈 메타데이터 객체로 조용히 대체하는 대신 경고 로그를 남기도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen document normalization typing and observability for tool metadata handling.

Bug Fixes:
- Ensure _normalize_doc always returns a value conforming to SerializedDoc for better static type safety.
- Log a warning when metadata is not a dict instead of silently falling back to an empty metadata object to surface upstream schema issues.

</details>