### PR TITLE
✨ feat [#11.9.2]: Fine-tuning 데이터셋 JSONL 변환 및 마스킹 직렬화 모듈 추가

### DIFF
--- a/backend/utils/finetune_parser.py
+++ b/backend/utils/finetune_parser.py
@@ -38,6 +38,21 @@ def format_finetune_message(
     }
 
 
+def _mask_nested_pii(data: Any, pii_fields: set[str]) -> Any:
+    """
+    딕셔너리와 리스트를 재귀적으로 탐색하여 pii_fields에 지정된 키를 찾아 안전하게 마스킹합니다.
+    """
+    if isinstance(data, dict):
+        return {
+            k: (mask_pii_id(str(v)) if v is not None else v) if k in pii_fields else _mask_nested_pii(v, pii_fields)
+            for k, v in data.items()
+        }
+    elif isinstance(data, list):
+        return [_mask_nested_pii(item, pii_fields) for item in data]
+    else:
+        return data
+
+
 def serialize_to_jsonl(
     dataset: List[Dict[str, Any]],
     output_filepath: str,
@@ -50,6 +65,7 @@ def serialize_to_jsonl(
         dataset: 변환된 OpenAI Fine-tuning 포맷 데이터셋 리스트
         output_filepath: 저장할 jsonl 파일의 대상 경로
         pii_fields: 값에 마스킹을 적용할 딕셔너리 필드 목록 (예: ["session_id", "user_id"])
+                    (중첩된 구조 내부의 필드 깊이와 관계없이 재귀적으로 찾아 마스킹함)
 
     Returns:
         성공적으로 저장된 파일의 절대 경로
@@ -58,21 +74,16 @@ def serialize_to_jsonl(
     os.makedirs(os.path.dirname(absolute_path), exist_ok=True)
 
     try:
+        pii_fields_set = set(pii_fields) if pii_fields else set()
+        
         with open(absolute_path, "w", encoding="utf-8") as f:
             for item in dataset:
-                # 불변성 유지를 위해 얕은 복사 수행
-                item_copy = item.copy()
-
-                # PII 필드 대상 마스킹 적용 (backend.utils.mask_pii_id 재사용)
-                if pii_fields:
-                    for field in pii_fields:
-                        if field in item_copy:
-                            # 문자열인 경우에만 해시 마스킹 (숫자나 객체는 별도 처리 필요)
-                            val = item_copy[field]
-                            item_copy[field] = mask_pii_id(str(val)) if val else val
+                # PII 필드 대상 재귀적 깊은 마스킹 적용 (backend.utils.mask_pii_id 재사용)
+                # _mask_nested_pii 함수를 통해 원본을 훼손하지 않는 새 딕셔너리 반환 보장
+                masked_item = _mask_nested_pii(item, pii_fields_set)
 
                 # JSON 직렬화 (유니코드 문자 보존)
-                json_line = json.dumps(item_copy, ensure_ascii=False)
+                json_line = json.dumps(masked_item, ensure_ascii=False)
                 f.write(json_line + "\n")
 
         logger.info(
@@ -80,7 +91,7 @@ def serialize_to_jsonl(
             extra={
                 "filepath": absolute_path,
                 "total_items": len(dataset),
-                "masked_fields": pii_fields,
+                "masked_fields": list(pii_fields_set) if pii_fields_set else None,
             },
         )
         return absolute_path

--- a/backend/utils/finetune_parser.py
+++ b/backend/utils/finetune_parser.py
@@ -1,0 +1,96 @@
+# backend/utils/finetune_parser.py
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from backend.utils import mask_pii_id
+
+logger = logging.getLogger(__name__)
+
+
+def format_finetune_message(
+    question: str,
+    answer: str,
+    system_prompt: str = "You are a helpful AI assistant that answers questions based on the provided context.",
+) -> Dict[str, List[Dict[str, str]]]:
+    """
+    RAG 검색 컨텍스트(Q)와 LLM 생성 응답(A)을 OpenAI Chat Fine-tuning 포맷으로 변환합니다.
+
+    Args:
+        question: 사용자 질문 및 RAG 컨텍스트 (Q)
+        answer: LLM 생성 응답 (A)
+        system_prompt: 시스템 프롬프트 (옵션)
+
+    Returns:
+        OpenAI Fine-tuning JSON 포맷 ({"messages": [...]})
+    """
+    # 사용자의 질문이나 응답 내에 있는 PII성 식별자(보통 이메일이나, 특정 패턴)를
+    # 마스킹하는 로직이 필요한 경우 여기서 처리할 수 있습니다.
+    # 현재는 구조 변환만 수행하며, 식별자 자체의 마스킹은 직렬화 등 별도로 적용 가능합니다.
+    return {
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": question},
+            {"role": "assistant", "content": answer},
+        ]
+    }
+
+
+def serialize_to_jsonl(
+    dataset: List[Dict[str, Any]],
+    output_filepath: str,
+    pii_fields: Optional[List[str]] = None,
+) -> str:
+    """
+    데이터셋을 .jsonl 파일로 직렬화하며, 필요한 경우 지정된 PII 필드들을 안전하게 마스킹 처리합니다.
+
+    Args:
+        dataset: 변환된 OpenAI Fine-tuning 포맷 데이터셋 리스트
+        output_filepath: 저장할 jsonl 파일의 대상 경로
+        pii_fields: 값에 마스킹을 적용할 딕셔너리 필드 목록 (예: ["session_id", "user_id"])
+
+    Returns:
+        성공적으로 저장된 파일의 절대 경로
+    """
+    absolute_path = os.path.abspath(output_filepath)
+    os.makedirs(os.path.dirname(absolute_path), exist_ok=True)
+
+    try:
+        with open(absolute_path, "w", encoding="utf-8") as f:
+            for item in dataset:
+                # 불변성 유지를 위해 얕은 복사 수행
+                item_copy = item.copy()
+
+                # PII 필드 대상 마스킹 적용 (backend.utils.mask_pii_id 재사용)
+                if pii_fields:
+                    for field in pii_fields:
+                        if field in item_copy:
+                            # 문자열인 경우에만 해시 마스킹 (숫자나 객체는 별도 처리 필요)
+                            val = item_copy[field]
+                            item_copy[field] = mask_pii_id(str(val)) if val else val
+
+                # JSON 직렬화 (유니코드 문자 보존)
+                json_line = json.dumps(item_copy, ensure_ascii=False)
+                f.write(json_line + "\n")
+
+        logger.info(
+            "Successfully serialized dataset to JSONL",
+            extra={
+                "filepath": absolute_path,
+                "total_items": len(dataset),
+                "masked_fields": pii_fields,
+            },
+        )
+        return absolute_path
+
+    except Exception as e:
+        logger.error(
+            "Failed to serialize dataset to JSONL",
+            extra={
+                "filepath": absolute_path,
+                "error": str(e),
+            },
+        )
+        raise


### PR DESCRIPTION
- **[OpenAI Fine-tuning 포맷 변환]**
  - RAG 검색 컨텍스트(Q)와 LLM 응답(A)을 OpenAI의 `{"messages": [...]}` 포맷으로 구조화하는 `format_finetune_message` 함수 구현
- **[데이터 직렬화 및 보안 마스킹 (PII)]**
  - 데이터를 `.jsonl` 파일로 직렬화하여 저장하는 `serialize_to_jsonl` 함수 구현
  - 기존 PII 마스킹 시스템(`backend.utils.mask_pii_id`)을 연동하여, `session_id` 등 민감한 식별자 필드가 파일에 쓰이기 직전에 안전하게 마스킹되도록 파이프라인 구성 완료
  - 로깅을 통해 직렬화 결과와 파일 I/O 과정을 모니터링할 수 있도록 Observability 연동

🔗 Related: Issue [#933]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

RAG Q&A 데이터를 OpenAI 챗 파인튜닝 메시지 형식으로 변환하고, 선택적 PII 마스킹 및 로깅과 함께 데이터셋을 JSONL로 직렬화하기 위한 유틸리티를 추가합니다.

New Features:
- 질문과 답변을 OpenAI 챗 파인튜닝 메시지 구조로 변환하는 포매터를 도입합니다.
- 데이터셋을 디스크에 기록하는 JSONL 직렬화 헬퍼를 추가합니다.

Enhancements:
- 기존 PII 마스킹 유틸리티를 직렬화 파이프라인에 통합하여, 파일을 기록하기 전에 민감한 식별자 필드를 안전하게 난독화합니다.
- JSONL 직렬화 과정에 로깅을 추가하여 출력 경로, 데이터셋 크기, 마스킹 설정을 추적할 수 있도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add utilities to format RAG Q&A data into OpenAI chat fine-tuning messages and serialize datasets to JSONL with optional PII masking and logging.

New Features:
- Introduce a formatter that converts questions and answers into OpenAI chat fine-tuning message structure.
- Add a JSONL serialization helper that writes datasets to disk.

Enhancements:
- Integrate existing PII masking utility into the serialization pipeline to safely obfuscate sensitive identifier fields before writing files.
- Add logging around JSONL serialization to track output paths, dataset size, and masking configuration.

</details>