### PR TITLE
Feature/v8 phase5 data flywheel

### DIFF
--- a/backend/utils/finetune_parser.py
+++ b/backend/utils/finetune_parser.py
@@ -56,7 +56,8 @@ def _mask_nested_pii(data: Any, pii_fields: set[str]) -> Any:
                 result[k] = v
         return result
     elif isinstance(data, (list, tuple, set)):
-        container_type = type(data)
+        # JSON 직렬화 시 구조를 유지하기 위해 set은 list로 정규화
+        container_type = list if isinstance(data, set) else type(data)
         return container_type(_mask_nested_pii(item, pii_fields) for item in data)
     else:
         return data
@@ -85,12 +86,12 @@ def serialize_to_jsonl(
     try:
         pii_fields_set = set(pii_fields) if pii_fields else set()
         
+        fallback_counts: Dict[str, int] = {}
+        
         # Dataclass, datetime 등 비-직렬화 객체 발생으로 인한 런타임 에러 방지용 안전 장치
         def _json_fallback(obj: Any) -> str:
-            logger.warning(
-                "[OBS] Non-serializable type encountered in JSONL serialization; falling back to string conversion.",
-                extra={"type": type(obj).__name__}
-            )
+            obj_type = type(obj).__name__
+            fallback_counts[obj_type] = fallback_counts.get(obj_type, 0) + 1
             return str(obj)
         
         with open(absolute_path, "w", encoding="utf-8") as f:
@@ -103,12 +104,19 @@ def serialize_to_jsonl(
                 json_line = json.dumps(masked_item, ensure_ascii=False, default=_json_fallback)
                 f.write(json_line + "\n")
 
+        if fallback_counts:
+            logger.debug(
+                "[OBS] Non-serializable types encountered during JSONL serialization (fallback applied).",
+                extra={"fallback_counts": fallback_counts}
+            )
+
         logger.info(
             "Successfully serialized dataset to JSONL",
             extra={
                 "filepath": absolute_path,
                 "total_items": len(dataset),
                 "masked_fields": list(pii_fields_set) if pii_fields_set else None,
+                "fallback_occurrences": fallback_counts if fallback_counts else None,
             },
         )
         return absolute_path


### PR DESCRIPTION
🐛 fix [#11.9.2]: 4차 개선 - JSON Set 변환 정규화 및 로깅 성능 최적화

## Summary by Sourcery

PII가 마스킹된 반복 가능한(iterable) 구조를 정규화하고 JSONL 직렬화 로깅 동작을 최적화합니다.

Bug Fixes:
- JSON 직렬화 동안 구조를 보존할 수 있도록, 중첩된 데이터 구조 내의 `set`을 `list`로 변환하도록 보장합니다.

Enhancements:
- JSONL 직렬화 중에 발생하는 직렬화 불가능한 객체 타입에 대해, 발생할 때마다 경고를 남기는 대신 타입별 개수를 집계하여 로그에 기록합니다.
- 가시성(observability)을 위해 최종 JSONL 직렬화 정보 로그에 폴백(fallback) 발생 메타데이터를 포함합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize PII-masked iterable structures and optimize JSONL serialization logging behavior.

Bug Fixes:
- Ensure sets within nested data structures are converted to lists to preserve structure during JSON serialization.

Enhancements:
- Aggregate and log counts of non-serializable object types encountered during JSONL serialization instead of logging a warning per occurrence.
- Include fallback occurrence metadata in the final JSONL serialization info log for observability.

</details>