### PR TITLE
☘️ refactor [#11.10.2]: 1차 개선 - `sampling_rate DI` 도입 및 `정합성 post-check` 추가

### DIFF
--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -641,18 +641,23 @@ async def classify_negative_feedback(
 async def run_negative_feedback_eval_pipeline(
     *,
     batch_size: int = 100,
+    sampling_rate: Optional[float] = None,
 ) -> dict[str, Any]:
     """
     Redis의 모든 '싫어요' 피드백을 대상으로 분류 파이프라인을 실행합니다.
     이미 평가된 항목(chat:eval:* 키 존재)은 건너뛰어 중복 LLM 호출을 방지합니다.
 
     [Step 2-2 - 샘플링 전략]
-    EVAL_SAMPLING_RATE 환경변수(기본 1.0)로 평가 비율을 제어합니다.
-    예: EVAL_SAMPLING_RATE=0.2 → '싫어요' 중 무작위 20%만 LLM 분류하여 API 비용 절감.
+    sampling_rate 인자 또는 EVAL_SAMPLING_RATE 환경변수(기본 1.0)로 평가 비율을 제어합니다.
+    예: sampling_rate=0.2 → '싫어요' 중 무작위 20%만 LLM 분류하여 API 비용 절감.
     Ragas 미사용 시 자체 LLM 판별(classify_negative_feedback)이 기본 전략으로 동작합니다.
 
     Args:
-        batch_size: Redis SCAN 한 번에 반환할 최대 키 수.
+        batch_size:     Redis SCAN 한 번에 반환할 최대 키 수.
+        sampling_rate:  평가를 수행할 비율 (0.0 초과 ~ 1.0 이하).
+                        None이면 EVAL_SAMPLING_RATE 환경변수에서 읽어옵니다.
+                        명시적으로 전달하면 환경변수보다 우선합니다.
+                        (테스트 시 환경변수 조작 없이 비율을 제어할 수 있습니다.)
 
     Returns:
         실행 요약 dict:
@@ -668,7 +673,19 @@ async def run_negative_feedback_eval_pipeline(
                 "label_counts": {"hallucination": int, "rag_retrieval_failure": int, "uncertain": int}
             }
     """
-    sampling_rate = _get_eval_sampling_rate()
+    # [DI] 명시적 인자가 제공되면 우선 사용, 아니면 환경변수에서 조회
+    if sampling_rate is None:
+        sampling_rate = _get_eval_sampling_rate()
+    else:
+        # 인자로 전달된 값도 동일한 범위 검증 적용
+        if not (0.0 < sampling_rate <= 1.0):
+            logger.warning(
+                "[OBS] Explicit sampling_rate=%.4f is out of range (0.0, 1.0]; "
+                "using default=%.1f.",
+                sampling_rate,
+                _DEFAULT_EVAL_SAMPLING_RATE,
+            )
+            sampling_rate = _DEFAULT_EVAL_SAMPLING_RATE
     summary: dict[str, Any] = {
         "total_negative": 0,
         "sampled": 0,
@@ -837,6 +854,26 @@ async def run_negative_feedback_eval_pipeline(
 
             if int(cursor) == 0:
                 break
+
+        # [Invariant Post-Check] summary 필드 정합성 검증
+        # total_negative가 모든 하위 분기(skipped + sampled)의 합과 일치하는지 확인.
+        # 어긋나면 파이프라인 내 분기 로직에 누락 경로가 있다는 신호이므로 경고 로그 기록.
+        # (프로덕션 크래시를 방지하기 위해 assert 대신 WARNING 로그 사용)
+        expected_sum = (
+            summary["skipped_already_evaluated"]
+            + summary["skipped_sampling"]
+            + summary["skipped_no_response"]
+            + summary["classified"]
+            + summary["errors"]
+        )
+        if summary["total_negative"] != expected_sum:
+            logger.warning(
+                "[OBS] Pipeline summary invariant mismatch: "
+                "total_negative=%d != sum_of_outcomes=%d. "
+                "This may indicate a logic regression in the pipeline branching.",
+                summary["total_negative"],
+                expected_sum,
+            )
 
         logger.info(
             "[OBS] Negative feedback eval pipeline complete.",

--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -212,14 +212,35 @@ def _get_eval_sampling_rate() -> float:
         )
         return _DEFAULT_EVAL_SAMPLING_RATE
 
+    # [SSOT] 범위 검증을 공통 헬퍼에 위임 (중복 로직 제거)
+    return _validate_sampling_rate(rate, "EVAL_SAMPLING_RATE env")
+
+
+def _validate_sampling_rate(rate: float, source: str) -> float:
+    """
+    [SSOT] sampling_rate 범위 검증 로직의 단일 진실 공급원.
+
+    유효 범위: (0.0, 1.0]. 범위 벗어난 값은 기본값으로 복원하고 경고 로그를 기록.
+    ‘_get_eval_sampling_rate()’(환경변수 경로)와
+    ‘run_negative_feedback_eval_pipeline’(명시적 인자 경로) 모두에서
+    호출하여 검증 로직과 로그 메시지가 한 곳에서 일관되게 유지되도록 합니다.
+
+    Args:
+        rate:   검증할 부동소수점 비율.
+        source: 에러 로그에 표시할 키 출소 ("EVAL_SAMPLING_RATE env" 또는 "explicit arg" 등).
+
+    Returns:
+        유효한 비율 값 또는 복원된 기본값 (_DEFAULT_EVAL_SAMPLING_RATE).
+    """
     if not (0.0 < rate <= 1.0):
         logger.warning(
-            "[OBS] EVAL_SAMPLING_RATE=%.4f is out of range (0.0, 1.0]; using default=%.1f.",
+            "[OBS] sampling_rate=%.4f from '%s' is out of range (0.0, 1.0]; "
+            "using default=%.1f.",
             rate,
+            source,
             _DEFAULT_EVAL_SAMPLING_RATE,
         )
         return _DEFAULT_EVAL_SAMPLING_RATE
-
     return rate
 
 
@@ -674,18 +695,11 @@ async def run_negative_feedback_eval_pipeline(
             }
     """
     # [DI] 명시적 인자가 제공되면 우선 사용, 아니면 환경변수에서 조회
+    # 범위 검증은 _validate_sampling_rate() SSOT 헬퍼로 준수 (로직 중복 제거)
     if sampling_rate is None:
         sampling_rate = _get_eval_sampling_rate()
     else:
-        # 인자로 전달된 값도 동일한 범위 검증 적용
-        if not (0.0 < sampling_rate <= 1.0):
-            logger.warning(
-                "[OBS] Explicit sampling_rate=%.4f is out of range (0.0, 1.0]; "
-                "using default=%.1f.",
-                sampling_rate,
-                _DEFAULT_EVAL_SAMPLING_RATE,
-            )
-            sampling_rate = _DEFAULT_EVAL_SAMPLING_RATE
+        sampling_rate = _validate_sampling_rate(sampling_rate, "explicit arg")
     summary: dict[str, Any] = {
         "total_negative": 0,
         "sampled": 0,
@@ -855,24 +869,32 @@ async def run_negative_feedback_eval_pipeline(
             if int(cursor) == 0:
                 break
 
-        # [Invariant Post-Check] summary 필드 정합성 검증
-        # total_negative가 모든 하위 분기(skipped + sampled)의 합과 일치하는지 확인.
-        # 어긋나면 파이프라인 내 분기 로직에 누락 경로가 있다는 신호이므로 경고 로그 기록.
-        # (프로덕션 크래시를 방지하기 위해 assert 대신 WARNING 로그 사용)
-        expected_sum = (
+        # [Invariant Post-Check] 외부 불변식 검증 (False-Positive 제거 버전)
+        #
+        # 파이프라인 분기 트리는 total_negative가 정확히 3가의 배타적 경로로 소진됨:
+        #   total_negative
+        #   ├── skipped_already_evaluated  (중복 평가 방지, continue)
+        #   ├── skipped_sampling            (샘플링 제외, continue)
+        #   └── sampled                     (평가 진행 대상)
+        #       └── (내부: classified, skipped_no_response, errors, None반환등 복합)
+        #
+        # classified/errors를 포함하면 classify_negative_feedback()가 None을 반환하는
+        # 정상 경로를 눌리는 게산 오류로 거짓 경고 발생 가능.
+        # 따라서 진정으로 배타적이고 전체를 포괄하는 외부 불물식만 사용.
+        outer_sum = (
             summary["skipped_already_evaluated"]
             + summary["skipped_sampling"]
-            + summary["skipped_no_response"]
-            + summary["classified"]
-            + summary["errors"]
+            + summary["sampled"]
         )
-        if summary["total_negative"] != expected_sum:
+        if summary["total_negative"] != outer_sum:
             logger.warning(
                 "[OBS] Pipeline summary invariant mismatch: "
-                "total_negative=%d != sum_of_outcomes=%d. "
+                "total_negative=%d != (skipped_already_evaluated=%d + skipped_sampling=%d + sampled=%d). "
                 "This may indicate a logic regression in the pipeline branching.",
                 summary["total_negative"],
-                expected_sum,
+                summary["skipped_already_evaluated"],
+                summary["skipped_sampling"],
+                summary["sampled"],
             )
 
         logger.info(


### PR DESCRIPTION
- **[테스트 용이성: sampling_rate 명시적 인자(DI) 도입]**
  - `run_negative_feedback_eval_pipeline(sampling_rate=0.2)` 형태로 직접 전달 가능
  - `Optional[float] = None`: None이면 기존과 동일하게 EVAL_SAMPLING_RATE 환경변수에서 조회
  - 명시적 전달 시 환경변수보다 우선 → 테스트에서 os.environ 조작 없이 비율 제어
  - 인자로 전달된 값에도 동일한 범위 검증 (0.0, 1.0) 적용 + 범위 초과 시 경고 로그

- **[방어 코딩: summary 필드 정합성 불변식(Invariant) post-check 추가]**
  - 파이프라인 완료 후 `total_negative == skipped_already_evaluated + skipped_sampling + skipped_no_response + classified + errors` 검증
  - 불변식 위반 시 WARNING 로그 기록 (assert 대신 → 프로덕션 크래시 방지)
  - 향후 파이프라인 분기 로직 변경 시 누락 경로를 자동 감지하여 회귀 버그 사전 차단

- **[하위 호환성 100% 보장]**
  - 기존 호출부(인자 미전달): 기존과 완전 동일하게 환경변수 기반 동작
  - 외부 호출처 grep 결과: 현재 없음 → 시그니처 변경이 안전하게 적용됨

🔗 Related:
- Issue [#934]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/973#pullrequestreview-4062850898)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

부정 피드백 평가 파이프라인에 주입 가능한 샘플링 비율을 도입하고, 파이프라인 요약 불변식을 검증하기 위한 방어적인 사후 검사(post-check)를 추가합니다.

향상 사항:
- 부정 피드백 평가 파이프라인이 명시적인 `sampling_rate` 인자를 받아 환경 변수를 재정의하되, 이전 버전과의 호환 동작을 유지하도록 허용합니다.
- 실행 후 `total_negative` 값과 모든 결과 카운터의 합을 비교하는 불변식 검사를 추가하고, 불일치 시 경고 로그를 남겨 로직 회귀를 더 쉽게 감지할 수 있도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce injectable sampling rate for the negative feedback evaluation pipeline and add a defensive post-check to validate pipeline summary invariants.

Enhancements:
- Allow the negative feedback evaluation pipeline to accept an explicit sampling_rate argument that overrides the environment variable while preserving backward-compatible behavior.
- Add a post-execution invariant check that compares total_negative against the sum of all outcome counters and logs a warning on mismatch for easier detection of logic regressions.

</details>