### PR TITLE
☘️ refactor [#11.5.13]: 4차 개선 - 피드백 프록시 헤더 불일치 수정 및 UX 렌더링 최적화

### DIFF
--- a/web_ui/src/app/api/chat/feedback/route.ts
+++ b/web_ui/src/app/api/chat/feedback/route.ts
@@ -17,16 +17,25 @@ import { NextResponse } from 'next/server';
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
 
 /**
- * [Helper] 백엔드 헤더를 복제하되, body 재구성 시 무효화되는 헤더를 제거합니다.
- *
- * `backendRes.text()`는 fetch가 내부적으로 압축 해제(decompress)를 수행합니다.
- * 원본 `content-encoding`(gzip 등)과 `content-length`는 해제된 body와 맞지 않으므로
- * 반드시 제거해야 클라이언트의 재해제 시도나 길이 불일치 오류를 방지할 수 있습니다.
+ * backendRes.text()가 호출되면 fetch가 내부적으로 body를 decode(압축 해제)합니다.
+ * 이로 인해 원본 body와 연관된 아래 헤더들이 무효화됩니다.
+ * 향후 헤더 추가/제거 시 이 배열만 수정하면 됩니다.
+ */
+const BODY_META_HEADERS_TO_STRIP = [
+  'content-encoding', // body가 이미 decode됨 (gzip 등 재해제 시도 방지)
+  'content-length',   // 재구성된 body의 바이트 길이와 다를 수 있음
+  'content-md5',      // body MD5 체크섬이 무효화됨
+  'content-range',    // partial content 범위 정보가 재구성 후 의미 없음
+] as const;
+
+/**
+ * [Helper] 백엔드 헤더를 복제하되, body 재구성 시 무효화되는 헤더를 일괄 제거합니다.
  */
 function cloneHeadersWithoutBodyMeta(source: Headers): Headers {
   const headers = new Headers(source);
-  headers.delete('content-encoding'); // body가 이미 decode됨
-  headers.delete('content-length');   // 재구성된 body의 길이와 다를 수 있음
+  for (const name of BODY_META_HEADERS_TO_STRIP) {
+    headers.delete(name);
+  }
   return headers;
 }
 
@@ -44,7 +53,7 @@ export async function POST(req: Request) {
 
     // 204/205 No Content: HTTP 명세상 바디가 없어야 합니다.
     // 백엔드 헤더(캐시, CORS 등)는 그대로 복제하여 보존합니다.
-    // body가 없으므로 content-encoding/content-length 제거도 불필요합니다.
+    // body가 없으므로 body-meta 헤더 제거도 불필요합니다.
     if (backendRes.status === 204 || backendRes.status === 205) {
       return new NextResponse(null, {
         status: backendRes.status,
@@ -65,7 +74,7 @@ export async function POST(req: Request) {
     }
 
     // non-JSON 응답: backendRes.text()로 body를 재구성하므로
-    // content-encoding/content-length는 더 이상 유효하지 않습니다. 반드시 제거합니다.
+    // BODY_META_HEADERS_TO_STRIP에 명시된 헤더는 더 이상 유효하지 않습니다.
     let text: string | null = null;
     try {
       text = await backendRes.text();

--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -281,7 +281,9 @@ export const MessageBubble = memo(
    * - 좋아요/취소 → 바로 API 호출
    */
   function handleFeedback(rating: 'up' | 'down') {
-    if (isFeedbackPending) return;
+    // [Defense in Depth] canShowFeedbackUI로 UI가 이미 숨겨지지만,
+    // 향후 코드 변경이나 프로그래밍 방식 호출에도 안전하도록 방어 가드 추가
+    if (!sessionId || isFeedbackPending) return;
 
     const newRating: FeedbackRating = feedback === rating ? 'none' : rating;
     setFeedback(newRating);


### PR DESCRIPTION
- **[web_ui/api/chat/feedback/route.ts]**
  - [Robustness]: backendRes.text() 호출로 바디가 재구성될 때 무효화되는 content-encoding, content-length 헤더를 명시적으로 제거하여 클라이언트 사이드 파싱 오류 방지
  - `cloneHeadersWithoutBodyMeta` 헬퍼를 도입하여 원본 헤더 보존과 메타데이터 동기화를 동시에 달성

- **[web_ui/components/chat/MessageBubble.tsx]**
  - [UX]: canShowFeedbackUI 조건에 !!sessionId를 추가하여 피드백 제출이 불가능한 경우 버튼 비활성화 대신 UI를 아예 숨기도록 개선
  - 불필요해진 FeedbackButton의 개별 sessionId 체크 로직 제거

🔗 Related:
- Issue [#777]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/857#pullrequestreview-4017113642)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

채팅 피드백 프록시 처리를 개선하고, 사용할 수 없는 피드백 UI를 숨겨 더 견고하고 일관된 사용자 경험을 제공합니다.

버그 수정:
- 피드백 API 프록시에서 비‑JSON 응답 본문을 재구성할 때 무효화되는 `content-encoding` 및 `content-length` 헤더를 제거하여, 클라이언트 측 파싱 문제를 방지합니다.

개선 사항:
- 본문 재구성 후 무효화되는 본문 관련 메타데이터를 제외하고, 백엔드 응답 헤더를 복제하기 위한 헬퍼를 도입합니다.
- `sessionId`가 없는 경우 피드백 컨트롤을 완전히 숨기고, 버튼 비활성화 로직을 스트리밍 및 보류 상태만 반영하도록 단순화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine chat feedback proxy handling and hide unusable feedback UI for a more robust and consistent user experience.

Bug Fixes:
- Prevent client-side parsing issues by removing invalidated content-encoding and content-length headers when reconstructing non-JSON response bodies in the feedback API proxy.

Enhancements:
- Introduce a helper to clone backend response headers while excluding body-related metadata that becomes invalid after body reconstruction.
- Hide feedback controls entirely when no sessionId is available and simplify button disabling logic to only reflect streaming and pending states.

</details>