### PR TITLE
♻️ refactor [#11.6.1]: 6차 개선 - Admin Layout 타입 클린 코드 적용 및 주석 범용성 확보

### DIFF
--- a/web_ui/src/app/[locale]/(admin)/admin/layout.tsx
+++ b/web_ui/src/app/[locale]/(admin)/admin/layout.tsx
@@ -2,9 +2,14 @@ import type React from 'react';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-// Note: In Next.js 14, `params` are synchronous, but `getTranslations` requires async/await.
-// Therefore, the function remains `async` while `params` are NOT awaited.
-export async function generateMetadata({ params }: { params: { locale: string } }): Promise<Metadata> {
+type Props = {
+  params: { locale: string };
+};
+
+// Note: While route parameters are accessed synchronously in this context,
+// fetching translations via `getTranslations` is inherently an asynchronous operation.
+// Therefore, this function correctly retains its `async` signature.
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = params;
   const t = await getTranslations({ locale, namespace: 'admin.metadata' });
   return {

--- a/web_ui/src/app/[locale]/(admin)/admin/layout.tsx
+++ b/web_ui/src/app/[locale]/(admin)/admin/layout.tsx
@@ -2,14 +2,13 @@ import type React from 'react';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-type Props = {
+type AdminLayoutMetadataProps = {
   params: { locale: string };
 };
 
-// Note: While route parameters are accessed synchronously in this context,
-// fetching translations via `getTranslations` is inherently an asynchronous operation.
-// Therefore, this function correctly retains its `async` signature.
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
+// Note: This function is async because `getTranslations` is an asynchronous operation,
+// even though route parameters are accessed synchronously.
+export async function generateMetadata({ params }: AdminLayoutMetadataProps): Promise<Metadata> {
   const { locale } = params;
   const t = await getTranslations({ locale, namespace: 'admin.metadata' });
   return {


### PR DESCRIPTION
- **[Clean Code & Future-proofing]**
  - [TypeScript] `generateMetadata`의 인라인 파라미터 타입을 분리하여 재사용 가능한 `Props` 타입 별칭(Alias)으로 추출함 (DRY 원칙 준수)
  - [Documentation] 비동기 함수 설계 이유를 설명하는 주석에서 특정 프레임워크 버전(Next.js 14)에 종속된 표현을 제거하고, 향후 프레임워크 업그레이드 시에도 오해의 소지가 없도록 버전에 구애받지 않는(Framework-agnostic) 문장으로 재구성함.

🔗 Related:
- Issue [#866]
- ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/875#pullrequestreview-4027024534)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

관리자 레이아웃 메타데이터 생성을 재사용 가능한 props 타입과 프레임워크에 구애받지 않는 문서화 방식으로 리팩터링합니다.

개선 사항:
- 관리자 레이아웃의 `generateMetadata` 함수 매개변수를 위해 재사용 가능한 `Props` 타입 별칭을 도입합니다.
- `generateMetadata`에서 async 사용에 대한 설명 주석을 프레임워크에 구애받지 않고 비동기 번역 조회에 초점을 맞추도록 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the admin layout metadata generation to use a reusable props type and framework-agnostic documentation.

Enhancements:
- Introduce a reusable Props type alias for the generateMetadata function parameters in the admin layout.
- Update comments explaining async usage in generateMetadata to be framework-agnostic and focused on asynchronous translation fetching.

</details>