### PR TITLE
🐛 fix [#11.5.14]: 4차 개선 - sessionId 빈 문자열 회귀 수정 및 canShowFeedbackUI 개선

### DIFF
--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -417,16 +417,15 @@ export const MessageBubble = memo(
 
   // [Clean Code] 피드백 UI 표시 조건을 명명된 boolean으로 추출하여 JSX 중복 제거
   //
-  // [Type Safety + Defense] `!!message.id`
-  //   - `UIMessage.id: string` (non-optional) 타입이므로 TypeScript가 null/undefined를 보장
-  //   - 외부 untpyed 데이터 파이프라인에서 유입될 경우를 대비한 경량 런타임 방어 겸용
+  // [Type Safety] `message`는 Vercel AI SDK `useChat()` 훅이 생성하는 typed 내부 객체입니다.
+  //   경계 레이어(boundary) = AI SDK 자체. `UIMessage.id: string` (non-optional) 타입이므로
+  //   별도 런타임 null 체크 없이 TypeScript 타입 보장에 의존합니다.
   //
   // [UX] `!!sessionId` — undefined AND 빈 문자열('')을 모두 차단
   //   - `sessionId?: string` 이므로 undefined는 물론, 유효하지 않은 빈 문자열도 피드백 불가
   //   - `sessionId !== undefined`를 쓰면 '' 통과 → 잘못된 세션에서 UI 노출되는 회귀 발생
   const canShowFeedbackUI =
     !isUser &&
-    !!message.id &&
     message.id !== 'welcome' &&
     !!sessionId;
 

--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -417,15 +417,18 @@ export const MessageBubble = memo(
 
   // [Clean Code] 피드백 UI 표시 조건을 명명된 boolean으로 추출하여 JSX 중복 제거
   //
-  // [Type Safety] `UIMessage.id`는 `string` (non-optional) 타입이므로
-  //               TypeScript 컴파일러가 null/undefined를 이미 대럽합니다.
-  //               런타임 null 체크가 불필요하므로 `=== 'welcome'` 한 곳만 사용합니다.
+  // [Type Safety + Defense] `!!message.id`
+  //   - `UIMessage.id: string` (non-optional) 타입이므로 TypeScript가 null/undefined를 보장
+  //   - 외부 untpyed 데이터 파이프라인에서 유입될 경우를 대비한 경량 런타임 방어 겸용
   //
-  // [UX] `sessionId?: string` 타입 기준: undefined이면 피드백 불가 → UI 숨김
+  // [UX] `!!sessionId` — undefined AND 빈 문자열('')을 모두 차단
+  //   - `sessionId?: string` 이므로 undefined는 물론, 유효하지 않은 빈 문자열도 피드백 불가
+  //   - `sessionId !== undefined`를 쓰면 '' 통과 → 잘못된 세션에서 UI 노출되는 회귀 발생
   const canShowFeedbackUI =
     !isUser &&
+    !!message.id &&
     message.id !== 'welcome' &&
-    sessionId !== undefined;
+    !!sessionId;
 
   return (
     <>


### PR DESCRIPTION
- **[web_ui/components/chat/MessageBubble.tsx]**
  - [BugFix]: PR [#862]에서 `!!sessionId` → `sessionId !== undefined`로 변경 시 발생한 빈 문자열('') 통과 회귀를 수정하여 `!!sessionId`로 복구
  - [Defense]: `!!message.id` 경량 런타임 체크 추가로 외부 untyped 데이터 파이프라인 방어
  - [Docs]: 각 조건의 선택 근거를 주석에 영구 기록하여 미래의 동일한 리뷰 방지
  - 최종 형태: `!isUser && !!message.id && id !== 'welcome' && !!sessionId`

🔗 Related:
- Issue [#777]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/863#pullrequestreview-4021793442)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

잘못된 세션을 방지하기 위해 채팅 피드백 UI를 표시하는 조건을 더 엄격하게 하고, 형식이 올바르지 않은 메시지 ID에 대한 가벼운 런타임 방어 로직을 추가합니다.

버그 수정:
- `sessionId`에 참 같은(truthy) 값이 필요하도록 하여, `sessionId`가 빈 문자열일 때 피드백 UI가 나타나지 않도록 방지합니다.

개선 사항:
- 피드백 UI를 표시할지 여부를 결정할 때 `message.id`에 대한 방어적인 truthy 체크를 추가합니다.
- 피드백 UI 보호(guard) 조건의 근거를 설명하는 인라인 문서를 더 명확하게 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten the conditions for showing the chat feedback UI to prevent invalid sessions and add lightweight runtime defense against malformed message IDs.

Bug Fixes:
- Prevent feedback UI from appearing when sessionId is an empty string by requiring a truthy sessionId value.

Enhancements:
- Add a defensive truthy check for message.id when determining whether to show the feedback UI.
- Clarify inline documentation explaining the rationale behind feedback UI guard conditions.

</details>