### PR TITLE
🐛 fix [#11.7.1]: 6차 개선 - timestamp 타입 검증에서 bool 명시적 제외

### DIFF
--- a/backend/services/chat_history_service.py
+++ b/backend/services/chat_history_service.py
@@ -89,11 +89,12 @@ def _process_feedback_entry(
     rating = raw_rating if raw_rating in ("up", "down") else "none"
     
     # timestamp가 int(epoch)이거나 str(ISO)일 수 있으므로 타입을 명시적으로 검증하여 정규화
+    # 주의: bool은 int의 서브클래스이므로 명시적으로 제외 (True/False가 0/1 epoch으로 처리되는 것을 방지)
     raw_ts = meta.get("timestamp")
-    if isinstance(raw_ts, (int, float, str)):
+    if isinstance(raw_ts, (int, float, str)) and not isinstance(raw_ts, bool):
         ts = str(raw_ts).strip()
     else:
-        # 비-스칼라 값(Dict/List) 또는 None의 경우 빈 문자열로 처리하여 예기치 못한 객체 문자화 방지
+        # bool·비-스칼라 값(Dict/List) 또는 None인 경우 빈 문자열로 처리하여 예기치 못한 객체 문자화 방지
         ts = ""
 
     up_delta = 1 if rating == "up" else 0


### PR DESCRIPTION
- **[Python bool-int 서브클래스 함정 차단으로 데이터 오염 방지]**
  - [Type-Safety] bool은 int의 서브클래스이므로, isinstance 검사 시 not isinstance(raw_ts, bool) 조건을 추가하여 True/False가 유효한 epoch 값으로 처리되는 동작 원천 차단
  - [Data Integrity] ts[:10] 슬라이싱 결과가 항상 'YYYY-MM-DD' 형식임을 보장하여, 트렌드 집계 딕셔너리에 'True'/'False'와 같은 잘못된 날짜 키가 삽입되는 데이터 오염 방지
  - [Code Quality] 방어 로직 의도를 주석으로 명시하여 유지보수 시 혼란 예방

🔗 Related:
- Issue [#866]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/910#pullrequestreview-4039411996)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Bug Fixes:
- 불리언 값이 허용되는 스칼라 타임스탬프 타입에서 제외되도록 하여, `True/False`가 `1/0` 에포크 타임스탬프로 해석되어 날짜 기반 집계 결과를 오염시키는 문제를 방지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Exclude boolean values from accepted scalar timestamp types to prevent True/False from being interpreted as 1/0 epoch timestamps and polluting date-based aggregations.

</details>