### PR TITLE
📝 docs [#11.10.2]: 3차 개선 - _validate_sampling_rate Docstring 오타 수정

### DIFF
--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -227,7 +227,7 @@ def _validate_sampling_rate(rate: float, source: str) -> float:
 
     Args:
         rate:   검증할 부동소수점 비율.
-        source: 에러 로그에 표시할 키 출소 ("EVAL_SAMPLING_RATE env" 또는 "explicit arg" 등).
+        source: 에러 로그에 표시할 키 출처 ("EVAL_SAMPLING_RATE env" 또는 "explicit arg" 등).
 
     Returns:
         유효한 비율 값 또는 복원된 기본값 (_DEFAULT_EVAL_SAMPLING_RATE).


### PR DESCRIPTION
- **[사소한 오타 개선]**
  - `_validate_sampling_rate` 함수의 파라미터 `source`에 대한 한국어 설명 수정
  - 수정 전: 에러 로그에 표시할 키 출소
  - 수정 후: 에러 로그에 표시할 키 출처
- **[코드 영향도]**
  - 코드 로직에는 전혀 영향이 없는 Docstring 단순 변경 (nitpick)

🔗 Related:
- Issue [#934]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/975#pullrequestreview-4062951714)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Documentation:
- `_validate_sampling_rate`의 `source` 파라미터에 대한 한국어 설명에서 잘못된 어휘를 올바르게 수정하여 오타를 바로잡습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Correct the Korean description of the `source` parameter in `_validate_sampling_rate` to fix a wording typo.

</details>