### PR TITLE
☘️ refactor [#11.5.9]: 2차 개선 - 불필요한 useMemo 제거로 명시성 확보

### DIFF
--- a/web_ui/src/app/[locale]/chat/page.tsx
+++ b/web_ui/src/app/[locale]/chat/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Menu } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { 
@@ -58,13 +58,14 @@ export default function ChatPage() {
     setIsMobileOpen(false); // 모바일 서랍 닫기
   }, []);
 
-  // 공통 사이드바 Props: 데스크탑과 모바일 Sheet에서 동일하게 사용되는 속성을 하나로 묶어 중복(DRY 위반) 방지
-  const sidebarProps = useMemo(() => ({
+  // 공통 사이드바 Props: 데스크탑과 모바일 Sheet에서 동일하게 사용되는 속성을 묶어 중복(DRY 위반) 방지
+  // (ChatSidebar가 React.memo로 감싸져 있지 않으므로 useMemo는 불필요한 복잡도만 유발함)
+  const sidebarProps = {
     currentSessionId: sessionId,
     userId,
     onSelectSession: handleSelectSession,
     onNewChat: handleNewChat
-  }), [sessionId, userId, handleSelectSession, handleNewChat]);
+  };
 
   // Hydration mismatch 방지
   if (isMounting) {


### PR DESCRIPTION
- [Refactor]: `ChatSidebar`가 `React.memo`로 최적화되지 않은 상태에서 불필요하게 렌더링 성능 최적화를 흉내 내던 `useMemo(sidebarProps)` 위반 패턴(anti-pattern) 완전히 제거
- [Simplify]: 컴포넌트의 Props를 다시 단순 직관적인 인라인 변수 할당(`const sidebarProps = {...}`)으로 돌려놔 향후 의존성 버그 발생 가능성 제거 및 코드 가독성 대폭 향상

🔗 Related:
- Issue [#776]
- ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/826#pullrequestreview-3991255433)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개선 사항:
- `useMemo`를 사용하던 ChatSidebar props 구성 방식을, 데스크톱 및 모바일 뷰에서 공유하는 단순한 인라인 props 객체로 교체하여 간소화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Simplify ChatSidebar props construction by replacing useMemo with a straightforward inline props object shared between desktop and mobile views.

</details>