### PR TITLE
☘️ refactor [#11.9.3]: 4차 개선 - 예외 체계 정밀화 및 헬퍼 함수 재사용성(Reusability) 확보

### DIFF
--- a/backend/services/scheduler_service.py
+++ b/backend/services/scheduler_service.py
@@ -4,7 +4,7 @@ import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -99,23 +99,26 @@ async def extract_and_serialize_golden_dataset():
         )
 
 
+def parse_env_int(key: str, default: int, min_val: int, max_val: int) -> int:
+    """환경 변수에서 정수값을 안전하게 추출하고, 실패 시 기본값으로 폴백합니다."""
+    val = os.environ.get(key)
+    if not val:
+        return default
+    try:
+        parsed = int(val)
+        if min_val <= parsed <= max_val:
+            return parsed
+        logger.warning("[OBS] %s is out of range (%d-%d). Falling back to default %d.", key, min_val, max_val, default)
+    except ValueError:
+        logger.warning("[OBS] %s is invalid. Falling back to default %d.", key, default)
+    return default
+
+
 def start_scheduler():
     """
     APScheduler를 시작하고 예약된 작업들을 등록합니다.
     (FastAPI lifespan 이벤트 등에서 1회 호출)
     """
-    def parse_env_int(key: str, default: int, min_val: int, max_val: int) -> int:
-        val = os.environ.get(key)
-        if not val:
-            return default
-        try:
-            parsed = int(val)
-            if min_val <= parsed <= max_val:
-                return parsed
-            logger.warning("[OBS] %s is out of range (%d-%d). Falling back to default %d.", key, min_val, max_val, default)
-        except ValueError:
-            logger.warning("[OBS] %s is invalid. Falling back to default %d.", key, default)
-        return default
 
     # 환경 변수에서 실행 시간 및 타임존을 불러와 유연성 확보 (기본값: UTC 03:00)
     cron_hour = parse_env_int("GOLDEN_DATASET_CRON_HOUR", 3, 0, 23)
@@ -125,7 +128,7 @@ def start_scheduler():
     # 타임존 문자열을 검증/정규화하고, 실패 시 기본값(UTC)으로 폴백
     try:
         cron_timezone = ZoneInfo(cron_timezone_name)
-    except Exception:
+    except ZoneInfoNotFoundError:
         logger.warning("[OBS] Timezone '%s' is invalid. Falling back to UTC.", cron_timezone_name)
         cron_timezone = ZoneInfo("UTC")
 


### PR DESCRIPTION
- **[정밀한 예외 처리(Exception Handling)]**
  - 타임존 검증 시 사용되던 광범위한 `except Exception:` 안티 패턴을 제거하고 `except ZoneInfoNotFoundError:`로 한정
  - 타임존 오타로 인한 예외는 안전하게 UTC로 우회하되, 메모리나 모듈 로드 실패 등 치명적인 타 시스템 에러가 의도치 않게 은닉(Masking)되는 런타임 잠재 위험 차단
- **[모듈화 및 재사용성(Reusability) 향상]**
  - `start_scheduler()` 내부에 갇혀(Nested) 구현되어 있던 `parse_env_int` 환경 변수 파싱 헬퍼 로직을 모듈 최상위(Top-level)로 호이스팅(Hoisting)
  - 향후 다른 스케줄러 로직이나 글로벌 상수 환경 변수 파싱 시에도 안전하게 호출하여 공유할 수 있도록 구조적 유지보수성 대폭 도약

🔗 Related:
- Issue [#933]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/953#pullrequestreview-4059489028)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

스케줄러 구성 헬퍼를 다듬고 타임존 오류 처리를 더욱 엄격하게 개선합니다.

개선 사항:
- `start_scheduler` 내부에 있던 환경 변수 정수 파싱 헬퍼를 모듈 수준의 재사용 가능한 함수로 끌어올렸습니다.
- 설정된 타임존이 유효하지 않을 때만 `ZoneInfoNotFoundError`를 포착하도록 타임존 검증 오류 처리를 범위 축소하고, 이 경우 UTC로 폴백하도록 변경했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine scheduler configuration helpers and tighten timezone error handling.

Enhancements:
- Hoist the environment integer parsing helper from inside start_scheduler into a reusable module-level function.
- Narrow timezone validation error handling to only catch ZoneInfoNotFoundError and fall back to UTC when the configured timezone is invalid.

</details>