### PR TITLE
Feature/v8 phase5 data flywheel

### DIFF
--- a/backend/utils/finetune_parser.py
+++ b/backend/utils/finetune_parser.py
@@ -56,7 +56,10 @@ def _mask_nested_pii(data: Any, pii_fields: set[str]) -> Any:
                 result[k] = v
         return result
     elif isinstance(data, (list, tuple, set)):
-        # JSON 직렬화 시 구조를 유지하기 위해 set은 list로 정규화
+        # 참고: JSON 명세는 set(집합)을 네이티브 배열 타입으로 지원하지 않습니다. 
+        # 이를 무방비로 직렬화하면 단순 문자열 "{x, y}" 형태로 데이터 구조가 오염될 수 있습니다.
+        # 향후 학습 파이프라인에서 예측 가능하고 일관된 JSON 배열([]) 형태로 
+        # 구조를 보존하기 위해, 여기서 의도적으로 set을 list로 정규화합니다.
         container_type = list if isinstance(data, set) else type(data)
         return container_type(_mask_nested_pii(item, pii_fields) for item in data)
     else:
@@ -89,6 +92,8 @@ def serialize_to_jsonl(
         fallback_counts: Dict[str, int] = {}
         
         # Dataclass, datetime 등 비-직렬화 객체 발생으로 인한 런타임 에러 방지용 안전 장치
+        # (주의: 대규모 데이터셋 처리 시 I/O 부하와 로그 스팸을 방지하기 위해 
+        # 여기서 개별 건마다 직접 로깅하지 않고, 타입별 발생 횟수만 집계하여 최종 요약합니다.)
         def _json_fallback(obj: Any) -> str:
             obj_type = type(obj).__name__
             fallback_counts[obj_type] = fallback_counts.get(obj_type, 0) + 1
@@ -105,7 +110,9 @@ def serialize_to_jsonl(
                 f.write(json_line + "\n")
 
         if fallback_counts:
-            logger.debug(
+            # 개별 객체 단위의 시끄러운 로그 대신, 전체 루프 종료 후 
+            # 단일 warning으로 요약 보고하여 운영상의 가시성과 성능을 동시에 확보합니다.
+            logger.warning(
                 "[OBS] Non-serializable types encountered during JSONL serialization (fallback applied).",
                 extra={"fallback_counts": fallback_counts}
             )

--- a/backend/utils/finetune_parser.py
+++ b/backend/utils/finetune_parser.py
@@ -70,6 +70,7 @@ def serialize_to_jsonl(
     dataset: List[Dict[str, Any]],
     output_filepath: str,
     pii_fields: Optional[List[str]] = None,
+    strict_alert: bool = False,
 ) -> str:
     """
     데이터셋을 .jsonl 파일로 직렬화하며, 필요한 경우 지정된 PII 필드들을 안전하게 마스킹 처리합니다.
@@ -79,6 +80,8 @@ def serialize_to_jsonl(
         output_filepath: 저장할 jsonl 파일의 대상 경로
         pii_fields: 값에 마스킹을 적용할 딕셔너리 필드 목록 (예: ["session_id", "user_id"])
                     (중첩된 구조 내부의 필드 깊이와 관계없이 재귀적으로 찾아 마스킹함)
+        strict_alert: True일 경우 직렬화 폴백 발생 시 [OBS] 태그 기반 Warning을 통해 적극적인 운영 알람을 발생시킵니다.
+                      False(기본값)일 경우 일반 Info 레벨로 로깅하여 저위험 환경의 경고 피로(Alert Fatigue)를 방지합니다.
 
     Returns:
         성공적으로 저장된 파일의 절대 경로
@@ -110,12 +113,24 @@ def serialize_to_jsonl(
                 f.write(json_line + "\n")
 
         if fallback_counts:
-            # 개별 객체 단위의 시끄러운 로그 대신, 전체 루프 종료 후 
-            # 단일 warning으로 요약 보고하여 운영상의 가시성과 성능을 동시에 확보합니다.
-            logger.warning(
-                "[OBS] Non-serializable types encountered during JSONL serialization (fallback applied).",
-                extra={"fallback_counts": fallback_counts}
-            )
+            # 개별 객체 단위의 시끄러운 로그 대신, 단일 요약본으로 운영상의 가시성과 성능을 동시 확보
+            # 운영자 디버깅 향상을 위한 추가 컨텍스트(filepath, total_items 등) 포함
+            extra_payload = {
+                "fallback_counts": fallback_counts,
+                "filepath": absolute_path,
+                "total_items": len(dataset)
+            }
+            
+            if strict_alert:
+                logger.warning(
+                    "[OBS] Non-serializable types encountered during JSONL serialization (fallback applied).",
+                    extra=extra_payload
+                )
+            else:
+                logger.info(
+                    "Non-serializable types encountered during JSONL serialization (fallback applied).",
+                    extra=extra_payload
+                )
 
         logger.info(
             "Successfully serialized dataset to JSONL",


### PR DESCRIPTION
📝 docs [#11.9.2]: 5차 개선 - 아키텍처 결정 사항 문서화 및 Fallback 로그 레벨 조정 
🐛 fix [#11.9.2]: 6차 개선 - Alert Fatigue 방지 및 운영 가시성(Context) 강화

## Summary by Sourcery

경고 피로(alert fatigue)를 줄이면서도 직렬화 불가능한 항목에 대한 폴백 처리 관측 가능성은 유지할 수 있도록 JSONL 직렬화 로깅을 조정합니다.

New Features:
- JSONL 직렬화에 `strict_alert` 플래그를 추가하여, 필요할 경우 폴백 이벤트를 경고 수준(warning-level) 알림으로 상향 조정할 수 있도록 합니다.

Enhancements:
- 이후 파이프라인의 일관성을 위해 JSON 직렬화 과정에서 set을 list로 정규화하는 동작을 더 명확히 합니다.
- 직렬화할 수 없는 타입에 대한 폴백 발생들을 하나의 요약 로그 엔트리로 집계하고, 파일 경로와 항목 개수와 같은 추가 컨텍스트를 포함합니다. 로그 레벨은 설정에 따라 info 또는 warning으로 기록됩니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust JSONL serialization logging to reduce alert fatigue while preserving observability for non-serializable fallback handling.

New Features:
- Add a strict_alert flag to JSONL serialization to optionally elevate fallback events to warning-level alerts.

Enhancements:
- Clarify behavior of set-to-list normalization during JSON serialization for downstream pipeline consistency.
- Aggregate non-serializable type fallback occurrences into a single summary log entry with additional context such as file path and item count, using info or warning level based on configuration.

</details>