### PR TITLE
✨ feat [#11.7.3]: 상세 피드백 텍스트 피드리스트 패널 및 페이지네이션 구현

### DIFF
--- a/web_ui/src/app/[locale]/(admin)/admin/_components/analytics-dashboard-view.tsx
+++ b/web_ui/src/app/[locale]/(admin)/admin/_components/analytics-dashboard-view.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from 'next-intl';
 import { FeedbackTrendChart } from './feedback-trend-chart';
+import { FeedbackListPanel } from './feedback-list-panel';
 import type { FeedbackStatsResponse } from '../analytics/actions';
 
 interface AnalyticsViewProps {
@@ -46,13 +47,22 @@ export function AnalyticsDashboardView({ stats, total, upRatio, downRatio }: Ana
         />
       </div>
 
-      {/* 트렌드 차트 섹션 */}
-      <section className="rounded-xl border bg-card p-6 shadow-sm">
-        <h2 className="mb-4 text-base font-semibold">
-          {t('trend_chart.title')}
-        </h2>
-        <FeedbackTrendChart data={stats.trends} />
-      </section>
+      {/* 트렌드 차트 및 피드 리스트 섹션 */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <section className="rounded-xl border bg-card p-6 shadow-sm">
+          <h2 className="mb-4 text-base font-semibold">
+            {t('trend_chart.title')}
+          </h2>
+          <FeedbackTrendChart data={stats.trends} />
+        </section>
+
+        <section className="rounded-xl border bg-card p-6 shadow-sm">
+          <h2 className="mb-4 text-base font-semibold">
+            {t('feed_list.title')}
+          </h2>
+          <FeedbackListPanel feedbacks={stats.recent_feedbacks} />
+        </section>
+      </div>
     </div>
   );
 }

--- a/web_ui/src/app/[locale]/(admin)/admin/_components/feedback-list-panel.tsx
+++ b/web_ui/src/app/[locale]/(admin)/admin/_components/feedback-list-panel.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { ThumbsUp, ThumbsDown, MessageSquareOff, ChevronLeft, ChevronRight } from 'lucide-react';
+import type { FeedbackDetail } from '../analytics/actions';
+import { clsx } from 'clsx';
+
+interface FeedbackListPanelProps {
+  feedbacks: FeedbackDetail[];
+}
+
+const ITEMS_PER_PAGE = 10;
+
+export function FeedbackListPanel({ feedbacks }: FeedbackListPanelProps) {
+  const t = useTranslations('admin.analytics.feed_list');
+  const [currentPage, setCurrentPage] = useState(1);
+
+  if (!feedbacks || feedbacks.length === 0) {
+    return (
+      <div className="flex h-48 flex-col items-center justify-center rounded-lg border border-dashed text-slate-500">
+        <MessageSquareOff className="mb-2 h-8 w-8 opacity-50" />
+        <p className="text-sm">{t('empty')}</p>
+      </div>
+    );
+  }
+
+  const totalPages = Math.ceil(feedbacks.length / ITEMS_PER_PAGE);
+  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+  const currentFeedbacks = feedbacks.slice(startIndex, startIndex + ITEMS_PER_PAGE);
+
+  return (
+    <div className="flex flex-col space-y-4">
+      <div className="space-y-3">
+        {currentFeedbacks.map((fb, idx) => {
+          // Rating Badge 스타일 결정
+          const isUp = fb.rating === 'up';
+          const isDown = fb.rating === 'down';
+          
+          return (
+            <div
+              key={`${fb.message_id}-${idx}`}
+              className="flex flex-col gap-2 rounded-lg border bg-card p-4 shadow-sm transition-colors hover:bg-slate-50/50 dark:hover:bg-slate-800/10"
+            >
+              <div className="flex items-start justify-between">
+                <div className="flex items-center gap-2">
+                  <div
+                    className={clsx(
+                      "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold",
+                      isUp && "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400",
+                      isDown && "bg-rose-100 text-rose-700 dark:bg-rose-500/20 dark:text-rose-400",
+                      !isUp && !isDown && "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400"
+                    )}
+                  >
+                    {isUp && <ThumbsUp className="h-3.5 w-3.5" />}
+                    {isDown && <ThumbsDown className="h-3.5 w-3.5" />}
+                    {!isUp && !isDown && <MessageSquareOff className="h-3.5 w-3.5" />}
+                    
+                    <span>
+                      {isUp ? t('rating_up') : isDown ? t('rating_down') : t('rating_none')}
+                    </span>
+                  </div>
+                  <span className="text-xs text-muted-foreground">
+                    {new Date(fb.timestamp).toLocaleString(undefined, {
+                      year: 'numeric',
+                      month: '2-digit',
+                      day: '2-digit',
+                      hour: '2-digit',
+                      minute: '2-digit'
+                    })}
+                  </span>
+                </div>
+              </div>
+
+              {/* 사용자 입력 텍스트 */}
+              <p className={clsx("text-sm", !fb.text && "italic text-muted-foreground/60")}>
+                {fb.text ? fb.text : t('no_text')}
+              </p>
+
+              {/* 메타데이터 */}
+              <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                <div className="flex items-center gap-1">
+                  <span className="font-medium">{t('meta_session')}:</span>
+                  <span className="font-mono text-[10px]">{fb.session_id.split('-')[0]}...</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <span className="font-medium">{t('meta_message')}:</span>
+                  <span className="font-mono text-[10px]">{fb.message_id.split('-')[0]}...</span>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Pagination Controls */}
+      {totalPages > 1 && (
+        <div className="mt-4 flex items-center justify-center gap-2">
+          <button
+            onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+            disabled={currentPage === 1}
+            className="flex h-8 w-8 items-center justify-center rounded-md border text-slate-500 transition-colors hover:bg-slate-100 disabled:opacity-50 dark:hover:bg-slate-800"
+            aria-label="Previous Page"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <span className="text-sm text-muted-foreground">
+            {currentPage} / {totalPages}
+          </span>
+          <button
+            onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
+            disabled={currentPage === totalPages}
+            className="flex h-8 w-8 items-center justify-center rounded-md border text-slate-500 transition-colors hover:bg-slate-100 disabled:opacity-50 dark:hover:bg-slate-800"
+            aria-label="Next Page"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web_ui/src/app/[locale]/(admin)/admin/_components/feedback-list-panel.tsx
+++ b/web_ui/src/app/[locale]/(admin)/admin/_components/feedback-list-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { useTranslations } from 'next-intl';
+import { useTranslations, useFormatter } from 'next-intl';
 import { ThumbsUp, ThumbsDown, MessageSquareOff, ChevronLeft, ChevronRight } from 'lucide-react';
 import type { FeedbackDetail } from '../analytics/actions';
 import { clsx } from 'clsx';
@@ -14,7 +14,12 @@ const ITEMS_PER_PAGE = 10;
 
 export function FeedbackListPanel({ feedbacks }: FeedbackListPanelProps) {
   const t = useTranslations('admin.analytics.feed_list');
+  const format = useFormatter();
   const [currentPage, setCurrentPage] = useState(1);
+
+  // feedbacks 배열 변경에 따른 페이지 강제 보정 로직 (useEffect 대신 파생 상태 활용)
+  const totalPages = Math.ceil((feedbacks?.length || 0) / ITEMS_PER_PAGE) || 1;
+  const safeCurrentPage = Math.min(Math.max(1, currentPage), totalPages);
 
   if (!feedbacks || feedbacks.length === 0) {
     return (
@@ -25,8 +30,7 @@ export function FeedbackListPanel({ feedbacks }: FeedbackListPanelProps) {
     );
   }
 
-  const totalPages = Math.ceil(feedbacks.length / ITEMS_PER_PAGE);
-  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+  const startIndex = (safeCurrentPage - 1) * ITEMS_PER_PAGE;
   const currentFeedbacks = feedbacks.slice(startIndex, startIndex + ITEMS_PER_PAGE);
 
   return (
@@ -61,7 +65,7 @@ export function FeedbackListPanel({ feedbacks }: FeedbackListPanelProps) {
                     </span>
                   </div>
                   <span className="text-xs text-muted-foreground">
-                    {new Date(fb.timestamp).toLocaleString(undefined, {
+                    {format.dateTime(new Date(fb.timestamp), {
                       year: 'numeric',
                       month: '2-digit',
                       day: '2-digit',
@@ -81,11 +85,11 @@ export function FeedbackListPanel({ feedbacks }: FeedbackListPanelProps) {
               <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
                 <div className="flex items-center gap-1">
                   <span className="font-medium">{t('meta_session')}:</span>
-                  <span className="font-mono text-[10px]">{fb.session_id.split('-')[0]}...</span>
+                  <span className="font-mono text-[10px]">{fb.session_id ? `${fb.session_id.split('-')[0]}...` : t('unknown')}</span>
                 </div>
                 <div className="flex items-center gap-1">
                   <span className="font-medium">{t('meta_message')}:</span>
-                  <span className="font-mono text-[10px]">{fb.message_id.split('-')[0]}...</span>
+                  <span className="font-mono text-[10px]">{fb.message_id ? `${fb.message_id.split('-')[0]}...` : t('unknown')}</span>
                 </div>
               </div>
             </div>
@@ -98,20 +102,20 @@ export function FeedbackListPanel({ feedbacks }: FeedbackListPanelProps) {
         <div className="mt-4 flex items-center justify-center gap-2">
           <button
             onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
-            disabled={currentPage === 1}
+            disabled={safeCurrentPage === 1}
             className="flex h-8 w-8 items-center justify-center rounded-md border text-slate-500 transition-colors hover:bg-slate-100 disabled:opacity-50 dark:hover:bg-slate-800"
-            aria-label="Previous Page"
+            aria-label={t('prev_page')}
           >
             <ChevronLeft className="h-4 w-4" />
           </button>
           <span className="text-sm text-muted-foreground">
-            {currentPage} / {totalPages}
+            {safeCurrentPage} / {totalPages}
           </span>
           <button
             onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
-            disabled={currentPage === totalPages}
+            disabled={safeCurrentPage === totalPages}
             className="flex h-8 w-8 items-center justify-center rounded-md border text-slate-500 transition-colors hover:bg-slate-100 disabled:opacity-50 dark:hover:bg-slate-800"
-            aria-label="Next Page"
+            aria-label={t('next_page')}
           >
             <ChevronRight className="h-4 w-4" />
           </button>

--- a/web_ui/src/locales/en.json
+++ b/web_ui/src/locales/en.json
@@ -155,7 +155,10 @@
         "rating_none": "No Rating",
         "meta_session": "Session ID",
         "meta_message": "Message ID",
-        "no_text": "(No text feedback provided)"
+        "no_text": "(No text feedback provided)",
+        "prev_page": "Previous Page",
+        "next_page": "Next Page",
+        "unknown": "Unknown"
       }
     },
     "error": {

--- a/web_ui/src/locales/en.json
+++ b/web_ui/src/locales/en.json
@@ -146,6 +146,16 @@
         "up": "Positive",
         "down": "Negative",
         "empty": "No trend data available yet."
+      },
+      "feed_list": {
+        "title": "Recent User Feedbacks",
+        "empty": "No text feedbacks available.",
+        "rating_up": "Helpful",
+        "rating_down": "Needs Improvement",
+        "rating_none": "No Rating",
+        "meta_session": "Session ID",
+        "meta_message": "Message ID",
+        "no_text": "(No text feedback provided)"
       }
     },
     "error": {

--- a/web_ui/src/locales/ko.json
+++ b/web_ui/src/locales/ko.json
@@ -146,6 +146,16 @@
         "up": "긍정",
         "down": "부정",
         "empty": "아직 표시할 트렌드 데이터가 없습니다."
+      },
+      "feed_list": {
+        "title": "최근 사용자 피드백",
+        "empty": "아직 작성된 텍스트 피드백이 없습니다.",
+        "rating_up": "유용함",
+        "rating_down": "개선 필요",
+        "rating_none": "응답 없음",
+        "meta_session": "세션 ID",
+        "meta_message": "메시지 ID",
+        "no_text": "(텍스트 피드백 없음)"
       }
     },
     "error": {

--- a/web_ui/src/locales/ko.json
+++ b/web_ui/src/locales/ko.json
@@ -155,7 +155,10 @@
         "rating_none": "응답 없음",
         "meta_session": "세션 ID",
         "meta_message": "메시지 ID",
-        "no_text": "(텍스트 피드백 없음)"
+        "no_text": "(텍스트 피드백 없음)",
+        "prev_page": "이전 페이지",
+        "next_page": "다음 페이지",
+        "unknown": "알 수 없음"
       }
     },
     "error": {


### PR DESCRIPTION
- **[AI 피드백 원문 및 메타데이터를 확인하기 위한 리스트 UI 구현]**
  - [UI/UX]: 사용자의 구체적 피드백 텍스트와 메타데이터(세션 ID, 메시지 ID, 타임스탬프)를 카드 형태로 나열하는 `FeedbackListPanel` 컴포넌트 신규 개발
  - [Component]: Tailwind CSS 변수를 활용한 긍정/부정(Up/Down) 뱃지 렌더링 및 Null/Empty 텍스트에 대한 방어적 렌더링 로직 추가
  - [Feature]: 대량의 데이터 표출을 대비해 프론트엔드 단일 10개 항목의 상태 기반 페이지네이션(Pagination) 기능 내장
  - [i18n]: 최신 피드백, 긍정/부정 상태별 번역 키(`feed_list.rating_up` 등)를 한국어 및 영어 로케일 파일에 병합 등록

🔗 Related: Issue [#866]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

관리자 분석 대시보드의 트렌드 차트 옆에 최근 상세 피드백을 보여주는 피드백 리스트 패널을 추가합니다.

New Features:
- 평점 배지, 타임스탬프, 메타데이터와 함께 최근 피드백 항목을 표시하는 `FeedbackListPanel` 컴포넌트를 도입합니다.
- 더 큰 데이터 세트를 처리하기 위해 분석 대시보드의 피드백 항목에 클라이언트 사이드 페이지네이션을 추가합니다.
- 기존 트렌드 차트 옆에 최근 피드백 데이터를 관리자 분석 뷰에서 노출합니다.

Enhancements:
- 큰 화면에서 트렌드 차트와 피드백 리스트를 나란히 표시하도록 관리자 분석 레이아웃을 개선합니다.
- 피드백 리스트, 평점 레이블, 빈 상태(Empty state)에 대한 새로운 i18n 키를 한국어와 영어 로케일에 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a feedback list panel with recent detailed feedback to the admin analytics dashboard alongside the trend chart.

New Features:
- Introduce a FeedbackListPanel component that displays recent feedback entries with rating badges, timestamps, and metadata.
- Add client-side pagination for feedback entries in the analytics dashboard to handle larger data sets.
- Expose recent feedback data in the admin analytics view next to the existing trend chart.

Enhancements:
- Enhance the admin analytics layout to show the trend chart and feedback list side by side on large screens.
- Add new i18n keys for the feedback list, rating labels, and empty states in Korean and English locales.

</details>