### PR TITLE
Feature/v8 phase5 data flywheel

### DIFF
--- a/backend/utils/finetune_parser.py
+++ b/backend/utils/finetune_parser.py
@@ -41,12 +41,20 @@ def format_finetune_message(
 def _mask_nested_pii(data: Any, pii_fields: set[str]) -> Any:
     """
     딕셔너리와 리스트를 재귀적으로 탐색하여 pii_fields에 지정된 키를 찾아 안전하게 마스킹합니다.
+    (스칼라 값만 마스킹 처리하여 딕셔너리/리스트 등 중첩 구조 파괴를 방지합니다.)
     """
     if isinstance(data, dict):
-        return {
-            k: (mask_pii_id(str(v)) if v is not None else v) if k in pii_fields else _mask_nested_pii(v, pii_fields)
-            for k, v in data.items()
-        }
+        result = {}
+        for k, v in data.items():
+            # 값이 딕셔너리나 리스트 등 내부 구조를 가지면 강제 문자열 변환 없이 재귀 진입
+            if isinstance(v, (dict, list)):
+                result[k] = _mask_nested_pii(v, pii_fields)
+            # pii_fields에 해당하고 값이 스칼라(None 제외)일 때만 마스킹
+            elif k in pii_fields and v is not None:
+                result[k] = mask_pii_id(str(v))
+            else:
+                result[k] = v
+        return result
     elif isinstance(data, list):
         return [_mask_nested_pii(item, pii_fields) for item in data]
     else:
@@ -76,14 +84,18 @@ def serialize_to_jsonl(
     try:
         pii_fields_set = set(pii_fields) if pii_fields else set()
         
+        # Dataclass, datetime 등 비-직렬화 객체 발생으로 인한 런타임 에러 방지용 안전 장치
+        def _json_fallback(obj: Any) -> str:
+            return str(obj)
+        
         with open(absolute_path, "w", encoding="utf-8") as f:
             for item in dataset:
                 # PII 필드 대상 재귀적 깊은 마스킹 적용 (backend.utils.mask_pii_id 재사용)
                 # _mask_nested_pii 함수를 통해 원본을 훼손하지 않는 새 딕셔너리 반환 보장
                 masked_item = _mask_nested_pii(item, pii_fields_set)
 
-                # JSON 직렬화 (유니코드 문자 보존)
-                json_line = json.dumps(masked_item, ensure_ascii=False)
+                # JSON 직렬화 (유니코드 문자 보존 및 비-직렬화 객체 문자열 변환 처리)
+                json_line = json.dumps(masked_item, ensure_ascii=False, default=_json_fallback)
                 f.write(json_line + "\n")
 
         logger.info(

--- a/backend/utils/finetune_parser.py
+++ b/backend/utils/finetune_parser.py
@@ -40,14 +40,14 @@ def format_finetune_message(
 
 def _mask_nested_pii(data: Any, pii_fields: set[str]) -> Any:
     """
-    딕셔너리와 리스트를 재귀적으로 탐색하여 pii_fields에 지정된 키를 찾아 안전하게 마스킹합니다.
+    딕셔너리와 컨테이너를 재귀적으로 탐색하여 pii_fields에 지정된 키를 찾아 안전하게 마스킹합니다.
     (스칼라 값만 마스킹 처리하여 딕셔너리/리스트 등 중첩 구조 파괴를 방지합니다.)
     """
     if isinstance(data, dict):
         result = {}
         for k, v in data.items():
-            # 값이 딕셔너리나 리스트 등 내부 구조를 가지면 강제 문자열 변환 없이 재귀 진입
-            if isinstance(v, (dict, list)):
+            # 값이 딕셔너리, 리스트, 튜플, 세트 등 내부 구조를 가지면 강제 문자열 변환 없이 재귀 진입
+            if isinstance(v, (dict, list, tuple, set)):
                 result[k] = _mask_nested_pii(v, pii_fields)
             # pii_fields에 해당하고 값이 스칼라(None 제외)일 때만 마스킹
             elif k in pii_fields and v is not None:
@@ -55,8 +55,9 @@ def _mask_nested_pii(data: Any, pii_fields: set[str]) -> Any:
             else:
                 result[k] = v
         return result
-    elif isinstance(data, list):
-        return [_mask_nested_pii(item, pii_fields) for item in data]
+    elif isinstance(data, (list, tuple, set)):
+        container_type = type(data)
+        return container_type(_mask_nested_pii(item, pii_fields) for item in data)
     else:
         return data
 
@@ -86,6 +87,10 @@ def serialize_to_jsonl(
         
         # Dataclass, datetime 등 비-직렬화 객체 발생으로 인한 런타임 에러 방지용 안전 장치
         def _json_fallback(obj: Any) -> str:
+            logger.warning(
+                "[OBS] Non-serializable type encountered in JSONL serialization; falling back to string conversion.",
+                extra={"type": type(obj).__name__}
+            )
             return str(obj)
         
         with open(absolute_path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
🐛 fix [#11.9.2]: 2차 개선 - PII 마스킹 구조 파괴 방지 및 JSON Fallback 핸들러 추가 
🐛 fix [#11.9.2]: 3차 개선 - 컨테이너 마스킹 사각지대 해소 및 Fallback 로깅 추가

## Summary by Sourcery

파인튜닝 데이터 직렬화의 안정성과 PII 마스킹 동작을 개선합니다.

버그 수정:
- PII 필드를 재귀적으로 마스킹하는 동안 중첩 컨테이너 구조를 보존하여 dict/list 및 관련 컨테이너가 원치 않게 문자열로 변환되는 문제를 방지합니다.
- 직렬화할 수 없는 객체에 대해 관찰 가능성을 위한 로깅과 함께 안전하게 문자열로 변환하는 폴백 핸들러를 추가하여 JSON 직렬화 시 런타임 오류가 발생하는 것을 방지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve finetune data serialization robustness and PII masking behavior.

Bug Fixes:
- Preserve nested container structures while recursively masking PII fields, avoiding unintended stringification of dicts/lists and related containers.
- Prevent JSON serialization runtime errors by adding a fallback handler that safely stringifies non-serializable objects with observability logging.

</details>