### PR TITLE
Feature/v7 phase3 agent

### DIFF
--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -9,6 +9,8 @@ logger = logging.getLogger(__name__)
 
 # 도구 내 단일 문서 최대 길이 상수 (하드코딩 방지)
 _MAX_DOC_CONTENT_CHARS = 1_000
+# [Security] 로그에 포함되는 doc_id의 최대 길이 제한 (PII 경계값 명시)
+_MAX_LOG_DOC_ID_LEN = 50
 
 
 class SerializedDoc(TypedDict):
@@ -59,10 +61,16 @@ def _normalize_doc(doc: Any) -> SerializedDoc:
     # --- id 정규화: Optional[str] — metadata 경고 로깅 콘텍스트를 위해 먼저 추출 ---
     raw_id = doc.get("id") if is_dict else getattr(doc, "id", None)
     normalized_id: Optional[str] = str(raw_id) if raw_id is not None else None
-    # [Security] normalized_id는 이미 Optional[str]이므로 str() 재래핑 불필요.
-    # 우연한 PII 포함 방지를 위해 50자로 잘라서 로깅 컨텍스트로만 활용.
-    # type: ignore[index]: is not None 가드가 있음에도 Pyre2가 str 슬라이스를 오판단하는 False Positive 우회.
-    _doc_id_for_log: Optional[str] = normalized_id[:50] if normalized_id is not None else None  # type: ignore[index]
+    # [주의] normalized_id는 위 63행에서 str(raw_id)로 코어션되었으므로 항상 str | None.
+    # → isinstance(normalized_id, str)은 사실상 "normalized_id is not None"과 동일.
+    # → int, UUID 등 비-str raw_id도 이미 str()로 변환된 뒤 이 가드에 도달하므로 로깅에서 탈락하지 않음.
+    # [Security] _MAX_LOG_DOC_ID_LEN으로 잘라 PII 방지.
+    # type: ignore[index]: isinstance(str) 블록 내에서도 Pyre2가 str 슬라이스를 오판단하는 알려진 False Positive.
+    if isinstance(normalized_id, str):
+        _doc_id_for_log: Optional[str] = normalized_id[:_MAX_LOG_DOC_ID_LEN]  # type: ignore[index]
+    else:
+        # raw_id가 None이었을 때만 이 분기에 도달 (str() 코어션 보장에 의해 str 탈락 없음)
+        _doc_id_for_log = None
 
     # --- content 정규화: str 보장 ---
     raw_content = (
@@ -178,6 +186,6 @@ async def search_documents_tool(query: str, k: int = 5) -> dict:
         # → 경로·서비스명·인프라 정보 누출 방지
         logger.error(
             "[Tool] 검색 중 오류 발생",
-            extra={"error_type": type(e).__name__}
+            extra=_build_log_extra(None, error_type=type(e).__name__),
         )
         return {"context": "문서 검색 중 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.", "docs": []}


### PR DESCRIPTION
♻️ refactor [#11.5.3]: 10차 개선 - 매직넘버 상수화, isinstance 가드 도입, 로그 헬퍼 일관 적용 
📝 docs [#11.5.3]: 11차 개선 - isinstance 가드 의도 명확화 주석 추가

## Summary by Sourcery

문서 검색 도구의 문서 정규화 로깅 안전장치와 오류 로깅 컨텍스트를 개선합니다.

개선 사항:
- 로그에 기록할 수 있는 문서 ID 길이의 최대값에 대한 명명된 상수를 도입하고, 로그용으로 ID를 잘라낼 때 이를 적용하여 PII(개인 식별 정보) 유출을 더 잘 방지합니다.
- 최신 인라인 주석을 통해 정규화된 문서 ID 주변의 `isinstance` 가드 의도와 로깅 동작을 명확히 합니다.
- 문서 검색 오류 로깅이 공용 log-extra 빌더를 일관되게 사용하도록 업데이트하여, 더 풍부하고 균일한 로그 컨텍스트를 제공합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine document normalization logging safeguards and error logging context for the document search tool.

Enhancements:
- Introduce a named constant for the maximum loggable document ID length and apply it when truncating IDs for logging to better guard against PII leakage.
- Clarify the intent of isinstance guards and logging behavior around normalized document IDs through updated inline comments.
- Update document search error logging to consistently use the shared log-extra builder for richer and more uniform log context.

</details>