### PR TITLE
Feature/v7 phase3 agent

### DIFF
--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -15,6 +15,8 @@ from backend.api.models import (  # type: ignore[import]
     SessionListResponse,
     ChatSessionMeta,
     RenameSessionRequest,
+    FeedbackRequest,
+    FeedbackResponse,
 )
 from backend.services.chat_service import ChatService, get_chat_service  # type: ignore[import]
 from backend.services.chat_history_service import (  # type: ignore[import]
@@ -186,3 +188,42 @@ async def rename_session(
         return {"status": "success", "session_id": session_id, "name": body.name}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+
+# ─────────────────────────────────────────────────────────────
+# Observability / Feedback endpoints (Issue #777)
+# ─────────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/feedback",
+    response_model=FeedbackResponse,
+    summary="AI 응답 피드백 수집",
+)
+async def submit_feedback(
+    body: FeedbackRequest,
+):
+    """
+    사용자의 AI 답변 평가(Thumbs up/down) 및 코멘트를 수집합니다.
+    (데이터베이스 연동 전 시범용 로깅)
+    """
+    # Observability 목적으로 정형화된 로그(Structured log) 기록
+    # 원본 텍스트는 개인정보(PII) 유출 위험이 있으므로 길이(length) 확보로 보안 규칙(Checklist) 준수
+    comment_length: int = len(body.feedback_text) if body.feedback_text else 0
+    
+    logger.info(
+        "[OBS] Feedback received",
+        extra={
+            "session_id": body.session_id,
+            "message_id": body.message_id,
+            "rating": body.rating,
+            "has_comment": bool(body.feedback_text),
+            "comment_length": comment_length,
+        },
+    )
+
+    return FeedbackResponse(
+        status="success",
+        message_id=body.message_id,
+        rating=body.rating,
+    )

--- a/backend/api/models/__init__.py
+++ b/backend/api/models/__init__.py
@@ -6,11 +6,12 @@ API Models Package
 
 from enum import Enum
 from functools import lru_cache
-from typing import List, Dict, Any, Optional
-from pydantic import BaseModel, Field
+from typing import List, Dict, Any, Optional, Literal
+from pydantic import BaseModel, Field  # type: ignore[import]
 
 # Core Models - Classification
-from backend.models.classification import (
+from backend.models.classification import (  # type: ignore[import]
+
     ClassifyRequest,
     ClassifyResponse,
     FileMetadata,
@@ -22,7 +23,8 @@ from backend.models.classification import (
 )
 
 # Core Models - Conflict
-from backend.models.conflict import (
+from backend.models.conflict import (  # type: ignore[import]
+
     ConflictType,
     ResolutionMethod,
     ResolutionStatus,
@@ -95,7 +97,7 @@ class PARACategory(str, Enum):
 
 
 # 하위 호환용 문자열 리스트 (기존 코드 참조 시 사용)
-PARA_CATEGORIES: List[str] = [cat.value for cat in PARACategory]
+PARA_CATEGORIES: List[str] = [cat.value for cat in PARACategory]  # type: ignore
 
 
 class HybridSearchRequest(BaseModel):
@@ -240,6 +242,28 @@ class RenameSessionRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=100, description="새 세션 이름")
 
 
+# ---------------------------------------------------------
+# Feedback / Observability Models (Issue #777)
+# ---------------------------------------------------------
+
+
+class FeedbackRequest(BaseModel):
+    """AI 응답 피드백(Thumbs) 요청 모델"""
+
+    session_id: str = Field(..., description="현재 세션 ID")
+    message_id: str = Field(..., description="피드백 대상 메시지 ID")
+    rating: Literal["up", "down", "none"] = Field(..., description="평가 ('up', 'down', 'none')")
+    feedback_text: Optional[str] = Field(None, description="추가 코멘트 (선택사항)")
+
+
+class FeedbackResponse(BaseModel):
+    """피드백 제출 응답 모델"""
+
+    status: str = Field(..., description="응답 상태")
+    message_id: str = Field(..., description="적용된 메시지 ID")
+    rating: Literal["up", "down", "none"] = Field(..., description="적용된 평가 값")
+
+
 __all__ = [
     # Classification (Core)
     "ClassifyRequest",
@@ -283,4 +307,7 @@ __all__ = [
     "ChatSessionMeta",
     "SessionListResponse",
     "RenameSessionRequest",
+    # Observability (Issue #777)
+    "FeedbackRequest",
+    "FeedbackResponse",
 ]


### PR DESCRIPTION
✨ feat [#11.5.10]: 백엔드 피드백 수집 및 품질 로깅 엔드포인트 추가 
☘️ refactor [#11.5.10]: 1차 개선 - 백엔드 피드백 수집 및 품질 로깅 엔드포인트 신설

## Summary by Sourcery

관측 가능성을 위해 AI 응답에 대한 사용자 피드백을 수집·로그할 수 있는 API 지원을 추가하면서, 향후 영속화를 고려해 페이로드는 가볍게 유지합니다.

New Features:
- AI 응답에 대한 엄지척/엄지내림 평가와 선택적 코멘트를 수집하기 위한 `/feedback` 엔드포인트를 추가합니다.
- 백엔드 전반에서 피드백 페이로드와 응답 형식을 표준화하기 위해 `FeedbackRequest` 및 `FeedbackResponse` 모델을 정의합니다.

Enhancements:
- 원시 텍스트를 저장하지 않고도, 평가값과 코멘트의 존재 여부/길이 등을 포함한 구조화된 관측 데이터(observability data)를 피드백 제출 시 로그에 기록합니다.
- 런타임 동작을 변경하지 않으면서 타입 체크를 만족시키기 위해 `PARA_CATEGORIES` export에 주석(annotate)을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add API support for collecting and logging user feedback on AI responses for observability while keeping payloads lightweight for future persistence.

New Features:
- Introduce a /feedback endpoint to collect thumbs up/down ratings and optional comments for AI responses.
- Define FeedbackRequest and FeedbackResponse models to standardize feedback payloads and responses across the backend.

Enhancements:
- Log structured observability data from feedback submissions, including rating and comment presence/length, without storing raw text.
- Annotate PARA_CATEGORIES export to satisfy type checking without altering runtime behavior.

</details>