### PR TITLE
Feature/v7 phase3 agent

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -350,8 +350,13 @@ export function ChatWindow() {
           onScrollCapture={handleScrollManual}
         >
           <div className="flex flex-col gap-0 w-full max-w-4xl mx-auto p-4 py-8">
-            {messages.map((m: UIMessage) => (
-              <MessageBubble key={m.id} message={m} />
+            {messages.map((m: UIMessage, idx: number) => (
+              <MessageBubble 
+                key={m.id} 
+                message={m} 
+                isLast={idx === messages.length - 1} 
+                isStreaming={status === 'streaming'}
+              />
             ))}
 
             {error && (

--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -14,6 +14,8 @@ import type { Components } from 'react-markdown';
 
 interface MessageBubbleProps {
   message: UIMessage;
+  isLast?: boolean;
+  isStreaming?: boolean;
 }
 
 // react-markdown v10 code 컴포넌트 타입
@@ -132,17 +134,49 @@ function extractSources(metadata: UIMessage['metadata'] | undefined): SourceItem
 }
 
 /** 
- * [Pure Function] 텍스트 가공 및 인용 링크 변환 (리뷰 반영)
+ * [Pure Function] 텍스트 가공 및 인용 링크 변환 (리뷰 반영) 
  */
-function buildProcessedContent(parts: UIMessage['parts'], isUser: boolean): string {
+function buildProcessedContent(
+  parts: UIMessage['parts'], 
+  isUser: boolean,
+  shouldPatch: boolean
+): string {
   const textContent = getTextContent(parts);
 
   if (isUser) return textContent;
 
-  return textContent.replace(INLINE_CITATION_REGEX, (match, code, num) => {
+  // 1. 인용 변환
+  const citedContent = textContent.replace(INLINE_CITATION_REGEX, (match, code, num) => {
     return code ? code : `[${num}](cite:${num})`;
   });
+
+  // 2. 점진적 파싱 보호 (스트리밍 중인 경우에만 한정적으로 수행)
+  return shouldPatch ? patchPartialMarkdown(citedContent) : citedContent;
 }
+
+/**
+ * [Pure Function] 점진적 파싱 보강 (Incremental Parsing Protection)
+ * 라인 단위 상태 추적을 통해 코드 블록이 열려 있는 경우에만 임시로 닫아 줍니다.
+ */
+function patchPartialMarkdown(markdown: string): string {
+  const lines = markdown.split('\n');
+  let inCodeBlock = false;
+  
+  for (const line of lines) {
+    // 팁: 마크다운 표준에 따라 줄 시작 부분이 3개 이상의 백틱이면 코드 블록 토글
+    if (line.trim().startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+    }
+  }
+
+  if (inCodeBlock) {
+    // 코드 블록이 열린 채로 끝났다면 닫는 펜스를 추가하여 렌더링 깨짐 방지
+    return markdown + '\n\n```';
+  }
+  
+  return markdown;
+}
+
 
 /**
  * [Refactoring] 유효하지 않거나 누락된 인용 소스에 대한 일관된 폴백 렌더러
@@ -165,7 +199,7 @@ function FallbackCitation({
 }
 
 export const MessageBubble = memo(
-  function MessageBubble({ message }: MessageBubbleProps) {
+  function MessageBubble({ message, isLast = false, isStreaming = false }: MessageBubbleProps) {
     const isUser = message.role === 'user';
 
 
@@ -271,10 +305,10 @@ export const MessageBubble = memo(
     },
   };
 
-  // [Performance] 순수 함수와 useMemo를 결합한 콘텐츠 변환 (가독성 향상)
+  // [Performance] 순수 함수와 useMemo를 결합한 콘텐츠 변환
   const processedContent = useMemo(
-    () => buildProcessedContent(message.parts, isUser),
-    [message.parts, isUser]
+    () => buildProcessedContent(message.parts, isUser, isLast && isStreaming),
+    [message.parts, isUser, isLast, isStreaming]
   );
 
   return (
@@ -354,13 +388,17 @@ export const MessageBubble = memo(
   );
   },
   (prev, next) => {
-    // 1. 객체 참조가 같으면 즉시 트루 (가장 빠른 비교)
+    // 1. Prop 기반 상태 변화 체크 (마크다운 파싱 가드 상태 전환용)
+    if (prev.isLast !== next.isLast) return false;
+    if (prev.isStreaming !== next.isStreaming) return false;
+
+    // 2. 객체 참조가 같으면 즉시 트루 (가장 빠른 비교)
     if (prev.message === next.message) return true;
 
-    // 2. ID가 다르면 무조건 리렌더링
+    // 3. ID가 다르면 무조건 리렌더링
     if (prev.message.id !== next.message.id) return false;
     
-    // 3. [PR 리뷰 반영] 간결하고 명확한 도메인 헬퍼 기반 비교
+    // 4. [PR 리뷰 반영] 간결하고 명확한 도메인 헬퍼 기반 비교
     if (!areTextPartsEqual(prev.message.parts, next.message.parts)) return false;
     if (!areSourcesEqual(prev.message.metadata, next.message.metadata)) return false;
 


### PR DESCRIPTION
✨ feat [#11.5.7]: 점진적 마크다운 파싱(Incremental Parsing) 로직 도입 
☘️ refactor [#11.5.7]: 1차 개선 - 점진적 마크다운 파싱 고도화 및 스트리밍 가드 적용

## Summary by Sourcery

스트리밍 어시스턴트 메시지에 대해 점진적인 마크다운 파싱 보호 기능을 도입하고, 이를 채팅 메시지 렌더링 흐름에 연결합니다.

New Features:
- 부분적으로 스트리밍된 콘텐츠에 대해 균형이 맞지 않는 코드 블록을 임시로 닫아 주는 점진적 마크다운 파싱 가드(incremental markdown parsing guard)를 추가합니다.

Enhancements:
- `MessageBubble`이 스트리밍 상태를 전달받도록 확장하고, 마지막 스트리밍 어시스턴트 메시지에만 인용(citation) 변환과 부분 마크다운 패칭(partial-markdown patching)을 적용하도록 합니다.
- 스트리밍 관련 props를 고려하면서도 불필요한 재렌더링을 피할 수 있도록 `MessageBubble`의 메모이제이션을 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce incremental markdown parsing protection for streaming assistant messages and wire it through chat message rendering.

New Features:
- Add incremental markdown parsing guard that temporarily closes unbalanced code blocks for partially streamed content.

Enhancements:
- Extend MessageBubble to receive streaming state and apply citation transformation plus partial-markdown patching only on the last streaming assistant message.
- Refine MessageBubble memoization to account for streaming-related props while avoiding unnecessary re-renders.

</details>