### PR TITLE
Feature/v7 phase4 admin analytics

### DIFF
--- a/web_ui/src/lib/auth.ts
+++ b/web_ui/src/lib/auth.ts
@@ -1,0 +1,52 @@
+// web_ui/src/lib/auth.ts
+
+import { AUTH_CONFIG } from './constants';
+
+/**
+ * 전역 관리자 판별 함수 (Role 기반)
+ * 
+ * @param role - 사용자 역할 문자열
+ * @returns 관리자 여부
+ */
+export const isAdmin = (role: string | null | undefined): boolean => {
+  return role === AUTH_CONFIG.ADMIN_ROLE;
+};
+
+/**
+ * 이메일 기반 관리자 판별 함수 (보조 수단)
+ * 
+ * @param email - 사용자 이메일
+ * @returns 관리자 여부
+ */
+export const isEmailAdmin = (email: string | null | undefined): boolean => {
+  if (!email) return false;
+  return (AUTH_CONFIG.ADMIN_EMAILS as readonly string[]).includes(email);
+};
+
+/**
+ * 사용자 권한 종합 판별 (Role || Email)
+ * 
+ * @param role - 사용자 역할
+ * @param email - 사용자 이메일
+ * @returns 관리자 권한 확인 여부
+ */
+export const hasAdminAccess = (
+  role: string | null | undefined, 
+  email: string | null | undefined
+): boolean => {
+  return isAdmin(role) || isEmailAdmin(email);
+};
+
+/**
+ * [Client-Side] 쿠키에서 인증 정보 가져오기
+ * 
+ * 브라우저 환경에서 cookie를 파싱하여 역할이나 이메일을 반환합니다.
+ */
+export const getAuthFromCookie = (name: string): string | null => {
+  if (typeof document === 'undefined') return null;
+  
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) return parts.pop()?.split(';').shift() || null;
+  return null;
+};

