### PR TITLE
☘️ refactor [#11.7.1]: 2차 개선 - Admin Analytics 엔드포인트 보안 강화 및 집계 로직 단순화

### DIFF
--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -268,8 +268,12 @@ async def get_feedback_stats_endpoint(
     - 최신 사용자 피드백 텍스트 리스트(최대 limit개) 추출
     """
     
-    # 백엔드 API 직접 호출 방지 (서버 간 인증)
-    expected_key = os.environ.get("ADMIN_API_KEY", "dev_secret")
+    # 백엔드 API 직접 호출 방지 (서버 간 인증) 및 하드코딩 제거 (Fail Closed 원칙)
+    expected_key = os.environ.get("ADMIN_API_KEY")
+    if not expected_key:
+        logger.error("[OBS] ADMIN_API_KEY is not configured in environment.")
+        raise HTTPException(status_code=500, detail="Server Configuration Error: Missing Secret")
+        
     if not x_admin_key or x_admin_key != expected_key:
         logger.warning("[OBS] Unauthorized attempt to access admin stats endpoint.")
         raise HTTPException(status_code=403, detail="Forbidden: Invalid Admin Key")

--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -5,8 +5,9 @@
 """
 
 import logging
+import os
 from typing import Optional
-from fastapi import APIRouter, Depends, HTTPException  # type: ignore[import]
+from fastapi import APIRouter, Depends, HTTPException, Query, Header  # type: ignore[import]
 from fastapi.responses import StreamingResponse  # type: ignore[import]
 
 from backend.api.models import (  # type: ignore[import]
@@ -255,7 +256,8 @@ async def submit_feedback(
     summary="AI 피드백 통계 및 트렌드 데이터 조회 (Admin)",
 )
 async def get_feedback_stats_endpoint(
-    limit: int = 50,
+    limit: int = Query(50, ge=1, le=500, description="최근 피드백 반환 최대 개수 (상한 500)"),
+    x_admin_key: Optional[str] = Header(None, description="Next.js 프록시 내부 인증 키"),
     chat_history_service: ChatHistoryService = Depends(get_chat_history_service),
 ):
     """
@@ -265,6 +267,13 @@ async def get_feedback_stats_endpoint(
     - 일자별 긍정/부정 트렌드 차트 데이터를 위해 집계
     - 최신 사용자 피드백 텍스트 리스트(최대 limit개) 추출
     """
+    
+    # 백엔드 API 직접 호출 방지 (서버 간 인증)
+    expected_key = os.environ.get("ADMIN_API_KEY", "dev_secret")
+    if not x_admin_key or x_admin_key != expected_key:
+        logger.warning("[OBS] Unauthorized attempt to access admin stats endpoint.")
+        raise HTTPException(status_code=403, detail="Forbidden: Invalid Admin Key")
+    
     try:
         stats = await chat_history_service.get_feedback_stats(limit_recent=limit)
         return FeedbackStatsResponse(

--- a/backend/services/chat_history_service.py
+++ b/backend/services/chat_history_service.py
@@ -71,8 +71,7 @@ def _process_feedback_entry(
     msg_id_raw: Any,
     meta_raw: Any,
     trends: Dict[str, Dict[str, int]],
-    recent_items: List[Dict[str, Any]],
-) -> tuple[int, int]:
+) -> tuple[int, int, Optional[Dict[str, Any]]]:
     """단일 피드백 항목 파싱 및 가공을 담당하는 헬퍼"""
     msg_id = _decode_str(msg_id_raw)
     meta_str = _decode_str(meta_raw)
@@ -80,9 +79,12 @@ def _process_feedback_entry(
     try:
         meta = json.loads(meta_str)
     except (JSONDecodeError, ValueError, TypeError):
-        return 0, 0
+        return 0, 0, None
 
-    rating = meta.get("rating")
+    raw_rating = meta.get("rating")
+    # Frontend FeedbackRating Union 타입('up' | 'down' | 'none')과 일치시키기 위한 강제 캐스팅
+    rating = raw_rating if raw_rating in ("up", "down") else "none"
+    
     ts = meta.get("timestamp", "")
 
     up_delta = 1 if rating == "up" else 0
@@ -93,19 +95,18 @@ def _process_feedback_entry(
         day = trends.setdefault(date_str, {"up": 0, "down": 0})
         day[rating] += 1
 
+    item = None
     text_content = meta.get("text")
     if text_content and (txt := str(text_content).strip()) and ts:
-        recent_items.append(
-            {
-                "session_id": session_id,
-                "message_id": msg_id,
-                "rating": rating,
-                "text": txt,
-                "timestamp": ts,
-            }
-        )
+        item = {
+            "session_id": session_id,
+            "message_id": msg_id,
+            "rating": rating,
+            "text": txt,
+            "timestamp": ts,
+        }
 
-    return up_delta, down_delta
+    return up_delta, down_delta, item
 
 
 class ChatHistoryService:
@@ -584,11 +585,17 @@ class ChatHistoryService:
         Redis의 `scan`을 사용하여 모든 `chat:feedback:*` 키를 차단(Blocking) 없이 순회하고,
         일자별(Up/Down) 트렌드 및 최근 상세 피드백 내역(텍스트 포함)을 묶어서 반환한다.
         """
+        import heapq
+        
+        # 내부 오작동 방지를 위한 상/하한선 (Service Layer clamping)
+        limit_recent = max(1, min(limit_recent, 500))
+        
         try:
             await self._ensure_connected("get_feedback_stats")
             
             cursor = 0
-            recent_items: List[Dict[str, Any]] = []
+            recent_heap: List[Any] = []
+            tiebreaker = 0
             up_count = down_count = 0
             trends: Dict[str, Dict[str, int]] = {}
 
@@ -603,11 +610,18 @@ class ChatHistoryService:
                     
                     feedback_hash = await redis_client.redis.hgetall(key_str)
                     for msg_id_raw, meta_raw in feedback_hash.items():
-                        up_delta, down_delta = _process_feedback_entry(
-                            session_id, msg_id_raw, meta_raw, trends, recent_items
+                        up_delta, down_delta, item = _process_feedback_entry(
+                            session_id, msg_id_raw, meta_raw, trends
                         )
                         up_count += up_delta
                         down_count += down_delta
+                        
+                        if item:
+                            tiebreaker += 1
+                            # Min-Heap 활용하여 O(1) 메모리 유지: timestamp가 가장 작은(오래된) 항목을 자동 pop
+                            heapq.heappush(recent_heap, (item["timestamp"], tiebreaker, item))
+                            if len(recent_heap) > limit_recent:
+                                heapq.heappop(recent_heap)
                             
                 # 안전하게 int로 캐스팅하여 종료 조건 체크
                 if int(cursor) == 0:
@@ -619,12 +633,12 @@ class ChatHistoryService:
                 for d in sorted(trends.keys())
             ]
             
-            # 4. 단순 리스트 정렬 후 자르기 (설계 단순화)
+            # 4. Heap에서 아이템 추출 후 최신순 역렬
             recent_feedbacks = sorted(
-                recent_items,
+                [val for _, _, val in recent_heap],
                 key=lambda x: x.get("timestamp", ""),
                 reverse=True,
-            )[:limit_recent]
+            )
             
             return {
                 "total_up": up_count,

--- a/backend/services/chat_history_service.py
+++ b/backend/services/chat_history_service.py
@@ -59,6 +59,55 @@ def _log_and_reraise_generic(
     raise exc
 
 
+def _decode_str(value: Any) -> str:
+    """바이트일 경우 디코드하고, 그 외에는 문자열로 캐스팅하는 헬퍼"""
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return str(value)
+
+
+def _process_feedback_entry(
+    session_id: str,
+    msg_id_raw: Any,
+    meta_raw: Any,
+    trends: Dict[str, Dict[str, int]],
+    recent_items: List[Dict[str, Any]],
+) -> tuple[int, int]:
+    """단일 피드백 항목 파싱 및 가공을 담당하는 헬퍼"""
+    msg_id = _decode_str(msg_id_raw)
+    meta_str = _decode_str(meta_raw)
+
+    try:
+        meta = json.loads(meta_str)
+    except (JSONDecodeError, ValueError, TypeError):
+        return 0, 0
+
+    rating = meta.get("rating")
+    ts = meta.get("timestamp", "")
+
+    up_delta = 1 if rating == "up" else 0
+    down_delta = 1 if rating == "down" else 0
+
+    if ts and rating in ("up", "down"):
+        date_str = ts[:10]
+        day = trends.setdefault(date_str, {"up": 0, "down": 0})
+        day[rating] += 1
+
+    text_content = meta.get("text")
+    if text_content and (txt := str(text_content).strip()) and ts:
+        recent_items.append(
+            {
+                "session_id": session_id,
+                "message_id": msg_id,
+                "rating": rating,
+                "text": txt,
+                "timestamp": ts,
+            }
+        )
+
+    return up_delta, down_delta
+
+
 class ChatHistoryService:
     """Redis 기반 채팅 히스토리 및 세션 관리 서비스.
 
@@ -535,69 +584,32 @@ class ChatHistoryService:
         Redis의 `scan`을 사용하여 모든 `chat:feedback:*` 키를 차단(Blocking) 없이 순회하고,
         일자별(Up/Down) 트렌드 및 최근 상세 피드백 내역(텍스트 포함)을 묶어서 반환한다.
         """
-        import heapq
-        
         try:
             await self._ensure_connected("get_feedback_stats")
             
-            up_count = 0
-            down_count = 0
-            trends: Dict[str, Dict[str, int]] = {}
-            # 메모리 최적화를 위한 Bounded Min-Heap (크기를 limit_recent로 유지)
-            recent_heap: List[Any] = []
-            tiebreaker = 0
-
             cursor = 0
+            recent_items: List[Dict[str, Any]] = []
+            up_count = down_count = 0
+            trends: Dict[str, Dict[str, int]] = {}
+
             # 1. 키 목록 수집 & 배치 단위 실시간 처리 (Streaming Aggregation 차용)
             while True:
                 cursor, partial_keys = await redis_client.redis.scan(cursor, match=f"{_FEEDBACK_PREFIX}*", count=100)
                 
-                # 2. 배치별로 즉시 처리하여 전체 키 목록을 메모리에 적재하는 것을 방지
+                # 2. 배치별 즉시 처리
                 for raw_key in partial_keys:
-                    key_str = raw_key.decode('utf-8') if isinstance(raw_key, bytes) else str(raw_key)
+                    key_str = _decode_str(raw_key)
                     session_id = key_str.replace(_FEEDBACK_PREFIX, "")
                     
                     feedback_hash = await redis_client.redis.hgetall(key_str)
                     for msg_id_raw, meta_raw in feedback_hash.items():
-                        msg_id = msg_id_raw.decode('utf-8') if isinstance(msg_id_raw, bytes) else str(msg_id_raw)
-                        meta_str = meta_raw.decode('utf-8') if isinstance(meta_raw, bytes) else str(meta_raw)
-                        
-                        try:
-                            meta = json.loads(meta_str)
-                            rating = meta.get("rating")
+                        up_delta, down_delta = _process_feedback_entry(
+                            session_id, msg_id_raw, meta_raw, trends, recent_items
+                        )
+                        up_count += up_delta
+                        down_count += down_delta
                             
-                            if rating == "up":
-                                up_count += 1
-                            elif rating == "down":
-                                down_count += 1
-                                
-                            ts = meta.get("timestamp", "")
-                            if ts:
-                                date_str = ts[:10]  # YYYY-MM-DD
-                                if date_str not in trends:
-                                    trends[date_str] = {"up": 0, "down": 0}
-                                if rating in ["up", "down"]:
-                                    trends[date_str][rating] += 1
-                            
-                            text_content = meta.get("text")
-                            if text_content and str(text_content).strip() and ts:
-                                tiebreaker += 1
-                                item = {
-                                    "session_id": session_id,
-                                    "message_id": msg_id,
-                                    "rating": rating,
-                                    "text": str(text_content).strip(),
-                                    "timestamp": ts
-                                }
-                                # 힙에 (timestamp, tiebreaker, item) 형태로 푸시 (Min-Heap 기준)
-                                heapq.heappush(recent_heap, (ts, tiebreaker, item))
-                                # 제한 크기를 초과하면 가장 과거(작은 ts) 항목을 pop
-                                if len(recent_heap) > limit_recent:
-                                    heapq.heappop(recent_heap)
-                        except (JSONDecodeError, ValueError, TypeError):
-                            continue
-                            
-                # 안전하고 통일된 안전 조건: redis-py 커서 포맷 변경에 영향받지 않게 int 캐스팅
+                # 안전하게 int로 캐스팅하여 종료 조건 체크
                 if int(cursor) == 0:
                     break
 
@@ -607,9 +619,12 @@ class ChatHistoryService:
                 for d in sorted(trends.keys())
             ]
             
-            # 4. 힙에서 아이템 추출 후 최신순(역순) 정렬
-            recent_feedbacks = [item for _, _, item in recent_heap]
-            recent_feedbacks.sort(key=lambda x: x.get("timestamp", ""), reverse=True)
+            # 4. 단순 리스트 정렬 후 자르기 (설계 단순화)
+            recent_feedbacks = sorted(
+                recent_items,
+                key=lambda x: x.get("timestamp", ""),
+                reverse=True,
+            )[:limit_recent]
             
             return {
                 "total_up": up_count,

--- a/web_ui/src/app/[locale]/(admin)/admin/analytics/actions.ts
+++ b/web_ui/src/app/[locale]/(admin)/admin/analytics/actions.ts
@@ -12,10 +12,12 @@ export interface FeedbackTrend {
   down: number;
 }
 
+export type FeedbackRating = 'up' | 'down' | 'none';
+
 export interface FeedbackDetail {
   session_id: string;
   message_id: string;
-  rating: string;
+  rating: FeedbackRating;
   text: string | null;
   timestamp: string;
 }
@@ -61,6 +63,7 @@ export async function fetchFeedbackStats(limit: number = 50): Promise<FeedbackSt
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
+        'X-Admin-Key': process.env.ADMIN_API_KEY || 'dev_secret',
       },
       // 통계는 실시간 성격이 강하므로 브라우저/루터 캐시 무효화 적용
       cache: 'no-store',

--- a/web_ui/src/app/[locale]/(admin)/admin/analytics/actions.ts
+++ b/web_ui/src/app/[locale]/(admin)/admin/analytics/actions.ts
@@ -59,11 +59,17 @@ export async function fetchFeedbackStats(limit: number = 50): Promise<FeedbackSt
       return fallbackResponse;
     }
 
+    const adminKey = process.env.ADMIN_API_KEY;
+    if (!adminKey) {
+      console.error("[OBS] ADMIN_API_KEY is missing from environment variables.");
+      return fallbackResponse;
+    }
+
     const res = await fetch(`${BACKEND_URL}/api/chat/feedback/stats?limit=${limit}`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
-        'X-Admin-Key': process.env.ADMIN_API_KEY || 'dev_secret',
+        'X-Admin-Key': adminKey,
       },
       // 통계는 실시간 성격이 강하므로 브라우저/루터 캐시 무효화 적용
       cache: 'no-store',


### PR DESCRIPTION
- [Security] FastAPI 백엔드 엔드포인트에 독립적인 `x-admin-key` 헤더 검증 로직을 추가하여 Next.js 외부에서의 비인가 스캔 시도 원천 차단
  - [Stability] Query 파라미터 `limit` 에 대해 최대 상한선(le=500)을 걸어 의도치 않은 대량 스캔(DOS 리스크) 방지
  - [Refactor] `chat_history_service.py` 내 과도한 Bounded-Heap 로직을 제거하고, `_decode_str`, `_process_feedback_entry` 등 역할별 Helper 함수로 추출하여 메인 순회 루프 가독성 개선
  - [Type-Safety] Next.js `actions.ts` 의 `FeedbackRating` 타입을 백엔드 스키마와 동일한 유니온 리터럴(`'up' | 'down' | 'none'`)로 강제하여 타입 안전성 확보

🔗 Related:
- Issue [#866]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/903#pullrequestreview-4039122548)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

관리자 분석 피드백 통계 엔드포인트의 보안을 강화하고, 백엔드와 프론트엔드 전반에서 피드백 집계 로직을 단순화합니다.

새 기능:
- 피드백 통계 API 엔드포인트에 대해 관리자 전용 헤더 기반 인증 가드를 도입합니다.

버그 수정:
- 피드백 제한 쿼리 파라미터에 상한을 강제하여 과도한 피드백 통계 스캔을 방지합니다.

개선 사항:
- 채팅 히스토리 서비스의 피드백 집계를, 피드백 항목을 디코딩/처리하는 헬퍼 함수들로 리팩터링하고, 제한된 힙(bounded heap)을 더 단순한 리스트 기반 처리로 교체합니다.
- 제약된 유니온 타입을 사용해 프론트엔드 피드백 평점 타입을 백엔드 스키마와 정렬하고, 애널리틱스 API 호출 시 Next.js에서 관리자 키가 전달되도록 보장합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen admin analytics feedback stats endpoint security and simplify feedback aggregation logic across backend and frontend.

New Features:
- Introduce an admin-only header-based authentication guard for the feedback statistics API endpoint.

Bug Fixes:
- Prevent excessive feedback stats scans by enforcing an upper bound on the feedback limit query parameter.

Enhancements:
- Refactor feedback aggregation in chat history service into helper functions for decoding and processing feedback entries while replacing the bounded heap with simpler list-based handling.
- Align frontend feedback rating typing with backend schema using a constrained union type and ensure admin key is forwarded from Next.js when calling the analytics API.

</details>