### PR TITLE
☘️ refactor [#11.7.1]: 5차 개선 - Admin 설정 중앙화 및 타임스탬프 타입 검증 강화

### DIFF
--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -26,16 +26,10 @@ from backend.services.chat_history_service import (  # type: ignore[import]
     get_chat_history_service,
     MAX_FEEDBACK_STATS_LIMIT,
 )
+from backend.config import AdminConfig
 from backend.utils import mask_pii_id  # type: ignore[import]
 
 logger = logging.getLogger(__name__)
-
-# 모듈 로드 시점에 한 번만 환경변수 읽기 (Fail-Fast at Startup)
-_ADMIN_API_KEY = os.environ.get("ADMIN_API_KEY")
-if not _ADMIN_API_KEY:
-    logger.critical(
-        "[OBS] ADMIN_API_KEY is not set. /feedback/stats endpoint will reject all requests."
-    )
 
 router = APIRouter(prefix="/chat", tags=["chat"])
 
@@ -276,12 +270,14 @@ async def get_feedback_stats_endpoint(
     - 최신 사용자 피드백 텍스트 리스트(최대 limit개) 추출
     """
     
-    # 모듈 로드 시점에 검증된 키를 사용: 설정 누락 시 Fail-Closed 보다 안전하게 처리
-    if not _ADMIN_API_KEY:
-        logger.error("[OBS] ADMIN_API_KEY is not configured in environment.")
+    # 설정 관리자를 통해 인증 키 조회 (핫 리로드 및 테스트 유연성 보장)
+    admin_key = AdminConfig.get_admin_key()
+    
+    if not admin_key:
+        logger.error("[OBS] ADMIN_API_KEY is not configured in environment. Rejecting access.")
         raise HTTPException(status_code=500, detail="Server Configuration Error: Missing Secret")
         
-    if not x_admin_key or x_admin_key != _ADMIN_API_KEY:
+    if not x_admin_key or x_admin_key != admin_key:
         logger.warning("[OBS] Unauthorized attempt to access admin stats endpoint.")
         raise HTTPException(status_code=403, detail="Forbidden: Invalid Admin Key")
     

--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -325,6 +325,7 @@ class PathConfig:
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 
+
 class AppConfig:
     """애플리케이션 설정"""
 
@@ -343,6 +344,23 @@ class AppConfig:
 
     # 자동화 설정
     ARCHIVE_DAYS_THRESHOLD = 30  # 아카이브 기준일 (미접근 기간)
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━
+# 어드민 설정
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class AdminConfig:
+    """관리자 권한 및 인증 설정"""
+
+    @staticmethod
+    def get_admin_key() -> Optional[str]:
+        """
+        ADMIN_API_KEY를 환경 변수에서 조회한다.
+        모듈 로드 시점이 아닌 호출 시점에 조회하여 핫 리로드 및 테스트 유연성 확보.
+        """
+        return os.getenv("ADMIN_API_KEY")
 
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/backend/services/chat_history_service.py
+++ b/backend/services/chat_history_service.py
@@ -88,9 +88,13 @@ def _process_feedback_entry(
     # Frontend FeedbackRating Union 타입('up' | 'down' | 'none')과 일치시키기 위한 강제 캐스팅
     rating = raw_rating if raw_rating in ("up", "down") else "none"
     
-    # timestamp가 int이거나 None일 수 있으므로 문자열로 정규화 (TypeError 방어)
+    # timestamp가 int(epoch)이거나 str(ISO)일 수 있으므로 타입을 명시적으로 검증하여 정규화
     raw_ts = meta.get("timestamp")
-    ts = str(raw_ts).strip() if raw_ts is not None else ""
+    if isinstance(raw_ts, (int, float, str)):
+        ts = str(raw_ts).strip()
+    else:
+        # 비-스칼라 값(Dict/List) 또는 None의 경우 빈 문자열로 처리하여 예기치 못한 객체 문자화 방지
+        ts = ""
 
     up_delta = 1 if rating == "up" else 0
     down_delta = 1 if rating == "down" else 0


### PR DESCRIPTION
- **[관리자 권한 인증 체계의 유연성 확보 및 데이터 파싱 무결성 고도화]**
  - [Configuration] `AdminConfig` 클래스 도입을 통해 `ADMIN_API_KEY` 관리를 중앙화하고, 호출 시점(Lazy-Loading)에 환경 변수를 조회하도록 하여 핫 리로드 및 테스트 유연성 확보
  - [Logging] 모듈 임포트 시점의 불필요한 `critical` 로그를 제거하고, 엔드포인트 요청 시점에만 명확한 에러 로그를 남기도록 단축하여 관측성(Observability) 노이즈 감소
  - [Type-Safety] `_process_feedback_entry` 내 타임스탬프 정규화 시 `int`, `float`, `str` 타입 여부를 명시적으로 검증하여, 비-스칼라 객체(Dict/List)의 의도치 않은 문자열화 및 런타임 오류 차단
  - [Clean Code] 프로젝트 표준 체크리스트의 '방어적 코딩' 및 '구조화된 로깅' 지침 준수

🔗 Related:
- Issue [#866]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/907#pullrequestreview-4039343887)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

관리자 통계 접근과 데이터 처리의 안전성을 높이기 위해 관리자 API 키 설정을 중앙집중화하고 피드백 타임스탬프 정규화를 강화합니다.

New Features:
- 요청 시점에 `ADMIN_API_KEY`를 제공하는 중앙집중식 호출 소스로서 `AdminConfig`를 도입합니다.

Enhancements:
- 관리자 통계 엔드포인트가 `AdminConfig`를 통해 관리자 API 키를 지연 로딩(lazy) 방식으로 가져오도록 변경하여, 핫 리로드와 테스트 유연성을 향상시킵니다.
- `ADMIN_API_KEY` 누락에 대한 모듈 임포트 시점의 크리티컬 로그를 제거하고, 요청 시점 오류에 대해서만 로그를 남기도록 제한하여 관측 가능성을 개선합니다.
- 예기치 않은 객체 문자열 변환을 방지하기 위해, 정규화 전에 스칼라 타입을 명시적으로 검증함으로써 피드백 메타데이터 타임스탬프 처리를 강화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize admin API key configuration and tighten feedback timestamp normalization for safer admin stats access and data processing.

New Features:
- Introduce AdminConfig to provide a centralized, callable source for the ADMIN_API_KEY at request time.

Enhancements:
- Switch admin stats endpoint to retrieve the admin API key lazily via AdminConfig, improving hot-reload and test flexibility.
- Remove module-import-time critical logging for missing ADMIN_API_KEY and limit logging to request-time errors for clearer observability.
- Harden feedback metadata timestamp handling by explicitly validating scalar types before normalization to prevent unexpected object stringification.

</details>