--- a/web_ui/src/lib/auth.ts
+++ b/web_ui/src/lib/auth.ts
@@ -13,14 +13,19 @@ export const isAdmin = (role: string | null | undefined): boolean => {
 };
 
 /**
- * 이메일 기반 관리자 판별 함수 (보조 수단)
+ * 이메일 기반 관리자 판별 함수 (서버 사이드 환경변수 기준)
+ * 
+ * NEXT_PUBLIC_ 접두어가 붙지 않은 환경변수는 클라이언트 번들에 노출되지 않으므로 보안이 유지됩니다.
  * 
  * @param email - 사용자 이메일
  * @returns 관리자 여부
  */
 export const isEmailAdmin = (email: string | null | undefined): boolean => {
   if (!email) return false;
-  return (AUTH_CONFIG.ADMIN_EMAILS as readonly string[]).includes(email);
+  
+  // 서버 환경변수에서 허용된 이메일 목록을 가져옴 (콤마로 구분된 형태 가정)
+  const allowedEmails = process.env.ADMIN_EMAILS?.split(',') || [];
+  return allowedEmails.includes(email);
 };
 
 /**

--- a/web_ui/src/lib/constants.ts
+++ b/web_ui/src/lib/constants.ts
@@ -14,8 +14,7 @@ export const STORAGE_KEYS = {
 export const AUTH_CONFIG = {
   ADMIN_ROLE: 'admin',
   USER_ROLE: 'user',
-  // 임시 관리자 계정 리스트 (실제 운영 시 DB 또는 환경변수에서 관리 권장)
-  ADMIN_EMAILS: ['jay@gmail.com', 'admin@flownote.com'],
+  // 관리자 계정 식별(이메일 등)은 클라이언트 번들에 포함되지 않도록 서버(Middleware 등) 환경변수에서 관리합니다.
 } as const;
 
 /**

--- a/web_ui/src/lib/constants.ts
+++ b/web_ui/src/lib/constants.ts
@@ -4,6 +4,18 @@
 export const STORAGE_KEYS = {
   CHAT_SESSION_ID: 'flownote_chat_session_id',
   USER_ID: 'flownote_user_id',
+  AUTH_ROLE: 'flownote_auth_role',
+  AUTH_EMAIL: 'flownote_auth_email',
+} as const;
+
+/**
+ * Auth 관련 기본 설정값
+ */
+export const AUTH_CONFIG = {
+  ADMIN_ROLE: 'admin',
+  USER_ROLE: 'user',
+  // 임시 관리자 계정 리스트 (실제 운영 시 DB 또는 환경변수에서 관리 권장)
+  ADMIN_EMAILS: ['jay@gmail.com', 'admin@flownote.com'],
 } as const;
 
 /**

--- a/web_ui/src/middleware.ts
+++ b/web_ui/src/middleware.ts
@@ -1,7 +1,8 @@
 import createMiddleware from 'next-intl/middleware';
 import { locales, defaultLocale } from './i18n/config';
 import { NextResponse, type NextRequest } from 'next/server';
-import { STORAGE_KEYS, AUTH_CONFIG } from './lib/constants';
+import { STORAGE_KEYS } from './lib/constants';
+import { hasAdminAccess } from './lib/auth';
 
 const intlMiddleware = createMiddleware({
   locales,
@@ -19,12 +20,12 @@ export default function middleware(request: NextRequest) {
   );
 
   if (isAdminPath) {
-    // 2. 권한 확인 (Request Cookies에서 인증 정보를 읽어옴)
+    // 2. 권한 확인 (lib/auth.ts 내의 공유 헬퍼 사용)
+    // Cookie에서 역할(Role)과 이메일 정보를 읽어와 중앙 집중식 로직으로 검증
     const role = request.cookies.get(STORAGE_KEYS.AUTH_ROLE)?.value;
     const email = request.cookies.get(STORAGE_KEYS.AUTH_EMAIL)?.value;
     
-    const isAdminUser = role === AUTH_CONFIG.ADMIN_ROLE || 
-                        (email && (AUTH_CONFIG.ADMIN_EMAILS as readonly string[]).includes(email));
+    const isAdminUser = hasAdminAccess(role, email);
 
     // 관리자 권한이 없을 경우
     if (!isAdminUser) {

--- a/web_ui/src/middleware.ts
+++ b/web_ui/src/middleware.ts
@@ -1,13 +1,48 @@
-// web_ui/src/middleware.ts
-
 import createMiddleware from 'next-intl/middleware';
 import { locales, defaultLocale } from './i18n/config';
+import { NextResponse, type NextRequest } from 'next/server';
+import { STORAGE_KEYS, AUTH_CONFIG } from './lib/constants';
 
-export default createMiddleware({
+const intlMiddleware = createMiddleware({
   locales,
   defaultLocale,
   localePrefix: 'always'
 });
+
+export default function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  
+  // 1. 관리자(/admin) 경로 접근 시도 감지
+  // locale 세그먼트가 포함된 경로를 정규식으로 정확히 매칭 (예: /ko/admin, /en/admin)
+  const isAdminPath = locales.some(locale => 
+    pathname.startsWith(`/${locale}/admin`)
+  );
+
+  if (isAdminPath) {
+    // 2. 권한 확인 (Request Cookies에서 인증 정보를 읽어옴)
+    const role = request.cookies.get(STORAGE_KEYS.AUTH_ROLE)?.value;
+    const email = request.cookies.get(STORAGE_KEYS.AUTH_EMAIL)?.value;
+    
+    const isAdminUser = role === AUTH_CONFIG.ADMIN_ROLE || 
+                        (email && (AUTH_CONFIG.ADMIN_EMAILS as readonly string[]).includes(email));
+
+    // 관리자 권한이 없을 경우
+    if (!isAdminUser) {
+      const currentLocale = pathname.split('/')[1] || defaultLocale;
+      const redirectUrl = request.nextUrl.clone();
+      
+      // 3. 메인(/) 페이지로 강제 리다이렉트 (전용 안내 팝업을 위해 쿼리 파라미터 등을 실어서 보낼 수도 있음)
+      redirectUrl.pathname = `/${currentLocale}`;
+      redirectUrl.searchParams.set('auth', 'admin_required');
+      
+      console.warn(`[Middleware] Unauthorized /admin access attempt denied. Redirecting to /${currentLocale}`);
+      return NextResponse.redirect(redirectUrl);
+    }
+  }
+
+  // 4. 권한 검증 통과 시 다국어(i18n) 미들웨어 정상 처리
+  return intlMiddleware(request);
+}
 
 export const config = {
   // API, static files, Next.js internal paths 제외


### PR DESCRIPTION
✨ feat [#11.6.3]: 관리자 전용 경로(/admin) 세션 기반 권한 체크 및 미들웨어 방어 로직 구현 
☘️ refactor [#11.6.3]: 1차 개선 - Admin 권한 체크 로직 보안 강화 및 중앙 집중화

## Summary by Sourcery

관리자 전용 라우트를 위한 중앙 집중식 세션 기반 인가를 추가하고, 이를 Next.js 미들웨어에 통합합니다.

New Features:
- 쿠키에 저장된 역할(role)과 이메일(email)을 기반으로 `/admin` 라우트에 대해 미들웨어에서 관리자 접근 검사를 도입합니다.
- 역할 및 이메일 기반 관리자 감지와 브라우저 쿠키 파싱을 위한 공용 인증 유틸리티를 추가합니다.

Enhancements:
- 중앙 집중식 인가 로직을 지원하기 위해 역할, 이메일 키 및 관리자/사용자 역할 설정을 인증 관련 상수에 확장합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add centralized, session-based authorization for admin-only routes and integrate it into the Next.js middleware.

New Features:
- Introduce admin access checking in the middleware for /admin routes based on role and email stored in cookies.
- Add shared auth utilities for role- and email-based admin detection and browser cookie parsing.

Enhancements:
- Extend auth-related constants with role, email keys, and configuration for admin/user roles to support centralized authorization logic.

</details>