### PR TITLE
☘️ refactor [#11.5.12]: 2차 개선 - 피드백 버튼 컴포넌트 분리 및 타입 안전성 향상

### DIFF
--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -85,10 +85,10 @@ function areMessageBubblePropsEqual(prev: MessageBubbleProps, next: MessageBubbl
 /**
  * [Refactoring] 피드백 버튼 컴포넌트 분리 (중복 제거 및 ARIA 타입 캐스팅 해소)
  */
-interface FeedbackButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+interface FeedbackButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'type'> {
   isActive: boolean;
   activeClassName: string;
-  icon: React.ElementType;
+  icon: React.ComponentType<{ className?: string }>;
 }
 
 function FeedbackButton({
@@ -100,15 +100,15 @@ function FeedbackButton({
 }: FeedbackButtonProps) {
   return (
     <button
+      {...props}
       type="button"
-      {...({ 'aria-pressed': isActive } as React.ButtonHTMLAttributes<HTMLButtonElement>)}
+      {...({ 'aria-pressed': isActive })}
       className={cn(
         "p-1.5 rounded-md transition-all duration-200 outline-none",
         "hover:bg-slate-100 disabled:opacity-50 disabled:cursor-not-allowed",
         isActive ? activeClassName : "text-slate-400",
         className
       )}
-      {...props}
     >
       <Icon className={cn("w-4 h-4", isActive && "fill-current")} />
     </button>


### PR DESCRIPTION
- [Refactor]: `MessageBubble.tsx` 내부에서 중복되던 Thumbs Up/Down 버튼의 JSX 마크업 및 스타일링(className) 로직을 일관성 있는 재사용 컴포넌트(`FeedbackButton`)로 분리(Extraction)하여 DRY 원칙 준수
- [Types]: `FeedbackButtonProps`가 `React.ButtonHTMLAttributes<HTMLButtonElement>`를 확장(extends)하도록 구조를 개선하여, `aria-pressed`를 비롯한 네이티브 DOM 버튼 속성들의 타입 안전성 확보 및 어색한 업캐스팅 제거

🔗 Related:
- Issue [#777]
- ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/849#pullrequestreview-4012611406)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

채팅 메시지 버블에 있는 피드백 엄지 버튼을 재사용 가능하고 타입 안정성이 보장되는 `FeedbackButton` 컴포넌트로 추출합니다.

향상 사항:
- `MessageBubble`에서 중복되던 엄지 올리기/내리기 버튼의 마크업과 스타일을 제거하기 위해 전용 `FeedbackButton` 컴포넌트를 생성합니다.
- React의 버튼 속성 타입을 `FeedbackButton`의 props에 활용하여 ARIA 및 기본 버튼 속성에 대한 타입 안정성을 향상합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract feedback thumb buttons in the chat message bubble into a reusable, type-safe FeedbackButton component.

Enhancements:
- Create a dedicated FeedbackButton component to remove duplicated thumbs up/down button markup and styling in MessageBubble.
- Leverage React button attribute types in FeedbackButton props to improve ARIA and native button attribute type safety.

</details>