### PR TITLE
🐛 fix [#11.6.3]: 2차 개선 - Admin 권한 체크 예외 처리 고도화 및 로케일 검증 방어 로직 추가

### DIFF
--- a/web_ui/src/lib/auth.ts
+++ b/web_ui/src/lib/auth.ts
@@ -26,9 +26,9 @@ export const isEmailAdmin = (email: string | null | undefined): boolean => {
   // 서버 환경변수에서 허용된 이메일 목록을 가져옴 (콤마로 구분된 형태 가정)
   // 대소문자 및 공백 제거 등의 정규화를 거쳐 비교
   const normalizedInputEmail = email.trim().toLowerCase();
-  const allowedEmails = process.env.ADMIN_EMAILS?.split(',')
+  const allowedEmails = (process.env.ADMIN_EMAILS || '').split(',')
     .map(e => e.trim().toLowerCase())
-    .filter(Boolean) || [];
+    .filter(Boolean);
     
   return allowedEmails.includes(normalizedInputEmail);
 };

--- a/web_ui/src/lib/auth.ts
+++ b/web_ui/src/lib/auth.ts
@@ -24,8 +24,13 @@ export const isEmailAdmin = (email: string | null | undefined): boolean => {
   if (!email) return false;
   
   // 서버 환경변수에서 허용된 이메일 목록을 가져옴 (콤마로 구분된 형태 가정)
-  const allowedEmails = process.env.ADMIN_EMAILS?.split(',') || [];
-  return allowedEmails.includes(email);
+  // 대소문자 및 공백 제거 등의 정규화를 거쳐 비교
+  const normalizedInputEmail = email.trim().toLowerCase();
+  const allowedEmails = process.env.ADMIN_EMAILS?.split(',')
+    .map(e => e.trim().toLowerCase())
+    .filter(Boolean) || [];
+    
+  return allowedEmails.includes(normalizedInputEmail);
 };
 
 /**
@@ -52,6 +57,17 @@ export const getAuthFromCookie = (name: string): string | null => {
   
   const value = `; ${document.cookie}`;
   const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop()?.split(';').shift() || null;
+  if (parts.length === 2) {
+    const raw = parts.pop()?.split(';').shift();
+    if (!raw) return null;
+
+    try {
+      return decodeURIComponent(raw);
+    } catch {
+      // If the cookie value is not a valid URI component, return it as-is
+      return raw;
+    }
+  }
+  
   return null;
 };

--- a/web_ui/src/middleware.ts
+++ b/web_ui/src/middleware.ts
@@ -30,8 +30,12 @@ export default function middleware(request: NextRequest) {
     // 관리자 권한이 없을 경우
     if (!isAdminUser) {
       let currentLocale = pathname.split('/')[1];
-      // 올바른 로케일인지 검증, 아닐 경우 defaultLocale로 폴백
-      if (!(locales as readonly string[]).includes(currentLocale)) {
+      
+      // 올바른 로케일인지 1차적으로 존재 여부 및 빈 문자열을 명시적으로 검증
+      if (!currentLocale || currentLocale.trim() === '') {
+        currentLocale = defaultLocale;
+      } else if (!(locales as readonly string[]).includes(currentLocale)) {
+        // 2차적으로 공식 지원 로케일 목록에 포함되는지 검증
         currentLocale = defaultLocale;
       }
       

--- a/web_ui/src/middleware.ts
+++ b/web_ui/src/middleware.ts
@@ -29,7 +29,12 @@ export default function middleware(request: NextRequest) {
 
     // 관리자 권한이 없을 경우
     if (!isAdminUser) {
-      const currentLocale = pathname.split('/')[1] || defaultLocale;
+      let currentLocale = pathname.split('/')[1];
+      // 올바른 로케일인지 검증, 아닐 경우 defaultLocale로 폴백
+      if (!(locales as readonly string[]).includes(currentLocale)) {
+        currentLocale = defaultLocale;
+      }
+      
       const redirectUrl = request.nextUrl.clone();
       
       // 3. 메인(/) 페이지로 강제 리다이렉트 (전용 안내 팝업을 위해 쿼리 파라미터 등을 실어서 보낼 수도 있음)


### PR DESCRIPTION
- **[엣지 케이스 방어 로직 전면 보강]**
  - [Security/Validation] `middleware.ts`에서 비정상 세그먼트 접근 시 `locales` 배열 포함 여부를 검증하고 누락 시 `defaultLocale`로 폴백하여 i18n 라우팅 붕괴 차단
  - [Auth/Robustness] `lib/auth.ts` 내 이메일 권한 확인 시, 환경 변수와 쿠키 양쪽 데이터를 `trim().toLowerCase()`로 정규화하여 대소문자/공백 차이로 인한 인증 누락 방지
  - [Type-Safe/Bug Fix] `getAuthFromCookie` 내 `decodeURIComponent` 적용 및 `try-catch` 안전 블록 래핑을 통해, URL 인코딩된 쿠키 값의 오분류 및 런타임 크래시 예방
  - [Code Quality] 기존 AI Bot Review Summary 체크리스트의 '방어적 코딩(Null Safety)' 및 '입력 데이터 검증' 가이드라인 완벽 준수

🔗 Related:
- Issue [#866]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/883#pullrequestreview-4032246283)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

관리자 이메일 검사를 정규화하고, 쿠키 기반 인증 값을 안전하게 디코딩하며, 미들웨어에서 로케일 세그먼트를 검증해 필요 시 기본 로케일로 폴백하도록 함으로써 관리자 권한 부여와 로케일 처리 방식을 강화했습니다.

Bug Fixes:
- 관리자 이메일을 환경 변수로 설정된 허용 목록과 비교할 때 대소문자나 공백으로 인해 권한 부여가 불일치하는 문제를 방지하기 위해 이메일 비교를 정규화했습니다.
- URL 인코딩되었거나 잘못된 형식의 값으로 인해 크래시나 오판독이 발생하지 않도록, 인증 정보 조회 시 쿠키 값을 방어적으로 디코딩하도록 수정했습니다.
- 미들웨어에서 로케일 경로 세그먼트를 검증하고, 잘못된 로케일이 감지되면 기본 로케일로 폴백하도록 하여, 깨진 i18n 라우팅 경로가 발생하지 않도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden admin authorization and locale handling by normalizing admin email checks, safely decoding cookie-based auth values, and validating locale segments in middleware to fall back to the default locale when needed.

Bug Fixes:
- Normalize admin email comparison against environment-configured allowlist to avoid authorization mismatches due to casing or whitespace.
- Decode cookie values defensively in auth retrieval to prevent crashes or misreads from URL-encoded or malformed values.
- Validate locale path segments in middleware and fall back to the default locale when an invalid locale is encountered, preventing broken i18n routing paths.

</details>