### PR TITLE
🐛 fix [#11.9.2]: 2차 개선 - PII 마스킹 구조 파괴 방지 및 JSON Fallback 핸들러 추가

### DIFF
--- a/backend/utils/finetune_parser.py
+++ b/backend/utils/finetune_parser.py
@@ -41,12 +41,20 @@ def format_finetune_message(
 def _mask_nested_pii(data: Any, pii_fields: set[str]) -> Any:
     """
     딕셔너리와 리스트를 재귀적으로 탐색하여 pii_fields에 지정된 키를 찾아 안전하게 마스킹합니다.
+    (스칼라 값만 마스킹 처리하여 딕셔너리/리스트 등 중첩 구조 파괴를 방지합니다.)
     """
     if isinstance(data, dict):
-        return {
-            k: (mask_pii_id(str(v)) if v is not None else v) if k in pii_fields else _mask_nested_pii(v, pii_fields)
-            for k, v in data.items()
-        }
+        result = {}
+        for k, v in data.items():
+            # 값이 딕셔너리나 리스트 등 내부 구조를 가지면 강제 문자열 변환 없이 재귀 진입
+            if isinstance(v, (dict, list)):
+                result[k] = _mask_nested_pii(v, pii_fields)
+            # pii_fields에 해당하고 값이 스칼라(None 제외)일 때만 마스킹
+            elif k in pii_fields and v is not None:
+                result[k] = mask_pii_id(str(v))
+            else:
+                result[k] = v
+        return result
     elif isinstance(data, list):
         return [_mask_nested_pii(item, pii_fields) for item in data]
     else:
@@ -76,14 +84,18 @@ def serialize_to_jsonl(
     try:
         pii_fields_set = set(pii_fields) if pii_fields else set()
         
+        # Dataclass, datetime 등 비-직렬화 객체 발생으로 인한 런타임 에러 방지용 안전 장치
+        def _json_fallback(obj: Any) -> str:
+            return str(obj)
+        
         with open(absolute_path, "w", encoding="utf-8") as f:
             for item in dataset:
                 # PII 필드 대상 재귀적 깊은 마스킹 적용 (backend.utils.mask_pii_id 재사용)
                 # _mask_nested_pii 함수를 통해 원본을 훼손하지 않는 새 딕셔너리 반환 보장
                 masked_item = _mask_nested_pii(item, pii_fields_set)
 
-                # JSON 직렬화 (유니코드 문자 보존)
-                json_line = json.dumps(masked_item, ensure_ascii=False)
+                # JSON 직렬화 (유니코드 문자 보존 및 비-직렬화 객체 문자열 변환 처리)
+                json_line = json.dumps(masked_item, ensure_ascii=False, default=_json_fallback)
                 f.write(json_line + "\n")
 
         logger.info(

--- a/backend/utils/finetune_parser.py
+++ b/backend/utils/finetune_parser.py
@@ -40,14 +40,14 @@ def format_finetune_message(
 
 def _mask_nested_pii(data: Any, pii_fields: set[str]) -> Any:
     """
-    딕셔너리와 리스트를 재귀적으로 탐색하여 pii_fields에 지정된 키를 찾아 안전하게 마스킹합니다.
+    딕셔너리와 컨테이너를 재귀적으로 탐색하여 pii_fields에 지정된 키를 찾아 안전하게 마스킹합니다.
     (스칼라 값만 마스킹 처리하여 딕셔너리/리스트 등 중첩 구조 파괴를 방지합니다.)
     """
     if isinstance(data, dict):
         result = {}
         for k, v in data.items():
-            # 값이 딕셔너리나 리스트 등 내부 구조를 가지면 강제 문자열 변환 없이 재귀 진입
-            if isinstance(v, (dict, list)):
+            # 값이 딕셔너리, 리스트, 튜플, 세트 등 내부 구조를 가지면 강제 문자열 변환 없이 재귀 진입
+            if isinstance(v, (dict, list, tuple, set)):
                 result[k] = _mask_nested_pii(v, pii_fields)
             # pii_fields에 해당하고 값이 스칼라(None 제외)일 때만 마스킹
             elif k in pii_fields and v is not None:
@@ -55,8 +55,9 @@ def _mask_nested_pii(data: Any, pii_fields: set[str]) -> Any:
             else:
                 result[k] = v
         return result
-    elif isinstance(data, list):
-        return [_mask_nested_pii(item, pii_fields) for item in data]
+    elif isinstance(data, (list, tuple, set)):
+        container_type = type(data)
+        return container_type(_mask_nested_pii(item, pii_fields) for item in data)
     else:
         return data
 
@@ -86,6 +87,10 @@ def serialize_to_jsonl(
         
         # Dataclass, datetime 등 비-직렬화 객체 발생으로 인한 런타임 에러 방지용 안전 장치
         def _json_fallback(obj: Any) -> str:
+            logger.warning(
+                "[OBS] Non-serializable type encountered in JSONL serialization; falling back to string conversion.",
+                extra={"type": type(obj).__name__}
+            )
             return str(obj)
         
         with open(absolute_path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
- **[데이터 구조 무결성 보호]**
  - `_mask_nested_pii` 재귀 마스킹 로직에서 값(`v`)이 스칼라(문자열/숫자)가 아닌 컨테이너 타입(dict, list)인 경우, `pii_fields` 일치 여부와 무관하게 무조건 내부로 계속 탐색하도록 분기 처리
  - `str()` 강제 변환으로 인해 발생할 수 있었던 내부 중첩 스키마 파괴 및 데이터 훼손(Data Corruption) 방지
- **[JSON 직렬화(Serialization) 안전성 강화]**
  - `serialize_to_jsonl` 내부의 `json.dumps` 호출 시 `default=_json_fallback` 파라미터 적용
  - `datetime`, `UUID`, `Pydantic Model` 등 비-직렬화 객체가 유입될 경우 TypeError 크래시를 유발하지 않고 자동으로 문자열(string representations)로 변환되도록 안전망 구축

🔗 Related:
- Issue [#933]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/943#pullrequestreview-4058560898)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

중첩된 데이터 구조의 무결성을 유지하고, 직렬화할 수 없는 객체가 존재할 때 발생하는 런타임 오류를 방지하기 위해 PII 마스킹 및 JSON 직렬화를 조정합니다.

버그 수정:
- PII 마스킹 과정에서 중첩된 딕셔너리와 리스트가 문자열로 강제 변환되지 않도록 하여, 스칼라 PII 값만 마스킹하면서 원래 데이터 구조는 그대로 유지합니다.
- 폴백(handler)을 통해 dataclass, datetime 등의 직렬화 불가능한 객체를 문자열로 변환하여, 파인튜닝 데이터셋 내보내기 과정에서 JSON 직렬화가 실패(crash)하지 않도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust PII masking and JSON serialization to preserve nested data structure integrity and avoid runtime errors when non-serializable objects are present.

Bug Fixes:
- Prevent nested dictionaries and lists from being coerced to strings during PII masking, preserving the original data structure while masking only scalar PII values.
- Avoid JSON serialization crashes in finetune dataset export by converting non-serializable objects such as dataclasses and datetimes to strings via a fallback handler.

</details>