### PR TITLE
Feature/v7 phase3 agent

### DIFF
--- a/backend/api/models/__init__.py
+++ b/backend/api/models/__init__.py
@@ -40,6 +40,15 @@ from backend.models.conflict import (  # type: ignore[import]
 )
 
 # ---------------------------------------------------------
+# Common Types & Aliases
+# ---------------------------------------------------------
+
+ApiStatus = Literal["success", "error"]
+SuccessStatus = Literal["success"]  # API가 항상 성공 객체만 반환하는 명시적 응답 컨트랙트용
+FeedbackRating = Literal["up", "down", "none"]
+
+
+# ---------------------------------------------------------
 # API Layer Specific Response Models (Merged from models.py)
 # ---------------------------------------------------------
 
@@ -97,8 +106,11 @@ class PARACategory(str, Enum):
 
 
 # 하위 호환용 문자열 리스트 (기존 코드 참조 시 사용)
-# Pyre2가 Enum 서브클래스 자체를 반복 가능 객체로 인식하지 못하는 오류(False Positive) 방지용 명시적 캐스팅
-PARA_CATEGORIES: List[str] = [str(cat.value) for cat in cast(Iterable[PARACategory], PARACategory)]
+# [Pyre2 Workaround]: Enum 반복 시 cat.value가 속성(property)으로 잘못 추론되어 발생하는
+# `list[property] is not assignable to list[str]` Type Error (False Positive)를 우회하기 위한 조치.
+# (유사 이슈: https://github.com/facebook/pyre-check/issues/224). 
+# list(PARACategory)에 명시적인 Iterable 캐스팅을 적용합니다.
+PARA_CATEGORIES: List[str] = [str(cat.value) for cat in cast(Iterable[PARACategory], list(PARACategory))]
 
 
 class HybridSearchRequest(BaseModel):
@@ -246,9 +258,6 @@ class RenameSessionRequest(BaseModel):
 # ---------------------------------------------------------
 # Feedback / Observability Models (Issue #777)
 # ---------------------------------------------------------
-
-FeedbackRating = Literal["up", "down", "none"]
-SuccessStatus = Literal["success"]
 
 
 class FeedbackRequest(BaseModel):


### PR DESCRIPTION
☘️ refactor [#11.5.10]: 4차 개선 - 백엔드 모델 타입 중앙화 및 Pyre2 명시적 방어 
☘️ refactor [#11.5.10]: 5차 개선 - 백엔드 API 계약(Contract) 무결성 일치 및 Pyre2 예외 문서화

## Summary by Sourcery

공유 백엔드 API 모델 타입을 중앙화하고, enum 순회에 대한 정적 타입 처리 방식을 개선합니다.

개선 사항:
- 백엔드 모델 전반에서 공유되는 공통 API 상태 및 피드백 타입 별칭을 도입합니다.
- Pyre2의 거짓 양성 타입 오류를 우회하기 위해 `PARA_CATEGORIES` enum → 리스트 캐스팅 및 문서를 조정합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize shared backend API model types and improve static type handling for enum iteration.

Enhancements:
- Introduce common API status and feedback type aliases shared across backend models.
- Adjust PARA_CATEGORIES enum-to-list casting and documentation to work around Pyre2 false-positive type errors.

</details>