### PR TITLE
Feature/v7 phase4 admin analytics

### DIFF
--- a/web_ui/src/lib/auth.ts
+++ b/web_ui/src/lib/auth.ts
@@ -89,12 +89,35 @@ export const getAuthFromCookie = (
 };
 
 /**
- * 복잡한 switch/if 체인 없이, 순수하게 디코딩된 쿠키 값만 필요한 호출측(Consumer) 컴포넌트를 위한 헬퍼 함수
+ * 복잡한 switch/if 체인 없이, 순수하게 디코딩된 쿠키 값만 필요한 호출측(Consumer) 컴포넌트를 위한 단일 헬퍼 함수
  * 
  * @param name - 가져올 쿠키의 이름
- * @returns 디코딩 성공 시 원본 문자열, 그 외(서버사이드, 디코드 실패, 없음 등) null 반환
+ * @param options.throwOnSSR - 서버 환경에서 호출할 경우 명시적으로 에러를 발생시켜 조용히 null 처리되는 것을 방지
+ * @returns 디코딩 성공 시 원본 문자열, 그 외 null 반환 (옵션에 따라 SSR 환경에서는 throw 발생 가능)
  */
-export const getDecodedCookieOrNull = (name: string): string | null => {
+export const getDecodedCookieOrNull = (
+  name: string,
+  options?: { throwOnSSR?: boolean }
+): string | null => {
   const auth = getAuthFromCookie(name);
+  if (options?.throwOnSSR && auth.kind === 'server_side') {
+    throw new Error(`[CookieAuth] Attempted to read browser cookie '${name}' in Server environment (SSR).`);
+  }
   return auth.kind === 'ok' ? auth.decoded : null;
+};
+
+/**
+ * SSR 환경(브라우저 외부)과 실제 미인증 상태(쿠키 부재)를 명확히 구분하여 처리해야 하는 특수 렌더링 컨텍스트용 헬퍼
+ * 
+ * @param name - 가져올 쿠키의 이름
+ * @returns 디코딩된 값(value)과 SSR 렌더링 환경 여부(isSSR)를 명시적으로 분리 반환
+ */
+export const getDecodedCookieState = (
+  name: string
+): { value: string | null; isSSR: boolean } => {
+  const auth = getAuthFromCookie(name);
+  return {
+    value: auth.kind === 'ok' ? auth.decoded : null,
+    isSSR: auth.kind === 'server_side',
+  };
 };

--- a/web_ui/src/lib/auth.ts
+++ b/web_ui/src/lib/auth.ts
@@ -58,12 +58,13 @@ export const hasAdminAccess = (
 export type CookieAuth =
   | { kind: 'ok'; raw: string; decoded: string }
   | { kind: 'decode_error'; raw: string; decoded: null }
-  | { kind: 'not_found' };
+  | { kind: 'not_found' }
+  | { kind: 'server_side' };
 
 export const getAuthFromCookie = (
   name: string
 ): CookieAuth => {
-  if (typeof document === 'undefined') return { kind: 'not_found' };
+  if (typeof document === 'undefined') return { kind: 'server_side' };
   
   const value = `; ${document.cookie}`;
   const parts = value.split(`; ${name}=`);
@@ -85,4 +86,15 @@ export const getAuthFromCookie = (
   }
   
   return { kind: 'not_found' };
+};
+
+/**
+ * 복잡한 switch/if 체인 없이, 순수하게 디코딩된 쿠키 값만 필요한 호출측(Consumer) 컴포넌트를 위한 헬퍼 함수
+ * 
+ * @param name - 가져올 쿠키의 이름
+ * @returns 디코딩 성공 시 원본 문자열, 그 외(서버사이드, 디코드 실패, 없음 등) null 반환
+ */
+export const getDecodedCookieOrNull = (name: string): string | null => {
+  const auth = getAuthFromCookie(name);
+  return auth.kind === 'ok' ? auth.decoded : null;
 };


### PR DESCRIPTION
✨ feat [#11.6.3]: 10차 개선 - Admin 쿠키 헬퍼 패턴(DX) 적용 및 SSR/CSR 컨텍스트 분리 
✨ feat [#11.6.3]: 11차 개선 - Admin 쿠키 헬퍼 유연성 확장 및 과도한 추상화(Over-abstraction) 방지 패치

## Summary by Sourcery

SSR(서버 사이드 렌더링) 컨텍스트와 브라우저 컨텍스트를 명확히 구분하고, 쿠키 디코딩 사용을 단순화하는 admin 쿠키 헬퍼 유틸리티를 도입합니다.

새 기능:
- 쿠키에 접근할 수 없는 SSR 환경을 나타내기 위해 cookie auth에 `server_side` 상태를 추가합니다.
- 디코딩된 쿠키 값을 가져오되 없으면 null을 반환하는 헬퍼를 제공하며, SSR 동안 사용될 경우 예외를 던지도록 선택적으로 설정할 수 있습니다.
- 디코딩된 쿠키 값과 명시적인 SSR 플래그를 함께 반환하여 컨텍스트 인식 렌더링을 가능하게 하는 헬퍼를 제공합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce admin cookie helper utilities that clearly distinguish SSR from browser contexts and simplify cookie decoding usage.

New Features:
- Add a server_side state to cookie auth to represent SSR environments when cookies are inaccessible.
- Provide a helper to retrieve a decoded cookie value or null, with an option to throw when used during SSR.
- Provide a helper that returns both decoded cookie value and an explicit SSR flag for context-aware rendering.

</details>