### PR TITLE
✨ feat [#11.5.10]: 백엔드 피드백 수집 및 품질 로깅 엔드포인트 추가

### DIFF
--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -207,13 +207,10 @@ async def submit_feedback(
     사용자의 AI 답변 평가(Thumbs up/down) 및 코멘트를 수집합니다.
     (데이터베이스 연동 전 시범용 로깅)
     """
-    if body.rating not in ["up", "down", "none"]:
-        raise HTTPException(
-            status_code=400, 
-            detail="Invalid rating value. Must be 'up', 'down', or 'none'."
-        )
-
     # Observability 목적으로 정형화된 로그(Structured log) 기록
+    # 원본 텍스트는 개인정보(PII) 유출 위험이 있으므로 길이(length) 확보로 보안 규칙(Checklist) 준수
+    comment_length: int = len(body.feedback_text) if body.feedback_text else 0
+    
     logger.info(
         "[OBS] Feedback received",
         extra={
@@ -221,7 +218,7 @@ async def submit_feedback(
             "message_id": body.message_id,
             "rating": body.rating,
             "has_comment": bool(body.feedback_text),
-            "feedback_text": body.feedback_text,
+            "comment_length": comment_length,
         },
     )
 

--- a/backend/api/models/__init__.py
+++ b/backend/api/models/__init__.py
@@ -6,7 +6,7 @@ API Models Package
 
 from enum import Enum
 from functools import lru_cache
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Literal
 from pydantic import BaseModel, Field  # type: ignore[import]
 
 # Core Models - Classification
@@ -252,7 +252,7 @@ class FeedbackRequest(BaseModel):
 
     session_id: str = Field(..., description="현재 세션 ID")
     message_id: str = Field(..., description="피드백 대상 메시지 ID")
-    rating: str = Field(..., description="평가 (예: 'up', 'down', 'none')")
+    rating: Literal["up", "down", "none"] = Field(..., description="평가 ('up', 'down', 'none')")
     feedback_text: Optional[str] = Field(None, description="추가 코멘트 (선택사항)")
 
 
@@ -261,7 +261,7 @@ class FeedbackResponse(BaseModel):
 
     status: str = Field(..., description="응답 상태")
     message_id: str = Field(..., description="적용된 메시지 ID")
-    rating: str = Field(..., description="적용된 평가 값")
+    rating: Literal["up", "down", "none"] = Field(..., description="적용된 평가 값")
 
 
 __all__ = [


### PR DESCRIPTION
- [Backend]: `POST /api/chat/feedback` API 엔드포인트 신설
- [Observability]: 사용자의 Thumbs up/down 평가를 수집하여 중앙 로거에 `[OBS]` 태그로 기록
- [Model]: `FeedbackRequest`, `FeedbackResponse` 스키마 정의

🔗 Related: Issue [#777]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

AI 채팅 응답에 대한 사용자 피드백을 수집하고, 이를 관측 가능성(observability)을 위해 로그로 남기는 API 엔드포인트를 추가합니다.

New Features:
- AI 응답에 대한 엄지 올림/내림 평가와 선택적 코멘트를 받기 위한 `POST /api/chat/feedback` 엔드포인트를 도입합니다.
- 구조화된 피드백 페이로드와 응답을 위해 `FeedbackRequest` 및 `FeedbackResponse` 모델을 정의합니다.

Enhancements:
- 제출된 피드백에 대해 세션, 메시지, 평가, 코멘트 메타데이터를 포함하는 [OBS] 태그 기반의 구조화된 관측 로그를 기록합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an API endpoint to collect user feedback on AI chat responses and log it for observability.

New Features:
- Introduce POST /api/chat/feedback endpoint to receive thumbs up/down evaluations and optional comments for AI responses.
- Define FeedbackRequest and FeedbackResponse models for structured feedback payloads and responses.

Enhancements:
- Record structured observability logs with an [OBS] tag capturing session, message, rating, and comment metadata for submitted feedback.

</details>