### PR TITLE
Feature/v7 phase4 admin analytics

### DIFF
--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -26,16 +26,10 @@ from backend.services.chat_history_service import (  # type: ignore[import]
     get_chat_history_service,
     MAX_FEEDBACK_STATS_LIMIT,
 )
+from backend.config import AdminConfig
 from backend.utils import mask_pii_id  # type: ignore[import]
 
 logger = logging.getLogger(__name__)
-
-# 모듈 로드 시점에 한 번만 환경변수 읽기 (Fail-Fast at Startup)
-_ADMIN_API_KEY = os.environ.get("ADMIN_API_KEY")
-if not _ADMIN_API_KEY:
-    logger.critical(
-        "[OBS] ADMIN_API_KEY is not set. /feedback/stats endpoint will reject all requests."
-    )
 
 router = APIRouter(prefix="/chat", tags=["chat"])
 
@@ -276,12 +270,14 @@ async def get_feedback_stats_endpoint(
     - 최신 사용자 피드백 텍스트 리스트(최대 limit개) 추출
     """
     
-    # 모듈 로드 시점에 검증된 키를 사용: 설정 누락 시 Fail-Closed 보다 안전하게 처리
-    if not _ADMIN_API_KEY:
-        logger.error("[OBS] ADMIN_API_KEY is not configured in environment.")
+    # 설정 관리자를 통해 인증 키 조회 (핫 리로드 및 테스트 유연성 보장)
+    admin_key = AdminConfig.get_admin_key()
+    
+    if not admin_key:
+        logger.error("[OBS] ADMIN_API_KEY is not configured in environment. Rejecting access.")
         raise HTTPException(status_code=500, detail="Server Configuration Error: Missing Secret")
         
-    if not x_admin_key or x_admin_key != _ADMIN_API_KEY:
+    if not x_admin_key or x_admin_key != admin_key:
         logger.warning("[OBS] Unauthorized attempt to access admin stats endpoint.")
         raise HTTPException(status_code=403, detail="Forbidden: Invalid Admin Key")
     

--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -325,6 +325,7 @@ class PathConfig:
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 
+
 class AppConfig:
     """애플리케이션 설정"""
 
@@ -343,6 +344,23 @@ class AppConfig:
 
     # 자동화 설정
     ARCHIVE_DAYS_THRESHOLD = 30  # 아카이브 기준일 (미접근 기간)
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━
+# 어드민 설정
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class AdminConfig:
+    """관리자 권한 및 인증 설정"""
+
+    @staticmethod
+    def get_admin_key() -> Optional[str]:
+        """
+        ADMIN_API_KEY를 환경 변수에서 조회한다.
+        모듈 로드 시점이 아닌 호출 시점에 조회하여 핫 리로드 및 테스트 유연성 확보.
+        """
+        return os.getenv("ADMIN_API_KEY")
 
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/backend/services/chat_history_service.py
+++ b/backend/services/chat_history_service.py
@@ -88,9 +88,13 @@ def _process_feedback_entry(
     # Frontend FeedbackRating Union 타입('up' | 'down' | 'none')과 일치시키기 위한 강제 캐스팅
     rating = raw_rating if raw_rating in ("up", "down") else "none"
     
-    # timestamp가 int이거나 None일 수 있으므로 문자열로 정규화 (TypeError 방어)
+    # timestamp가 int(epoch)이거나 str(ISO)일 수 있으므로 타입을 명시적으로 검증하여 정규화
     raw_ts = meta.get("timestamp")
-    ts = str(raw_ts).strip() if raw_ts is not None else ""
+    if isinstance(raw_ts, (int, float, str)):
+        ts = str(raw_ts).strip()
+    else:
+        # 비-스칼라 값(Dict/List) 또는 None의 경우 빈 문자열로 처리하여 예기치 못한 객체 문자화 방지
+        ts = ""
 
     up_delta = 1 if rating == "up" else 0
     down_delta = 1 if rating == "down" else 0


### PR DESCRIPTION
☘️ refactor [#11.7.1]: 5차 개선 - Admin 설정 중앙화 및 타임스탬프 타입 검증 강화

## Summary by Sourcery

채팅 피드백 분석을 위한 관리자 설정을 중앙집중화하고, 피드백 타임스탬프 정규화를 강화했습니다.

버그 수정:
- 비스칼라 값 또는 `None`인 피드백 타임스탬프가 문자열로 변환되면서 예상치 못한 표현이 되는 것을 방지하기 위해, 이를 빈 문자열로 정규화합니다.

개선 사항:
- 관리자 분석 접근 제어의 핫 리로드 및 테스트 용이성을 높이기 위해, 관리자 API 키 처리를 런타임 조회용 전용 `AdminConfig`로 이동했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize admin configuration for chat feedback analytics and harden feedback timestamp normalization.

Bug Fixes:
- Prevent non-scalar or None feedback timestamps from being stringified into unexpected representations by normalizing them to an empty string.

Enhancements:
- Move admin API key handling into a dedicated AdminConfig for runtime lookup, enabling hot-reload and better testability of admin analytics access control.

</details>