### PR TITLE
📝 docs [#11.8.5]: 6차 개선 - Rate Limit IP 헬퍼 및 LRU Eviction 복잡도 주석 명확화

### DIFF
--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -270,11 +270,16 @@ _test_alert_lock = threading.Lock()
 _TRUSTED_PROXIES = {"127.0.0.1", "::1", "localhost"}
 
 def _cleanup_test_alert_history(now: float) -> None:
-    """오래된 엔트리를 제거하고 최대 크기를 넘기면 가장 오래된 항목부터 삭제하여 메모리 릭을 방지합니다. (OrderedDict 기반 O(1) LRU)"""
+    """오래된 엔트리를 제거하고 최대 크기를 넘기면 가장 오래된 항목부터 삭제하여 메모리 릭을 방지합니다.
+
+    OrderedDict 기반 LRU로, 개별 삭제 연산은 O(1)이지만 한 번의 호출에서
+    만료된 항목 또는 초과된 항목 수만큼 최대 O(N)까지 스캔/삭제가 발생할 수 있습니다.
+    따라서 전체적으로는 항목 수에 대해 상한이 있는, 분할 상환(Amortized) O(1) 복잡도를 갖습니다.
+    """
     global _test_alert_history
     cutoff = now - _TEST_ALERT_THROTTLE_SECONDS
     
-    # 1) 만료된 항목 O(1) 삭제 (삽입 순서가 보장되므로, 오래된 것부터 순차 검사)
+    # 1) 만료된 항목 삭제 (분할 상환 O(1))
     while _test_alert_history:
         ip, ts = next(iter(_test_alert_history.items()))
         if ts < cutoff:
@@ -282,7 +287,7 @@ def _cleanup_test_alert_history(now: float) -> None:
         else:
             break
             
-    # 2) 허용된 최대 튜플 크기를 초과할 경우, 가장 오래된 항목 삭제
+    # 2) 허용된 최대 튜플 크기를 초과할 경우, 가장 오래된 항목 삭제 (개별 연산 O(1))
     while len(_test_alert_history) > _TEST_ALERT_MAX_ENTRIES:
         _test_alert_history.popitem(last=False)
 
@@ -293,7 +298,7 @@ def get_client_ip(request: Request) -> str:
     if client_ip in _TRUSTED_PROXIES:
         forwarded = request.headers.get("X-Forwarded-For")
         if forwarded:
-            # 첫 번째 구획 추출 (마지막 비신뢰 구간 클라이언트 IP)
+            # X-Forwarded-For의 가장 첫 번째 값(가장 좌측)은 최초 발신지(Original Client) IP입니다.
             return forwarded.split(",")[0].strip()
         real_ip = request.headers.get("X-Real-IP")
         if real_ip:
@@ -323,7 +328,7 @@ async def test_alert_endpoint(
 
     # [Fix] 락을 통한 동시성 레이스 컨디션 완벽 방어 처리
     with _test_alert_lock:
-        # [Fix] 메모리 릭 방지를 위한 Eviction 적용 (시간복잡도 해결 O(1))
+        # [Fix] 메모리 릭 방지를 위한 Eviction 적용 (분할 상환 O(1))
         _cleanup_test_alert_history(current_time)
         
         # [Fix] 개별 클라이언트 IP 기반 Rate Limiting 

--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -298,7 +298,8 @@ def get_client_ip(request: Request) -> str:
     if client_ip in _TRUSTED_PROXIES:
         forwarded = request.headers.get("X-Forwarded-For")
         if forwarded:
-            # X-Forwarded-For의 가장 첫 번째 값(가장 좌측)은 최초 발신지(Original Client) IP입니다.
+            # X-Forwarded-For의 가장 첫 번째 값(가장 좌측)은 최초 발신지(Original Client) IP이며,
+            # 이는 신뢰할 수 있는 프록시(_TRUSTED_PROXIES)를 거친 경우에만 위조되지 않은 것으로 간주하여 신뢰합니다.
             return forwarded.split(",")[0].strip()
         real_ip = request.headers.get("X-Real-IP")
         if real_ip:


### PR DESCRIPTION
- **[Documentation]**: `get_client_ip` 내의 `X-Forwarded-For` 헤더 추출(`split(',')[0]`) 시 사용하는 요소를 '마지막 비신뢰 구간' 이라는 모호한 표현 대신 '가장 좌측의 최초 발신지(Original Client) IP'로 명확화하여 오해 소지 철폐
  - **[Documentation]**: `_cleanup_test_alert_history`의 LRU 메커니즘이 엄격한 단일 O(1)가 아니라 한 번의 호출에 따라 만료된 횟수만큼 스캔할 수 있음을 적기 위해 '분할 상환(Amortized) O(1) 복잡도'라는 실질 최악 복잡도 한계(Max Upper bound)로 Docstring 및 인라인 주석 수정 수정

🔗 Related:
- Issue [#866]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/930#pullrequestreview-4051665175)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

테스트 알림 히스토리 정리와 클라이언트 IP 추출과 관련된 레이트 리미팅 헬퍼 동작 및 LRU 제거 복잡성에 대한 문서와 주석을 더 명확하게 합니다.

향상 사항:
- 제거 및 LRU 연산을 엄격한 O(1)이 아닌, 균등화된(amortized) O(1) 복잡도의 관점에서 설명하도록 인라인 주석을 다듬었습니다.

문서화:
- X-Forwarded-For 추출이 모호한 ‘신뢰할 수 없는(untrusted)’ 구간이 아니라, 가장 왼쪽 값을 원래 클라이언트 IP로 사용함을 명확히 했습니다.
- 테스트 알림 히스토리 LRU 정리가 여러 만료되었거나 초과된 항목들로 인해 호출당 O(N) 스캔이 발생할 수 있지만, 전체적으로는 균등화된(amortized) O(1) 복잡도를 갖는다는 점을 문서화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify documentation and comments around rate limiting helper behavior and LRU eviction complexity for test alert history cleanup and client IP extraction.

Enhancements:
- Refine inline comments to describe eviction and LRU operations in terms of amortized O(1) complexity instead of strict O(1).

Documentation:
- Clarify that X-Forwarded-For extraction uses the leftmost value as the original client IP rather than referring to a vague 'untrusted' segment.
- Document that the test alert history LRU cleanup has amortized O(1) complexity with potential O(N) scans per call due to multiple expired or excess entries.

</details>