### PR TITLE
Feature/v7 phase3 agent

### DIFF
--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -417,16 +417,15 @@ export const MessageBubble = memo(
 
   // [Clean Code] 피드백 UI 표시 조건을 명명된 boolean으로 추출하여 JSX 중복 제거
   //
-  // [Type Safety + Defense] `!!message.id`
-  //   - `UIMessage.id: string` (non-optional) 타입이므로 TypeScript가 null/undefined를 보장
-  //   - 외부 untpyed 데이터 파이프라인에서 유입될 경우를 대비한 경량 런타임 방어 겸용
+  // [Type Safety] `message`는 Vercel AI SDK `useChat()` 훅이 생성하는 typed 내부 객체입니다.
+  //   경계 레이어(boundary) = AI SDK 자체. `UIMessage.id: string` (non-optional) 타입이므로
+  //   별도 런타임 null 체크 없이 TypeScript 타입 보장에 의존합니다.
   //
   // [UX] `!!sessionId` — undefined AND 빈 문자열('')을 모두 차단
   //   - `sessionId?: string` 이므로 undefined는 물론, 유효하지 않은 빈 문자열도 피드백 불가
   //   - `sessionId !== undefined`를 쓰면 '' 통과 → 잘못된 세션에서 UI 노출되는 회귀 발생
   const canShowFeedbackUI =
     !isUser &&
-    !!message.id &&
     message.id !== 'welcome' &&
     !!sessionId;
 

--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -417,15 +417,18 @@ export const MessageBubble = memo(
 
   // [Clean Code] 피드백 UI 표시 조건을 명명된 boolean으로 추출하여 JSX 중복 제거
   //
-  // [Type Safety] `UIMessage.id`는 `string` (non-optional) 타입이므로
-  //               TypeScript 컴파일러가 null/undefined를 이미 대럽합니다.
-  //               런타임 null 체크가 불필요하므로 `=== 'welcome'` 한 곳만 사용합니다.
+  // [Type Safety + Defense] `!!message.id`
+  //   - `UIMessage.id: string` (non-optional) 타입이므로 TypeScript가 null/undefined를 보장
+  //   - 외부 untpyed 데이터 파이프라인에서 유입될 경우를 대비한 경량 런타임 방어 겸용
   //
-  // [UX] `sessionId?: string` 타입 기준: undefined이면 피드백 불가 → UI 숨김
+  // [UX] `!!sessionId` — undefined AND 빈 문자열('')을 모두 차단
+  //   - `sessionId?: string` 이므로 undefined는 물론, 유효하지 않은 빈 문자열도 피드백 불가
+  //   - `sessionId !== undefined`를 쓰면 '' 통과 → 잘못된 세션에서 UI 노출되는 회귀 발생
   const canShowFeedbackUI =
     !isUser &&
+    !!message.id &&
     message.id !== 'welcome' &&
-    sessionId !== undefined;
+    !!sessionId;
 
   return (
     <>


### PR DESCRIPTION
🐛 fix [#11.5.14]: 4차 개선 - sessionId 빈 문자열 회귀 수정 및 canShowFeedbackUI 개선 
☘️ refactor [#11.5.14]: 5차 개선 - message.id 런타임 체크 제거 및 주석 명확화

## Summary by Sourcery

채팅 메시지 버블 피드백 표시 로직을 업데이트하고 타입 안전성 관련 문서 주석을 명확히 했습니다.

버그 수정:
- 가시성 조건을 더 엄격하게 하여 `sessionId`가 빈 문자열일 때 피드백 UI가 표시되지 않도록 방지했습니다.

개선 사항:
- 채팅 메시지 버블 컴포넌트에서 `message.id`와 `sessionId`에 대한 타입 안전성 가정과 경계 조건을 명확히 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update chat message bubble feedback visibility logic and clarify type-safety documentation comments.

Bug Fixes:
- Prevent feedback UI from showing when sessionId is an empty string by tightening the visibility condition.

Enhancements:
- Clarify type-safety assumptions and boundary conditions around message.id and sessionId in the chat message bubble component.

</details>