### PR TITLE
Feature/v8 phase5 data flywheel

### DIFF
--- a/backend/services/golden_dataset_service.py
+++ b/backend/services/golden_dataset_service.py
@@ -29,6 +29,8 @@ logger = logging.getLogger(__name__)
 
 # SCAN 기본 배치 크기 (Redis 권장: 한 번에 너무 많은 키를 가져오지 않도록 제한)
 _DEFAULT_SCAN_BATCH_SIZE = 100
+_MIN_SCAN_BATCH_SIZE = 1
+_MAX_SCAN_BATCH_SIZE = 10_000
 
 
 # ─────────────────────────────────────────────────────────────
@@ -61,52 +63,43 @@ class FeedbackDataPoint:
 # ─────────────────────────────────────────────────────────────
 
 
-def _decode_str(value: Any) -> str:
-    """Redis 응답값이 bytes일 경우 UTF-8 디코드, 그 외에는 str 캐스팅."""
-    if isinstance(value, bytes):
-        return value.decode("utf-8")
-    return str(value)
-
-
-def _is_valid_timestamp(raw_ts: Any) -> bool:
-    """
-    timestamp 값이 처리 가능한 스칼라 타입인지 검증합니다.
-
-    주의: bool은 int의 서브클래스이므로 명시적으로 제외합니다.
-    (True/False가 각각 1/0 epoch 값으로 잘못 처리되는 것을 방지)
-    """
-    return isinstance(raw_ts, (int, float, str)) and not isinstance(raw_ts, bool)
-
-
 def _parse_feedback_meta(
     msg_id_raw: Any,
     meta_raw: Any,
-) -> Optional[tuple[str, str, Optional[str], str]]:
+) -> Optional[tuple[str, Optional[str], str]]:
     """
     Redis Hash의 단일 필드 (message_id, JSON 메타) 쌍을 파싱합니다.
 
-    반환 형식:
-        (message_id, rating, feedback_text, timestamp) 또는 파싱 실패 시 None
+    rating 체크를 헬퍼 내부에 통합하여, 호출 측 메인 루프가
+    이미 긍정("up") 평가가 확인된 엔트리만 다룰 수 있도록 설계되었습니다.
 
-    실패 케이스 (None 반환):
+    반환 형식:
+        (message_id, feedback_text, timestamp) 또는 파싱 실패/비긍정 평가 시 None
+
+    None 반환 조건:
         - JSON 디코딩 오류
+        - rating != "up" (부정/없음 포함)
         - timestamp가 유효하지 않은 타입이거나 빈 문자열
     """
-    msg_id = _decode_str(msg_id_raw)
-    meta_str = _decode_str(meta_raw)
+    # _decode_str 인라인: 별도 함수 호출 없이 직접 처리하여 호출 오버헤드 제거
+    msg_id = msg_id_raw.decode("utf-8") if isinstance(msg_id_raw, bytes) else str(msg_id_raw)
+    meta_str = meta_raw.decode("utf-8") if isinstance(meta_raw, bytes) else str(meta_raw)
 
     try:
         meta = json.loads(meta_str)
     except (JSONDecodeError, ValueError, TypeError):
         return None
 
-    # rating: Frontend FeedbackRating Union 타입('up' | 'down' | 'none')에 맞게 검증
-    raw_rating = meta.get("rating")
-    rating = raw_rating if raw_rating in ("up", "down") else "none"
+    # 긍정 피드백("up")이 아닌 모든 항목은 여기서 필터링됩니다.
+    # 호출 측 메인 루프는 rating 정규화("none" 등)에 대해 알 필요가 없습니다.
+    if meta.get("rating") != "up":
+        return None
 
     # timestamp: 유효한 스칼라 타입 + 비어있지 않아야 함
+    # 주의: bool은 int의 서브클래스이므로 명시적으로 제외합니다.
+    # (True/False가 각각 1/0 epoch 값으로 잘못 처리되는 것을 방지)
     raw_ts = meta.get("timestamp")
-    if not _is_valid_timestamp(raw_ts):
+    if not isinstance(raw_ts, (int, float, str)) or isinstance(raw_ts, bool):
         return None
     ts = str(raw_ts).strip()
     if not ts:
