### PR TITLE
Feature/v7 phase3 agent

### DIFF
--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -88,12 +88,14 @@ function areMessageBubblePropsEqual(prev: MessageBubbleProps, next: MessageBubbl
 interface FeedbackButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'type'> {
   isActive: boolean;
   activeClassName: string;
+  inactiveClassName?: string;
   icon: React.ComponentType<{ className?: string }>;
 }
 
 function FeedbackButton({
   isActive,
   activeClassName,
+  inactiveClassName = "text-slate-400",
   icon: Icon,
   className,
   ...props
@@ -102,11 +104,12 @@ function FeedbackButton({
     <button
       {...props}
       type="button"
+      // [A11y] Edge Tools Linter가 동적 중괄호 평가식({expression})을 에러로 잡는 문제를 우회하기 위한 기법
       {...({ 'aria-pressed': isActive })}
       className={cn(
         "p-1.5 rounded-md transition-all duration-200 outline-none",
         "hover:bg-slate-100 disabled:opacity-50 disabled:cursor-not-allowed",
-        isActive ? activeClassName : "text-slate-400",
+        isActive ? activeClassName : inactiveClassName,
         className
       )}
     >


### PR DESCRIPTION
☘️ refactor [#11.5.12]: 4차 개선 - 피드백 버튼 속성 확장 및 A11y 린트 주석 보강

## Summary by Sourcery

채팅 피드백 버튼 스타일링의 유연성을 확장하고, 접근성 린트 우회 방법을 문서화합니다.

개선 사항:
- 하드코딩된 기본값 대신 새 선택적 prop을 통해 피드백 버튼의 비활성 텍스트 색상을 커스터마이즈할 수 있도록 허용합니다.
- 린트 문제에 대한 aria-pressed 속성 우회 방법을 설명하는 인라인 접근성 노트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend chat feedback button styling flexibility and document an accessibility linting workaround.

Enhancements:
- Allow feedback buttons to customize inactive text color via a new optional prop instead of a hardcoded default.
- Add an inline accessibility note explaining the aria-pressed attribute workaround for a linting issue.

</details>