### PR TITLE
Feature/v7 phase4 admin analytics

### DIFF
--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -6,8 +6,10 @@
 
 import logging
 import os
-from typing import Optional
+import time
+from typing import Optional, Dict
 from fastapi import APIRouter, Depends, HTTPException, Query, Header, Request  # type: ignore[import]
+
 from fastapi.responses import StreamingResponse  # type: ignore[import]
 
 from backend.api.models import (  # type: ignore[import]
@@ -252,8 +254,8 @@ async def submit_feedback(
     )
 
 
-# 인메모리 테스트 알림 Rate Limiting 상태
-_test_alert_last_called = 0.0
+# 인메모리 테스트 알림 Rate Limiting 상태 (IP 기반 추적)
+_test_alert_history: Dict[str, float] = {}
 _TEST_ALERT_THROTTLE_SECONDS = 30.0
 
 @router.post(
@@ -267,25 +269,25 @@ async def test_alert_endpoint(
     """
     강제로 [OBS] 로그를 발생시켜 Discord 알림 파이프라인이 작동하는지 테스트합니다.
     """
-    global _test_alert_last_called
     admin_key = AdminConfig.get_admin_key()
     
     if not admin_key or x_admin_key != admin_key:
         logger.warning("[OBS] Unauthorized attempt to trigger alert test.")
         raise HTTPException(status_code=403, detail="Forbidden")
 
-    import time
     current_time = time.time()
     client_ip = request.client.host if request.client else "unknown"
 
-    # [Fix] 테스트 엔드포인트 무단 남용(Abuse) 방지를 위한 Rate Limiting
-    if current_time - _test_alert_last_called < _TEST_ALERT_THROTTLE_SECONDS:
+    # [Fix] 개별 클라이언트 IP 기반 Rate Limiting (Abuse 방어)
+    last_called = _test_alert_history.get(client_ip, 0.0)
+    if current_time - last_called < _TEST_ALERT_THROTTLE_SECONDS:
         logger.warning(f"[OBS] Rate limited: Test alert requested too frequently by IP: {client_ip}")
         raise HTTPException(status_code=429, detail="Too Many Requests. Please wait before testing again.")
 
-    _test_alert_last_called = current_time
+    _test_alert_history[client_ip] = current_time
 
     # 強제 [OBS] Warning 발생 -> DiscordAlertHandler가 가로챔 (호출자 IP 메타데이터 포함)
+
     logger.warning(f"[OBS] 🔔 Test Alert: 관리자 페이지에서 테스트 알림이 요청되었습니다. (IP: {client_ip})")
     
     return {"status": "success", "message": "Test alert triggered."}

--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -7,7 +7,7 @@
 import logging
 import os
 from typing import Optional
-from fastapi import APIRouter, Depends, HTTPException, Query, Header  # type: ignore[import]
+from fastapi import APIRouter, Depends, HTTPException, Query, Header, Request  # type: ignore[import]
 from fastapi.responses import StreamingResponse  # type: ignore[import]
 
 from backend.api.models import (  # type: ignore[import]
@@ -252,24 +252,41 @@ async def submit_feedback(
     )
 
 
+# 인메모리 테스트 알림 Rate Limiting 상태
+_test_alert_last_called = 0.0
+_TEST_ALERT_THROTTLE_SECONDS = 30.0
+
 @router.post(
     "/alert/test",
     summary="Discord 알림 테스트 발송 (Admin)",
 )
 async def test_alert_endpoint(
+    request: Request,
     x_admin_key: Optional[str] = Header(None, description="Next.js 프록시 내부 인증 키"),
 ):
     """
     강제로 [OBS] 로그를 발생시켜 Discord 알림 파이프라인이 작동하는지 테스트합니다.
     """
+    global _test_alert_last_called
     admin_key = AdminConfig.get_admin_key()
     
     if not admin_key or x_admin_key != admin_key:
         logger.warning("[OBS] Unauthorized attempt to trigger alert test.")
         raise HTTPException(status_code=403, detail="Forbidden")
 
-    # 강제 [OBS] Warning 발생 -> DiscordAlertHandler가 가로챔
-    logger.warning("[OBS] 🔔 Test Alert: 관리자 페이지에서 테스트 알림이 요청되었습니다.")
+    import time
+    current_time = time.time()
+    client_ip = request.client.host if request.client else "unknown"
+
+    # [Fix] 테스트 엔드포인트 무단 남용(Abuse) 방지를 위한 Rate Limiting
+    if current_time - _test_alert_last_called < _TEST_ALERT_THROTTLE_SECONDS:
+        logger.warning(f"[OBS] Rate limited: Test alert requested too frequently by IP: {client_ip}")
+        raise HTTPException(status_code=429, detail="Too Many Requests. Please wait before testing again.")
+
+    _test_alert_last_called = current_time
+
+    # 強제 [OBS] Warning 발생 -> DiscordAlertHandler가 가로챔 (호출자 IP 메타데이터 포함)
+    logger.warning(f"[OBS] 🔔 Test Alert: 관리자 페이지에서 테스트 알림이 요청되었습니다. (IP: {client_ip})")
     
     return {"status": "success", "message": "Test alert triggered."}
 

--- a/backend/utils/observability.py
+++ b/backend/utils/observability.py
@@ -115,6 +115,7 @@ class DiscordAlertHandler(logging.Handler):
     def close(self):
         """로깅 시스템 종료 시 ThreadPoolExecutor의 자원을 안전하게 회수(Shutdown Hook)합니다."""
         if hasattr(self, "_executor"):
-            self._executor.shutdown(wait=False)
+            # 최대한 생성된 알림 전송 태스크가 완료되도록 대기 (Best-effort delivery)
+            self._executor.shutdown(wait=True)
         super().close()
 

--- a/backend/utils/observability.py
+++ b/backend/utils/observability.py
@@ -42,6 +42,12 @@ class DiscordAlertHandler(logging.Handler):
 
         # [Fix] 동시 접속(Concurrent logging) 시 last_alerts 딕셔너리 Race Condition 방어
         with self._lock:
+            # [Fix] 메모리 누수 방지(Eviction Strategy): 저장된 키가 1000개를 초과하면 만료된 데이터 정리
+            if len(self.last_alerts) > 1000:
+                stale_keys = [k for k, v in self.last_alerts.items() if current_time - v >= self.throttle_seconds]
+                for k in stale_keys:
+                    del self.last_alerts[k]
+
             if alert_key in self.last_alerts:
                 if current_time - self.last_alerts[alert_key] < self.throttle_seconds:
                     return
@@ -105,3 +111,10 @@ class DiscordAlertHandler(logging.Handler):
         except Exception as e:
             # 로그 핸들러 내부에서 발생한 에러이므로 재로깅하지 않고 표준 출력만
             print(f"Error in DiscordAlertHandler: {e}")
+
+    def close(self):
+        """로깅 시스템 종료 시 ThreadPoolExecutor의 자원을 안전하게 회수(Shutdown Hook)합니다."""
+        if hasattr(self, "_executor"):
+            self._executor.shutdown(wait=False)
+        super().close()
+


### PR DESCRIPTION
🐛 fix [#11.8.5]: 2차 개선 - Discord 로깅 메모리 릭(Leak) 방어 및 테스트 API 보안(Rate Limit) 강화
🐛 fix [#11.8.5]: 3차 개선 - 테스트 알림 API 클라이언트별 Rate Limit 최적화 및 Graceful Shutdown 반영

## Summary by Sourcery

남용과 메모리 누수를 방지하고, Discord 알림 관측 가능성을 강화하며, 로깅 종료가 우아하게 이루어지도록 관리자 테스트 알림 엔드포인트를 개선합니다.

버그 수정:
- 관리자 Discord 테스트 알림 엔드포인트에 IP 기반 rate limiting 및 throttling을 추가하여 남용을 방지합니다.
- 메모리 내 알림 캐시가 임계값을 초과해 커질 때 오래된 항목을 제거(evict)하여 Discord 알림 로깅에서 발생할 수 있는 잠재적인 메모리 누수를 방지합니다.
- 애플리케이션 종료 시 리소스 누수를 피하기 위해 Discord 로깅 핸들러가 스레드 풀 실행기를 우아하게(gracefully) 종료하도록 합니다.

개선 사항:
- 감사 가능성과 관측 가능성을 향상하기 위해 테스트 알림 로그 메시지에 호출자 IP 메타데이터를 포함합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen Discord alert observability and admin test alert endpoint to prevent abuse, memory leaks, and ensure graceful logging shutdown.

Bug Fixes:
- Add IP-based rate limiting and throttling for the admin Discord test alert endpoint to prevent abuse.
- Prevent potential memory leaks in Discord alert logging by evicting stale entries when the in-memory alert cache grows beyond a threshold.
- Ensure the Discord logging handler shuts down its thread pool executor gracefully to avoid resource leaks during application shutdown.

Enhancements:
- Include caller IP metadata in test alert log messages to improve auditability and observability.

</details>