### PR TITLE
☘️ refactor [#11.5.9]: 1차 개선 - 사이드바 Props 중복(DRY 위반) 제거 및 렌더링 최적화

### DIFF
--- a/web_ui/src/app/[locale]/chat/page.tsx
+++ b/web_ui/src/app/[locale]/chat/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Menu } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { 
@@ -58,6 +58,14 @@ export default function ChatPage() {
     setIsMobileOpen(false); // 모바일 서랍 닫기
   }, []);
 
+  // 공통 사이드바 Props: 데스크탑과 모바일 Sheet에서 동일하게 사용되는 속성을 하나로 묶어 중복(DRY 위반) 방지
+  const sidebarProps = useMemo(() => ({
+    currentSessionId: sessionId,
+    userId,
+    onSelectSession: handleSelectSession,
+    onNewChat: handleNewChat
+  }), [sessionId, userId, handleSelectSession, handleNewChat]);
+
   // Hydration mismatch 방지
   if (isMounting) {
     return (
@@ -74,10 +82,7 @@ export default function ChatPage() {
           - h-[calc(100vh-constant)]로 상단 nav/header 공간 제외한 전체 높이 확보.
       */}
       <ChatSidebar 
-        currentSessionId={sessionId}
-        userId={userId}
-        onSelectSession={handleSelectSession}
-        onNewChat={handleNewChat}
+        {...sidebarProps}
         className="shrink-0 h-full hidden md:flex"
       />
       
@@ -101,10 +106,7 @@ export default function ChatPage() {
                     <SheetDescription>대화 세션 목록</SheetDescription>
                   </SheetHeader>
                   <ChatSidebar 
-                    currentSessionId={sessionId}
-                    userId={userId}
-                    onSelectSession={handleSelectSession}
-                    onNewChat={handleNewChat}
+                    {...sidebarProps}
                     className="w-full h-full border-none"
                   />
                 </SheetContent>


### PR DESCRIPTION
- [Refactor]: 데스크탑과 모바일 Sheet 컴포넌트에 중복 전달되던 \`ChatSidebar\` Props를 \`useMemo\`(sidebarProps) 객체로 추출하여 DRY 원칙 완벽 준수
- [Performance]: 불필요한 Props 객체 재생성을 방지하여 렌더링 성능 최적화

🔗 Related:
- Issue [#776]
- ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/824#pullrequestreview-3991137794)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개선 사항:
- 데스크톱 및 모바일 시트 레이아웃 전반에서 공유되는 `ChatSidebar` props를 추출하여 메모이제이션된 객체로 재사용함으로써 중복을 제거하고, 불필요한 props 객체 재생성을 방지했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Extract shared ChatSidebar props into a memoized object reused across desktop and mobile sheet layouts to eliminate duplication and avoid unnecessary prop object recreation.

</details>