### PR TITLE
🐛 fix [#11.9.2]: 4차 개선 - JSON Set 변환 정규화 및 로깅 성능 최적화

### DIFF
--- a/backend/utils/finetune_parser.py
+++ b/backend/utils/finetune_parser.py
@@ -56,7 +56,8 @@ def _mask_nested_pii(data: Any, pii_fields: set[str]) -> Any:
                 result[k] = v
         return result
     elif isinstance(data, (list, tuple, set)):
-        container_type = type(data)
+        # JSON 직렬화 시 구조를 유지하기 위해 set은 list로 정규화
+        container_type = list if isinstance(data, set) else type(data)
         return container_type(_mask_nested_pii(item, pii_fields) for item in data)
     else:
         return data
@@ -85,12 +86,12 @@ def serialize_to_jsonl(
     try:
         pii_fields_set = set(pii_fields) if pii_fields else set()
         
+        fallback_counts: Dict[str, int] = {}
+        
         # Dataclass, datetime 등 비-직렬화 객체 발생으로 인한 런타임 에러 방지용 안전 장치
         def _json_fallback(obj: Any) -> str:
-            logger.warning(
-                "[OBS] Non-serializable type encountered in JSONL serialization; falling back to string conversion.",
-                extra={"type": type(obj).__name__}
-            )
+            obj_type = type(obj).__name__
+            fallback_counts[obj_type] = fallback_counts.get(obj_type, 0) + 1
             return str(obj)
         
         with open(absolute_path, "w", encoding="utf-8") as f:
@@ -103,12 +104,19 @@ def serialize_to_jsonl(
                 json_line = json.dumps(masked_item, ensure_ascii=False, default=_json_fallback)
                 f.write(json_line + "\n")
 
+        if fallback_counts:
+            logger.debug(
+                "[OBS] Non-serializable types encountered during JSONL serialization (fallback applied).",
+                extra={"fallback_counts": fallback_counts}
+            )
+
         logger.info(
             "Successfully serialized dataset to JSONL",
             extra={
                 "filepath": absolute_path,
                 "total_items": len(dataset),
                 "masked_fields": list(pii_fields_set) if pii_fields_set else None,
+                "fallback_occurrences": fallback_counts if fallback_counts else None,
             },
         )
         return absolute_path


### PR DESCRIPTION
- **[JSON 구조 무결성 보장]**
  - `_mask_nested_pii` 재귀 마스킹 로직 내에서 `set` 자료구조를 만날 경우, JSON의 배열(Array) 속성과 호환되도록 강제로 `list`로 정규화(Normalization)하여 반환
  - 비-직렬화 폴백(Fallback)에 의해 `"{x, y}"` 형태의 단순 문자열로 파괴되는 현상 원천 방지
- **[대규모 데이터셋 옵저버빌리티 최적화]**
  - 단위 직렬화 시마다 발생하던 `_json_fallback`의 Warning 로그 스팸을 제거하여 I/O 오버헤드 방지
  - 조용한 변환을 허용하되, 변환이 발생한 객체 타입과 횟수를 집계(Aggregating)하여 `serialize_to_jsonl` 종료 시점에 로그 페이로드(`fallback_occurrences`)에 한 번에 탑재해 가시성 문제 해결

🔗 Related:
- Issue [#933]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/945#pullrequestreview-4058572088)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

마스킹된 데이터의 JSON 직렬화를 정규화하고, 폴백(serialization fallback) 직렬화 메트릭을 집계하여 가시성과 성능을 개선합니다.

버그 수정:
- 중첩된 PII 마스킹 과정에서 발견되는 set 컨테이너를 리스트로 정규화하여, JSON 호환 구조를 유지하고 set이 문자열로 변환되는 폴백을 방지합니다.

개선 사항:
- JSONL 직렬화 폴백 시 객체별 경고 로그를 남기던 방식을, 직렬화가 끝난 후 한 번만 로그를 남기도록 타입/개수 기반 집계 추적으로 대체하고, 성공 로그 페이로드에 폴백 통계 정보를 포함합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize JSON serialization of masked data and aggregate fallback serialization metrics for improved observability and performance.

Bug Fixes:
- Ensure set containers encountered during nested PII masking are normalized to lists to preserve JSON-compatible structure and prevent stringified set fallbacks.

Enhancements:
- Replace per-object warning logs in JSONL serialization fallback with aggregated type/count tracking logged once at the end of serialization, and include fallback statistics in the success log payload.

</details>