### PR TITLE
♻️ refactor [#11.5.3]: 10차 개선 - 매직넘버 상수화, isinstance 가드 도입, 로그 헬퍼 일관 적용

### DIFF
--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -61,11 +61,15 @@ def _normalize_doc(doc: Any) -> SerializedDoc:
     # --- id 정규화: Optional[str] — metadata 경고 로깅 콘텍스트를 위해 먼저 추출 ---
     raw_id = doc.get("id") if is_dict else getattr(doc, "id", None)
     normalized_id: Optional[str] = str(raw_id) if raw_id is not None else None
-    # [Security] isinstance 가드로 Pyre2 타입 좁히기 시도. _MAX_LOG_DOC_ID_LEN으로 잘라 PII 방지.
+    # [주의] normalized_id는 위 63행에서 str(raw_id)로 코어션되었으므로 항상 str | None.
+    # → isinstance(normalized_id, str)은 사실상 "normalized_id is not None"과 동일.
+    # → int, UUID 등 비-str raw_id도 이미 str()로 변환된 뒤 이 가드에 도달하므로 로깅에서 탈락하지 않음.
+    # [Security] _MAX_LOG_DOC_ID_LEN으로 잘라 PII 방지.
     # type: ignore[index]: isinstance(str) 블록 내에서도 Pyre2가 str 슬라이스를 오판단하는 알려진 False Positive.
     if isinstance(normalized_id, str):
         _doc_id_for_log: Optional[str] = normalized_id[:_MAX_LOG_DOC_ID_LEN]  # type: ignore[index]
     else:
+        # raw_id가 None이었을 때만 이 분기에 도달 (str() 코어션 보장에 의해 str 탈락 없음)
         _doc_id_for_log = None
 
     # --- content 정규화: str 보장 ---


### PR DESCRIPTION
- **[backend/agent/chat/tools.py]**:
  - _MAX_LOG_DOC_ID_LEN = 50 상수 추출: PII 경계값을 모듈 상단에 명시적으로 정의.
  - _doc_id_for_log에 isinstance(str) 분기 도입: Pyre2 type narrowing 우선 시도. 단, isinstance 블록 내에서도 str 슬라이스를 오판단하는 Pyre2 알려진 버그로 인해 type: ignore[index]는 슬라이스 표현식 한 줄만 최소 범위로 유지 (사유 주석 명시).
  - logger.error에도 _build_log_extra(None, ...) 적용하여 모듈 내 로그 extra 구조 완전 통일.

🔗 Related:
- Issue [#714]
- ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/764#pullrequestreview-3958160154)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.7 Pro

## Summary by Sourcery

채팅 도구 모듈에서 문서 로깅 동작을 개선하고 오류 로깅 메타데이터를 정렬합니다.

개선 사항:
- PII 경계 설정을 중앙에서 관리하기 위해, 로그에 기록 가능한 `doc_id` 길이의 최대값에 대한 전용 상수를 도입합니다.
- PII 노출을 줄이고 타입 체크를 충족하기 위해, `isinstance` 검사와 표준화된 잘림 길이(truncation length)로 `doc_id` 정규화를 보호합니다.
- 모듈 전반에서 로그의 `extra` 구조를 통일하기 위해, 문서 검색 오류 로깅에 공용 헬퍼인 `_build_log_extra`를 사용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine document logging behavior and align error logging metadata in the chat tools module.

Enhancements:
- Introduce a dedicated constant for maximum loggable doc_id length to centralize PII boundary configuration.
- Guard doc_id normalization with an isinstance check and standardized truncation length to reduce PII exposure and satisfy type checking.
- Use the shared _build_log_extra helper for error logging in document search to unify log extra structures across the module.

</details>