@@ -119,7 +112,7 @@ def _parse_feedback_meta(
         stripped = str(feedback_text_raw).strip()
         feedback_text = stripped if stripped else None
 
-    return msg_id, rating, feedback_text, ts
+    return msg_id, feedback_text, ts
 
 
 # ─────────────────────────────────────────────────────────────
@@ -136,13 +129,14 @@ async def filter_positive_feedbacks(
     품질 기준을 통과한 '좋아요(Thumbs Up)' 피드백 항목을 수집합니다.
 
     품질 게이트 (Quality Gates):
-        1. rating == "up" 인 항목만 포함 (부정/없음 제외)
+        1. rating == "up" 인 항목만 포함 (부정/없음 제외, _parse_feedback_meta 내부에서 처리)
         2. timestamp가 유효한 스칼라 타입이고 비어있지 않아야 함
         3. session_id와 message_id 모두 비어있지 않아야 함
         4. (session_id, message_id) 복합 키 기준으로 중복 제거
 
     Args:
-        batch_size: Redis SCAN이 한 번에 가져올 키 수 힌트 (기본값: 100)
+        batch_size: Redis SCAN이 한 번에 가져올 키 수 힌트.
+                    허용 범위: [{min_batch}, {max_batch}] (기본값: {default_batch})
                     실제 반환 수는 Redis 내부 정책에 따라 다를 수 있음.
 
     Returns:
@@ -150,9 +144,20 @@ async def filter_positive_feedbacks(
                                  순서는 Redis SCAN 탐색 순서에 따름.
 
     Raises:
+        ValueError: batch_size가 허용 범위를 벗어난 경우.
         redis.exceptions.ConnectionError: Redis 연결 실패 시.
-        Exception: 그 외 예상치 못한 Redis 오류 시.
+        redis.exceptions.RedisError: 그 외 Redis 명령 실패 시.
     """
+    # batch_size 유효성 검증: 잘못된 값으로 인한 Redis 성능 저하 방지
+    if not isinstance(batch_size, int) or isinstance(batch_size, bool):
+        raise ValueError(
+            f"batch_size must be an integer, got {type(batch_size).__name__!r}."
+        )
+    if not (_MIN_SCAN_BATCH_SIZE <= batch_size <= _MAX_SCAN_BATCH_SIZE):
+        raise ValueError(
+            f"batch_size must be between {_MIN_SCAN_BATCH_SIZE} and {_MAX_SCAN_BATCH_SIZE}, "
+            f"got {batch_size}."
+        )
     # (session_id, message_id) 복합 키로 중복을 O(1)에 체크하기 위한 집합
     seen: set[tuple[str, str]] = set()
     results: list[FeedbackDataPoint] = []
@@ -193,20 +198,16 @@ async def filter_positive_feedbacks(
                 feedback_hash = await redis_client.redis.hgetall(key_str)
 
                 for msg_id_raw, meta_raw in feedback_hash.items():
-                    # 파싱 시도 (실패 시 None 반환)
+                    # 파싱 + rating 체크를 헬퍼에 위임.
+                    # None 반환 = 파싱 실패 OR rating != "up"
                     parsed = _parse_feedback_meta(msg_id_raw, meta_raw)
                     if parsed is None:
                         total_skipped_parse += 1
                         continue
 
-                    msg_id, rating, feedback_text, timestamp = parsed
+                    msg_id, feedback_text, timestamp = parsed
 
-                    # 품질 게이트 2: 긍정 피드백("up")만 수집
-                    if rating != "up":
-                        total_skipped_quality += 1
-                        continue
-
-                    # 품질 게이트 3: message_id 비어있지 않아야 함
+                    # 품질 게이트: message_id 비어있지 않아야 함
                     if not msg_id:
                         logger.warning(
                             "[OBS] Empty message_id found in feedback hash, skipping.",
@@ -215,7 +216,7 @@ async def filter_positive_feedbacks(
                         total_skipped_quality += 1
                         continue
 
-                    # 품질 게이트 4: (session_id, message_id) 중복 제거
+                    # 품질 게이트: (session_id, message_id) 중복 제거
                     dedup_key = (session_id, msg_id)
                     if dedup_key in seen:
                         logger.debug(

--- a/backend/services/golden_dataset_service.py
+++ b/backend/services/golden_dataset_service.py
@@ -12,6 +12,7 @@
 
 import json
 import logging
+import numbers
 from dataclasses import dataclass
 from json import JSONDecodeError
 from typing import Any, Optional
@@ -136,7 +137,8 @@ async def filter_positive_feedbacks(
 
     Args:
         batch_size: Redis SCAN이 한 번에 가져올 키 수 힌트.
-                    허용 범위: [{min_batch}, {max_batch}] (기본값: {default_batch})
+                    허용 범위: [_MIN_SCAN_BATCH_SIZE, _MAX_SCAN_BATCH_SIZE]
+                    (기본값: _DEFAULT_SCAN_BATCH_SIZE = 100, 허용: 1 ~ 10,000)
                     실제 반환 수는 Redis 내부 정책에 따라 다를 수 있음.
 
     Returns:
@@ -149,7 +151,9 @@ async def filter_positive_feedbacks(
         redis.exceptions.RedisError: 그 외 Redis 명령 실패 시.
     """
     # batch_size 유효성 검증: 잘못된 값으로 인한 Redis 성능 저하 방지
-    if not isinstance(batch_size, int) or isinstance(batch_size, bool):
+    # numbers.Integral 사용: int뿐 아니라 numpy.int64 등 정수형 호환 타입도 허용.
+    # bool은 int의 서브클래스이며 numbers.Integral에도 포함되므로 명시적으로 제외합니다.
+    if not isinstance(batch_size, numbers.Integral) or isinstance(batch_size, bool):
         raise ValueError(
             f"batch_size must be an integer, got {type(batch_size).__name__!r}."
         )
@@ -169,9 +173,10 @@ async def filter_positive_feedbacks(
 
         cursor = 0
         total_scanned_keys = 0
-        total_skipped_parse = 0
-        total_skipped_quality = 0
-        total_skipped_dedup = 0
+        total_skipped_parse = 0    # JSON 디코딩 오류 또는 timestamp 유효성 실패
+        total_skipped_rating = 0   # rating != "up" (부정/없음 평가)
+        total_skipped_quality = 0  # session_id/message_id 비어있음
+        total_skipped_dedup = 0    # (session_id, message_id) 중복
 
         while True:
             cursor, partial_keys = await redis_client.redis.scan(
@@ -181,7 +186,8 @@ async def filter_positive_feedbacks(
             )
 
             for raw_key in partial_keys:
-                key_str = _decode_str(raw_key)
+                # _decode_str 인라인: 함수가 제거되었으므로 직접 디코딩
+                key_str = raw_key.decode("utf-8") if isinstance(raw_key, bytes) else str(raw_key)
                 session_id = key_str.removeprefix(FEEDBACK_KEY_PREFIX)
                 total_scanned_keys += 1
 
@@ -198,8 +204,19 @@ async def filter_positive_feedbacks(
                 feedback_hash = await redis_client.redis.hgetall(key_str)
 
                 for msg_id_raw, meta_raw in feedback_hash.items():
-                    # 파싱 + rating 체크를 헬퍼에 위임.
-                    # None 반환 = 파싱 실패 OR rating != "up"
+                    # 파싱 + rating("up") 필터를 헬퍼에 위임.
+                    # None 반환 = JSON 파싱 실패 OR timestamp 오류 OR rating != "up".
+                    # 카운터를 분리하기 위해, rating 필터는 헬퍼 외부에서 사전 체크합니다.
+                    try:
+                        meta_str = meta_raw.decode("utf-8") if isinstance(meta_raw, bytes) else str(meta_raw)
+                        meta_rating = json.loads(meta_str).get("rating")
+                    except (JSONDecodeError, ValueError, TypeError, AttributeError):
+                        meta_rating = None
+
+                    if meta_rating != "up":
+                        total_skipped_rating += 1
+                        continue
+
                     parsed = _parse_feedback_meta(msg_id_raw, meta_raw)
                     if parsed is None:
                         total_skipped_parse += 1
@@ -248,7 +265,8 @@ async def filter_positive_feedbacks(
             extra={
                 "total_collected": len(results),
                 "total_scanned_keys": total_scanned_keys,
-                "skipped_parse_error": total_skipped_parse,
+                "skipped_parse_error": total_skipped_parse,    # 실제 파싱/타입 오류만 집계
+                "skipped_rating_gate": total_skipped_rating,   # rating != "up" 필터 수
                 "skipped_quality_gate": total_skipped_quality,
                 "skipped_dedup": total_skipped_dedup,
             },


### PR DESCRIPTION
☘️ refactor [#11.9.1]: 2차 개선 - _parse_feedback_meta 단순화 및 batch_size 유효성 검증 추가
🐛 fix [#11.9.1]: 3차 개선 - docstring 수정, 카운터 분리, 타입 검증 강화

## Summary by Sourcery

Redis 피드백 필터링을 개선하기 위해 평점과 타임스탬프 검증을 강화하고, SCAN 배치 크기 범위를 추가하며, 관측 가능성(모니터링) 카운터를 개선합니다.

향상 사항:
- Redis SCAN 배치 크기에 대해 설정 가능한 최소/최대 값을 도입하고 검증 로직과 `filter_positive_feedbacks`용 에러 타입을 업데이트했습니다.
- 디코딩을 인라인 처리하여 피드백 메타데이터 파싱을 단순화하고, 긍정(positive) 평점만 허용하도록 강제하며, 타임스탬프와 타입 검증을 강화했습니다.
- 스킵된 피드백 카운터를 파싱, 평점, 품질, 중복 제거(deduplication) 카테고리로 분리하여 로깅과 메트릭을 개선했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine Redis feedback filtering by tightening rating and timestamp validation, adding scan batch size bounds, and improving observability counters.

Enhancements:
- Introduce configurable minimum and maximum Redis SCAN batch size with validation and updated error types for filter_positive_feedbacks.
- Simplify feedback metadata parsing by inlining decoding, enforcing positive-only ratings, and strengthening timestamp and type checks.
- Improve logging and metrics by splitting skipped feedback counters into parse, rating, quality, and deduplication categories.

</details>