### PR TITLE
☘️ refactor [#11.6.3]: 12차 개선 - Admin 쿠키 판별 중앙집중화 및 단일 진실 공급원(SSOT) 헬퍼 적용

### DIFF
--- a/web_ui/src/lib/auth.ts
+++ b/web_ui/src/lib/auth.ts
@@ -89,8 +89,35 @@ export const getAuthFromCookie = (
 };
 
 // --- 중앙집중화된 판별 헬퍼 (Internal Checkers) ---
-export const isServerSideAuth = (auth: CookieAuth): boolean => auth.kind === 'server_side';
-export const getDecodedValue = (auth: CookieAuth): string | null => auth.kind === 'ok' ? auth.decoded : null;
+// 외부 모듈에서 퍼블릭 API로 오용되는 것을 막기 위해 export 하지 않음
+const isServerSideAuth = (auth: CookieAuth): boolean => {
+  switch (auth.kind) {
+    case 'server_side':
+      return true;
+    case 'ok':
+    case 'decode_error':
+    case 'not_found':
+      return false;
+    default:
+      // 향후 CookieAuth 유니언에 새로운 타입이 추가될 때 컴파일 에러를 유발하는 완전(Exhaustive) 검사
+      const _exhaustiveCheck: never = auth;
+      return _exhaustiveCheck;
+  }
+};
+
+const getDecodedValue = (auth: CookieAuth): string | null => {
+  switch (auth.kind) {
+    case 'ok':
+      return auth.decoded;
+    case 'server_side':
+    case 'decode_error':
+    case 'not_found':
+      return null;
+    default:
+      const _exhaustiveCheck: never = auth;
+      return _exhaustiveCheck;
+  }
+};
 
 /**
  * 복잡한 switch/if 체인 없이, 순수하게 디코딩된 쿠키 값만 필요한 호출측(Consumer) 컴포넌트를 위한 단일 헬퍼 함수

--- a/web_ui/src/lib/auth.ts
+++ b/web_ui/src/lib/auth.ts
@@ -88,6 +88,10 @@ export const getAuthFromCookie = (
   return { kind: 'not_found' };
 };
 
+// --- 중앙집중화된 판별 헬퍼 (Internal Checkers) ---
+export const isServerSideAuth = (auth: CookieAuth): boolean => auth.kind === 'server_side';
+export const getDecodedValue = (auth: CookieAuth): string | null => auth.kind === 'ok' ? auth.decoded : null;
+
 /**
  * 복잡한 switch/if 체인 없이, 순수하게 디코딩된 쿠키 값만 필요한 호출측(Consumer) 컴포넌트를 위한 단일 헬퍼 함수
  * 
@@ -100,10 +104,10 @@ export const getDecodedCookieOrNull = (
   options?: { throwOnSSR?: boolean }
 ): string | null => {
   const auth = getAuthFromCookie(name);
-  if (options?.throwOnSSR && auth.kind === 'server_side') {
+  if (options?.throwOnSSR && isServerSideAuth(auth)) {
     throw new Error(`[CookieAuth] Attempted to read browser cookie '${name}' in Server environment (SSR).`);
   }
-  return auth.kind === 'ok' ? auth.decoded : null;
+  return getDecodedValue(auth);
 };
 
 /**
@@ -117,7 +121,7 @@ export const getDecodedCookieState = (
 ): { value: string | null; isSSR: boolean } => {
   const auth = getAuthFromCookie(name);
   return {
-    value: auth.kind === 'ok' ? auth.decoded : null,
-    isSSR: auth.kind === 'server_side',
+    value: getDecodedValue(auth),
+    isSSR: isServerSideAuth(auth),
   };
 };


### PR DESCRIPTION
- **[해석 로직의 파편화 방지 및 향후 확장성(Extensibility) 보장]**
  - [Architecture/SSOT] `CookieAuth` 유니온 타입의 상태(`server_side`, `ok`)를 해석하고 반환하는 로직이 여러 헬퍼 함수에 흩어지는 파편화(Divergence) 현상을 막기 위해, 중앙 집중화된 내부 검증 헬퍼(`isServerSideAuth`, `getDecodedValue`)를 순수 함수로 추출
  - [Robustness] 공개(Public) 헬퍼인 `getDecodedCookieOrNull`과 `getDecodedCookieState`가 오직 중앙 집중화된 내부 헬퍼만을 거쳐 값을 도출하도록 구조를 변경하여, 동일한 쿠키 상태가 서로 다르게 추론되는 논리적 미스매치 버그를 시스템 레이어에서 구조적으로 차단
  - [Impact Check] 전역 의존성 스캔 결과, 해당 `getAuthFromCookie` 모듈은 신규 차트 시각화 및 알림 API 통합 등 향후 개발(v7 Phase 5)을 위해 구축된 신규 진입점이므로, 이번 구조 변경으로 인한 기존 레이어의 브레이킹 체인지(Breaking Change)는 완전 무결(0%)함

🔗 Related:
- Issue [#866]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/893#pullrequestreview-4034629532)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

CookieAuth 상태 해석을 중앙 집중화하고 이를 쿠키 헬퍼 함수 전반에서 재사용합니다.

개선 사항:
- 서버 사이드 인증을 식별하고 디코딩된 쿠키 값을 추출하는 내부 헬퍼 함수를 도입하여 CookieAuth 처리를 위한 단일 소스 오브 트루스로 사용합니다.
- 공개 쿠키 디코딩 헬퍼들이 CookieAuth 상태 검사를 중복 구현하지 않고, 중앙 집중화된 내부 검사기들에 의존하도록 리팩터링합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize CookieAuth state interpretation and reuse it across cookie helper functions.

Enhancements:
- Introduce internal helper functions to identify server-side auth and extract decoded cookie values as the single source of truth for CookieAuth handling.
- Refactor public cookie decoding helpers to depend on the centralized internal checkers instead of duplicating CookieAuth state checks.

</details>