### PR TITLE
Feature/v7 phase3 agent

### DIFF
--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -30,6 +30,16 @@ class SerializedDoc(TypedDict):
     metadata: Dict[str, Any]
 
 
+def _build_log_extra(doc_id: Optional[str], **kwargs: Any) -> Dict[str, Any]:
+    """
+    운영 로그용 extra 페이로드를 표준화하여 반환합니다.
+
+    doc_id를 모든 경고 로깅에 포함하면 발생 문서를 로그만으로 추적할 수 있습니다.
+    **kwargs로 상황별 추가 필드(metadata_type, score_type 등)를 자유롭게 추가합니다.
+    """
+    return {"doc_id": doc_id, **kwargs}
+
+
 def _normalize_doc(doc: Any) -> SerializedDoc:
     """
     검색 결과 문서(dict 또는 LangChain Document 유사 객체)를
@@ -46,6 +56,14 @@ def _normalize_doc(doc: Any) -> SerializedDoc:
     """
     is_dict = isinstance(doc, dict)
 
+    # --- id 정규화: Optional[str] — metadata 경고 로깅 콘텍스트를 위해 먼저 추출 ---
+    raw_id = doc.get("id") if is_dict else getattr(doc, "id", None)
+    normalized_id: Optional[str] = str(raw_id) if raw_id is not None else None
+    # [Security] normalized_id는 이미 Optional[str]이므로 str() 재래핑 불필요.
+    # 우연한 PII 포함 방지를 위해 50자로 잘라서 로깅 컨텍스트로만 활용.
+    # type: ignore[index]: is not None 가드가 있음에도 Pyre2가 str 슬라이스를 오판단하는 False Positive 우회.
+    _doc_id_for_log: Optional[str] = normalized_id[:50] if normalized_id is not None else None  # type: ignore[index]
+
     # --- content 정규화: str 보장 ---
     raw_content = (
         doc.get("content", "")
@@ -59,16 +77,15 @@ def _normalize_doc(doc: Any) -> SerializedDoc:
     if isinstance(raw_metadata, dict):
         metadata: Dict[str, Any] = raw_metadata
     else:
-        # 업스트림 스키마 변경이나 오류를 조기에 탐지하기 위해 경고 로깅
+        # 업스트림 스키마 변경이나 오류를 조기에 탐지하기 위해 경고 로깅 (doc_id 식별 콘텍스트 포함)
         logger.warning(
             "[Tool] metadata가 dict가 아닌 타입. 빈 dict로 폴백",
-            extra={"metadata_type": type(raw_metadata).__name__},
+            extra=_build_log_extra(
+                _doc_id_for_log,
+                metadata_type=type(raw_metadata).__name__,
+            ),
         )
         metadata = {}
-
-    # --- id 정규화: Optional[str] ---
-    raw_id = doc.get("id") if is_dict else getattr(doc, "id", None)
-    normalized_id: Optional[str] = str(raw_id) if raw_id is not None else None
 
     # --- score 정규화: Optional[float] ---
     raw_score = doc.get("score") if is_dict else getattr(doc, "score", None)
@@ -81,10 +98,18 @@ def _normalize_doc(doc: Any) -> SerializedDoc:
         except (ValueError, TypeError):
             logger.warning(
                 "[Tool] score 정규화 실패, None으로 폴백",
-                extra={"score_type": type(raw_score).__name__},
+                extra=_build_log_extra(
+                    _doc_id_for_log,
+                    score_type=type(raw_score).__name__,
+                ),
             )
             normalized_score = None
 
+    # [Engineering Decision] Python TypedDict의 구조적 한계로 인해 반환 시 dict 리터럴은
+    # 타입 체커가 SerializedDoc 계약을 자동 검증하지 않습니다.
+    # 이 cast는 해당 단언이 필요하지만, 부정확한 cast가 아닙니다:
+    # 반환 지점에 도달하는 모든 필드(normalized_id, normalized_score, content, metadata)는
+    # 각각 위에서 명시적으로 타입 어노테이션되었으므로 mypy가 해당 시점까지 개별 유효성을 검증합니다.
     return cast(SerializedDoc, {
         "id": normalized_id,
         "score": normalized_score,


### PR DESCRIPTION
🩹 fix [#11.5.3]: 8차 개선 - 경고 로그 컨텍스트 강화 및 cast 필요성 명시 
♻️ refactor [#11.5.3]: 9차 개선 - 로그 extra 헬퍼 추출 및 불필요한 캐스팅 제거

## Summary by Sourcery

문서 정규화 경고에 대한 로깅 컨텍스트를 표준화하고, `SerializedDoc` 반환 값과 관련된 타입 안정성(type-safety) 결정 사항을 명확히 합니다.

개선 사항:
- 항상 잘린(truncated) 문서 ID를 포함하는 구조화된 로그 `extra` 페이로드를 생성하기 위한 헬퍼를 도입하여 추적 용이성을 높였습니다.
- 메타데이터 및 점수(score) 정규화에 대한 경고 로그를 확장하여 문서 식별자와 타입이 지정된 컨텍스트 필드를 포함하도록 했습니다.
- 정규화된 문서를 반환할 때 `TypedDict` 캐스트를 사용하는 이유를 문서화하고 정당화하여, 타입 체크에 이것이 왜 필요한지 명확히 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize logging context for document normalization warnings and clarify type-safety decisions around the SerializedDoc return value.

Enhancements:
- Introduce a helper to build structured log extra payloads that always include a truncated document ID for easier traceability.
- Expand warning logs for metadata and score normalization to include document identifiers and typed context fields.
- Document and justify the use of a TypedDict cast when returning normalized documents to clarify its necessity for type checking.

</details>