### PR TITLE
☘️ refactor [#11.5.10]: 3차 개선 - 메모리&저장소 동기화 무결성 확보 및 타입 정의 최적화

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -227,7 +227,7 @@ export function ChatWindow() {
 
       const newSid = generateId('sess');
       
-      // [Review 반영] 저장소 쓰기 성공 시에만 메모리 상태 업데이트 (원자성 확보)
+      // [Review 반영] 저장소 쓰기 성공 시에만 메모리 상태 업데이트
       localStorage.setItem(STORAGE_KEYS.CHAT_SESSION_ID, newSid);
       
       setSessionId(newSid);
@@ -236,7 +236,7 @@ export function ChatWindow() {
     } catch (err: unknown) {
       console.error('[ChatWindow] Clear/Reset History Error:', err);
       toast.error('초기화 중 오류 발생', {
-        description: err instanceof Error ? err.message : '저장소 접근 권한을 확인해주세요.'
+        description: err instanceof Error ? err.message : '저장소 권한을 확인해주세요.'
       });
     }
   };
@@ -339,7 +339,7 @@ export function ChatWindow() {
             ))}
             {error && (
               <div 
-                role="alert"
+                role="alert" 
                 aria-live="polite"
                 className="p-4 mb-4 bg-red-50 border border-red-100 rounded-xl text-xs text-red-600 flex items-center gap-2 animate-in fade-in slide-in-from-top-2"
               >


### PR DESCRIPTION
- **[Integrity]**: 세션 초기화 시 localStorage 성공 여부에 따른 원자적 상태 업데이트 보장.
- **[A11y]**: 에러 알림에 role='alert' 적용 및 접근성 표준 준수.
- **[Types]**: HistoryMessage 인터페이스를 전역 스코프로 이동하여 구조 최적화.
- **[UX]**: useChat의 reload 함수를 재시도 로직에 직접 연결.

🔗 Related:
- Issue [#775]
- ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/811#pullrequestreview-3982839684)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

채팅 세션 초기화의 완전성, 오류 처리, 접근성, 그리고 채팅 창에서의 재시도 UX를 개선합니다.

새로운 기능:
- 전송 오류가 발생했을 때 마지막 사용자 메시지를 다시 보내거나, 그게 불가능한 경우 현재 입력으로 대체해서 보내는 전용 재시도 핸들러를 추가했습니다.

버그 수정:
- 영구 저장소에 채팅 세션 ID를 성공적으로 업데이트한 후에만 세션 초기화를 진행하도록 보장하고, 초기화에 실패했을 때 더 명확한 오류 정보를 표시합니다.

개선 사항:
- `HistoryMessage` 타입 정의를 컴포넌트 범위로 승격하여 채팅 기록 매핑 시 재사용성을 높이고 타입을 더 명확하게 했습니다.
- 보조 기술 지원을 강화하기 위해 채팅 오류 알림에 적절한 ARIA 속성을 갖춘 경고(alert) 역할을 부여했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve chat session reset integrity, error handling, accessibility, and retry UX in the chat window.

New Features:
- Add a dedicated retry handler that resends the last user message or falls back to the current input when a send error occurs.

Bug Fixes:
- Ensure session reset only proceeds after successfully updating the chat session id in persistent storage, and surface clearer error details when reset fails.

Enhancements:
- Promote the HistoryMessage type definition to component scope for reuse and clearer typing in chat history mapping.
- Mark chat error notifications as alerts with appropriate ARIA attributes to better support assistive technologies.

</details>