### PR TITLE
♻️ refactor [#11.10.3]: 2차 개선 - 보안 강화 및 가독성을 위한 아키텍처 리팩토링

### DIFF
--- a/backend/api/endpoints/admin.py
+++ b/backend/api/endpoints/admin.py
@@ -2,6 +2,7 @@
 
 """Admin Endpoints"""
 
+import hmac
 import logging
 from typing import Optional
 
@@ -29,7 +30,7 @@ async def get_eval_report_endpoint(
         logger.error("[OBS] ADMIN_API_KEY is not configured in environment.")
         raise HTTPException(status_code=500, detail="Server Configuration Error")
         
-    if not x_admin_key or x_admin_key != admin_key:
+    if not x_admin_key or not hmac.compare_digest(str(x_admin_key), str(admin_key)):
         logger.warning("[OBS] Unauthorized attempt to access admin eval report.")
         raise HTTPException(status_code=403, detail="Forbidden: Invalid Admin Key")
         

--- a/backend/api/endpoints/admin.py
+++ b/backend/api/endpoints/admin.py
@@ -30,7 +30,10 @@ async def get_eval_report_endpoint(
         logger.error("[OBS] ADMIN_API_KEY is not configured in environment.")
         raise HTTPException(status_code=500, detail="Server Configuration Error")
         
-    if not x_admin_key or not hmac.compare_digest(str(x_admin_key), str(admin_key)):
+    provided = str(x_admin_key or "")
+    expected = str(admin_key or "")
+    
+    if not hmac.compare_digest(provided, expected):
         logger.warning("[OBS] Unauthorized attempt to access admin eval report.")
         raise HTTPException(status_code=403, detail="Forbidden: Invalid Admin Key")
         

--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import lru_cache
 from json import JSONDecodeError
-from typing import Any, Literal, Optional
+from typing import Any, AsyncIterator, Literal, Optional
 
 import redis.exceptions
 
@@ -974,7 +974,11 @@ def _extract_keywords(text: str) -> list[str]:
             
     return extracted
 
-async def _iter_eval_records(max_scan_iterations: int):
+async def _iter_eval_records(
+    redis_conn: Any,
+    key_pattern: str,
+    max_scan_iterations: int
+) -> AsyncIterator[dict[str, Any]]:
     """Redis SCAN 및 JSON 파싱을 수행하는 async 제너레이터 헬퍼"""
     cursor = 0
     iteration = 0
@@ -984,11 +988,11 @@ async def _iter_eval_records(max_scan_iterations: int):
             break
         iteration += 1
         
-        cursor, keys = await redis_client.redis.scan(cursor, match=f"{_EVAL_RESULT_PREFIX}*", count=500)
+        cursor, keys = await redis_conn.scan(cursor, match=key_pattern, count=500)
         
         for key in keys:
             key_str = key.decode("utf-8") if isinstance(key, bytes) else str(key)
-            eval_hash = await redis_client.redis.hgetall(key_str)
+            eval_hash = await redis_conn.hgetall(key_str)
             
             for _, raw_val in eval_hash.items():
                 try:
@@ -1016,7 +1020,11 @@ async def generate_eval_report() -> dict[str, Any]:
     labels_count: dict[str, int] = defaultdict(int)
     failed_queries: list[str] = []
     
-    async for parsed in _iter_eval_records(_EVAL_REPORT_MAX_SCAN_ITERATIONS):
+    async for parsed in _iter_eval_records(
+        redis_conn=redis_client.redis,
+        key_pattern=f"{_EVAL_RESULT_PREFIX}*",
+        max_scan_iterations=_EVAL_REPORT_MAX_SCAN_ITERATIONS
+    ):
         label = parsed.get("label", "uncertain")
         labels_count[label] += 1
             

--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -935,6 +935,20 @@ _POSTPOSITIONS_SORTED = tuple(
     )
 )
 
+def _strip_postpositions(token: str) -> str:
+    """조사(은/는/이/가/...)를 가능한 한 반복적으로 제거합니다."""
+    stem = token
+    while True:
+        stripped = False
+        for josa in _POSTPOSITIONS_SORTED:
+            if stem.endswith(josa) and len(stem) > len(josa):
+                stem = stem[:-len(josa)]
+                stripped = True
+                break
+        if not stripped:
+            break
+    return stem
+
 def _extract_keywords(text: str) -> list[str]:
     """
     텍스트에서 핵심 키워드를 추출합니다 (KoNLPy/TF-IDF 대안 경량화 알고리즘).
@@ -943,7 +957,6 @@ def _extract_keywords(text: str) -> list[str]:
     - 기본적인 한국어 조사 제거 (은/는/이/가/을/를/의/에/에서/으로/로/와/과/도/만/에게)
     - 불용어(Stopwords) 필터링
     """
-    # 특수문자를 제거하고 공백 단위 분리
     cleaned = re.sub(r'[^\w\s]', '', text)
     tokens = cleaned.split()
     
@@ -953,23 +966,39 @@ def _extract_keywords(text: str) -> list[str]:
         if token in _KOREAN_STOPWORDS:
             continue
             
-        stem = token
-        while True:
-            stripped_in_this_round = False
-            for josa in _POSTPOSITIONS_SORTED:
-                if stem.endswith(josa) and len(stem) > len(josa):
-                    stem = stem[:-len(josa)]
-                    stripped_in_this_round = True
-                    break
-            
-            if not stripped_in_this_round:
-                break
+        stem = _strip_postpositions(token)
                 
         # 추출된 단어가 2글자 이상이고 불용어가 아닌 경우만 보존
         if len(stem) > 1 and stem not in _KOREAN_STOPWORDS:
             extracted.append(stem)
             
     return extracted
+
+async def _iter_eval_records(max_scan_iterations: int):
+    """Redis SCAN 및 JSON 파싱을 수행하는 async 제너레이터 헬퍼"""
+    cursor = 0
+    iteration = 0
+    
+    while True:
+        if iteration >= max_scan_iterations:
+            break
+        iteration += 1
+        
+        cursor, keys = await redis_client.redis.scan(cursor, match=f"{_EVAL_RESULT_PREFIX}*", count=500)
+        
+        for key in keys:
+            key_str = key.decode("utf-8") if isinstance(key, bytes) else str(key)
+            eval_hash = await redis_client.redis.hgetall(key_str)
+            
+            for _, raw_val in eval_hash.items():
+                try:
+                    val_str = raw_val.decode("utf-8") if isinstance(raw_val, bytes) else str(raw_val)
+                    yield json.loads(val_str)
+                except (JSONDecodeError, ValueError):
+                    continue
+                    
+        if int(cursor) == 0:
+            break
 
 async def generate_eval_report() -> dict[str, Any]:
     """
@@ -985,48 +1014,22 @@ async def generate_eval_report() -> dict[str, Any]:
         await redis_client.connect()
         
     labels_count: dict[str, int] = defaultdict(int)
-    failed_queries = []
+    failed_queries: list[str] = []
     
-    cursor = 0
-    max_scan_iterations = _EVAL_REPORT_MAX_SCAN_ITERATIONS
-    iteration = 0
-    
-    while True:
-        # Safeguard: cap the amount of work this endpoint does per request
-        if iteration >= max_scan_iterations:
-            break
-        iteration += 1
-        
-        cursor, keys = await redis_client.redis.scan(cursor, match=f"{_EVAL_RESULT_PREFIX}*", count=500)
-        
-        for key in keys:
-            key_str = key.decode("utf-8") if isinstance(key, bytes) else str(key)
-            eval_hash = await redis_client.redis.hgetall(key_str)
+    async for parsed in _iter_eval_records(_EVAL_REPORT_MAX_SCAN_ITERATIONS):
+        label = parsed.get("label", "uncertain")
+        labels_count[label] += 1
             
-            for msg_id, raw_val in eval_hash.items():
-                try:
-                    val_str = raw_val.decode("utf-8") if isinstance(raw_val, bytes) else str(raw_val)
-                    parsed = json.loads(val_str)
-                    
-                    label = parsed.get("label", "uncertain")
-                    labels_count[label] += 1
-                        
-                    # 실패 케이스의 질문 수집
-                    if label in ("hallucination", "rag_retrieval_failure"):
-                        query = parsed.get("rag_query")
-                        if query:
-                            failed_queries.append(query)
-                except (JSONDecodeError, ValueError):
-                    continue
-                    
-        if int(cursor) == 0:
-            break
+        # 실패 케이스의 질문 수집
+        if label in ("hallucination", "rag_retrieval_failure"):
+            query = parsed.get("rag_query")
+            if query:
+                failed_queries.append(query)
             
     # 키워드 TF 계산 (TF-IDF 경량 대안)
     keyword_counter: Counter = Counter()
     for q in failed_queries:
-        keywords = _extract_keywords(q)
-        keyword_counter.update(keywords)
+        keyword_counter.update(_extract_keywords(q))
         
     # 클러스터링 (상위 5개의 핵심 키워드로 대표되는 토픽 반환)
     top_5_keywords = [{"keyword": k, "count": c} for k, c in keyword_counter.most_common(5)]
@@ -1043,7 +1046,7 @@ async def generate_eval_report() -> dict[str, Any]:
     return {
         "status": "success",
         "total_evaluated": sum(labels_count.values()),
-        "label_distribution": labels_count,
+        "label_distribution": dict(labels_count),
         "top_failing_topics": top_5_keywords,
         "failed_query_count": len(failed_queries),
         "timestamp": _now_utc_iso()


### PR DESCRIPTION
- **[보안 (Security) 강화]**
  - 관리자 API 비밀키 대조 시 타이밍 공격(Timing Attack) 방지를 위해 `hmac.compare_digest` 상수 시간 비교 적용 (`endpoints/admin.py`)

- **[데이터 직렬화 (Serialization) 안정화]**
  - JSON 인코더 호환성 확보 및 구현체 노출 방지를 위해 `defaultdict` 반환값을 순수 `dict()`로 캐스팅

- **[클린 코드 (Clean Code) 헬퍼 함수 분리]**
  - I/O 관심사 분리: Redis `SCAN` 및 JSON 파싱 로직을 `_iter_eval_records` 비동기 제너레이터로 분리하여 메인 함수 복잡도(Cyclomatic Complexity) 감소
  - 자연어 처리 최적화: 조사 반복 탈락 로직을 `_strip_postpositions` 헬퍼로 격리시켜 `_extract_keywords` 파이프라인 가독성 선형화

🔗 Related:
- Issue [#934]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/979#pullrequestreview-4068768767)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

평가 보고 파이프라인을 신뢰성, 가독성, 보안 측면에서 개선했습니다.

버그 수정:
- 관리자용 평가 보고서의 API 키 비교에서 타이밍 공격을 방지합니다.
- 평가 보고서의 라벨 분포가 JSON 직렬화와 호환되도록, plain dict 형태로 반환되도록 보장합니다.

개선 사항:
- 키워드 추출 로직을 단순화하기 위해, 한국어 조사 제거 기능을 별도의 헬퍼로 분리했습니다.
- 평가 레코드에 대한 Redis SCAN 및 JSON 파싱을 비동기 제너레이터로 분리하여, 평가 보고 파이프라인에서 I/O와 집계를 분리했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the evaluation report pipeline for reliability, readability, and security.

Bug Fixes:
- Prevent timing attacks on the admin evaluation report API key comparison.
- Ensure the label distribution in the evaluation report is returned as a plain dict for JSON serialization compatibility.

Enhancements:
- Extract Korean postposition stripping into a dedicated helper to simplify keyword extraction logic.
- Factor Redis SCAN and JSON parsing for evaluation records into an async generator to separate I/O from aggregation in the eval report pipeline.

</details>