### PR TITLE
🩹 fix [#11.5.3]: 8차 개선 - 경고 로그 컨텍스트 강화 및 cast 필요성 명시

### DIFF
--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -30,6 +30,16 @@ class SerializedDoc(TypedDict):
     metadata: Dict[str, Any]
 
 
+def _build_log_extra(doc_id: Optional[str], **kwargs: Any) -> Dict[str, Any]:
+    """
+    운영 로그용 extra 페이로드를 표준화하여 반환합니다.
+
+    doc_id를 모든 경고 로깅에 포함하면 발생 문서를 로그만으로 추적할 수 있습니다.
+    **kwargs로 상황별 추가 필드(metadata_type, score_type 등)를 자유롭게 추가합니다.
+    """
+    return {"doc_id": doc_id, **kwargs}
+
+
 def _normalize_doc(doc: Any) -> SerializedDoc:
     """
     검색 결과 문서(dict 또는 LangChain Document 유사 객체)를
@@ -49,8 +59,10 @@ def _normalize_doc(doc: Any) -> SerializedDoc:
     # --- id 정규화: Optional[str] — metadata 경고 로깅 콘텍스트를 위해 먼저 추출 ---
     raw_id = doc.get("id") if is_dict else getattr(doc, "id", None)
     normalized_id: Optional[str] = str(raw_id) if raw_id is not None else None
-    # [Security] id 값은 디버깅 컨텍스트이지만, 우연한 PII 포함 방지를 위해 50자로 잘라서 사용
-    _doc_id_for_log: Optional[str] = (str(normalized_id)[:50] if normalized_id is not None else None)  # type: ignore[index]
+    # [Security] normalized_id는 이미 Optional[str]이므로 str() 재래핑 불필요.
+    # 우연한 PII 포함 방지를 위해 50자로 잘라서 로깅 컨텍스트로만 활용.
+    # type: ignore[index]: is not None 가드가 있음에도 Pyre2가 str 슬라이스를 오판단하는 False Positive 우회.
+    _doc_id_for_log: Optional[str] = normalized_id[:50] if normalized_id is not None else None  # type: ignore[index]
 
     # --- content 정규화: str 보장 ---
     raw_content = (
@@ -68,7 +80,10 @@ def _normalize_doc(doc: Any) -> SerializedDoc:
         # 업스트림 스키마 변경이나 오류를 조기에 탐지하기 위해 경고 로깅 (doc_id 식별 콘텍스트 포함)
         logger.warning(
             "[Tool] metadata가 dict가 아닌 타입. 빈 dict로 폴백",
-            extra={"metadata_type": type(raw_metadata).__name__, "doc_id": _doc_id_for_log},
+            extra=_build_log_extra(
+                _doc_id_for_log,
+                metadata_type=type(raw_metadata).__name__,
+            ),
         )
         metadata = {}
 
@@ -83,7 +98,10 @@ def _normalize_doc(doc: Any) -> SerializedDoc:
         except (ValueError, TypeError):
             logger.warning(
                 "[Tool] score 정규화 실패, None으로 폴백",
-                extra={"score_type": type(raw_score).__name__, "doc_id": _doc_id_for_log},
+                extra=_build_log_extra(
+                    _doc_id_for_log,
+                    score_type=type(raw_score).__name__,
+                ),
             )
             normalized_score = None
 


### PR DESCRIPTION
- **[backend/agent/chat/tools.py]**:
  - id 추출 순서를 metadata 추출 이전으로 이동하여, metadata/score 경고 로그에 doc_id 컨텍스트 제공.
  - doc_id는 50자로 truncate하여 우연한 PII 노출 방지 (Security).
  - metadata/score 경고 로그에 doc_id 필드 추가 → 운영 시 이상 발생 문서 추적 용이.
  - cast(SerializedDoc, {...}) 에 [Engineering Decision] 주석 추가하여 Python TypedDict 구조적 한계에 의한 필요성과, 개별 필드가 이미 타입 검증된 사실을 문서화.

🔗 Related:
- Issue [#714]
- ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/762#pullrequestreview-3958123275)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.7 Pro

## Summary by Sourcery

문서 정규화 로깅 컨텍스트를 개선하고, TypedDict 캐스팅에 대한 근거를 문서화합니다.

개선 사항:
- 잠재적인 PII 노출을 제한하면서 문제 있는 문서를 식별할 수 있도록, 잘린(truncated) `doc_id` 컨텍스트를 메타데이터 및 점수 경고 로그에 포함합니다.
- 로깅에서 문서 식별자에 접근할 수 있도록, 메타데이터와 점수 처리보다 먼저 ID 추출이 수행되도록 순서를 재조정합니다.
- Python TypedDict 한계로 인해 `SerializedDoc`으로의 캐스트가 왜 필요하며 안전한지 설명하는 엔지니어링 결정 코멘트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve document normalization logging context and document the TypedDict cast rationale.

Enhancements:
- Include truncated doc_id context in metadata and score warning logs to aid in identifying problematic documents while limiting potential PII exposure.
- Reorder id extraction to occur before metadata and score handling so logging has access to the document identifier.
- Add an engineering decision comment explaining the necessity and safety of the cast to SerializedDoc given Python TypedDict limitations.

</details>