### PR TITLE
✨ feat [#11.5.12]: 프론트엔드 AI 메시지 툴바(피드백 액션바) UI 컴포넌트 추가

### DIFF
--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -97,7 +97,6 @@ export const MessageBubble = memo(
   const [feedback, setFeedback] = useState<'none' | 'up' | 'down'>('none');
 
   const handleFeedback = (rating: 'up' | 'down') => {
-    if (isStreaming) return;
     // 동일한 평가를 다시 클릭하면 취소(none)
     const newFeedback = feedback === rating ? 'none' : rating;
     setFeedback(newFeedback);
@@ -237,12 +236,14 @@ export const MessageBubble = memo(
                 type="button"
                 disabled={isStreaming}
                 onClick={() => handleFeedback('up')}
+                {...({ 'aria-pressed': feedback === 'up' } as React.HTMLAttributes<HTMLButtonElement>)}
+                aria-label="좋은 답변입니다"
+                title="좋은 답변입니다"
                 className={cn(
                   "p-1.5 rounded-md transition-all duration-200 outline-none",
                   "hover:bg-slate-100 disabled:opacity-50 disabled:cursor-not-allowed",
                   feedback === 'up' ? "text-blue-600 bg-blue-50" : "text-slate-400"
                 )}
-                title="좋은 답변입니다"
               >
                 <ThumbsUp className={cn("w-4 h-4", feedback === 'up' && "fill-current")} />
               </button>
@@ -250,12 +251,14 @@ export const MessageBubble = memo(
                 type="button"
                 disabled={isStreaming}
                 onClick={() => handleFeedback('down')}
+                {...({ 'aria-pressed': feedback === 'down' } as React.HTMLAttributes<HTMLButtonElement>)}
+                aria-label="아쉬운 답변입니다"
+                title="아쉬운 답변입니다"
                 className={cn(
                   "p-1.5 rounded-md transition-all duration-200 outline-none",
                   "hover:bg-slate-100 disabled:opacity-50 disabled:cursor-not-allowed",
                   feedback === 'down' ? "text-red-500 bg-red-50" : "text-slate-400"
                 )}
-                title="아쉬운 답변입니다"
               >
                 <ThumbsDown className={cn("w-4 h-4", feedback === 'down' && "fill-current")} />
               </button>


### PR DESCRIPTION
- [UI/UX]: `MessageBubble.tsx` 하단에 `lucide-react`의 ThumbsUp/ThumbsDown 아이콘을 적용한 피드백 액션바 버튼 도입 및 호버/클릭 시 애니메이션 효과(하이라이트) 적용
- [State]: `useState`를 이용하여 각 메시지 상태 내부에 평가 상태('up' | 'down' | 'none')를 로컬 캐싱하도록 관리하고, 토글 동작에 따른 Optimistic UI 상태 전이 구현
- [Interaction]: 답변이 생성되는 동안(isStreaming) 피드백 버튼을 비활성화(disabled)하여 비정상적인 액션을 방지하고 사용자 인지 경험 향상을 위해 네이티브 title 툴팁 적용

🔗 Related: Issue [#777]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

AI 메시지 버블에 인라인 피드백 툴바를 추가하여, 로컬 낙관적 상태 처리와 함께 엄지 업/다운 평가를 수집합니다.

신규 기능:
- 호버 및 활성 시각 상태를 포함한 엄지 업/다운 피드백 버튼을 AI 생성 메시지 아래에 도입합니다.

개선 사항:
- 메시지별 피드백 상태를 로컬에서 추적하고, 응답이 아직 스트리밍 중일 때는 피드백 상호작용을 방지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an inline feedback toolbar to AI message bubbles to capture thumbs up/down ratings with local optimistic state handling.

New Features:
- Introduce thumbs up/down feedback buttons below AI-generated messages with hover and active visual states.

Enhancements:
- Track per-message feedback state locally and prevent feedback interactions while a response is still streaming.

</details>