### PR TITLE
Feature/v8 phase5 data flywheel

### DIFF
--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -227,7 +227,7 @@ def _validate_sampling_rate(rate: float, source: str) -> float:
 
     Args:
         rate:   검증할 부동소수점 비율.
-        source: 에러 로그에 표시할 키 출소 ("EVAL_SAMPLING_RATE env" 또는 "explicit arg" 등).
+        source: 에러 로그에 표시할 키 출처 ("EVAL_SAMPLING_RATE env" 또는 "explicit arg" 등).
 
     Returns:
         유효한 비율 값 또는 복원된 기본값 (_DEFAULT_EVAL_SAMPLING_RATE).


### PR DESCRIPTION
📝 docs [#11.10.2]: 3차 개선 - _validate_sampling_rate Docstring 오타 수정

## Summary by Sourcery

Documentation:
- `_validate_sampling_rate` 함수의 docstring에서 `source` 매개변수 설명에 있는 오타를 수정하기 위해 한국어 표현을 바로잡습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Correct the Korean wording in the _validate_sampling_rate function docstring to fix a typo in the description of the source parameter.

</details>