### PR TITLE
🐛 fix [#11.8.5]: 2차 개선 - Discord 로깅 메모리 릭(Leak) 방어 및 테스트 API 보안(Rate Limit) 강화

### DIFF
--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -6,8 +6,10 @@
 
 import logging
 import os
-from typing import Optional
+import time
+from typing import Optional, Dict
 from fastapi import APIRouter, Depends, HTTPException, Query, Header, Request  # type: ignore[import]
+
 from fastapi.responses import StreamingResponse  # type: ignore[import]
 
 from backend.api.models import (  # type: ignore[import]
@@ -252,8 +254,8 @@ async def submit_feedback(
     )
 
 
-# 인메모리 테스트 알림 Rate Limiting 상태
-_test_alert_last_called = 0.0
+# 인메모리 테스트 알림 Rate Limiting 상태 (IP 기반 추적)
+_test_alert_history: Dict[str, float] = {}
 _TEST_ALERT_THROTTLE_SECONDS = 30.0
 
 @router.post(
@@ -267,25 +269,25 @@ async def test_alert_endpoint(
     """
     강제로 [OBS] 로그를 발생시켜 Discord 알림 파이프라인이 작동하는지 테스트합니다.
     """
-    global _test_alert_last_called
     admin_key = AdminConfig.get_admin_key()
     
     if not admin_key or x_admin_key != admin_key:
         logger.warning("[OBS] Unauthorized attempt to trigger alert test.")
         raise HTTPException(status_code=403, detail="Forbidden")
 
-    import time
     current_time = time.time()
     client_ip = request.client.host if request.client else "unknown"
 
-    # [Fix] 테스트 엔드포인트 무단 남용(Abuse) 방지를 위한 Rate Limiting
-    if current_time - _test_alert_last_called < _TEST_ALERT_THROTTLE_SECONDS:
+    # [Fix] 개별 클라이언트 IP 기반 Rate Limiting (Abuse 방어)
+    last_called = _test_alert_history.get(client_ip, 0.0)
+    if current_time - last_called < _TEST_ALERT_THROTTLE_SECONDS:
         logger.warning(f"[OBS] Rate limited: Test alert requested too frequently by IP: {client_ip}")
         raise HTTPException(status_code=429, detail="Too Many Requests. Please wait before testing again.")
 
-    _test_alert_last_called = current_time
+    _test_alert_history[client_ip] = current_time
 
     # 強제 [OBS] Warning 발생 -> DiscordAlertHandler가 가로챔 (호출자 IP 메타데이터 포함)
+
     logger.warning(f"[OBS] 🔔 Test Alert: 관리자 페이지에서 테스트 알림이 요청되었습니다. (IP: {client_ip})")
     
     return {"status": "success", "message": "Test alert triggered."}

--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -7,7 +7,7 @@
 import logging
 import os
 from typing import Optional
-from fastapi import APIRouter, Depends, HTTPException, Query, Header  # type: ignore[import]
+from fastapi import APIRouter, Depends, HTTPException, Query, Header, Request  # type: ignore[import]
 from fastapi.responses import StreamingResponse  # type: ignore[import]
 
 from backend.api.models import (  # type: ignore[import]
@@ -252,24 +252,41 @@ async def submit_feedback(
     )
 
 
+# 인메모리 테스트 알림 Rate Limiting 상태
+_test_alert_last_called = 0.0
+_TEST_ALERT_THROTTLE_SECONDS = 30.0
+
 @router.post(
     "/alert/test",
     summary="Discord 알림 테스트 발송 (Admin)",
 )
 async def test_alert_endpoint(
+    request: Request,
     x_admin_key: Optional[str] = Header(None, description="Next.js 프록시 내부 인증 키"),
 ):
     """
     강제로 [OBS] 로그를 발생시켜 Discord 알림 파이프라인이 작동하는지 테스트합니다.
     """
+    global _test_alert_last_called
     admin_key = AdminConfig.get_admin_key()
     
     if not admin_key or x_admin_key != admin_key:
         logger.warning("[OBS] Unauthorized attempt to trigger alert test.")
         raise HTTPException(status_code=403, detail="Forbidden")
 
-    # 강제 [OBS] Warning 발생 -> DiscordAlertHandler가 가로챔
-    logger.warning("[OBS] 🔔 Test Alert: 관리자 페이지에서 테스트 알림이 요청되었습니다.")
+    import time
+    current_time = time.time()
+    client_ip = request.client.host if request.client else "unknown"
+
+    # [Fix] 테스트 엔드포인트 무단 남용(Abuse) 방지를 위한 Rate Limiting
+    if current_time - _test_alert_last_called < _TEST_ALERT_THROTTLE_SECONDS:
+        logger.warning(f"[OBS] Rate limited: Test alert requested too frequently by IP: {client_ip}")
+        raise HTTPException(status_code=429, detail="Too Many Requests. Please wait before testing again.")
+
+    _test_alert_last_called = current_time
+
+    # 強제 [OBS] Warning 발생 -> DiscordAlertHandler가 가로챔 (호출자 IP 메타데이터 포함)
+    logger.warning(f"[OBS] 🔔 Test Alert: 관리자 페이지에서 테스트 알림이 요청되었습니다. (IP: {client_ip})")
     
     return {"status": "success", "message": "Test alert triggered."}
 

--- a/backend/utils/observability.py
+++ b/backend/utils/observability.py
@@ -115,6 +115,7 @@ class DiscordAlertHandler(logging.Handler):
     def close(self):
         """로깅 시스템 종료 시 ThreadPoolExecutor의 자원을 안전하게 회수(Shutdown Hook)합니다."""
         if hasattr(self, "_executor"):
-            self._executor.shutdown(wait=False)
+            # 최대한 생성된 알림 전송 태스크가 완료되도록 대기 (Best-effort delivery)
+            self._executor.shutdown(wait=True)
         super().close()
 

--- a/backend/utils/observability.py
+++ b/backend/utils/observability.py
@@ -42,6 +42,12 @@ class DiscordAlertHandler(logging.Handler):
 
         # [Fix] 동시 접속(Concurrent logging) 시 last_alerts 딕셔너리 Race Condition 방어
         with self._lock:
+            # [Fix] 메모리 누수 방지(Eviction Strategy): 저장된 키가 1000개를 초과하면 만료된 데이터 정리
+            if len(self.last_alerts) > 1000:
+                stale_keys = [k for k, v in self.last_alerts.items() if current_time - v >= self.throttle_seconds]
+                for k in stale_keys:
+                    del self.last_alerts[k]
+
             if alert_key in self.last_alerts:
                 if current_time - self.last_alerts[alert_key] < self.throttle_seconds:
                     return
@@ -105,3 +111,10 @@ class DiscordAlertHandler(logging.Handler):
         except Exception as e:
             # 로그 핸들러 내부에서 발생한 에러이므로 재로깅하지 않고 표준 출력만
             print(f"Error in DiscordAlertHandler: {e}")
+
+    def close(self):
+        """로깅 시스템 종료 시 ThreadPoolExecutor의 자원을 안전하게 회수(Shutdown Hook)합니다."""
+        if hasattr(self, "_executor"):
+            self._executor.shutdown(wait=False)
+        super().close()
+


### PR DESCRIPTION
- **[Memory Optimization]** `observability.py`: `last_alerts` 딕셔너리 무한 증식 방지를 위해, 1,000개 이상 초과 시 만료된(Stale) 캐시 키들을 찾아 일괄 파기(Eviction)하는 로직 추가
  - **[Resource Management]** `observability.py`: 파이썬 로깅 시스템 종료 시, `close()` 후크를 오버라이드하여 `ThreadPoolExecutor`에 귀속된 데몬 스레드들을 안전하게 자원 회수(Shut down)하도록 조치
  - **[Security & Logging]** `chat.py (/alert/test)`:
    - 무단 남용(Abuse) 해킹 방어용 인메모리 30초 Rate Limit 쿨타임 적용.
    - `fastapi.Request`를 통해 호출자의 IP 호스트를 식별하여 Discord 메타데이터 및 경고 로그에 추적 가능성 확보

🔗 Related:
- Issue [#866]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/926#pullrequestreview-4051482897)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Discord 관측 가능성을 강화하여 알림 캐시가 무한히 커지는 것을 방지하고, 테스트 알림 트리거를 더 안전하고 악용 가능성이 낮도록 개선합니다.

Bug Fixes:
- 캐시가 크기 임계값을 초과할 때 오래된 엔트리를 제거하여 Discord 알림 throttling 캐시의 무제한 성장을 방지합니다.
- 로깅 시스템이 종료될 때 Discord 알림 핸들러의 thread pool executor가 깔끔하게 종료되도록 보장합니다.

Enhancements:
- 남용을 줄이고 추적 가능성을 향상시키기 위해 Discord 테스트 알림 엔드포인트에 인메모리 rate limiting과 호출자 IP 로깅을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen Discord observability by preventing alert cache growth and making test alert triggering safer and less abuse‑prone.

Bug Fixes:
- Prevent unbounded growth of the Discord alert throttling cache by evicting stale entries when the cache exceeds a size threshold.
- Ensure the Discord alert handler’s thread pool executor is cleanly shut down when the logging system closes.

Enhancements:
- Add in-memory rate limiting and caller IP logging to the Discord test alert endpoint to reduce abuse and improve traceability.

</details>