### PR TITLE
Feature/v7 phase3 agent

### DIFF
--- a/backend/api/models/__init__.py
+++ b/backend/api/models/__init__.py
@@ -47,6 +47,11 @@ ApiStatus = Literal["success", "error"]
 SuccessStatus = Literal["success"]  # API가 항상 성공 객체만 반환하는 명시적 응답 컨트랙트용
 FeedbackRating = Literal["up", "down", "none"]
 
+# OpenAPI/Swagger Field Descriptions
+API_STATUS_DESC = "API 응답 상태 ('success' 또는 'error')"
+SUCCESS_STATUS_DESC = "API 성공 응답 상태 ('success')"
+FEEDBACK_RATING_DESC = "피드백 평가 값 ('up', 'down', 'none')"
+
 
 # ---------------------------------------------------------
 # API Layer Specific Response Models (Merged from models.py)
@@ -56,8 +61,8 @@ FeedbackRating = Literal["up", "down", "none"]
 class BaseResponse(BaseModel):
     """기본 응답 모델 (다국어 메시지 포함)"""
 
-    status: str
-    message: str
+    status: ApiStatus = Field(..., description=API_STATUS_DESC)
+    message: str = Field(..., description="응답 메시지")
 
 
 class HealthCheckResponse(BaseResponse):
@@ -180,7 +185,7 @@ class SearchResultItem(BaseModel):
 class HybridSearchResponse(BaseModel):
     """하이브리드 검색 응답 스키마"""
 
-    status: str = Field(..., description="응답 상태 ('success' 또는 'error')")
+    status: ApiStatus = Field(..., description=API_STATUS_DESC)
     query: str = Field(..., description="원본 검색 질의")
     results: List[SearchResultItem] = Field(
         default_factory=list, description="RRF 점수 기준 정렬된 검색 결과"
@@ -224,7 +229,7 @@ class ChatMessage(BaseModel):
 class ChatHistoryResponse(BaseModel):
     """채팅 히스토리 응답 모델"""
 
-    status: str = Field(..., description="응답 상태")
+    status: ApiStatus = Field(..., description=API_STATUS_DESC)
     session_id: str = Field(..., description="세션 ID")
     messages: List[ChatMessage] = Field(default_factory=list, description="대화 내역 리스트")
 
@@ -243,7 +248,7 @@ class ChatSessionMeta(BaseModel):
 class SessionListResponse(BaseModel):
     """세션 목록 응답 모델"""
 
-    status: str = Field(..., description="응답 상태")
+    status: ApiStatus = Field(..., description=API_STATUS_DESC)
     user_id: str = Field(..., description="사용자 ID")
     sessions: List[ChatSessionMeta] = Field(default_factory=list, description="세션 목록")
     count: int = Field(0, description="세션 수")
@@ -265,7 +270,7 @@ class FeedbackRequest(BaseModel):
 
     session_id: str = Field(..., description="현재 세션 ID")
     message_id: str = Field(..., description="피드백 대상 메시지 ID")
-    rating: FeedbackRating = Field(..., description="평가 ('up', 'down', 'none')")
+    rating: FeedbackRating = Field(..., description=FEEDBACK_RATING_DESC)
     feedback_text: Optional[str] = Field(
         None, 
         max_length=1000, 
@@ -276,9 +281,9 @@ class FeedbackRequest(BaseModel):
 class FeedbackResponse(BaseModel):
     """피드백 제출 응답 모델"""
 
-    status: SuccessStatus = Field(..., description="응답 상태")
+    status: SuccessStatus = Field(..., description=SUCCESS_STATUS_DESC)
     message_id: str = Field(..., description="적용된 메시지 ID")
-    rating: FeedbackRating = Field(..., description="적용된 평가 값")
+    rating: FeedbackRating = Field(..., description=FEEDBACK_RATING_DESC)
 
 
 __all__ = [
@@ -305,6 +310,9 @@ __all__ = [
     "ConflictDetectResponse",
     "ConflictResolveResponse",
     # API Responses
+    "ApiStatus",
+    "SuccessStatus",
+    "FeedbackRating",
     "BaseResponse",
     "HealthCheckResponse",
     "FileProcessingResponse",


### PR DESCRIPTION
☘️ refactor [#11.5.10]: 6차 개선 - 백엔드 전역 API 상태(Status) 타입 통일화 (Global Consistency)
☘️ refactor [#11.5.10]: 7차 개선 - OpenAPI Field Description 하드코딩 제거 및 중앙 상수화 (SSOT)
☘️ refactor [#11.5.10]: 8차 개선 - 내부 상수(Internal Constants) 은닉화 및 캡슐화

## Summary by Sourcery

백엔드 응답 모델 전반에서 API 응답 상태 타입을 표준화하고, 관련 OpenAPI 필드 설명을 중앙에서 관리하도록 개선했습니다.

Enhancements:
- API 응답 모델의 문자열 기반 status 필드를 공용 타입 별칭인 `ApiStatus` 및 `SuccessStatus`로 교체하여 타입 일관성을 확보했습니다.
- status 및 feedback rating에 대한 OpenAPI/Swagger 필드 설명을 공용 상수로 중앙화하여 재사용성을 높이고 단일 진실 공급원(single source of truth)을 확보했습니다.
- 백엔드 전반에서 일관되게 사용할 수 있도록 models 패키지에서 `ApiStatus`, `SuccessStatus`, `FeedbackRating`를 export했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize API response status types and centralize related OpenAPI field descriptions across backend response models.

Enhancements:
- Replace string-based status fields in API response models with shared ApiStatus and SuccessStatus type aliases for consistent typing.
- Centralize OpenAPI/Swagger field descriptions for status and feedback rating into shared constants for reuse and single source of truth.
- Export ApiStatus, SuccessStatus, and FeedbackRating from the models package for consistent usage across the backend.

</details>