### PR TITLE
Feature/v7 phase3 agent

### DIFF
--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -95,7 +95,7 @@ class TestChatAgent(unittest.IsolatedAsyncioTestCase):
         result = await planner_node(state)
         
         # Verify State Update
-        self.assertIn("3/18 업무 보고서", result.get("search_context", ""))
+        self.assertIn("업무 보고서", result.get("search_context", ""))
         self.assertEqual(len(result.get("source_documents", [])), 1)
         self.assertFalse(result.get("planner_failed", False))
         
@@ -121,9 +121,15 @@ class TestChatAgent(unittest.IsolatedAsyncioTestCase):
         # Execute
         result = await planner_node(state)
         
-        # Verify Failure State
+        # Verify Failure State (Atomic Update Check)
         self.assertTrue(result.get("planner_failed"))
+        # 오류 메시지 전체 매칭 대신 핵심 키워드 유무만 확인하여 결합도 낮춤
         self.assertIn("오류가 발생했습니다", str(result.get("planner_error_message", "")))
+        
+        # [Strict Check] 실패 시 검색 문맥이나 문서 목록이 오염되지 않았는지(입력 상태 유지) 검증
+        # 하드코딩된 "" 이나 [] 대신 입력값과 직접 비교하여 기본값 변경에 유연하게 대응
+        self.assertEqual(result.get("search_context"), state.get("search_context"))
+        self.assertEqual(result.get("source_documents"), state.get("source_documents"))
 
     @patch("backend.agent.chat.nodes.get_chat_service")
     async def test_responder_node_state_transition(self, mock_get_svc):
@@ -131,13 +137,12 @@ class TestChatAgent(unittest.IsolatedAsyncioTestCase):
         # Mock ChatService & LLM
         mock_svc = MagicMock()
         mock_llm = MagicMock()
-        mock_llm.ainvoke = AsyncMock()
+        # Mock LLM response - AsyncMock 생성 시 return_value를 즉시 할당하여 중복 제거
+        mock_llm.ainvoke = AsyncMock(return_value=AIMessage(content="보고서에 따르면 프로젝트 A가 진행 중입니다."))
+        
         mock_get_svc.return_value = mock_svc
         mock_svc._get_llm.return_value = mock_llm
         mock_svc._get_user_context_prompt_text.return_value = "User is a manager."
-        
-        # Mock LLM response
-        mock_llm.ainvoke.return_value = AIMessage(content="보고서에 따르면 프로젝트 A가 진행 중입니다.")
         
         state = copy.deepcopy(self.base_state)
         state["search_context"] = "프로젝트 A 진행 중."
@@ -145,8 +150,8 @@ class TestChatAgent(unittest.IsolatedAsyncioTestCase):
         
         result = await responder_node(state)
         
-        # Verify State Update
-        self.assertEqual(result.get("final_answer"), "보고서에 따르면 프로젝트 A가 진행 중입니다.")
+        # Verify State Update - 핵심 의미 포함 여부만 확인
+        self.assertIn("프로젝트 A", result.get("final_answer", ""))
         
         # Null Safety check for message list
         ans_messages = result.get("messages", [])


### PR DESCRIPTION
☘️ refactor [#11.5.4]: 3차 개선 - 상태 원자성 검증 및 Mock 로직 최적화 
☘️ refactor [#11.5.4]: 4차 개선 - 탄력적 상태 검증 및 문자열 결합도 완화

## Summary by Sourcery

플래너 실패 시 상태의 원자성을 검증하고, 모의 LLM 설정을 단순화하면서 정확한 문자열 출력에 대한 결합도를 낮추도록 챗 에이전트 테스트를 개선합니다.

Tests:
- 플래너 및 응답자 노드 테스트에서 문자열 단언을 완화하여 전체 메시지 일치 대신 핵심 구문(키 프레이즈)을 검사하도록 변경.
- `planner_node`에서의 실패가 입력 상태의 검색 컨텍스트나 소스 문서를 변경하지 않는다는 점을 명시적으로 검증하는 체크를 추가.
- `AsyncMock`의 반환 값을 생성 시점에 설정하여 응답자 노드 LLM 모킹을 단순화.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve chat agent tests to validate state atomicity on planner failures and reduce coupling to exact string outputs while simplifying mock LLM setup.

Tests:
- Relax string assertions in planner and responder node tests to check for key phrases instead of full message matches.
- Add explicit checks that failure in planner_node does not mutate search context or source documents from the input state.
- Simplify responder node LLM mocking by configuring AsyncMock return values at creation time.

</details>