### PR TITLE
Feature/v7 phase4 admin analytics

### DIFF
--- a/web_ui/src/lib/utils.ts
+++ b/web_ui/src/lib/utils.ts
@@ -6,15 +6,24 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export class ExhaustiveCheckError extends Error {
-  // 에러 발생 위치(context)와 유발 인자(kind)를 추상화된 메시지 파싱 없이 하위/상위 컴포넌트에서 직접 접근할 수 있도록 메타데이터 노출
+  // 에러 발생 위치(context)와 유발 인자(kind)를 개별적으로 노출 (기존 하위 호환성 및 다이렉트 접근용)
   public readonly context?: string;
   public readonly kind?: unknown;
 
-  constructor(message: string, kind?: unknown, context?: string) {
-    super(message);
+  constructor(context?: string, kind?: unknown) {
+    const detail = kind !== undefined ? ` (kind: ${String(kind)})` : '';
+    const message = `[ExhaustiveCheck] Unhandled variant${context ? ` in ${context}` : ''}${detail}`;
+
+    const hasMetadata = kind !== undefined || context !== undefined;
+    const cause = hasMetadata ? { kind, context } : undefined;
+
+    // 표준 ErrorOptions.cause를 통해 메타데이터를 노출하여 기존 error.cause 기반 도구/코드와의 호환성을 극대화
+    super(message, cause ? { cause } : undefined);
+
     this.name = 'ExhaustiveCheckError';
-    this.kind = kind;
     this.context = context;
+    this.kind = kind;
+    
     // TypeScript 내장 Error 클래스를 상속할 때 프로토타입 체인 유실을 방지하기 위한 보정
     Object.setPrototypeOf(this, ExhaustiveCheckError.prototype);
   }
@@ -27,12 +36,6 @@ export class ExhaustiveCheckError extends Error {
 export const assertNever = (x: never, context?: string): never => {
   // PII(개인정보)나 민감한 토큰 데이터 유출을 막기 위해 전체 구조체(stringify) 대신 `kind` 식별자만 참조
   const kind = (x as { kind?: unknown })?.kind;
-  // 비원시(non-primitive) 값이 들어오더라도 [object Object]가 아니라 실제 값을 알아볼 수 있도록 명시적 String 변환
-  const detail = kind !== undefined ? ` (kind: ${String(kind)})` : '';
   
-  throw new ExhaustiveCheckError(
-    `Unhandled variant${context ? ` in ${context}` : ''}${detail}`,
-    kind,
-    context
-  );
+  throw new ExhaustiveCheckError(context, kind);
 };

--- a/web_ui/src/lib/utils.ts
+++ b/web_ui/src/lib/utils.ts
@@ -6,9 +6,15 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export class ExhaustiveCheckError extends Error {
-  constructor(message: string) {
+  // 에러 발생 위치(context)와 유발 인자(kind)를 추상화된 메시지 파싱 없이 하위/상위 컴포넌트에서 직접 접근할 수 있도록 메타데이터 노출
+  public readonly context?: string;
+  public readonly kind?: unknown;
+
+  constructor(message: string, kind?: unknown, context?: string) {
     super(message);
     this.name = 'ExhaustiveCheckError';
+    this.kind = kind;
+    this.context = context;
     // TypeScript 내장 Error 클래스를 상속할 때 프로토타입 체인 유실을 방지하기 위한 보정
     Object.setPrototypeOf(this, ExhaustiveCheckError.prototype);
   }
@@ -24,5 +30,9 @@ export const assertNever = (x: never, context?: string): never => {
   // 비원시(non-primitive) 값이 들어오더라도 [object Object]가 아니라 실제 값을 알아볼 수 있도록 명시적 String 변환
   const detail = kind !== undefined ? ` (kind: ${String(kind)})` : '';
   
-  throw new ExhaustiveCheckError(`Unhandled variant${context ? ` in ${context}` : ''}${detail}`);
+  throw new ExhaustiveCheckError(
+    `Unhandled variant${context ? ` in ${context}` : ''}${detail}`,
+    kind,
+    context
+  );
 };


### PR DESCRIPTION
✨ feat [#11.6.3]: 18차 개선 - Exhaustive Error의 구조화된 메타데이터 격리 및 로깅 최적화(SRE/Ops)
✨ feat [#11.6.3]: 19차 개선 - Exhaustive Error 객체지향 캡슐화 및 최신 표준 Error.cause 도입

## Summary by Sourcery

구조화된 메타데이터를 캡슐화하고 최신 에러 원인(cause) 의미론과의 호환성을 개선하도록 포괄적인 에러 처리(exhaustive error handling)를 다듬습니다.

개선 사항:
- `ExhaustiveCheckError`를 확장하여 컨텍스트(context)와 종류(kind)를 구조화된 메타데이터로 캡처하면서도 기존의 직접 프로퍼티 접근은 유지합니다.
- 표준 `ErrorOptions.cause`를 채택하여, 도구 및 관측 가능성(observability)과의 호환성을 개선할 수 있도록 포괄적인 에러 메타데이터를 노출합니다.
- `assertNever`를 단순화하여, 원시 페이로드(raw payload)를 메시지에 포함하지 않고 컨텍스트와 종류로부터 `ExhaustiveCheckError`를 생성하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine exhaustive error handling to encapsulate structured metadata and improve compatibility with modern error-cause semantics.

Enhancements:
- Extend ExhaustiveCheckError to capture context and kind as structured metadata while preserving direct property access.
- Adopt standard ErrorOptions.cause to expose exhaustive error metadata for improved tooling and observability compatibility.
- Simplify assertNever to construct ExhaustiveCheckError from context and kind without embedding raw payloads in the message.

</details>