### PR TITLE
🐛 fix [#11.8.5]: 4차 개선 - 서버 시간 동기화 결함 방지 및 프록시 환경의 IP Rate Limiting 메모리 구조 고도화

### DIFF
--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -255,8 +255,38 @@ async def submit_feedback(
 
 
 # 인메모리 테스트 알림 Rate Limiting 상태 (IP 기반 추적)
+# key: IP, value: timestamp (monotonic)
 _test_alert_history: Dict[str, float] = {}
 _TEST_ALERT_THROTTLE_SECONDS = 30.0
+_TEST_ALERT_MAX_ENTRIES = 1000
+
+def _cleanup_test_alert_history(now: float) -> None:
+    """오래된 엔트리를 제거하고 최대 크기를 넘기면 가장 오래된 항목부터 삭제하여 메모리 릭을 방지합니다."""
+    global _test_alert_history
+    cutoff = now - _TEST_ALERT_THROTTLE_SECONDS
+    if _test_alert_history:
+        _test_alert_history = {ip: ts for ip, ts in _test_alert_history.items() if ts >= cutoff}
+    
+    size = len(_test_alert_history)
+    if size <= _TEST_ALERT_MAX_ENTRIES:
+        return
+    
+    excess = size - _TEST_ALERT_MAX_ENTRIES
+    sorted_items = sorted(_test_alert_history.items(), key=lambda item: item[1])
+    for ip, _ in sorted_items[:excess]:
+        _test_alert_history.pop(ip, None)
+
+def get_client_ip(request: Request) -> str:
+    """프록시/로드밸런서 환경을 고려하여 실제 클라이언트 IP를 안전하게 추출합니다."""
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    real_ip = request.headers.get("X-Real-IP")
+    if real_ip:
+        return real_ip.strip()
+    if request.client and request.client.host:
+        return request.client.host
+    return "unknown"
 
 @router.post(
     "/alert/test",
@@ -275,10 +305,13 @@ async def test_alert_endpoint(
         logger.warning("[OBS] Unauthorized attempt to trigger alert test.")
         raise HTTPException(status_code=403, detail="Forbidden")
 
-    current_time = time.time()
-    client_ip = request.client.host if request.client else "unknown"
+    current_time = time.monotonic()
+    client_ip = get_client_ip(request)
 
-    # [Fix] 개별 클라이언트 IP 기반 Rate Limiting (Abuse 방어)
+    # [Fix] 메모리 릭 방지를 위한 Eviction 적용
+    _cleanup_test_alert_history(current_time)
+
+    # [Fix] 개별 클라이언트 IP 기반 Rate Limiting (Abuse 방어 및 프록시 환경 지원)
     last_called = _test_alert_history.get(client_ip, 0.0)
     if current_time - last_called < _TEST_ALERT_THROTTLE_SECONDS:
         logger.warning(f"[OBS] Rate limited: Test alert requested too frequently by IP: {client_ip}")
@@ -287,7 +320,6 @@ async def test_alert_endpoint(
     _test_alert_history[client_ip] = current_time
 
     # 強제 [OBS] Warning 발생 -> DiscordAlertHandler가 가로챔 (호출자 IP 메타데이터 포함)
-
     logger.warning(f"[OBS] 🔔 Test Alert: 관리자 페이지에서 테스트 알림이 요청되었습니다. (IP: {client_ip})")
     
     return {"status": "success", "message": "Test alert triggered."}

--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -7,6 +7,8 @@
 import logging
 import os
 import time
+import threading
+from collections import OrderedDict
 from typing import Optional, Dict
 from fastapi import APIRouter, Depends, HTTPException, Query, Header, Request  # type: ignore[import]
 
@@ -255,38 +257,49 @@ async def submit_feedback(
 
 
 # 인메모리 테스트 알림 Rate Limiting 상태 (IP 기반 추적)
+# 인메모리 테스트 알림 Rate Limiting 상태 (IP 기반 추적)
 # key: IP, value: timestamp (monotonic)
-_test_alert_history: Dict[str, float] = {}
+_test_alert_history: OrderedDict[str, float] = OrderedDict()
 _TEST_ALERT_THROTTLE_SECONDS = 30.0
 _TEST_ALERT_MAX_ENTRIES = 1000
 
+# 동시성 환경 레이스 컨디션 방지를 위한 모듈 레벨 락
+_test_alert_lock = threading.Lock()
+
+# 신뢰할 수 있는 프록시 IP 목록 (실제 환경에서는 환경변수나 설정값으로 분리)
+_TRUSTED_PROXIES = {"127.0.0.1", "::1", "localhost"}
+
 def _cleanup_test_alert_history(now: float) -> None:
-    """오래된 엔트리를 제거하고 최대 크기를 넘기면 가장 오래된 항목부터 삭제하여 메모리 릭을 방지합니다."""
+    """오래된 엔트리를 제거하고 최대 크기를 넘기면 가장 오래된 항목부터 삭제하여 메모리 릭을 방지합니다. (OrderedDict 기반 O(1) LRU)"""
     global _test_alert_history
     cutoff = now - _TEST_ALERT_THROTTLE_SECONDS
-    if _test_alert_history:
-        _test_alert_history = {ip: ts for ip, ts in _test_alert_history.items() if ts >= cutoff}
     
-    size = len(_test_alert_history)
-    if size <= _TEST_ALERT_MAX_ENTRIES:
-        return
-    
-    excess = size - _TEST_ALERT_MAX_ENTRIES
-    sorted_items = sorted(_test_alert_history.items(), key=lambda item: item[1])
-    for ip, _ in sorted_items[:excess]:
-        _test_alert_history.pop(ip, None)
+    # 1) 만료된 항목 O(1) 삭제 (삽입 순서가 보장되므로, 오래된 것부터 순차 검사)
+    while _test_alert_history:
+        ip, ts = next(iter(_test_alert_history.items()))
+        if ts < cutoff:
+            _test_alert_history.pop(ip)
+        else:
+            break
+            
+    # 2) 허용된 최대 튜플 크기를 초과할 경우, 가장 오래된 항목 삭제
+    while len(_test_alert_history) > _TEST_ALERT_MAX_ENTRIES:
+        _test_alert_history.popitem(last=False)
 
 def get_client_ip(request: Request) -> str:
-    """프록시/로드밸런서 환경을 고려하여 실제 클라이언트 IP를 안전하게 추출합니다."""
-    forwarded = request.headers.get("X-Forwarded-For")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
-    real_ip = request.headers.get("X-Real-IP")
-    if real_ip:
-        return real_ip.strip()
-    if request.client and request.client.host:
-        return request.client.host
-    return "unknown"
+    """신뢰할 수 있는 프록시에 한하여 X-Forwarded-For 헤더를 사용함으로써 IP 스푸핑을 방지합니다."""
+    client_ip = request.client.host if request.client else "unknown"
+
+    if client_ip in _TRUSTED_PROXIES:
+        forwarded = request.headers.get("X-Forwarded-For")
+        if forwarded:
+            # 첫 번째 구획 추출 (마지막 비신뢰 구간 클라이언트 IP)
+            return forwarded.split(",")[0].strip()
+        real_ip = request.headers.get("X-Real-IP")
+        if real_ip:
+            return real_ip.strip()
+
+    return client_ip
 
 @router.post(
     "/alert/test",
@@ -308,16 +321,19 @@ async def test_alert_endpoint(
     current_time = time.monotonic()
     client_ip = get_client_ip(request)
 
-    # [Fix] 메모리 릭 방지를 위한 Eviction 적용
-    _cleanup_test_alert_history(current_time)
+    # [Fix] 락을 통한 동시성 레이스 컨디션 완벽 방어 처리
+    with _test_alert_lock:
+        # [Fix] 메모리 릭 방지를 위한 Eviction 적용 (시간복잡도 해결 O(1))
+        _cleanup_test_alert_history(current_time)
+        
+        # [Fix] 개별 클라이언트 IP 기반 Rate Limiting 
+        last_called = _test_alert_history.get(client_ip, 0.0)
+        if current_time - last_called < _TEST_ALERT_THROTTLE_SECONDS:
+            logger.warning(f"[OBS] Rate limited: Test alert requested too frequently by IP: {client_ip}")
+            raise HTTPException(status_code=429, detail="Too Many Requests. Please wait before testing again.")
 
-    # [Fix] 개별 클라이언트 IP 기반 Rate Limiting (Abuse 방어 및 프록시 환경 지원)
-    last_called = _test_alert_history.get(client_ip, 0.0)
-    if current_time - last_called < _TEST_ALERT_THROTTLE_SECONDS:
-        logger.warning(f"[OBS] Rate limited: Test alert requested too frequently by IP: {client_ip}")
-        raise HTTPException(status_code=429, detail="Too Many Requests. Please wait before testing again.")
-
-    _test_alert_history[client_ip] = current_time
+        _test_alert_history[client_ip] = current_time
+        _test_alert_history.move_to_end(client_ip)  # 최근 접속한 항목을 뒤로 보내 LRU 체계를 확립
 
     # 強제 [OBS] Warning 발생 -> DiscordAlertHandler가 가로챔 (호출자 IP 메타데이터 포함)
     logger.warning(f"[OBS] 🔔 Test Alert: 관리자 페이지에서 테스트 알림이 요청되었습니다. (IP: {client_ip})")

--- a/backend/utils/observability.py
+++ b/backend/utils/observability.py
@@ -38,7 +38,7 @@ class DiscordAlertHandler(logging.Handler):
         # 2. 알림 임계값(Throttling) 체크 (포맷이 적용된 최종 메시지 기준)
         # record.msg 대신 getMessage()를 사용하여 파라미터가 포맷팅된 실제 내용을 기준으로 필터링
         alert_key = f"{record.levelno}:{record.getMessage()}"
-        current_time = time.time()
+        current_time = time.monotonic()
 
         # [Fix] 동시 접속(Concurrent logging) 시 last_alerts 딕셔너리 Race Condition 방어
         with self._lock:


### PR DESCRIPTION
- **[Performance]** `chat.py`: 인메모리 테스트 알림 Rate Limit(`_test_alert_history`)의 딕셔너리 무한 증식(OOM) 방지를 위해 최대 한도 1000개를 유지하는 LRU 형태의 Eviction(추방) 클린업 알고리즘을 구현하여 적용
  - **[Security]** `chat.py`: Next.js 역방향 프록시 및 로드밸런서 환경에서 발생하는 IP 식별 우회(Bypass) 결함을 차단하기 위해 `X-Forwarded-For`, `X-Real-IP` 헤더를 정밀 파싱하는 `get_client_ip` 헬퍼 도입
  - **[Stability]** 양측 파일(`chat.py`, `observability.py`) 내의 모든 기간(Interval) 및 쿨타임 측정 함수를 시스템 시계 변경의 영항을 받는 `time.time()`에서 안전한 단조순증가 타이머인 `time.monotonic()`으로 전면 교체

🔗 Related:
- Issue [#866]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/928#pullrequestreview-4051590407)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

관측 기능을 위한 테스트 알림(rate limiting) 제한의 견고성과 시간 처리 방식을 개선합니다.

Bug Fixes:
- 최대 엔트리 수 제한과 함께 정리(cleanup) 로직을 추가하여, 메모리 상의 테스트 알림 rate limit 추적 데이터가 무한히 증가하는 문제를 방지합니다.
- 전달된 IP 헤더를 파싱하여, 프록시 및 로드 밸런서 환경에서 rate limiting을 위한 클라이언트 IP 감지를 올바르게 수행하도록 수정합니다.
- 시스템 시계 변경에도 관측 관련 throttling 로직이 영향을 받지 않도록, 모노토닉 타이머로 전환합니다.

Enhancements:
- 클라이언트 IP 추출을 위한 헬퍼와 중앙집중식 정리(cleanup) 로직을 사용하도록 테스트 알림 rate limiting을 정교하게 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve test alert rate limiting robustness and time handling for observability.

Bug Fixes:
- Prevent unbounded growth of in-memory test alert rate limit tracking by adding cleanup with a maximum entry cap.
- Correct client IP detection for rate limiting in proxy and load balancer environments by parsing forwarded IP headers.
- Make observability throttling logic resilient to system clock changes by switching to a monotonic timer.

Enhancements:
- Refine test alert rate limiting to use a helper for client IP extraction and centralized cleanup logic.

</details>