### PR TITLE
Feature/v8 phase5 data flywheel

### DIFF
--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -602,17 +602,20 @@ async def run_negative_feedback_eval_pipeline(
                     # RAG context(chat:rag_context)가 존재하면 message_id로 정확히 매칭되지만,
                     # 없는 경우에도 최대한 정확한 assistant 메시지를 찾아야 합니다.
 
-                    # [Memory Guard] LRU 단위 제거: 상한 초과 시 가장 오래된 세션 1개만 퇴출
-                    # 전체 clear() 방식과 달리, 최근 hot 세션을 보존하여 cache thrashing을 방지합니다.
-                    if len(session_history_cache) >= _MAX_SESSION_HISTORY_CACHE_SIZE:
-                        evicted_session_id, _ = session_history_cache.popitem(last=False)
-                        logger.debug(
-                            "[OBS] session_history_cache LRU eviction: removed oldest session "
-                            "(cache_size=%s).",
-                            _MAX_SESSION_HISTORY_CACHE_SIZE,
-                        )
-
                     if session_id not in session_history_cache:
+                        # [Bug Fix] LRU 퇴출을 신규 삽입 시에만 실행 (캐시 히트 시에는 퇴출하지 않음)
+                        # 기존: eviction이 cache 조회 전에 실행되어, 히트 임에도 불필요한 퇴출 발생
+                        # 수정: not-in 체크 후 신규 삽입이 확정된 경우에만 퇴출 실행
+                        if len(session_history_cache) >= _MAX_SESSION_HISTORY_CACHE_SIZE:
+                            evicted_session_id, _ = session_history_cache.popitem(last=False)
+                            logger.debug(
+                                "[OBS] session_history_cache LRU eviction: removed oldest session "
+                                "(evicted=%s, current_size=%s, max_size=%s).",
+                                mask_pii_id(evicted_session_id),   # PII 안전 익명화
+                                len(session_history_cache),        # 퇴출 후 실제 캐시 크기
+                                _MAX_SESSION_HISTORY_CACHE_SIZE,   # 설정된 최대 한도
+                            )
+
                         history_key = f"{_HISTORY_PREFIX}{session_id}"
                         # lrange 범위 제한: 최근 N개만 조회하여 메모리·속도 절약
                         history_raw = await redis_client.redis.lrange(

--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -14,6 +14,7 @@
 import json
 import logging
 import os
+from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import lru_cache
@@ -553,9 +554,13 @@ async def run_negative_feedback_eval_pipeline(
         if not redis_client.is_connected():
             await redis_client.connect()
 
-        # [Performance] 세션별 history 캐시: 동일 session의 여러 피드백에 대해 lrange를 1회만 수행
-        # 키: session_id, 값: 역순 정렬된 파싱 완료 메시지 dict 리스트
-        session_history_cache: dict[str, list[dict]] = {}
+        # [Performance] 세션별 history LRU 캐시: 동일 session의 여러 피드백에 대해 lrange를 1회만 수행
+        # [Engineering Decision]
+        # - OrderedDict + LRU 단위 제거로 캐시 Thrashing 방지
+        #   (dict.clear() 방식은 상한 도달 시 유효 캐시를 전부 날려 Redis 재조회 폭탄 유발)
+        # - 상한(_MAX_SESSION_HISTORY_CACHE_SIZE) 초과 시 가장 오래된 세션 1개만 제거하여
+        #   "최근 hot 세션은 보존, 메모리 상한 준수" 두 목표를 동시에 달성합니다.
+        session_history_cache: OrderedDict[str, list[dict]] = OrderedDict()
         history_scan_limit = _get_eval_history_scan_limit()
 
         cursor = 0
@@ -593,19 +598,19 @@ async def run_negative_feedback_eval_pipeline(
                         summary["skipped_already_evaluated"] += 1
                         continue
 
-                    # ── chat:history 조회 (세션별 1회 캐싱으로 N×M Redis 호출 원천 차단) ──
+                    # ── chat:history 조회 (세션별 LRU 캐싱으로 N×M Redis 호출 원천 차단) ──
                     # RAG context(chat:rag_context)가 존재하면 message_id로 정확히 매칭되지만,
                     # 없는 경우에도 최대한 정확한 assistant 메시지를 찾아야 합니다.
 
-                    # [Memory Guard] 캐시 크기 상한 초과 시 캐시 전체 제거
-                    # 장기 실행 프로세스에서 세션 수가 무한히 증가하는 메모리 스파이크를 방지합니다.
+                    # [Memory Guard] LRU 단위 제거: 상한 초과 시 가장 오래된 세션 1개만 퇴출
+                    # 전체 clear() 방식과 달리, 최근 hot 세션을 보존하여 cache thrashing을 방지합니다.
                     if len(session_history_cache) >= _MAX_SESSION_HISTORY_CACHE_SIZE:
-                        logger.warning(
-                            "[OBS] session_history_cache reached max size (%s); clearing cache "
-                            "to prevent memory spike.",
+                        evicted_session_id, _ = session_history_cache.popitem(last=False)
+                        logger.debug(
+                            "[OBS] session_history_cache LRU eviction: removed oldest session "
+                            "(cache_size=%s).",
                             _MAX_SESSION_HISTORY_CACHE_SIZE,
                         )
-                        session_history_cache.clear()
 
                     if session_id not in session_history_cache:
                         history_key = f"{_HISTORY_PREFIX}{session_id}"
@@ -625,6 +630,9 @@ async def run_negative_feedback_eval_pipeline(
                                 continue
                         # 역순 저장: 최신 메시지부터 탐색할 수 있도록 준비
                         session_history_cache[session_id] = list(reversed(parsed))
+                    else:
+                        # 캐시 히트: 해당 세션을 OrderedDict의 끝(최신)으로 이동하여 LRU 순위 갱신
+                        session_history_cache.move_to_end(session_id)
 
                     cached_history = session_history_cache[session_id]
 
@@ -653,7 +661,11 @@ async def run_negative_feedback_eval_pipeline(
 
                     # 정확 매칭 실패 시 최신 assistant 응답으로 fallback
                     if not ai_response and latest_assistant_response:
-                        logger.info(
+                        logger.debug(
+                            # [Log Level: DEBUG]
+                            # 배치 실행 중 message_id가 없는 기존 히스토리(배포 이전 저장분)에서
+                            # 대량으로 발생할 수 있으므로, INFO 대신 DEBUG로 유지하여 로그 노이즈를 방지합니다.
+                            # 운영 중 매칭 실패 추세를 모니터링하려면 배치 완료 요약 로그를 활용하세요.
                             "[OBS] message_id exact match failed; using latest assistant response as fallback.",
                             extra={
                                 "session_id_hash": mask_pii_id(session_id),


### PR DESCRIPTION
🐛 fix [#11.10.1]: 4차 개선 - LRU 캐시 제거 전략 및 로그 레벨 최적화 
🐛 fix [#11.10.1]: 5차 개선 - LRU 퇴출 위치 버그 수정 및 로그 정보 개선

## Summary by Sourcery

부정적 피드백 평가를 위해 LRU 기반 세션 히스토리 캐시를 도입하고, 과도한 노이즈 없이 가시성을 높이도록 관련 로깅을 튜닝합니다.

Bug Fixes:
- 잘못된 LRU 제거 시점을 수정하여, 캐시 히트 시가 아니라 새로운 세션이 삽입될 때만 캐시 엔트리가 제거되도록 합니다.

Enhancements:
- 전체 캐시 초기화 대신, 메모리 한도를 지키면서 캐시 스래싱을 방지하기 위해 가장 오래된 세션만을 제거하는 제한된 LRU 방식으로 교체합니다.
- 세션 히스토리 캐시를 `OrderedDict` 기반 LRU 구조로 승격하고, 히트 처리 시 최신 사용 순서가 반영되도록 갱신 로직을 업데이트합니다.
- 시끄러운 fallback 매칭 로그의 레벨을 INFO에서 DEBUG로 낮추고, 제거(eviction) 로그를 보강하여 더 안전하고 저노이즈의 모니터링이 가능하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an LRU-based session history cache for negative feedback evaluation and tune related logging for better observability without excessive noise.

Bug Fixes:
- Fix incorrect LRU eviction timing so that cache entries are only evicted on new session insertions rather than on cache hits.

Enhancements:
- Replace full cache clears with bounded LRU eviction of the oldest session to prevent cache thrashing while respecting memory limits.
- Promote session history cache to an OrderedDict-based LRU structure and update hit handling to refresh recency ordering.
- Downgrade noisy fallback matching log from INFO to DEBUG and enrich eviction logs for safer, lower-noise monitoring.

</details>