### PR TITLE
☘️ refactor [#11.5.13]: 2차 개선 - 프론트엔드 피드백 API 연동 및 고도화된 UI/UX 개선

### DIFF
--- a/web_ui/src/app/api/chat/feedback/route.ts
+++ b/web_ui/src/app/api/chat/feedback/route.ts
@@ -6,10 +6,10 @@
  * 프론트엔드에서 /api/chat/feedback으로 POST 요청을 수신하여
  * 파이썬 백엔드의 동일한 경로로 안전하게 중계합니다.
  *
- * [Robustness] 응답 유형에 따라 정확히 분기합니다:
- *   - 204/205: 바디 없이 status만 전달 (HTTP 명세 준수)
+ * [Robustness] 응답 유형에 따라 정확히 분기하며, 백엔드의 모든 헤더를 보존합니다:
+ *   - 204/205: 백엔드 헤더 복제 후 바디 없이 전달 (HTTP 명세 준수)
  *   - application/json: JSON 안전 파싱 후 NextResponse.json()
- *   - 그 외: 원본 바디 text + 원본 content-type 그대로 전달
+ *   - 그 외: 백엔드 헤더 전체 보존 + 원본 바디 그대로 전달
  */
 
 import { NextResponse } from 'next/server';
@@ -29,9 +29,12 @@ export async function POST(req: Request) {
     const contentType = backendRes.headers.get('content-type') ?? '';
 
     // 204/205 No Content: HTTP 명세상 바디가 없어야 합니다.
-    // NextResponse.json()은 content-type: application/json + null 바디를 강제하므로 사용 불가.
+    // 백엔드 헤더(캐시, CORS 등)는 그대로 복제하여 보존합니다.
     if (backendRes.status === 204 || backendRes.status === 205) {
-      return new NextResponse(null, { status: backendRes.status });
+      return new NextResponse(null, {
+        status: backendRes.status,
+        headers: new Headers(backendRes.headers),
+      });
     }
 
     // JSON 응답: 안전하게 파싱 후 그대로 전달
@@ -46,7 +49,8 @@ export async function POST(req: Request) {
       return NextResponse.json(data, { status: backendRes.status });
     }
 
-    // non-JSON 응답: 원본 바디와 content-type을 그대로 보존
+    // non-JSON 응답: 백엔드 헤더 전체를 복제하여 보존
+    // content-type이 없는 경우에만 text/plain으로 보완합니다.
     let text: string | null = null;
     try {
       text = await backendRes.text();
@@ -54,9 +58,14 @@ export async function POST(req: Request) {
       text = null;
     }
 
+    const headers = new Headers(backendRes.headers);
+    if (!contentType) {
+      headers.set('content-type', 'text/plain');
+    }
+
     return new NextResponse(text, {
       status: backendRes.status,
-      headers: { 'content-type': contentType || 'text/plain' },
+      headers,
     });
   } catch (error) {
     console.error('[Feedback Proxy Error]', error);

--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -236,8 +236,11 @@ export const MessageBubble = memo(
    * - 이중 제출 방지: isFeedbackPending 가드로 처리
    */
   async function submitFeedbackApi(rating: FeedbackRating, feedbackText?: string) {
-    if (!sessionId || !message.id || message.id === 'welcome') {
-      // [Observability] sessionId 또는 message.id가 없으면 API 호출 불가 - 예상치 못한 상황 경고
+    // welcome 메시지는 의도적으로 피드백 대상에서 제외됩니다.
+    if (message.id === 'welcome') return;
+
+    // sessionId 또는 message.id가 없으면 예상치 못한 누락 상황 → 경고 로그
+    if (!sessionId || !message.id) {
       console.warn('[Feedback] Skipped: missing sessionId or message.id', {
         hasSessionId: Boolean(sessionId),
         messageId: message.id,
@@ -404,6 +407,9 @@ export const MessageBubble = memo(
     return ensureRenderableMarkdown(base, isLast && isStreaming);
   }, [message.parts, isUser, isLast, isStreaming]);
 
+  // [Clean Code] 피드백 UI 표시 조건을 명명된 boolean으로 추출하여 JSX 중복 제거
+  const canShowFeedbackUI = !isUser && message.id !== 'welcome';
+
   return (
     <>
       <div className={`flex gap-3 w-full ${isUser ? 'justify-end' : 'justify-start'} mb-5 animate-in fade-in slide-in-from-bottom-2 duration-300`}>
@@ -432,7 +438,7 @@ export const MessageBubble = memo(
           </div>
 
           {/* 피드백 액션바 (AI 메시지 전용, 환영 메시지 제외) */}
-          {!isUser && message.id !== 'welcome' && (
+          {canShowFeedbackUI && (
             <div className="flex items-center gap-1.5 px-1 mt-0.5">
               <FeedbackButton
                 disabled={isStreaming || isFeedbackPending || !sessionId}
@@ -456,7 +462,7 @@ export const MessageBubble = memo(
           )}
 
           {/* 싫어요 선택 시 의견 입력 Dialog (AI 메시지 전용, 환영 메시지 제외) */}
-          {!isUser && message.id !== 'welcome' && (
+          {canShowFeedbackUI && (
             <FeedbackDialog
               isOpen={isDialogOpen}
               onSubmit={handleDialogSubmit}


### PR DESCRIPTION
- **[web_ui/api/chat/feedback/route.ts]**
  - [BugFix]: 204/205 응답에 `NextResponse.json(null)` 사용 시 HTTP 명세 위반 수정 → `new NextResponse(null, { status })`로 body-free 응답 보장
  - [BugFix]: non-JSON 백엔드 응답을 JSON으로 강제 래핑하던 문제 수정 → 원본 바디 + 원본 content-type 그대로 중계
  - [Robustness]: JSON/non-JSON/No-Content 3단계 명확한 분기 구조 완성

- **[web_ui/components/chat/MessageBubble.tsx]**
  - [UX]: `FeedbackButton`의 disabled 조건에 `!sessionId` 추가 → sessionId 없을 때 UI 상태 변경 없이 버튼 자체 비활성화로 silent no-op 제거
  - [Performance]: `FeedbackDialog`를 `!isUser && message.id !== 'welcome'` 조건으로 래핑하여 사용자 메시지/환영 메시지에서 불필요한 컴포넌트 마운트 제거
  - [Observability]: `submitFeedbackApi` early-return 시 `console.warn` 추가로 예상치 못한 ID 누락 상황 탐지 가능

🔗 Related:
- Issue [#777]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/855#pullrequestreview-4017012917)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

채팅 피드백 API 프록시 처리 방식을 개선하고, 어시스턴트 메시지에 대한 피드백 UI/UX를 간소화합니다.

버그 수정:
- HTTP 사양을 준수하기 위해 204/205 피드백 API 호출에 대해 본문이 없는 올바른 응답을 반환합니다.
- 피드백 API 응답을 프록시할 때 JSON 래핑을 강제하는 대신, 백엔드의 비‑JSON 응답과 `content-type`을 그대로 유지합니다.

개선 사항:
- 피드백 API 프록시 로직을 JSON, 비‑JSON, 무응답(내용 없음) 응답에 대한 명확한 분기 구조로 단순화하여 견고성을 향상합니다.
- 조용한 no-op 상호작용을 방지하기 위해 `sessionId`가 없을 때 피드백 버튼을 비활성화합니다.
- 피드백 다이얼로그 렌더링을 사용자 메시지 및 환영 메시지가 아닌 경우로 제한하고, 식별자 누락으로 인해 피드백 제출이 건너뛰어진 경우 로깅을 추가하여 관측 가능성을 향상합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine chat feedback API proxy handling and streamline the feedback UI/UX for assistant messages.

Bug Fixes:
- Return proper body-free responses for 204/205 feedback API calls to comply with HTTP specification.
- Preserve non-JSON backend responses and content-types when proxying feedback API responses instead of forcing JSON wrapping.

Enhancements:
- Simplify feedback API proxy logic into clear branches for JSON, non-JSON, and no-content responses to improve robustness.
- Disable feedback buttons when no sessionId is available to prevent silent no-op interactions.
- Restrict feedback dialog rendering to non-user, non-welcome messages and add logging when feedback submission is skipped due to missing identifiers for better observability.

</details>