### PR TITLE
Feature/v7 phase3 agent

### DIFF
--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -5,10 +5,18 @@
 """
 
 import logging
+from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException
+
 from fastapi.responses import StreamingResponse
 
-from backend.api.models import ChatQueryRequest, ChatHistoryResponse
+from backend.api.models import (
+    ChatQueryRequest,
+    ChatHistoryResponse,
+    SessionListResponse,
+    ChatSessionMeta,
+    RenameSessionRequest,
+)
 from backend.services.chat_service import ChatService, get_chat_service
 from backend.services.chat_history_service import (
     ChatHistoryService,
@@ -51,6 +59,11 @@ async def stream_chat(
     )
 
 
+# ─────────────────────────────────────────────────────────────
+# History endpoints (기존)
+# ─────────────────────────────────────────────────────────────
+
+
 @router.get(
     "/history/{session_id}",
     response_model=ChatHistoryResponse,
@@ -76,16 +89,100 @@ async def get_chat_history(
 @router.delete("/history/{session_id}", summary="대화 히스토리 초기화")
 async def clear_chat_history(
     session_id: str,
+    user_id: Optional[str] = None,
     chat_history_service: ChatHistoryService = Depends(get_chat_history_service),
 ):
     """
-    지정된 세션 ID의 대화 내역을 모두 삭제합니다.
+    지정된 세션 ID의 대화 내역과 세션 메타데이터를 완전 삭제합니다.
+    user_id를 함께 전달하면 세션 목록(ZSET)에서도 제거됩니다.
     """
     try:
-        await chat_history_service.clear_history(session_id)
+        await chat_history_service.clear_history(session_id, user_id=user_id)
         return {
             "status": "success",
-            "message": f"History for session {session_id} cleared.",
+            "message": f"Session {session_id} cleared.",
         }
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+# ─────────────────────────────────────────────────────────────
+# Session management endpoints (Issue #776 신규)
+# ─────────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/sessions",
+    summary="세션 등록 또는 갱신",
+)
+async def register_session(
+    session_id: str,
+    user_id: str,
+    name: str | None = None,
+    chat_history_service: ChatHistoryService = Depends(get_chat_history_service),
+):
+    """
+    세션 메타데이터(session_id, user_id, name)를 Redis에 등록하거나 갱신합니다.
+    채팅창이 처음 열릴 때 또는 새 세션이 생성될 때 호출합니다.
+    """
+    try:
+        await chat_history_service.register_session(
+            session_id=session_id,
+            user_id=user_id,
+            name=name,
+        )
+        return {"status": "success", "session_id": session_id}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get(
+    "/sessions",
+    response_model=SessionListResponse,
+    summary="사용자 세션 목록 조회",
+)
+async def list_sessions(
+    user_id: str,
+    chat_history_service: ChatHistoryService = Depends(get_chat_history_service),
+):
+    """
+    지정된 user_id의 세션 목록을 최근 활성순으로 반환합니다.
+    """
+    try:
+        sessions_raw = await chat_history_service.list_sessions(user_id=user_id)
+        sessions = [ChatSessionMeta(**s) for s in sessions_raw]
+        return SessionListResponse(
+            status="success",
+            user_id=user_id,
+            sessions=sessions,
+            count=len(sessions),
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.patch(
+    "/sessions/{session_id}/name",
+    summary="세션 이름 수정",
+)
+async def rename_session(
+    session_id: str,
+    body: RenameSessionRequest,
+    chat_history_service: ChatHistoryService = Depends(get_chat_history_service),
+):
+    """
+    특정 세션의 표시 이름을 수정합니다.
+    """
+    try:
+        success = await chat_history_service.rename_session(
+            session_id=session_id,
+            name=body.name,
+        )
+        if not success:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Session '{session_id}' not found.",
+            )
+        return {"status": "success", "session_id": session_id, "name": body.name}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/backend/api/models/__init__.py
+++ b/backend/api/models/__init__.py
@@ -214,6 +214,32 @@ class ChatHistoryResponse(BaseModel):
     messages: List[ChatMessage] = Field(default_factory=list, description="대화 내역 리스트")
 
 
+class ChatSessionMeta(BaseModel):
+    """세션 메타데이터 모델"""
+
+    session_id: str = Field(..., description="세션 ID")
+    user_id: str = Field(..., description="사용자 ID")
+    name: Optional[str] = Field(None, description="세션 이름 (선택)")
+    created_at: str = Field(..., description="생성 시각 (ISO 형식)")
+    last_active_at: str = Field(..., description="마지막 활성 시각 (ISO 형식)")
+    preview: Optional[str] = Field(None, description="마지막 메시지 미리보기")
+
+
+class SessionListResponse(BaseModel):
+    """세션 목록 응답 모델"""
+
+    status: str = Field(..., description="응답 상태")
+    user_id: str = Field(..., description="사용자 ID")
+    sessions: List[ChatSessionMeta] = Field(default_factory=list, description="세션 목록")
+    count: int = Field(0, description="세션 수")
+
+
+class RenameSessionRequest(BaseModel):
+    """세션 이름 수정 요청 모델"""
+
+    name: str = Field(..., min_length=1, max_length=100, description="새 세션 이름")
+
+
 __all__ = [
     # Classification (Core)
     "ClassifyRequest",
@@ -253,4 +279,8 @@ __all__ = [
     "ChatQueryRequest",
     "ChatMessage",
     "ChatHistoryResponse",
+    # Session Management (Issue #776)
+    "ChatSessionMeta",
+    "SessionListResponse",
+    "RenameSessionRequest",
 ]

--- a/backend/services/chat_history_service.py
+++ b/backend/services/chat_history_service.py
@@ -1,56 +1,245 @@
 # backend/services/chat_history_service.py
 
+import hashlib
 import json
 import logging
+from json import JSONDecodeError
 from typing import List, Dict, Any, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 from backend.services.redis_pubsub import redis_client
 from backend.api.models import ChatMessage
 
 logger = logging.getLogger(__name__)
 
+# Redis 키 프리픽스 상수
+_HISTORY_PREFIX = "chat:history:"
+_SESSION_META_PREFIX = "chat:session:meta:"
+_USER_SESSIONS_PREFIX = "chat:user:sessions:"
+
+# preview 최대 길이 (하드코딩 방지)
+_PREVIEW_MAX_LEN = 80
+
+
+def _now_utc() -> datetime:
+    """항상 UTC timezone-aware datetime을 반환하는 중앙 헬퍼."""
+    return datetime.now(timezone.utc)
+
+
+def _mask_id(value: str) -> str:
+    """민감 ID를 SHA-256 앞 12자리로 마스킹하여 로그에 안전하게 기록."""
+    return hashlib.sha256(value.encode()).hexdigest()[:12]
+
 
 class ChatHistoryService:
-    """Redis 기반 채팅 히스토리 관리 서비스"""
+    """Redis 기반 채팅 히스토리 및 세션 관리 서비스"""
 
     def __init__(self, ttl: int = 86400 * 7):  # 기본 7일 유지
         self.ttl = ttl
 
-    def _get_key(self, session_id: str) -> str:
-        return f"chat:history:{session_id}"
+    def _history_key(self, session_id: str) -> str:
+        return f"{_HISTORY_PREFIX}{session_id}"
 
-    async def add_message(self, session_id: str, role: str, content: str):
-        """메시지를 Redis 리스트에 추가"""
-        if not session_id or not session_id.strip():
-            logger.error("Operation failed: session_id is missing or empty.")
-            raise ValueError("session_id is required to add messages to history.")
+    def _session_meta_key(self, session_id: str) -> str:
+        return f"{_SESSION_META_PREFIX}{session_id}"
 
+    def _user_sessions_key(self, user_id: str) -> str:
+        return f"{_USER_SESSIONS_PREFIX}{user_id}"
+
+    async def _ensure_connected(self, context: str) -> bool:
+        """Redis 연결 보장 헬퍼. 연결 실패 시 False 반환."""
         if not redis_client.is_connected():
             try:
                 await redis_client.connect()
             except Exception as e:
-                logger.error(
-                    "Redis connection failed in ChatHistoryService",
-                    extra={"session_id": session_id, "error": str(e)},
+                logger.exception(
+                    "Redis connection failed in ChatHistoryService [%s]",
+                    context,
+                    extra={"error": str(e)},
                 )
-                return
+                return False
+        return True
 
-        key = self._get_key(session_id)
-        message = {
+    async def register_session(
+        self,
+        session_id: str,
+        user_id: str,
+        name: Optional[str] = None,
+        preview: Optional[str] = None,
+    ) -> None:
+        """세션 메타데이터를 Redis에 등록하거나 갱신한다.
+
+        동일 session_id로 재호출 시 created_at은 최초값을 유지하고
+        last_active_at과 Sorted Set score만 갱신된다.
+        """
+        if not session_id or not user_id:
+            raise ValueError("session_id and user_id are required.")
+
+        if not await self._ensure_connected("register_session"):
+            return
+
+        # 단일 now 객체로 ISO string과 ZSET score를 동시에 파생 → drift 제거
+        now = _now_utc()
+        now_iso = now.isoformat()
+        now_score = now.timestamp()
+
+        meta_key = self._session_meta_key(session_id)
+
+        try:
+            # 기존 메타가 있으면 created_at 유지, 없으면 현재 시각 사용
+            existing_raw = await redis_client.redis.get(meta_key)
+            created_at = now_iso
+            if existing_raw:
+                try:
+                    existing = json.loads(existing_raw)
+                    if not isinstance(existing, dict):
+                        raise ValueError("Corrupted session meta: not a dict")
+                    created_at = existing.get("created_at", now_iso)
+                except (JSONDecodeError, ValueError) as e:
+                    logger.error(
+                        "Failed to parse existing session meta, resetting.",
+                        extra={"session_id_hash": _mask_id(session_id), "error": str(e)},
+                    )
+
+            meta: Dict[str, Any] = {
+                "session_id": session_id,
+                "user_id": user_id,
+                "name": name,
+                "created_at": created_at,
+                "last_active_at": now_iso,
+                "preview": preview,
+            }
+            await redis_client.redis.set(meta_key, json.dumps(meta, ensure_ascii=False))
+            await redis_client.redis.expire(meta_key, self.ttl)
+
+            # User → Session 역색인: Sorted Set (score = UTC timestamp)
+            user_sessions_key = self._user_sessions_key(user_id)
+            await redis_client.redis.zadd(user_sessions_key, {session_id: now_score})
+            await redis_client.redis.expire(user_sessions_key, self.ttl)
+
+        except Exception as e:
+            logger.exception(
+                "Failed to register session",
+                extra={"session_id_hash": _mask_id(session_id), "error": str(e)},
+            )
+
+    async def list_sessions(self, user_id: str) -> List[Dict[str, Any]]:
+        """사용자의 세션 목록을 최근 활성순으로 반환한다."""
+        if not user_id:
+            raise ValueError("user_id is required.")
+
+        if not await self._ensure_connected("list_sessions"):
+            return []
+
+        try:
+            user_sessions_key = self._user_sessions_key(user_id)
+            # Sorted Set에서 score(timestamp) 내림차순 조회
+            # decode_responses=True 환경에서도 str() 보장 (방어적 처리)
+            raw_ids = await redis_client.redis.zrevrange(user_sessions_key, 0, -1)
+            sessions = []
+            for raw_sid in raw_ids:
+                sid = str(raw_sid)  # bytes 방어: decode_responses 설정 변경에도 안전
+                meta_key = self._session_meta_key(sid)
+                raw = await redis_client.redis.get(meta_key)
+                if not raw:
+                    continue
+                try:
+                    meta = json.loads(raw)
+                    if not isinstance(meta, dict):
+                        raise ValueError("Corrupted meta: not a dict")
+                    sessions.append(meta)
+                except (JSONDecodeError, ValueError) as e:
+                    logger.error(
+                        "Skipping malformed session meta during listing.",
+                        extra={"session_id_hash": _mask_id(sid), "error": str(e)},
+                    )
+            return sessions
+        except Exception as e:
+            logger.exception(
+                "Failed to list sessions",
+                extra={"user_id_hash": _mask_id(user_id), "error": str(e)},
+            )
+            return []
+
+    async def rename_session(self, session_id: str, name: str) -> bool:
+        """세션 이름을 수정한다. 세션이 없으면 False 반환."""
+        if not session_id or not name:
+            raise ValueError("session_id and name are required.")
+
+        if not await self._ensure_connected("rename_session"):
+            return False
+
+        meta_key = self._session_meta_key(session_id)
+        try:
+            raw = await redis_client.redis.get(meta_key)
+            if not raw:
+                return False
+            try:
+                meta = json.loads(raw)
+                if not isinstance(meta, dict):
+                    raise ValueError("Corrupted meta: not a dict")
+            except (JSONDecodeError, ValueError) as e:
+                logger.error(
+                    "Failed to parse session meta on rename.",
+                    extra={"session_id_hash": _mask_id(session_id), "error": str(e)},
+                )
+                return False
+
+            meta["name"] = name
+            await redis_client.redis.set(meta_key, json.dumps(meta, ensure_ascii=False))
+            await redis_client.redis.expire(meta_key, self.ttl)
+            return True
+        except Exception as e:
+            logger.exception(
+                "Failed to rename session",
+                extra={"session_id_hash": _mask_id(session_id), "error": str(e)},
+            )
+            return False
+
+    async def add_message(self, session_id: str, role: str, content: str):
+        """메시지를 Redis 리스트에 추가하고 세션 미리보기를 갱신한다."""
+        if not session_id or not session_id.strip():
+            logger.error("Operation failed: session_id is missing or empty.")
+            raise ValueError("session_id is required to add messages to history.")
+
+        if not await self._ensure_connected("add_message"):
+            return
+
+        now = _now_utc()
+        key = self._history_key(session_id)
+        message: Dict[str, Any] = {
             "role": role,
             "content": content,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": now.isoformat(),
         }
 
         try:
-            # 리스트 끝에 추가
             await redis_client.redis.rpush(key, json.dumps(message))
-            # 만료 시간 갱신
             await redis_client.redis.expire(key, self.ttl)
+
+            # 세션 메타 존재 시 preview 및 last_active_at 갱신
+            meta_key = self._session_meta_key(session_id)
+            raw = await redis_client.redis.get(meta_key)
+            if raw:
+                try:
+                    meta = json.loads(raw)
+                    if not isinstance(meta, dict):
+                        raise ValueError("Corrupted meta: not a dict")
+                    meta["last_active_at"] = now.isoformat()
+                    meta["preview"] = content[:_PREVIEW_MAX_LEN] if content else None
+                    await redis_client.redis.set(
+                        meta_key, json.dumps(meta, ensure_ascii=False)
+                    )
+                    await redis_client.redis.expire(meta_key, self.ttl)
+                except (JSONDecodeError, ValueError) as e:
+                    logger.error(
+                        "Failed to update session preview on add_message.",
+                        extra={"session_id_hash": _mask_id(session_id), "error": str(e)},
+                    )
+
         except Exception as e:
-            logger.error(
+            logger.exception(
                 "Failed to add message to history",
-                extra={"session_id": session_id, "error": str(e)},
+                extra={"session_id_hash": _mask_id(session_id), "error": str(e)},
             )
 
     async def get_history(self, session_id: str, limit: int = 20) -> List[ChatMessage]:
@@ -59,55 +248,68 @@ class ChatHistoryService:
             logger.error("Operation failed: session_id is missing or empty.")
             raise ValueError("session_id is required to get chat history.")
 
-        if not redis_client.is_connected():
-            try:
-                await redis_client.connect()
-            except Exception as e:
-                logger.error(
-                    "Redis connection failed in ChatHistoryService",
-                    extra={"session_id": session_id, "error": str(e)},
-                )
-                return []
+        if not await self._ensure_connected("get_history"):
+            return []
 
-        key = self._get_key(session_id)
+        key = self._history_key(session_id)
         try:
-            # 최근 limit개의 메시지 가져오기 (리스트의 끝에서부터)
             data = await redis_client.redis.lrange(key, -limit, -1)
             messages = []
+            parse_errors = 0
             for item in data:
-                msg_dict = json.loads(item)
-                messages.append(ChatMessage(**msg_dict))
+                try:
+                    msg_dict = json.loads(item)
+                    if not isinstance(msg_dict, dict):
+                        parse_errors += 1
+                        continue
+                    messages.append(ChatMessage(**msg_dict))
+                except (JSONDecodeError, TypeError):
+                    parse_errors += 1
+            if parse_errors:
+                logger.error(
+                    "Skipped malformed messages during get_history.",
+                    extra={
+                        "session_id_hash": _mask_id(session_id),
+                        "skipped_count": parse_errors,
+                    },
+                )
             return messages
         except Exception as e:
-            logger.error(
+            logger.exception(
                 "Failed to get history",
-                extra={"session_id": session_id, "error": str(e)},
+                extra={"session_id_hash": _mask_id(session_id), "error": str(e)},
             )
             return []
 
-    async def clear_history(self, session_id: str):
-        """특정 세션의 히스토리 삭제"""
+    async def clear_history(self, session_id: str, user_id: Optional[str] = None):
+        """특정 세션의 히스토리 + 메타 + ZSET 역색인을 완전 삭제한다.
+
+        user_id가 제공된 경우 사용자의 Sorted Set에서 해당 session_id도 제거한다.
+        user_id가 없으면 히스토리와 메타만 삭제되고 ZSET 항목은 잔류할 수 있다.
+        완전 정리를 보장하려면 호출 측에서 user_id를 함께 전달하는 것을 권장한다.
+        """
         if not session_id or not session_id.strip():
             logger.error("Operation failed: session_id is missing or empty.")
             raise ValueError("session_id is required to clear history.")
 
-        if not redis_client.is_connected():
-            try:
-                await redis_client.connect()
-            except Exception as e:
-                logger.error(
-                    "Failed to connect to Redis for clearing history",
-                    extra={"session_id": session_id, "error": str(e)},
-                )
-                return
+        if not await self._ensure_connected("clear_history"):
+            return
 
-        key = self._get_key(session_id)
+        history_key = self._history_key(session_id)
+        meta_key = self._session_meta_key(session_id)
         try:
-            await redis_client.redis.delete(key)
+            # 히스토리 삭제
+            await redis_client.redis.delete(history_key)
+            # 세션 메타 삭제
+            await redis_client.redis.delete(meta_key)
+            # ZSET 역색인 제거 (user_id 알 수 있을 때만)
+            if user_id:
+                user_sessions_key = self._user_sessions_key(user_id)
+                await redis_client.redis.zrem(user_sessions_key, session_id)
         except Exception as e:
-            logger.error(
+            logger.exception(
                 "Failed to clear history",
-                extra={"session_id": session_id, "error": str(e)},
+                extra={"session_id_hash": _mask_id(session_id), "error": str(e)},
             )
 
 


### PR DESCRIPTION
✨ feat [#11.5.8]: 세션 관리 API 구현 - 목록 조회, 등록, 이름 수정 
☘️ refactor [#11.5.8]: 1차 개선 - 타임스탬프 일관성·데이터 정합성·보안 강화

## Summary by Sourcery

기존 히스토리 저장 방식과 함께 Redis 기반의 채팅 세션 메타데이터 관리를 도입하고, 세션 등록, 목록 조회, 이름 변경, 전체 정리(삭제)를 위한 API를 추가합니다.

New Features:
- 사용자와 세션을 키로 사용하는 Redis 기반 세션 메타데이터 모델 및 스토리지를 추가하여 세션 이름, 타임스탬프, 메시지 미리보기 정보를 추적합니다.
- 세션을 등록하거나 업데이트하고, 최근 활동 순으로 정렬된 사용자의 세션 목록을 조회하며, 세션 제목을 변경할 수 있는 HTTP 엔드포인트를 제공합니다.

Enhancements:
- `ChatHistoryService` 내에서 Redis 연결 처리와 키 생성 로직을 헬퍼 메서드로 통합하고, ID 마스킹을 포함한 더 강력한 에러 로그를 추가합니다.
- 메시지와 세션에 대해 저장된 JSON 데이터를 파싱하거나 업데이트할 때, UTC 타임스탬프를 일관되게 사용하고, 처리의 견고성을 향상합니다.
- 히스토리 삭제 기능을 확장하여 관련 세션 메타데이터와 선택적인 사용자-세션 인덱스 엔트리도 함께 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce Redis-backed chat session metadata management alongside existing history storage, including APIs for session registration, listing, renaming, and full cleanup.

New Features:
- Add Redis-based session metadata model and storage keyed by user and session to track name, timestamps, and message preview.
- Expose HTTP endpoints to register or update sessions, fetch a user’s session list ordered by recent activity, and rename session titles.

Enhancements:
- Unify Redis connection handling and key generation in ChatHistoryService with helper methods and stronger error logging, including safe ID masking.
- Ensure consistent UTC timestamps and improved robustness when parsing or updating stored JSON data for messages and sessions.
- Extend history clearing to remove associated session metadata and optional user-to-session index entries.

</details>