### PR TITLE
✨ feat [#11.5.7]: 점진적 마크다운 파싱(Incremental Parsing) 로직 도입

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -350,8 +350,13 @@ export function ChatWindow() {
           onScrollCapture={handleScrollManual}
         >
           <div className="flex flex-col gap-0 w-full max-w-4xl mx-auto p-4 py-8">
-            {messages.map((m: UIMessage) => (
-              <MessageBubble key={m.id} message={m} />
+            {messages.map((m: UIMessage, idx: number) => (
+              <MessageBubble 
+                key={m.id} 
+                message={m} 
+                isLast={idx === messages.length - 1} 
+                isStreaming={status === 'streaming'}
+              />
             ))}
 
             {error && (

--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -14,6 +14,8 @@ import type { Components } from 'react-markdown';
 
 interface MessageBubbleProps {
   message: UIMessage;
+  isLast?: boolean;
+  isStreaming?: boolean;
 }
 
 // react-markdown v10 code 컴포넌트 타입
@@ -132,9 +134,13 @@ function extractSources(metadata: UIMessage['metadata'] | undefined): SourceItem
 }
 
 /** 
- * [Pure Function] 텍스트 가공 및 인용 링크 변환 (리뷰 반영)
+ * [Pure Function] 텍스트 가공 및 인용 링크 변환 (리뷰 반영) 
  */
-function buildProcessedContent(parts: UIMessage['parts'], isUser: boolean): string {
+function buildProcessedContent(
+  parts: UIMessage['parts'], 
+  isUser: boolean,
+  shouldPatch: boolean
+): string {
   const textContent = getTextContent(parts);
 
   if (isUser) return textContent;
@@ -144,19 +150,27 @@ function buildProcessedContent(parts: UIMessage['parts'], isUser: boolean): stri
     return code ? code : `[${num}](cite:${num})`;
   });
 
-  // 2. 점진적 파싱 보호 (코드 블록 등 유효하지 않은 마크다운 구조 보완)
-  return patchPartialMarkdown(citedContent);
+  // 2. 점진적 파싱 보호 (스트리밍 중인 경우에만 한정적으로 수행)
+  return shouldPatch ? patchPartialMarkdown(citedContent) : citedContent;
 }
 
 /**
  * [Pure Function] 점진적 파싱 보강 (Incremental Parsing Protection)
- * 스트리밍 중 깨지는 마크다운 구조(코드 블록 등)를 임시로 닫아 렌더링 안정성을 확보합니다.
+ * 라인 단위 상태 추적을 통해 코드 블록이 열려 있는 경우에만 임시로 닫아 줍니다.
  */
 function patchPartialMarkdown(markdown: string): string {
-  // 1. 코드 블록 (```) 홀수 개수 확인 및 자동 닫기
-  const codeBlockCount = (markdown.match(/```/g) || []).length;
-  if (codeBlockCount % 2 !== 0) {
-    // 팁: 마지막 ``` 뒤에 개행이 없는 경우를 대비해 유연하게 줄바꿈 추가
+  const lines = markdown.split('\n');
+  let inCodeBlock = false;
+  
+  for (const line of lines) {
+    // 팁: 마크다운 표준에 따라 줄 시작 부분이 3개 이상의 백틱이면 코드 블록 토글
+    if (line.trim().startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+    }
+  }
+
+  if (inCodeBlock) {
+    // 코드 블록이 열린 채로 끝났다면 닫는 펜스를 추가하여 렌더링 깨짐 방지
     return markdown + '\n\n```';
   }
   
@@ -185,7 +199,7 @@ function FallbackCitation({
 }
 
 export const MessageBubble = memo(
-  function MessageBubble({ message }: MessageBubbleProps) {
+  function MessageBubble({ message, isLast = false, isStreaming = false }: MessageBubbleProps) {
     const isUser = message.role === 'user';
 
 
@@ -291,10 +305,10 @@ export const MessageBubble = memo(
     },
   };
 
-  // [Performance] 순수 함수와 useMemo를 결합한 콘텐츠 변환 (가독성 향상)
+  // [Performance] 순수 함수와 useMemo를 결합한 콘텐츠 변환
   const processedContent = useMemo(
-    () => buildProcessedContent(message.parts, isUser),
-    [message.parts, isUser]
+    () => buildProcessedContent(message.parts, isUser, isLast && isStreaming),
+    [message.parts, isUser, isLast, isStreaming]
   );
 
   return (
@@ -374,13 +388,17 @@ export const MessageBubble = memo(
   );
   },
   (prev, next) => {
-    // 1. 객체 참조가 같으면 즉시 트루 (가장 빠른 비교)
+    // 1. Prop 기반 상태 변화 체크 (마크다운 파싱 가드 상태 전환용)
+    if (prev.isLast !== next.isLast) return false;
+    if (prev.isStreaming !== next.isStreaming) return false;
+
+    // 2. 객체 참조가 같으면 즉시 트루 (가장 빠른 비교)
     if (prev.message === next.message) return true;
 
-    // 2. ID가 다르면 무조건 리렌더링
+    // 3. ID가 다르면 무조건 리렌더링
     if (prev.message.id !== next.message.id) return false;
     
-    // 3. [PR 리뷰 반영] 간결하고 명확한 도메인 헬퍼 기반 비교
+    // 4. [PR 리뷰 반영] 간결하고 명확한 도메인 헬퍼 기반 비교
     if (!areTextPartsEqual(prev.message.parts, next.message.parts)) return false;
     if (!areSourcesEqual(prev.message.metadata, next.message.metadata)) return false;
 


### PR DESCRIPTION
- **[MessageBubble.tsx]**:
  - [마크다운 보호]: 스트리밍 중 열려 있는 코드 블록(```)을 감지하여 자동으로 닫아주는 patchPartialMarkdown 헬퍼 추가.
  - [UX 개선]: AI 응답 도중 코드 블록이 깨져서 텍스트로 노출되거나 레이아웃이 출렁이는 현상 원천 차단.
  - [통합]: buildProcessedContent 내에서 가공된 텍스트에 파싱 가드 적용.

🔗 Related: Issue [#775]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

스트리밍되는 AI 메시지 콘텐츠에 대해 점진적인 마크다운 파싱 보호를 도입하여 깨진 코드 블록 렌더링을 방지합니다.

새 기능:
- 부분적으로 스트리밍된 마크다운 콘텐츠에서 균형이 맞지 않는 코드 펜스를 자동으로 닫기 위한 `patchPartialMarkdown` 헬퍼를 추가합니다.

개선 사항:
- 스트리밍 중 렌더링을 안정화하기 위해 메시지 처리 과정에서 인라인 인용 변환 이후에 마크다운 패칭을 적용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce incremental markdown parsing protection for streamed AI message content to prevent broken code block rendering.

New Features:
- Add a patchPartialMarkdown helper to automatically close unbalanced code fences in partially streamed markdown content.

Enhancements:
- Apply markdown patching after inline citation transformation in message processing to stabilize rendering during streaming.

</details>