### PR TITLE
Feature/v7 phase3 agent

### DIFF
--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -1,7 +1,7 @@
 # backend/agent/chat/tools.py
 
 import logging
-from typing import Any, Dict, List, Optional, TypedDict
+from typing import Any, Dict, Optional, TypedDict, cast
 from langchain_core.tools import tool  # type: ignore[import, import-untyped, reportMissingImports]
 from backend.services.hybrid_search_service import get_hybrid_search_service  # type: ignore[import, import-untyped, reportMissingImports]
 
@@ -56,7 +56,15 @@ def _normalize_doc(doc: Any) -> SerializedDoc:
 
     # --- metadata 정규화: dict 보장 ---
     raw_metadata = doc.get("metadata", {}) if is_dict else getattr(doc, "metadata", {})
-    metadata: Dict[str, Any] = raw_metadata if isinstance(raw_metadata, dict) else {}
+    if isinstance(raw_metadata, dict):
+        metadata: Dict[str, Any] = raw_metadata
+    else:
+        # 업스트림 스키마 변경이나 오류를 조기에 탐지하기 위해 경고 로깅
+        logger.warning(
+            "[Tool] metadata가 dict가 아닌 타입. 빈 dict로 폴백",
+            extra={"metadata_type": type(raw_metadata).__name__},
+        )
+        metadata = {}
 
     # --- id 정규화: Optional[str] ---
     raw_id = doc.get("id") if is_dict else getattr(doc, "id", None)
@@ -77,12 +85,12 @@ def _normalize_doc(doc: Any) -> SerializedDoc:
             )
             normalized_score = None
 
-    return {
+    return cast(SerializedDoc, {
         "id": normalized_id,
         "score": normalized_score,
         "content": content,
         "metadata": metadata,
-    }
+    })
 
 
 @tool


### PR DESCRIPTION
🩹 fix [#11.5.3]: 6차 개선 - cast(SerializedDoc) 적용 및 관찰성 강화 
🩹 fix [#11.5.3]: 7차 개선 - logger.warning 메시지 내 잘못된 {} 플레이스홀더 수정

## Summary by Sourcery

채팅 도구에서 문서 정규화의 견고성을 높이기 위해 `SerializedDoc` 타입을 강제하고, 잘못된 메타데이터에 대한 관측 가능성을 추가합니다.

버그 수정:
- `_normalize_doc`이 항상 `SerializedDoc`으로 캐스팅된 값을 반환하도록 보장하여, 다운스트림 소비자에서 발생할 수 있는 타입 관련 문제를 방지합니다.
- 문서 메타데이터가 dict가 아닐 경우 경고를 로그로 남기고 빈 메타데이터 dict로 대체하여, 업스트림 스키마 변경으로 인해 발생할 수 있는 조용한 실패를 방지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve document normalization robustness in the chat tools by enforcing the SerializedDoc type and adding observability around malformed metadata.

Bug Fixes:
- Ensure _normalize_doc always returns a value cast to SerializedDoc to prevent type-related issues in downstream consumers.
- Log a warning and fall back to an empty metadata dict when document metadata is not a dict, avoiding silent failures from upstream schema changes.

</details>