### PR TITLE
Feature/v7 phase4 admin analytics

### DIFF
--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -24,10 +24,18 @@ from backend.services.chat_service import ChatService, get_chat_service  # type:
 from backend.services.chat_history_service import (  # type: ignore[import]
     ChatHistoryService,
     get_chat_history_service,
+    MAX_FEEDBACK_STATS_LIMIT,
 )
 from backend.utils import mask_pii_id  # type: ignore[import]
 
 logger = logging.getLogger(__name__)
+
+# 모듈 로드 시점에 한 번만 환경변수 읽기 (Fail-Fast at Startup)
+_ADMIN_API_KEY = os.environ.get("ADMIN_API_KEY")
+if not _ADMIN_API_KEY:
+    logger.critical(
+        "[OBS] ADMIN_API_KEY is not set. /feedback/stats endpoint will reject all requests."
+    )
 
 router = APIRouter(prefix="/chat", tags=["chat"])
 
@@ -256,7 +264,7 @@ async def submit_feedback(
     summary="AI 피드백 통계 및 트렌드 데이터 조회 (Admin)",
 )
 async def get_feedback_stats_endpoint(
-    limit: int = Query(50, ge=1, le=500, description="최근 피드백 반환 최대 개수 (상한 500)"),
+    limit: int = Query(50, ge=1, le=MAX_FEEDBACK_STATS_LIMIT, description=f"최근 피드백 반환 최대 개수 (상한 {MAX_FEEDBACK_STATS_LIMIT})"),
     x_admin_key: Optional[str] = Header(None, description="Next.js 프록시 내부 인증 키"),
     chat_history_service: ChatHistoryService = Depends(get_chat_history_service),
 ):
@@ -268,13 +276,12 @@ async def get_feedback_stats_endpoint(
     - 최신 사용자 피드백 텍스트 리스트(최대 limit개) 추출
     """
     
-    # 백엔드 API 직접 호출 방지 (서버 간 인증) 및 하드코딩 제거 (Fail Closed 원칙)
-    expected_key = os.environ.get("ADMIN_API_KEY")
-    if not expected_key:
+    # 모듈 로드 시점에 검증된 키를 사용: 설정 누락 시 Fail-Closed 보다 안전하게 처리
+    if not _ADMIN_API_KEY:
         logger.error("[OBS] ADMIN_API_KEY is not configured in environment.")
         raise HTTPException(status_code=500, detail="Server Configuration Error: Missing Secret")
         
-    if not x_admin_key or x_admin_key != expected_key:
+    if not x_admin_key or x_admin_key != _ADMIN_API_KEY:
         logger.warning("[OBS] Unauthorized attempt to access admin stats endpoint.")
         raise HTTPException(status_code=403, detail="Forbidden: Invalid Admin Key")
     

--- a/backend/services/chat_history_service.py
+++ b/backend/services/chat_history_service.py
@@ -24,6 +24,9 @@ _FEEDBACK_PREFIX = "chat:feedback:"
 # preview 최대 길이 (하드코딩 방지)
 _PREVIEW_MAX_LEN = 80
 
+# 피드백 통계 최대 반환 건수 (DRY: 엔드포인트와 서비스 계층 단일 진실 공급원)
+MAX_FEEDBACK_STATS_LIMIT = 500
+
 
 # ─────────────────────────────────────────────────────────────
 # 커스텀 예외
@@ -85,7 +88,9 @@ def _process_feedback_entry(
     # Frontend FeedbackRating Union 타입('up' | 'down' | 'none')과 일치시키기 위한 강제 캐스팅
     rating = raw_rating if raw_rating in ("up", "down") else "none"
     
-    ts = meta.get("timestamp", "")
+    # timestamp가 int이거나 None일 수 있으므로 문자열로 정규화 (TypeError 방어)
+    raw_ts = meta.get("timestamp")
+    ts = str(raw_ts).strip() if raw_ts is not None else ""
 
     up_delta = 1 if rating == "up" else 0
     down_delta = 1 if rating == "down" else 0
@@ -588,7 +593,7 @@ class ChatHistoryService:
         import heapq
         
         # 내부 오작동 방지를 위한 상/하한선 (Service Layer clamping)
-        limit_recent = max(1, min(limit_recent, 500))
+        limit_recent = max(1, min(limit_recent, MAX_FEEDBACK_STATS_LIMIT))
         
         try:
             await self._ensure_connected("get_feedback_stats")


### PR DESCRIPTION
☘️ refactor [#11.7.1]: 4차 개선 - Timestamp 타입 방어 및 limit 단일 진실 공급원 적용

## Summary by Sourcery

피드백 통계 제한 설정을 중앙집중화하고, 관리자 분석용 피드백 통계 엔드포인트 처리 방식을 강화합니다.

개선 사항:
- 관리자 피드백 통계 엔드포인트에 대해 `ADMIN_API_KEY`를 모듈 로드 시점에 읽고 검증하여, 설정 누락 시 빠르게 실패하도록 하고 인증 검사에서 캐시된 키를 재사용합니다.
- 서비스 레이어에 단일 `MAX_FEEDBACK_STATS_LIMIT` 상수를 도입하고, API 엔드포인트와 서비스 메서드 양쪽에서 이를 참조하여 피드백 통계 조회에 대해 일관된 상한을 강제합니다.
- 피드백 항목을 처리할 때 문자열이 아닌 타임스탬프나 누락된 타임스탬프 값을 안전하게 다룰 수 있도록 피드백 메타데이터의 타임스탬프를 문자열로 정규화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize feedback stats limit configuration and harden admin analytics feedback stats endpoint handling.

Enhancements:
- Read and validate ADMIN_API_KEY at module load time for the admin feedback stats endpoint, failing fast on missing configuration and reusing the cached key for authentication checks.
- Introduce a single MAX_FEEDBACK_STATS_LIMIT constant in the service layer and reference it from both the API endpoint and service method to enforce a consistent upper bound on feedback stats queries.
- Normalize feedback metadata timestamps to strings to safely handle non-string or missing timestamp values when processing feedback entries.

</details>