### PR TITLE
☘️ refactor [#11.5.10]: 2차 개선 - 백엔드 피드백 수집 및 품질 로깅 엔드포인트 신설 & 초강력 타입 방어

### DIFF
--- a/backend/api/models/__init__.py
+++ b/backend/api/models/__init__.py
@@ -97,8 +97,8 @@ class PARACategory(str, Enum):
 
 
 # 하위 호환용 문자열 리스트 (기존 코드 참조 시 사용)
-# Pyre2가 Enum 서브클래스 자체를 반복 가능 객체로 인식하지 못하는 오류(False Positive)를 방지하기 위해 강제 캐스팅
-PARA_CATEGORIES: List[str] = [cast(str, cat.value) for cat in cast(Iterable[Any], PARACategory)]
+# Pyre2가 Enum 서브클래스 자체를 반복 가능 객체로 인식하지 못하는 오류(False Positive) 방지용 명시적 캐스팅
+PARA_CATEGORIES: List[str] = [str(cat.value) for cat in cast(Iterable[PARACategory], PARACategory)]
 
 
 class HybridSearchRequest(BaseModel):
@@ -247,13 +247,16 @@ class RenameSessionRequest(BaseModel):
 # Feedback / Observability Models (Issue #777)
 # ---------------------------------------------------------
 
+FeedbackRating = Literal["up", "down", "none"]
+SuccessStatus = Literal["success"]
+
 
 class FeedbackRequest(BaseModel):
     """AI 응답 피드백(Thumbs) 요청 모델"""
 
     session_id: str = Field(..., description="현재 세션 ID")
     message_id: str = Field(..., description="피드백 대상 메시지 ID")
-    rating: Literal["up", "down", "none"] = Field(..., description="평가 ('up', 'down', 'none')")
+    rating: FeedbackRating = Field(..., description="평가 ('up', 'down', 'none')")
     feedback_text: Optional[str] = Field(
         None, 
         max_length=1000, 
@@ -264,9 +267,9 @@ class FeedbackRequest(BaseModel):
 class FeedbackResponse(BaseModel):
     """피드백 제출 응답 모델"""
 
-    status: Literal["success"] = Field(..., description="응답 상태")
+    status: SuccessStatus = Field(..., description="응답 상태")
     message_id: str = Field(..., description="적용된 메시지 ID")
-    rating: Literal["up", "down", "none"] = Field(..., description="적용된 평가 값")
+    rating: FeedbackRating = Field(..., description="적용된 평가 값")
 
 
 __all__ = [


### PR DESCRIPTION
- [Backend]: `POST /api/chat/feedback` API 엔드포인트 추가 (동작 완료)
- [Security]: 로거 페이로드에서 `feedback_text` 원본 PII 데이터 제거. 더불어 `FeedbackRequest.feedback_text` 필드에 `max_length=1000`을 강제하여 악성 페이로드 주입(DoS) 완전 차단
- [Model]: `FeedbackResponse.status`를 `Literal['success']`로 강력 보장하고, 기존 Enum(`PARA_CATEGORIES`)의 `type: ignore` 안티-패턴을 클린한 `cast()` 로직으로 고도화 처리 완료

🔗 Related:
- Issue [#777]
- ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/830#pullrequestreview-3991614675)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

피드백 모델과 PARA 카테고리 정의에 대한 타입 지정과 검증을 강화했습니다.

개선 사항:
- Enum 반복 및 값에 대해 명시적으로 캐스팅하여 정적 타입 체커의 오탐(false positives)을 피하도록 `PARA_CATEGORIES` 정의를 정교하게 다듬었습니다.
- 과도하게 큰 입력을 방지하기 위해 `FeedbackRequest`의 `feedback_text`를 최대 길이 1000자의 선택적 문자열(optional string)로 제한했습니다.
- 더 엄격한 응답 타입 지정을 위해 `FeedbackResponse.status`를 리터럴 값 `"success"`로만 제한했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen typing and validation for feedback models and PARA category definitions.

Enhancements:
- Refine PARA_CATEGORIES definition to avoid static type checker false positives by explicitly casting Enum iteration and values.
- Restrict feedback_text in FeedbackRequest to an optional string with a maximum length of 1000 characters to guard against oversized input.
- Constrain FeedbackResponse.status to the literal value "success" for stricter response typing.

</details>