### PR TITLE
🐛 fix [#11.6.2]: 2차 개선 - Admin Navbar 버튼 태그 명시적 type 지정으로 폼 오류 차단

### DIFF
--- a/web_ui/src/app/[locale]/(admin)/admin/_components/admin-navbar.tsx
+++ b/web_ui/src/app/[locale]/(admin)/admin/_components/admin-navbar.tsx
@@ -16,6 +16,7 @@ export function AdminNavbar({ onMenuClick }: AdminNavbarProps) {
     <header className="sticky top-0 z-30 flex h-16 w-full items-center justify-between border-b bg-white px-4 shadow-sm sm:px-6">
       <div className="flex items-center gap-4">
         <button
+          type="button"
           onClick={onMenuClick}
           className="inline-flex h-10 w-10 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-900 md:hidden"
           aria-label={t('toggle_menu')}
@@ -33,7 +34,7 @@ export function AdminNavbar({ onMenuClick }: AdminNavbarProps) {
           <span className="text-sm font-medium">{t('role')}</span>
           <span className="text-xs text-slate-500">{t('profile')}</span>
         </div>
-        <button className="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors hover:bg-slate-100 hover:text-slate-900 h-10 px-4 py-2 text-slate-600">
+        <button type="button" className="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors hover:bg-slate-100 hover:text-slate-900 h-10 px-4 py-2 text-slate-600">
           <LogOut className="mr-2 h-4 w-4" />
           <span>{t('logout')}</span>
         </button>


### PR DESCRIPTION
- **[코드 리뷰 피드백 수용 및 잠재적 버그(Bug Risk) 원천 예방]**
  - [UI/Bug Risk] `AdminNavbar` 내의 '로그아웃' 버튼과 '모바일 메뉴 토글' 버튼 요소에 `type="button"` 속성을 명시적으로 추가함.
  - [Next.js/React] React 구조상 `<button>` 요소는 기본이 `submit` 타입으로 동작하므로, 나중에 컴포넌트가 폼(Form) 내부에 배치되더라도 화면이 새로고침(Reload)되는 의도치 않은 폼 제출 사이드 이펙트를 사전에 완벽히 차단함.

🔗 Related:
- Issue [#866]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/879#pullrequestreview-4032044311)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro