### PR TITLE
✨ feat [#11.5.9]: 모바일 반응형 사이드바(Drawer) UI 추가 및 레이아웃 최적화

### DIFF
--- a/web_ui/src/app/[locale]/chat/page.tsx
+++ b/web_ui/src/app/[locale]/chat/page.tsx
@@ -1,6 +1,16 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
+import { Menu } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { 
+  Sheet, 
+  SheetContent, 
+  SheetTrigger, 
+  SheetTitle, 
+  SheetDescription, 
+  SheetHeader 
+} from '@/components/ui/sheet';
 import { ChatWindow } from '@/components/chat/ChatWindow';
 import { ChatSidebar } from '@/components/chat/ChatSidebar';
 import { STORAGE_KEYS } from '@/lib/constants';
@@ -14,6 +24,7 @@ export default function ChatPage() {
   const [isMounting, setIsMounting] = useState(true);
   const [sessionId, setSessionId] = useState<string>('');
   const [userId, setUserId] = useState<string>('');
+  const [isMobileOpen, setIsMobileOpen] = useState(false);
 
   useEffect(() => {
     const storedSid = localStorage.getItem(STORAGE_KEYS.CHAT_SESSION_ID);
@@ -38,11 +49,13 @@ export default function ChatPage() {
     const newSid = generateId('sess');
     localStorage.setItem(STORAGE_KEYS.CHAT_SESSION_ID, newSid);
     setSessionId(newSid);
+    setIsMobileOpen(false); // 모바일 서랍 닫기
   }, []);
 
   const handleSelectSession = useCallback((id: string) => {
     localStorage.setItem(STORAGE_KEYS.CHAT_SESSION_ID, id);
     setSessionId(id);
+    setIsMobileOpen(false); // 모바일 서랍 닫기
   }, []);
 
   // Hydration mismatch 방지
@@ -65,7 +78,7 @@ export default function ChatPage() {
         userId={userId}
         onSelectSession={handleSelectSession}
         onNewChat={handleNewChat}
-        className="shrink-0 h-full"
+        className="shrink-0 h-full hidden md:flex"
       />
       
       <div className="flex-1 h-full min-w-0 bg-slate-50/10 flex flex-col">
@@ -74,6 +87,29 @@ export default function ChatPage() {
             externalSessionId={sessionId}
             externalUserId={userId}
             onSessionChange={handleSelectSession}
+            headerLeftSlot={
+              <Sheet open={isMobileOpen} onOpenChange={setIsMobileOpen}>
+                <SheetTrigger asChild>
+                  <Button variant="ghost" size="icon" className="md:hidden shrink-0 -ml-2 text-slate-500 hover:text-slate-800">
+                    <Menu className="w-5 h-5" />
+                    <span className="sr-only">메뉴 토글</span>
+                  </Button>
+                </SheetTrigger>
+                <SheetContent side="left" className="p-0 w-72 h-full flex flex-col border-none">
+                  <SheetHeader className="sr-only">
+                    <SheetTitle>메뉴</SheetTitle>
+                    <SheetDescription>대화 세션 목록</SheetDescription>
+                  </SheetHeader>
+                  <ChatSidebar 
+                    currentSessionId={sessionId}
+                    userId={userId}
+                    onSelectSession={handleSelectSession}
+                    onNewChat={handleNewChat}
+                    className="w-full h-full border-none"
+                  />
+                </SheetContent>
+              </Sheet>
+            }
           />
         </div>
       </div>

--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -67,12 +67,14 @@ interface ChatWindowProps {
   externalSessionId?: string;
   externalUserId?: string;
   onSessionChange?: (sessionId: string) => void;
+  headerLeftSlot?: React.ReactNode;
 }
 
 export function ChatWindow({ 
   externalSessionId, 
   externalUserId,
-  onSessionChange 
+  onSessionChange,
+  headerLeftSlot
 }: ChatWindowProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const viewportRef = useRef<HTMLDivElement | null>(null);
@@ -304,10 +306,13 @@ export function ChatWindow({
     <div 
       className="flex flex-col w-full border-none shadow-none bg-transparent overflow-hidden relative h-full"
     >
-      <div className="bg-white/80 backdrop-blur-md border-b px-6 py-4 flex items-center justify-between shadow-sm z-10 sticky top-0">
-        <div>
-          <h2 className="text-lg font-bold text-slate-800 tracking-tight">Flownote AI</h2>
-          <p className="text-xs text-slate-500 font-medium">사용자 데이터 기반 RAG 에이전트</p>
+      <div className="bg-white/80 backdrop-blur-md border-b px-4 md:px-6 py-3 md:py-4 flex items-center justify-between shadow-sm z-10 sticky top-0">
+        <div className="flex items-center gap-2 md:gap-4">
+          {headerLeftSlot}
+          <div>
+            <h2 className="text-base md:text-lg font-bold text-slate-800 tracking-tight leading-tight">Flownote AI</h2>
+            <p className="text-[10px] md:text-xs text-slate-500 font-medium hidden sm:block">사용자 데이터 기반 RAG 에이전트</p>
+          </div>
         </div>
         <div className="flex items-center gap-3">
           <div className="hidden md:flex flex-col items-end mr-2">


### PR DESCRIPTION
- [Frontend]: `ChatWindow.tsx` 상단 헤더에 `headerLeftSlot` prop 추가로 확장성 확보
- [Frontend]: `page.tsx`에 `Sheet` 컴포넌트를 활용하여 모바일 해상도(md 이하)에서 햄버거 메뉴를 통한 서랍형 대화 목록 접근 UI 구현
- [UX]: 모바일 환경에서 세션 선택/생성 시 Drawer가 자동으로 닫히는 동작 구현 및 작은 해상도용 텍스트 노출 최적화
- [QA]: 기기별 레이아웃 검증 및 `npm run lint` 에러 통과 확인

🔗 Related: Issue [#776]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

모바일 친화적인 드로어 기반 채팅 사이드바를 도입하고 메인 채팅 헤더 레이아웃을 반응형으로 개선합니다.

New Features:
- 작은 뷰포트에서 헤더 트리거를 통해 채팅 세션 사이드바에 접근할 수 있는 시트 기반 모바일 드로어를 추가합니다.
- 모바일 메뉴 버튼과 같은 플러그형 헤더 컨트롤을 지원하기 위해 채팅 창에 설정 가능한 왼쪽 헤더 슬롯을 노출합니다.

Enhancements:
- 작은 화면에서 데스크톱 채팅 사이드바를 숨기고, 모바일에서 더 나은 반응성을 위해 채팅 헤더의 간격과 타이포그래피를 조정합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a mobile-friendly drawer-based chat sidebar and make the main chat header layout responsive.

New Features:
- Add a sheet-based mobile drawer to access the chat session sidebar via a header trigger on small viewports.
- Expose a configurable left-side header slot in the chat window to support pluggable header controls such as the mobile menu button.

Enhancements:
- Hide the desktop chat sidebar on small screens and adjust chat header spacing and typography for better responsiveness on mobile.

</details>