### PR TITLE
Feature/v7 phase4 admin analytics

### DIFF
--- a/web_ui/src/lib/auth.ts
+++ b/web_ui/src/lib/auth.ts
@@ -12,7 +12,8 @@ export const isAdmin = (role: string | null | undefined): boolean => {
   return role === AUTH_CONFIG.ADMIN_ROLE;
 };
 
-// 모듈 로드 시점에 환경변수에서 허용된 이메일 목록을 한 번만 정규화하여 Set으로 캐싱 (O(1) 성능 최적화 및 고유성 강제)
+// 모듈 로드(서버/엣지 실행) 시점에 환경변수에서 허용된 이메일 목록을 정규화하여 Set으로 캐싱.
+// NOTE: 이 캐시 목록은 정적(static)으로 유지되며, 런타임에 동적으로 변경해야 할 경우 서버/앱 재배포(또는 재실행)가 필요합니다.
 const cachedAdminEmails = new Set(
   (process.env.ADMIN_EMAILS || '').split(',')
     .map(e => e.trim().toLowerCase())
@@ -66,12 +67,13 @@ export const getAuthFromCookie = (name: string): string | null => {
     try {
       return decodeURIComponent(raw);
     } catch (error) {
-      // 디코딩 실패 시 호출자가 기대하는 예측 가능한 동작(null 반환) 보장 
-      // 및 프로덕션 환경 로그 스팸 방지를 위해 개발 환경에서만 오류 추적 로깅
+      // 디코딩 실패 시 개발 환경에서 오류 추적을 위한 로깅 (프로덕션 로그 스팸 방지)
       if (process.env.NODE_ENV === 'development') {
         console.warn(`[getAuthFromCookie] URI decoding failed for cookie '${name}':`, error);
       }
-      return null;
+      
+      // 기존 API Contract(계약) 유지를 위해 에러 시 null 대신 디코딩되지 않은 원본(raw) 유지
+      return raw;
     }
   }
   

--- a/web_ui/src/lib/auth.ts
+++ b/web_ui/src/lib/auth.ts
@@ -55,7 +55,9 @@ export const hasAdminAccess = (
  * 
  * 브라우저 환경에서 cookie를 파싱하여 역할이나 이메일을 반환합니다.
  */
-export const getAuthFromCookie = (name: string): string | null => {
+export const getAuthFromCookie = (
+  name: string
+): { raw: string; decoded: string | null; error: boolean } | null => {
   if (typeof document === 'undefined') return null;
   
   const value = `; ${document.cookie}`;
@@ -65,15 +67,15 @@ export const getAuthFromCookie = (name: string): string | null => {
     if (!raw) return null;
 
     try {
-      return decodeURIComponent(raw);
+      const decoded = decodeURIComponent(raw);
+      return { raw, decoded, error: false };
     } catch (error) {
-      // 디코딩 실패 시 개발 환경에서 오류 추적을 위한 로깅 (프로덕션 로그 스팸 방지)
+      // 디코딩 실패 시 명확한 구분을 위해 구조화된 상태(error: true) 반환
       if (process.env.NODE_ENV === 'development') {
         console.warn(`[getAuthFromCookie] URI decoding failed for cookie '${name}':`, error);
       }
       
-      // 기존 API Contract(계약) 유지를 위해 에러 시 null 대신 디코딩되지 않은 원본(raw) 유지
-      return raw;
+      return { raw, decoded: null, error: true };
     }
   }
   

--- a/web_ui/src/middleware.ts
+++ b/web_ui/src/middleware.ts
@@ -30,10 +30,11 @@ export default function middleware(request: NextRequest) {
     // 관리자 권한이 없을 경우
     if (!isAdminUser) {
       const rawLocale = pathname.split('/')[1];
+      const trimmedLocale = rawLocale?.trim();
       
-      // 유효한 로케일인지 단일 조건문으로 명확하게 검증, 아닐 경우 defaultLocale로 폴백
-      const currentLocale = (rawLocale && rawLocale.trim() !== '' && (locales as readonly string[]).includes(rawLocale))
-        ? rawLocale 
+      // 유효한 로케일인지 명확히 검증, 불일치 시 defaultLocale로 폴백
+      const currentLocale = (trimmedLocale && (locales as readonly string[]).includes(trimmedLocale))
+        ? trimmedLocale 
         : defaultLocale;
       
       const redirectUrl = request.nextUrl.clone();

--- a/web_ui/src/middleware.ts
+++ b/web_ui/src/middleware.ts
@@ -30,11 +30,11 @@ export default function middleware(request: NextRequest) {
     // 관리자 권한이 없을 경우
     if (!isAdminUser) {
       const rawLocale = pathname.split('/')[1];
-      const trimmedLocale = rawLocale?.trim();
+      const normalizedLocale = rawLocale?.trim().toLowerCase();
       
       // 유효한 로케일인지 명확히 검증, 불일치 시 defaultLocale로 폴백
-      const currentLocale = (trimmedLocale && (locales as readonly string[]).includes(trimmedLocale))
-        ? trimmedLocale 
+      const currentLocale = (normalizedLocale && (locales as readonly string[]).includes(normalizedLocale))
+        ? normalizedLocale 
         : defaultLocale;
       
       const redirectUrl = request.nextUrl.clone();


### PR DESCRIPTION
☘️ refactor [#11.6.3]: 6차 개선 - Admin API Contract 복구 및 Middleware 상태 단일화(Source of Truth) 적용
☘️ refactor [#11.6.3]: 7차 개선 - Admin 쿠키 반환 구조체화 및 Middleware 로케일 완벽 정규화

## Summary by Sourcery

관리자 인증 이메일 캐싱 동작을 명확히 하고, 관리자 관련 쿠키 및 로케일 처리 방식을 개선합니다.

개선 사항:
- 브라우저 인증 쿠키 파싱 구조를 개선하여, 원본 값과 디코딩된 값을 명시적인 오류 상태와 함께 반환하도록 합니다.
- 기본 로케일로의 명확한 폴백(fallback)을 사용하여, 미들웨어에서 소문자 값 기준으로 로케일을 정규화하고 검증합니다.
- 캐시된 관리자 이메일 허용 목록이 서버/앱 프로세스의 수명 동안 정적으로 유지된다는 점을 문서화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify admin auth email caching behavior and improve admin-related cookie and locale handling.

Enhancements:
- Structure browser auth cookie parsing to return raw and decoded values along with an explicit error state.
- Normalize and validate locales in middleware using a lowercased value with a clear fallback to the default locale.
- Document that the cached admin email allowlist is static for the lifetime of the server/app process.

</details>