### PR TITLE
☘️ refactor [#11.5.10]: 9차 개선 - OpenAPI 상수 ও 범용 타입 전용 모듈(shared.py)로 …

### DIFF
--- a/backend/api/models/__init__.py
+++ b/backend/api/models/__init__.py
@@ -6,8 +6,18 @@ API Models Package
 
 from enum import Enum
 from functools import lru_cache
-from typing import cast, Iterable, List, Dict, Any, Optional, Literal
+from typing import cast, Iterable, List, Dict, Any, Optional
 from pydantic import BaseModel, Field  # type: ignore[import]
+
+from backend.api.models.shared import (  # type: ignore[import]
+    ApiStatus,
+    SuccessStatus,
+    FeedbackRating,
+    API_STATUS_DESC,
+    SUCCESS_STATUS_DESC,
+    FEEDBACK_RATING_DESC,
+    API_MESSAGE_DESC,
+)
 
 # Core Models - Classification
 from backend.models.classification import (  # type: ignore[import]
@@ -40,20 +50,6 @@ from backend.models.conflict import (  # type: ignore[import]
 )
 
 # ---------------------------------------------------------
-# Common Types & Aliases
-# ---------------------------------------------------------
-
-ApiStatus = Literal["success", "error"]
-SuccessStatus = Literal["success"]  # API가 항상 성공 객체만 반환하는 명시적 응답 컨트랙트용
-FeedbackRating = Literal["up", "down", "none"]
-
-# OpenAPI/Swagger Field Descriptions
-API_STATUS_DESC = "API 응답 상태 ('success' 또는 'error')"
-SUCCESS_STATUS_DESC = "API 성공 응답 상태 ('success')"
-FEEDBACK_RATING_DESC = "피드백 평가 값 ('up', 'down', 'none')"
-
-
-# ---------------------------------------------------------
 # API Layer Specific Response Models (Merged from models.py)
 # ---------------------------------------------------------
 
@@ -62,7 +58,7 @@ class BaseResponse(BaseModel):
     """기본 응답 모델 (다국어 메시지 포함)"""
 
     status: ApiStatus = Field(..., description=API_STATUS_DESC)
-    message: str = Field(..., description="응답 메시지")
+    message: str = Field(..., description=API_MESSAGE_DESC)
 
 
 class HealthCheckResponse(BaseResponse):

--- a/backend/api/models/shared.py
+++ b/backend/api/models/shared.py
@@ -1,0 +1,20 @@
+# backend/api/models/shared.py
+
+from typing import Literal
+
+# ---------------------------------------------------------
+# Shared Types
+# ---------------------------------------------------------
+ApiStatus = Literal["success", "error"]
+SuccessStatus = Literal[
+    "success"
+]  # API가 항상 성공 객체만 반환하는 명시적 응답 컨트랙트용
+FeedbackRating = Literal["up", "down", "none"]
+
+# ---------------------------------------------------------
+# OpenAPI/Swagger Field Descriptions
+# ---------------------------------------------------------
+API_STATUS_DESC = "API 응답 상태 ('success' 또는 'error')"
+SUCCESS_STATUS_DESC = "API 성공 응답 상태 ('success')"
+FEEDBACK_RATING_DESC = "피드백 평가 값 ('up', 'down', 'none')"
+API_MESSAGE_DESC = "API 반환 메시지"


### PR DESCRIPTION
…분리 (Decoupling)

- [Architecture]: 모델의 데이터 구조와 OpenAPI 문서용 메타데이터가 강하게 결합된 것을 해소(Decoupling)하기 위해 `backend/api/models/shared.py` 모듈 신설
- [Refactor]: `ApiStatus`, `FeedbackRating` 등 범용 타입 식별자와 `API_STATUS_DESC` 등 스웨거 설명용 문자열 상수를 `shared.py`로 전면 이주
- [SSOT]: `BaseResponse.message`에 남아있던 유일한 하드코딩 문자열을 `API_MESSAGE_DESC` 상수로 치환하여 Single Source of Truth 달성

🔗 Related:
- Issue [#777]
- ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/837#pullrequestreview-3996516295)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

공유 API 타입과 OpenAPI 설명 상수를 전용 공용 모듈로 분리하고, 기본 응답 메시지 설명을 중앙에서 관리하도록 변경합니다.

개선 사항:
- 모델 정의와 분리된 공유 API 상태/피드백 리터럴 타입 및 OpenAPI 설명 상수를 보관하기 위해 `backend/api/models/shared.py`를 도입합니다.
- 응답 설명을 일관되고 중앙에서 관리할 수 있도록 `BaseResponse.message`에 공용 상수 `API_MESSAGE_DESC`를 사용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract shared API types and OpenAPI description constants into a dedicated shared module and centralize the base response message description.

Enhancements:
- Introduce backend/api/models/shared.py to host shared API status/feedback literal types and OpenAPI description constants decoupled from model definitions.
- Use a shared API_MESSAGE_DESC constant for BaseResponse.message to keep response descriptions consistent and centralized.

</details>