### PR TITLE
🐛 fix [#11.9.3]: 2차 개선 - 인프라 유연성 확보(환경변수) 및 견고한 I/O 처리 (pathlib)

### DIFF
--- a/backend/services/scheduler_service.py
+++ b/backend/services/scheduler_service.py
@@ -3,6 +3,7 @@
 import logging
 import os
 from datetime import datetime, timezone
+from pathlib import Path
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -62,14 +63,14 @@ async def extract_and_serialize_golden_dataset():
         now_dt = datetime.now(timezone.utc)
         date_str = now_dt.strftime("%Y-%m-%d")
 
-        # 프로젝트 최상단 디렉토리 기준 data/golden_dataset
-        # (만약 backend/ 내부에 저장하려면 경로 수정 필요)
-        project_root = os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-        output_filepath = os.path.join(
-            project_root, "data", "golden_dataset", f"{date_str}.jsonl"
-        )
+        # 프로젝트 최상단 디렉토리 구조 파악 (pathlib 활용)
+        project_root = Path(__file__).resolve().parent.parent.parent
+        output_dir = project_root / "data" / "golden_dataset"
+        
+        # 디렉토리가 존재하지 않을 경우 안전하게 생성 (parents=True)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        
+        output_filepath = str(output_dir / f"{date_str}.jsonl")
 
         # 4. JSONL 파일로 직렬화 (finetune_parser 모듈 활용)
         # strict_alert=True를 주어 변환 중 실패 타입이 생기면 운영 알람을 보내도록 함
@@ -102,10 +103,14 @@ def start_scheduler():
     APScheduler를 시작하고 예약된 작업들을 등록합니다.
     (FastAPI lifespan 이벤트 등에서 1회 호출)
     """
-    # 일 1회 실행: 매일 새벽 3시 정각에 실행 (UTC 기준)
+    # 환경 변수에서 실행 시간 및 타임존을 불러와 유연성 확보 (기본값: UTC 03:00)
+    cron_hour = int(os.environ.get("GOLDEN_DATASET_CRON_HOUR", "3"))
+    cron_minute = int(os.environ.get("GOLDEN_DATASET_CRON_MINUTE", "0"))
+    cron_timezone = os.environ.get("GOLDEN_DATASET_CRON_TIMEZONE", "UTC")
+
     scheduler.add_job(
         extract_and_serialize_golden_dataset,
-        CronTrigger(hour=3, minute=0, timezone="UTC"),
+        CronTrigger(hour=cron_hour, minute=cron_minute, timezone=cron_timezone),
         id="daily_golden_dataset_extractor",
         replace_existing=True,
     )

--- a/backend/services/scheduler_service.py
+++ b/backend/services/scheduler_service.py
@@ -4,6 +4,7 @@ import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -103,10 +104,30 @@ def start_scheduler():
     APScheduler를 시작하고 예약된 작업들을 등록합니다.
     (FastAPI lifespan 이벤트 등에서 1회 호출)
     """
+    def parse_env_int(key: str, default: int, min_val: int, max_val: int) -> int:
+        val = os.environ.get(key)
+        if not val:
+            return default
+        try:
+            parsed = int(val)
+            if min_val <= parsed <= max_val:
+                return parsed
+            logger.warning("[OBS] %s is out of range (%d-%d). Falling back to default %d.", key, min_val, max_val, default)
+        except ValueError:
+            logger.warning("[OBS] %s is invalid. Falling back to default %d.", key, default)
+        return default
+
     # 환경 변수에서 실행 시간 및 타임존을 불러와 유연성 확보 (기본값: UTC 03:00)
-    cron_hour = int(os.environ.get("GOLDEN_DATASET_CRON_HOUR", "3"))
-    cron_minute = int(os.environ.get("GOLDEN_DATASET_CRON_MINUTE", "0"))
-    cron_timezone = os.environ.get("GOLDEN_DATASET_CRON_TIMEZONE", "UTC")
+    cron_hour = parse_env_int("GOLDEN_DATASET_CRON_HOUR", 3, 0, 23)
+    cron_minute = parse_env_int("GOLDEN_DATASET_CRON_MINUTE", 0, 0, 59)
+    cron_timezone_name = os.environ.get("GOLDEN_DATASET_CRON_TIMEZONE", "UTC")
+
+    # 타임존 문자열을 검증/정규화하고, 실패 시 기본값(UTC)으로 폴백
+    try:
+        cron_timezone = ZoneInfo(cron_timezone_name)
+    except Exception:
+        logger.warning("[OBS] Timezone '%s' is invalid. Falling back to UTC.", cron_timezone_name)
+        cron_timezone = ZoneInfo("UTC")
 
     scheduler.add_job(
         extract_and_serialize_golden_dataset,


### PR DESCRIPTION
- **[스케줄링 유연성 확보 (12-Factor 원칙 준수)]**
  - 추출 배치(Batch) 주기를 하드코딩된 값에서 환경 변수 기반으로 동적 할당되도록 리팩토링 (`GOLDEN_DATASET_CRON_HOUR`, `MINUTE`, `TIMEZONE`)
  - 코드 변경과 재배포 없이 각 인프라 환경(로컬/Dev/Prod)별, 그리고 서비스 대상 지역(Timezone)별로 파이프라인 구동 시점 제어 기능 확보
- **[파일 I/O 로직 견고성(Robustness) 향상]**
  - 파이프라인의 출력 저장 경로 도출 방식을 장황한 `os.path` 체이닝에서 `pathlib.Path` 객체 기반으로 현대화하여 가독성 강화
  - JSONL 파일 직렬화 이전, 목적지 디렉터리의 존재 여부를 체크하고 안전하게 자동 생성되도록 보강(`mkdir(parents=True, exist_ok=True)`)
  - 신규 배포 및 클린 컨테이너 환경에서 발생할 수 있는 `FileNotFoundError` 런타임 장애 원천 차단

🔗 Related:
- Issue [#933]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/951#pullrequestreview-4059479677)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

환경 변수를 통해 골든 데이터셋 스케줄러를 더 유연하게 설정할 수 있도록 하고, 파일 출력 처리의 견고성을 개선합니다.

New Features:
- 시, 분, 타임존을 환경 변수로 설정하여 골든 데이터셋 추출 스케줄을 구성할 수 있도록 허용합니다.

Bug Fixes:
- JSONL 파일을 쓰기 전에 출력 디렉터리가 생성되도록 보장함으로써 골든 데이터셋 직렬화 시 런타임 오류가 발생하지 않도록 합니다.

Enhancements:
- 더 명확하고 유지보수가 쉬운 경로 처리를 위해 `pathlib`을 사용하도록 골든 데이터셋 출력 경로 구성 로직을 리팩터링합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the golden dataset scheduler more configurable via environment variables and improve robustness of file output handling.

New Features:
- Allow configuring the golden dataset extraction schedule via environment variables for hour, minute, and timezone.

Bug Fixes:
- Prevent runtime failures in golden dataset serialization by ensuring the output directory is created before writing JSONL files.

Enhancements:
- Refactor golden dataset output path construction to use pathlib for clearer and more maintainable path handling.

</details>