### PR TITLE
☘️ refactor [#11.5.7]: 4차 개선 - 아키텍처 계층 정립 및 URL/렌더링 버그 수정

### DIFF
--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -9,7 +9,8 @@ import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import type { UIMessage } from 'ai';
-import { SourcePanel, SourceItem } from './SourcePanel';
+import { SourcePanel } from './SourcePanel';
+import { type SourceItem } from '@/types/chat';
 import type { Components } from 'react-markdown';
 import { stabilizeIncompleteMarkdown } from '@/lib/markdown';
 import { 
@@ -69,8 +70,9 @@ function areMessageBubblePropsEqual(prev: MessageBubbleProps, next: MessageBubbl
   // 2. 메시지 객체 참조 동일성 (가장 빠른 레퍼런스 체크)
   if (prev.message === next.message) return true;
 
-  // 3. 메시지 ID 동일성
+  // 3. 메시지 ID 또는 역할 동일성 (역할 변경 시 스타일이 바뀌어야 함)
   if (prev.message.id !== next.message.id) return false;
+  if (prev.message.role !== next.message.role) return false;
   
   // 4. 의미적 콘텐츠 동등성 (텍스트 파트 및 소스 리스트)
   if (!areTextPartsEqual(prev.message.parts, next.message.parts)) return false;

--- a/web_ui/src/components/chat/SourcePanel.tsx
+++ b/web_ui/src/components/chat/SourcePanel.tsx
@@ -11,15 +11,7 @@ import {
 } from '@/components/ui/sheet';
 import { Badge } from '@/components/ui/badge';
 import { ScrollArea } from '@/components/ui/scroll-area';
-
-export interface SourceItem {
-  id?: string;
-  score?: number;
-  page_content?: string;
-  source?: string;
-  title?: string;
-  [key: string]: unknown;
-}
+import { type SourceItem } from '@/types/chat';
 
 interface SourcePanelProps {
   source: SourceItem | null;

--- a/web_ui/src/lib/chat-utils.ts
+++ b/web_ui/src/lib/chat-utils.ts
@@ -1,5 +1,5 @@
 import type { UIMessage } from 'ai';
-import { SourceItem } from '@/components/chat/SourcePanel';
+import { type SourceItem } from '@/types/chat';
 
 /**
  * [Constants] 인용 및 텍스트 처리 정규식

--- a/web_ui/src/lib/i18n-utils.ts
+++ b/web_ui/src/lib/i18n-utils.ts
@@ -9,17 +9,20 @@ import { type Locale, locales } from '@/i18n/config';
 export function createPathWithLocale(pathname: string, newLocale: Locale): string {
   if (!pathname) return '/';
 
-  const segments = pathname.split('/');
+  // [PR 리뷰 반영] pathname에 쿼리 스트링이나 해시가 포함된 경우를 분리 처리
+  const [purePathname, ...rest] = pathname.split(/(\?|#)/);
+  const suffix = rest.join('');
+
+  const segments = purePathname.split('/');
   
   // Helper Check: 루트 경로인지 확인
-  // pathname이 '/' 일 때 split('/') 결과는 ['', ''] 입니다.
   const isRootPath = segments.length === 2 && segments[1] === '';
 
   if (isRootPath) {
     // 루트 경로인 경우, 빈 문자열 세그먼트를 새 로케일로 교체하여
     // 불필요한 Trailing Slash 방지 (예: /ko/ 대신 /ko 생성)
     segments[1] = newLocale;
-    return segments.join('/');
+    return segments.join('/') + suffix;
   }
 
   // 동적으로 현재 로케일 세그먼트 위치 탐색
@@ -34,5 +37,5 @@ export function createPathWithLocale(pathname: string, newLocale: Locale): strin
     segments.splice(1, 0, newLocale);
   }
 
-  return segments.join('/');
+  return segments.join('/') + suffix;
 }

--- a/web_ui/src/types/chat.ts
+++ b/web_ui/src/types/chat.ts
@@ -1,0 +1,11 @@
+/**
+ * [Type] 채팅에서 참조되는 개별 문서(Source) 아이템의 구조를 정의합니다.
+ */
+export interface SourceItem {
+  id?: string;
+  score?: number;
+  page_content?: string;
+  source?: string;
+  title?: string;
+  [key: string]: unknown;
+}


### PR DESCRIPTION
- **[types]**: shared chat 타입 레이어 신설 및 SourceItem 이동 (계층 구조 위반 해결).
- **[i18n-utils]**: createPathWithLocale에서 Query/Hash 소실 방지 로직 도입.
- **[MessageBubble]**: props 비교 시 role 체크 추가하여 렌더링 정합성 확보.
- **[SourcePanel/chat-utils]**: 신규 타입 레이어 참조로 변경.

🔗 Related:
- Issue [#775]
- ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/801#pullrequestreview-3973271464)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro