### PR TITLE
✨ feat [#11.6.3]: 10차 개선 - Admin 쿠키 헬퍼 패턴(DX) 적용 및 SSR/CSR 컨텍스트 분리

### DIFF
--- a/web_ui/src/lib/auth.ts
+++ b/web_ui/src/lib/auth.ts
@@ -89,12 +89,35 @@ export const getAuthFromCookie = (
 };
 
 /**
- * 복잡한 switch/if 체인 없이, 순수하게 디코딩된 쿠키 값만 필요한 호출측(Consumer) 컴포넌트를 위한 헬퍼 함수
+ * 복잡한 switch/if 체인 없이, 순수하게 디코딩된 쿠키 값만 필요한 호출측(Consumer) 컴포넌트를 위한 단일 헬퍼 함수
  * 
  * @param name - 가져올 쿠키의 이름
- * @returns 디코딩 성공 시 원본 문자열, 그 외(서버사이드, 디코드 실패, 없음 등) null 반환
+ * @param options.throwOnSSR - 서버 환경에서 호출할 경우 명시적으로 에러를 발생시켜 조용히 null 처리되는 것을 방지
+ * @returns 디코딩 성공 시 원본 문자열, 그 외 null 반환 (옵션에 따라 SSR 환경에서는 throw 발생 가능)
  */
-export const getDecodedCookieOrNull = (name: string): string | null => {
+export const getDecodedCookieOrNull = (
+  name: string,
+  options?: { throwOnSSR?: boolean }
+): string | null => {
   const auth = getAuthFromCookie(name);
+  if (options?.throwOnSSR && auth.kind === 'server_side') {
+    throw new Error(`[CookieAuth] Attempted to read browser cookie '${name}' in Server environment (SSR).`);
+  }
   return auth.kind === 'ok' ? auth.decoded : null;
+};
+
+/**
+ * SSR 환경(브라우저 외부)과 실제 미인증 상태(쿠키 부재)를 명확히 구분하여 처리해야 하는 특수 렌더링 컨텍스트용 헬퍼
+ * 
+ * @param name - 가져올 쿠키의 이름
+ * @returns 디코딩된 값(value)과 SSR 렌더링 환경 여부(isSSR)를 명시적으로 분리 반환
+ */
+export const getDecodedCookieState = (
+  name: string
+): { value: string | null; isSSR: boolean } => {
+  const auth = getAuthFromCookie(name);
+  return {
+    value: auth.kind === 'ok' ? auth.decoded : null,
+    isSSR: auth.kind === 'server_side',
+  };
 };

--- a/web_ui/src/lib/auth.ts
+++ b/web_ui/src/lib/auth.ts
@@ -58,12 +58,13 @@ export const hasAdminAccess = (
 export type CookieAuth =
   | { kind: 'ok'; raw: string; decoded: string }
   | { kind: 'decode_error'; raw: string; decoded: null }
-  | { kind: 'not_found' };
+  | { kind: 'not_found' }
+  | { kind: 'server_side' };
 
 export const getAuthFromCookie = (
   name: string
 ): CookieAuth => {
-  if (typeof document === 'undefined') return { kind: 'not_found' };
+  if (typeof document === 'undefined') return { kind: 'server_side' };
   
   const value = `; ${document.cookie}`;
   const parts = value.split(`; ${name}=`);
@@ -85,4 +86,15 @@ export const getAuthFromCookie = (
   }
   
   return { kind: 'not_found' };
+};
+
+/**
+ * 복잡한 switch/if 체인 없이, 순수하게 디코딩된 쿠키 값만 필요한 호출측(Consumer) 컴포넌트를 위한 헬퍼 함수
+ * 
+ * @param name - 가져올 쿠키의 이름
+ * @returns 디코딩 성공 시 원본 문자열, 그 외(서버사이드, 디코드 실패, 없음 등) null 반환
+ */
+export const getDecodedCookieOrNull = (name: string): string | null => {
+  const auth = getAuthFromCookie(name);
+  return auth.kind === 'ok' ? auth.decoded : null;
 };


### PR DESCRIPTION
- **[개발자 경험(DX) 극대화 및 하이드레이션(Hydration) 안전성 확보]**
  - [Architecture/Context] `getAuthFromCookie` 내 브라우저 객체 부재 시의 반환 상태를 기존 `not_found`에서 `{ kind: 'server_side' }` 로 분리. SSR 환경에 의한 빈 값 반환과, 실제 사용자의 미인증(쿠키 부재) 상태의 비즈니스 도메인을 명확히 구분하여 타 컴포넌트의 논리적 버그(Logical Bug) 원천 봉쇄
  - [Developer Experience] 복잡한 판별 유니온(Discriminated Union) 처리를 캡슐화하는 `getDecodedCookieOrNull` 헬퍼(Wrapper) 래퍼를 도입하여, 예외 상세 디버깅이 불필요한 내부 소비자(Consumer) 객체들의 보일러플레이트 코드량을 대폭 절감하고 직관적인 API를 제공
  - [Clean Code] AI Bot Review Summary 권고사항 중 '에러 전파 방지' 및 '방어적 어댑터 패턴 구축' 스펙 완전 구현

🔗 Related:
- Issue [#866]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/891#pullrequestreview-4034578927)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

쿠키 인증 처리에서 서버 사이드 렌더링과 인증 누락 케이스를 구분하고, 디코드된 관리자 쿠키를 가져오기 위한 간단한 헬퍼를 도입합니다.

개선 사항:
- 서버 사이드 환경에 대해 별도의 CookieAuth 상태를 추가하여 SSR과 비인증 사용자를 구분합니다.
- 디코드된 쿠키 값을 접근하기 위한, 단순하고 null-safe한 API인 `getDecodedCookieOrNull` 헬퍼를 도입합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Differentiate server-side rendering from missing-auth cases in cookie auth handling and introduce a simple helper for retrieving decoded admin cookies.

Enhancements:
- Add a distinct CookieAuth state for server-side environments to separate SSR from unauthenticated users.
- Introduce a getDecodedCookieOrNull helper to provide a simplified, null-safe API for accessing decoded cookie values.

</details>