### PR TITLE
☘️ refactor [#11.9.1]: 4차 개선 - 이중 JSON 파싱 제거 및 rating 게이트 단일 레이어화

### DIFF
--- a/backend/services/golden_dataset_service.py
+++ b/backend/services/golden_dataset_service.py
@@ -66,35 +66,27 @@ class FeedbackDataPoint:
 
 def _parse_feedback_meta(
     msg_id_raw: Any,
-    meta_raw: Any,
+    meta: dict[str, Any],
 ) -> Optional[tuple[str, Optional[str], str]]:
     """
-    Redis Hash의 단일 필드 (message_id, JSON 메타) 쌍을 파싱합니다.
+    이미 파싱된 피드백 메타데이터 dict에서 필드를 검증하고 추출합니다.
 
-    rating 체크를 헬퍼 내부에 통합하여, 호출 측 메인 루프가
-    이미 긍정("up") 평가가 확인된 엔트리만 다룰 수 있도록 설계되었습니다.
+    **책임 범위**: 이 함수는 순수하게 필드 존재 여부, 타입 유효성, 형식 검증만 담당합니다.
+    - rating 게이트(\"up\" 필터링) 책임은 전적으로 호출부 메인 루프에 있습니다.
+    - JSON 디코딩/파싱은 호출부에서 1회만 수행하여 이 함수에 dict로 전달합니다.
+
+    Args:
+        msg_id_raw: Redis Hash field (message_id), bytes 또는 str.
+        meta:       이미 json.loads()로 파싱된 피드백 메타데이터 dict.
 
     반환 형식:
-        (message_id, feedback_text, timestamp) 또는 파싱 실패/비긍정 평가 시 None
+        (message_id, feedback_text, timestamp) 또는 검증 실패 시 None
 
     None 반환 조건:
-        - JSON 디코딩 오류
-        - rating != "up" (부정/없음 포함)
         - timestamp가 유효하지 않은 타입이거나 빈 문자열
     """
-    # _decode_str 인라인: 별도 함수 호출 없이 직접 처리하여 호출 오버헤드 제거
+    # message_id 디코딩 (인라인)
     msg_id = msg_id_raw.decode("utf-8") if isinstance(msg_id_raw, bytes) else str(msg_id_raw)
-    meta_str = meta_raw.decode("utf-8") if isinstance(meta_raw, bytes) else str(meta_raw)
-
-    try:
-        meta = json.loads(meta_str)
-    except (JSONDecodeError, ValueError, TypeError):
-        return None
-
-    # 긍정 피드백("up")이 아닌 모든 항목은 여기서 필터링됩니다.
-    # 호출 측 메인 루프는 rating 정규화("none" 등)에 대해 알 필요가 없습니다.
-    if meta.get("rating") != "up":
-        return None
 
     # timestamp: 유효한 스칼라 타입 + 비어있지 않아야 함
     # 주의: bool은 int의 서브클래스이므로 명시적으로 제외합니다.
@@ -130,8 +122,8 @@ async def filter_positive_feedbacks(
     품질 기준을 통과한 '좋아요(Thumbs Up)' 피드백 항목을 수집합니다.
 
     품질 게이트 (Quality Gates):
-        1. rating == "up" 인 항목만 포함 (부정/없음 제외, _parse_feedback_meta 내부에서 처리)
-        2. timestamp가 유효한 스칼라 타입이고 비어있지 않아야 함
+        1. rating == "up" 인 항목만 포함 (부정/없음 제외) — 호출부 루프에서 단일 처리
+        2. timestamp가 유효한 스칼라 타입이고 비어있지 않아야 함 — _parse_feedback_meta에서 검증
         3. session_id와 message_id 모두 비어있지 않아야 함
         4. (session_id, message_id) 복합 키 기준으로 중복 제거
 
@@ -204,20 +196,24 @@ async def filter_positive_feedbacks(
                 feedback_hash = await redis_client.redis.hgetall(key_str)
 
                 for msg_id_raw, meta_raw in feedback_hash.items():
-                    # 파싱 + rating("up") 필터를 헬퍼에 위임.
-                    # None 반환 = JSON 파싱 실패 OR timestamp 오류 OR rating != "up".
-                    # 카운터를 분리하기 위해, rating 필터는 헬퍼 외부에서 사전 체크합니다.
+                    # [Step 1] JSON을 이 지점에서 한 번만 파싱합니다.
+                    # 파싱된 dict를 헬퍼에 전달하여 이중 파싱을 방지합니다.
                     try:
                         meta_str = meta_raw.decode("utf-8") if isinstance(meta_raw, bytes) else str(meta_raw)
-                        meta_rating = json.loads(meta_str).get("rating")
-                    except (JSONDecodeError, ValueError, TypeError, AttributeError):
-                        meta_rating = None
+                        meta = json.loads(meta_str)
+                    except (JSONDecodeError, ValueError, TypeError):
+                        total_skipped_parse += 1
+                        continue
 
-                    if meta_rating != "up":
+                    # [Step 2] rating 게이트: 이 루프가 유일한 rating 필터 레이어입니다.
+                    # _parse_feedback_meta는 rating에 관여하지 않습니다.
+                    if meta.get("rating") != "up":
                         total_skipped_rating += 1
                         continue
 
-                    parsed = _parse_feedback_meta(msg_id_raw, meta_raw)
+                    # [Step 3] 나머지 필드(timestamp, feedback_text) 검증은 헬퍼에 위임.
+                    # 이미 파싱된 dict를 전달하므로 JSON 재파싱 없음.
+                    parsed = _parse_feedback_meta(msg_id_raw, meta)
                     if parsed is None:
                         total_skipped_parse += 1
                         continue

--- a/backend/services/golden_dataset_service.py
+++ b/backend/services/golden_dataset_service.py
@@ -65,19 +65,20 @@ class FeedbackDataPoint:
 
 
 def _parse_feedback_meta(
-    msg_id_raw: Any,
+    msg_id: str,
     meta: dict[str, Any],
 ) -> Optional[tuple[str, Optional[str], str]]:
     """
     이미 파싱된 피드백 메타데이터 dict에서 필드를 검증하고 추출합니다.
 
-    **책임 범위**: 이 함수는 순수하게 필드 존재 여부, 타입 유효성, 형식 검증만 담당합니다.
-    - rating 게이트(\"up\" 필터링) 책임은 전적으로 호출부 메인 루프에 있습니다.
-    - JSON 디코딩/파싱은 호출부에서 1회만 수행하여 이 함수에 dict로 전달합니다.
+    **책임 범위**: 이 함수는 이미 정규화된(디코딩/파싱 완료된) 타입만 입력받습니다.
+    - msg_id: 호출부에서 bytes 디코딩을 완료한 str.
+    - meta: 호출부에서 json.loads()를 완료한 dict.
+    - rating 게이트("up" 필터링) 책임은 전적으로 호출부 루프에 있습니다.
 
     Args:
-        msg_id_raw: Redis Hash field (message_id), bytes 또는 str.
-        meta:       이미 json.loads()로 파싱된 피드백 메타데이터 dict.
+        msg_id: 디코딩이 완료된 message_id (str).
+        meta:   json.loads()로 파싱된 피드백 메타데이터 dict.
 
     반환 형식:
         (message_id, feedback_text, timestamp) 또는 검증 실패 시 None
@@ -85,8 +86,6 @@ def _parse_feedback_meta(
     None 반환 조건:
         - timestamp가 유효하지 않은 타입이거나 빈 문자열
     """
-    # message_id 디코딩 (인라인)
-    msg_id = msg_id_raw.decode("utf-8") if isinstance(msg_id_raw, bytes) else str(msg_id_raw)
 
     # timestamp: 유효한 스칼라 타입 + 비어있지 않아야 함
     # 주의: bool은 int의 서브클래스이므로 명시적으로 제외합니다.
@@ -196,12 +195,15 @@ async def filter_positive_feedbacks(
                 feedback_hash = await redis_client.redis.hgetall(key_str)
 
                 for msg_id_raw, meta_raw in feedback_hash.items():
-                    # [Step 1] JSON을 이 지점에서 한 번만 파싱합니다.
-                    # 파싱된 dict를 헬퍼에 전달하여 이중 파싱을 방지합니다.
+                    # [Step 1] meta_raw와 msg_id_raw를 이 지점에서 한 번만 디코딩/파싱합니다.
+                    # 헬퍼(_parse_feedback_meta)은 이미 정규화된(str/dict) 타입만 입력받습니다.
+                    msg_id = msg_id_raw.decode("utf-8") if isinstance(msg_id_raw, bytes) else str(msg_id_raw)
                     try:
                         meta_str = meta_raw.decode("utf-8") if isinstance(meta_raw, bytes) else str(meta_raw)
                         meta = json.loads(meta_str)
-                    except (JSONDecodeError, ValueError, TypeError):
+                    except (JSONDecodeError, ValueError):
+                        # json.loads는 meta_str이 str임이 보장되는 시점에 호출되므로
+                        # TypeError는 발생할 수 없습니다. JSONDecodeError/ValueError만 대응.
                         total_skipped_parse += 1
                         continue
 
@@ -212,8 +214,8 @@ async def filter_positive_feedbacks(
                         continue
 
                     # [Step 3] 나머지 필드(timestamp, feedback_text) 검증은 헬퍼에 위임.
-                    # 이미 파싱된 dict를 전달하므로 JSON 재파싱 없음.
-                    parsed = _parse_feedback_meta(msg_id_raw, meta)
+                    # 이미 정규화된 msg_id(str)와 meta(dict)를 전달.
+                    parsed = _parse_feedback_meta(msg_id, meta)
                     if parsed is None:
                         total_skipped_parse += 1
                         continue


### PR DESCRIPTION
- **[설계 근본 해결: 단일 책임 원칙(SRP) 완전 적용]**
  - [Architecture] `_parse_feedback_meta` 시그니처 변경:
    - `(msg_id_raw, meta_raw: bytes)` → `(msg_id_raw, meta: dict)`
    - JSON 파싱 책임을 호출부로 이전, 헬퍼는 '순수 필드 검증/추출'만 담당
    - rating 게이트 로직이 헬퍼 내부에서 완전히 제거됨
  - [Performance] 메인 루프에서 `meta_raw`를 1회만 json.loads():
    - 기존: 외부 rating 체크용 1회 + 헬퍼 내부 1회 = 2회 파싱
    - 개선: 외부에서 1회 파싱 → dict를 헬퍼에 전달 = 1회 파싱
  - [Clarity]: rating 게이트가 외부 루프의 [Step 2]에서만 처리되어 `total_skipped_rating` 카운터의 의미론적 정확성 보장
  - [Docs]: docstring을 실제 책임 범위(필드 검증만)에 맞게 재작성

🔗 Related:
- Issue [#933]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/939#pullrequestreview-4056302954)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

피드백 메타데이터 처리 로직을 리팩터링하여 JSON 파싱과 평점 필터링의 책임을 분리하면서, 중복 파싱을 방지합니다.

개선 사항:
- `_parse_feedback_meta`가 미리 파싱된 메타데이터 dict를 입력으로 받아 필드 검증과 추출에만 집중하도록 변경합니다.
- `rating == "up"` 필터링 로직을 `_parse_feedback_meta`에서 메인 피드백 루프로 이동시켜, 단일 게이팅 레이어로 동작하도록 합니다.
- 메인 루프에서 항목당 한 번만 피드백 메타데이터 JSON을 파싱하고, 결과 dict를 재사용하여 이중 파싱을 방지합니다.
- 파싱, 평점 게이팅, 필드 검증 간의 새로운 단일 책임 경계를 반영하도록 문서 문자열을 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor feedback metadata handling to separate JSON parsing and rating filtering responsibilities while avoiding duplicate parsing.

Enhancements:
- Change _parse_feedback_meta to accept pre-parsed metadata dicts and focus solely on field validation and extraction.
- Move rating == "up" filtering logic from _parse_feedback_meta into the main feedback loop as a single gating layer.
- Parse feedback metadata JSON once per entry in the main loop and reuse the resulting dict to prevent double parsing.
- Update documentation strings to reflect the new single-responsibility boundaries between parsing, rating gating, and field validation.

</details>