### PR TITLE
🩹 fix [#11.5.10]: 2차 개선 - 접근성 강화 및 에러 피드백 UI 재도입

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -156,7 +156,7 @@ export function ChatWindow() {
     },
   }), [userId, sessionId, alpha, scrollToBottom]);
 
-  const { messages, sendMessage, status, setMessages } = useChat(chatOptions);
+  const { messages, sendMessage, status, setMessages, error } = useChat(chatOptions);
 
   useEffect(() => {
     if (!sessionId) return;
@@ -182,7 +182,13 @@ export function ChatWindow() {
           });
 
           if (data.messages && data.messages.length > 0) {
-            const historyMessages: UIMessage[] = data.messages.map((m: any, index: number) => ({
+            interface HistoryMessage {
+              role: 'assistant' | 'user';
+              content: string;
+              timestamp?: string | number;
+            }
+
+            const historyMessages: UIMessage[] = data.messages.map((m: HistoryMessage, index: number) => ({
               id: `hist-${index}-${sessionId}`,
               role: m.role,
               parts: [{ type: 'text', text: m.content }],
@@ -220,7 +226,11 @@ export function ChatWindow() {
       if (!res.ok) throw new Error('Failed to clear history');
 
       const newSid = generateId('sess');
-      localStorage.setItem(STORAGE_KEYS.CHAT_SESSION_ID, newSid);
+      try {
+        localStorage.setItem(STORAGE_KEYS.CHAT_SESSION_ID, newSid);
+      } catch (err) {
+        console.warn('[Storage] Failed to update session_id in localStorage:', err);
+      }
       setSessionId(newSid);
       setMessages([WELCOME_MESSAGE]);
       toast.success('대화가 초기화되었습니다.');
@@ -311,6 +321,20 @@ export function ChatWindow() {
                 isStreaming={status === 'streaming'}
               />
             ))}
+            {error && (
+              <div className="p-4 mb-4 bg-red-50 border border-red-100 rounded-xl text-xs text-red-600 flex items-center gap-2 animate-in fade-in slide-in-from-top-2">
+                <span className="font-bold">Error:</span>
+                <span>{error.message || '메시지 전송 중 오류가 발생했습니다.'}</span>
+                <Button 
+                  variant="ghost" 
+                  size="sm" 
+                  onClick={() => handleSubmit()} 
+                  className="ml-auto h-6 text-[10px] hover:bg-red-100"
+                >
+                  재시도
+                </Button>
+              </div>
+            )}
             <div className="h-4" />
           </div>
         </ScrollArea>
@@ -319,6 +343,7 @@ export function ChatWindow() {
           <Button
             size="sm"
             onClick={() => scrollToBottom('smooth')}
+            aria-label="최근 메시지로 이동"
             className={`
               absolute bottom-6 right-8 rounded-full shadow-lg border border-slate-200 
               bg-white/90 backdrop-blur-sm hover:bg-slate-50 text-slate-600 z-20 
@@ -351,6 +376,7 @@ export function ChatWindow() {
             <Button
               type="submit"
               size="icon"
+              aria-label="메시지 전송"
               disabled={!input.trim() || isLoading}
               className="absolute right-3 bottom-3 h-8 w-8 rounded-lg bg-zinc-800 hover:bg-zinc-700 text-white transition-opacity disabled:opacity-50"
             >

--- a/web_ui/src/lib/constants.ts
+++ b/web_ui/src/lib/constants.ts
@@ -20,5 +20,4 @@ export const CHAT_CONFIG = {
  */
 export const UI_CONFIG = {
   SCROLL_THRESHOLD: 100, // UX 바닥 인식 임계치 (px)
-  ANIMATION_DURATION: 300, // 트랜지션 시간 (ms)
 } as const;


### PR DESCRIPTION
- **[A11y]**: 전송 및 스크롤 버튼에 aria-label 추가로 접근성 표준 준수.
- **[Robustness]**: localStorage.setItem에 try/catch 가드를 재적용하여 제한적 환경 대응.
- **[UX]**: useChat 에러 상태를 시각화하고 하단 에러 배너 및 재시도 로직 추가.
- **[Cleanup]**: 미사용 상수(ANIMATION_DURATION) 제거.

🔗 Related:
- Issue [#775]
- ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/809#pullrequestreview-3982767811)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

채팅 창 접근성, 오류 처리, 및 저장 안정성을 개선합니다.

새로운 기능:
- 인라인 오류 배너와 재시도 액션 버튼을 통해 채팅 오류를 UI에 표시합니다.

버그 수정:
- 제한된 환경에서 발생하는 실패를 방지하기 위해 `localStorage`에 채팅 세션 ID를 기록할 때 `try/catch`로 보호합니다.

개선 사항:
- 복원된 히스토리 메시지를 UI 메시지로 매핑할 때 타입을 명시하여 메시지 페이로드를 더 안전하게 처리할 수 있도록 합니다.

잡무(Chores):
- 설정에서 사용되지 않는 UI 애니메이션 지속 시간 상수를 제거합니다.
- 화면 읽기 프로그램 지원을 강화하기 위해 채팅 스크롤 및 전송 버튼에 `aria-label`을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve chat window accessibility, error handling, and storage robustness.

New Features:
- Surface chat errors in the UI with an inline error banner and retry action button.

Bug Fixes:
- Guard chat session ID writes to localStorage with a try/catch to avoid failures in restricted environments.

Enhancements:
- Type the restored history messages mapped into UI messages to ensure safer handling of message payloads.

Chores:
- Remove unused UI animation duration constant from configuration.
- Add aria-labels to chat scroll and send buttons to better support screen readers.

</details>