### PR TITLE
☘️ refactor [#11.5.12]: 4차 개선 - 피드백 버튼 속성 확장 및 A11y 린트 주석 보강

### DIFF
--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -88,12 +88,14 @@ function areMessageBubblePropsEqual(prev: MessageBubbleProps, next: MessageBubbl
 interface FeedbackButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'type'> {
   isActive: boolean;
   activeClassName: string;
+  inactiveClassName?: string;
   icon: React.ComponentType<{ className?: string }>;
 }
 
 function FeedbackButton({
   isActive,
   activeClassName,
+  inactiveClassName = "text-slate-400",
   icon: Icon,
   className,
   ...props
@@ -102,11 +104,12 @@ function FeedbackButton({
     <button
       {...props}
       type="button"
+      // [A11y] Edge Tools Linter가 동적 중괄호 평가식({expression})을 에러로 잡는 문제를 우회하기 위한 기법
       {...({ 'aria-pressed': isActive })}
       className={cn(
         "p-1.5 rounded-md transition-all duration-200 outline-none",
         "hover:bg-slate-100 disabled:opacity-50 disabled:cursor-not-allowed",
-        isActive ? activeClassName : "text-slate-400",
+        isActive ? activeClassName : inactiveClassName,
         className
       )}
     >


### PR DESCRIPTION
- [Refactor]: `FeedbackButton` 컴포넌트에 `inactiveClassName` prop을 추가하여 비활성 상태의 스타일 커스터마이징이 가능하도록 범용성 확장 및 하드코딩 제거
- [A11y]: Edge Tools Linter의 오탐지를 피하기 위한 스프레드 속성 문법의 사용 이유를 주석으로 명시하여 코드 가독성과 유지보수성 확보
- [Type]: Props 구조를 `Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'type'>`으로 유지하여 `type="button"`의 고정 속성 안전성 유지

🔗 Related:
- Issue [#777]
- ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/851#pullrequestreview-4012694299)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

피드백 버튼 스타일링 옵션을 확장하고 접근성 관련 주석을 개선합니다.

새로운 기능:
- 소비자가 선택적 `inactiveClassName` prop을 통해 비활성 상태 스타일을 커스터마이즈할 수 있도록 `FeedbackButton`을 확장합니다.

개선 사항:
- 하드코딩된 비활성 텍스트 색상을 설정 가능한 클래스로 교체하여 `FeedbackButton`의 재사용성과 일관성을 높입니다.
- 린터 우회 방법을 문서화하기 위해 접근성에 초점을 맞춘 주석을 추가하여, `aria-pressed`에 대한 스프레드 속성 사용 목적을 명확히 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend feedback button styling options and improve accessibility-related annotations.

New Features:
- Allow FeedbackButton consumers to customize inactive state styling via an optional inactiveClassName prop.

Enhancements:
- Replace hard-coded inactive text color with a configurable class to increase FeedbackButton reusability and consistency.
- Clarify the use of spread attributes for aria-pressed with an accessibility-focused comment to document the linter workaround.

</details>