### PR TITLE
⚡️ perf [#11.10.3]: 4차 개선 - 마이크로 성능 최적화 및 매직 넘버 하드코딩 제거

### DIFF
--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -917,10 +917,10 @@ async def run_negative_feedback_eval_pipeline(
 
 # [Step 2-3] 관리자 보고서용 Redis SCAN 상한 (요청당 최대 반복 횟수)
 # 환경변수 EVAL_REPORT_MAX_SCAN_ITERATIONS 로 조정 가능
-_EVAL_REPORT_MAX_SCAN_ITERATIONS = int(os.getenv("EVAL_REPORT_MAX_SCAN_ITERATIONS", "100"))
+_EVAL_REPORT_MAX_SCAN_ITERATIONS = max(1, int(os.getenv("EVAL_REPORT_MAX_SCAN_ITERATIONS", "100")))
 
-# [Step 2-3] Redis SCAN 1회당 조회할 키 개수 (기본 500)
-_EVAL_REPORT_SCAN_BATCH_SIZE = int(os.getenv("EVAL_REPORT_SCAN_BATCH_SIZE", "500"))
+# [Step 2-3] Redis SCAN 1회당 조회할 키 개수 (기본 500, 최소 1 이상 보장)
+_EVAL_REPORT_SCAN_BATCH_SIZE = max(1, int(os.getenv("EVAL_REPORT_SCAN_BATCH_SIZE", "500")))
 
 # [Step 2-3] 조사 제거 및 TF 계산을 위한 경량화된 한국어 불용어
 _KOREAN_STOPWORDS = {
@@ -941,10 +941,7 @@ _POSTPOSITIONS_SORTED = tuple(
 def _strip_postpositions(token: str) -> str:
     """조사(은/는/이/가/...)를 가능한 한 반복적으로 제거합니다."""
     stem = token
-    while True:
-        if len(stem) <= 1:
-            break
-            
+    while len(stem) > 1:
         stripped = False
         for josa in _POSTPOSITIONS_SORTED:
             if stem.endswith(josa) and len(stem) > len(josa):
@@ -984,7 +981,7 @@ async def _iter_eval_records(
     redis_conn: Any,
     key_pattern: str,
     max_scan_iterations: int,
-    scan_count: int = 500
+    scan_count: int = _EVAL_REPORT_SCAN_BATCH_SIZE
 ) -> AsyncIterator[dict[str, Any]]:
     """Redis SCAN 및 JSON 파싱을 수행하는 async 제너레이터 헬퍼"""
     cursor = 0

--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -919,6 +919,9 @@ async def run_negative_feedback_eval_pipeline(
 # 환경변수 EVAL_REPORT_MAX_SCAN_ITERATIONS 로 조정 가능
 _EVAL_REPORT_MAX_SCAN_ITERATIONS = int(os.getenv("EVAL_REPORT_MAX_SCAN_ITERATIONS", "100"))
 
+# [Step 2-3] Redis SCAN 1회당 조회할 키 개수 (기본 500)
+_EVAL_REPORT_SCAN_BATCH_SIZE = int(os.getenv("EVAL_REPORT_SCAN_BATCH_SIZE", "500"))
+
 # [Step 2-3] 조사 제거 및 TF 계산을 위한 경량화된 한국어 불용어
 _KOREAN_STOPWORDS = {
     "어떻게", "무엇인가요", "알려줘", "설명해줘", "어떤", "무엇", "이건", "저건", 
@@ -939,6 +942,9 @@ def _strip_postpositions(token: str) -> str:
     """조사(은/는/이/가/...)를 가능한 한 반복적으로 제거합니다."""
     stem = token
     while True:
+        if len(stem) <= 1:
+            break
+            
         stripped = False
         for josa in _POSTPOSITIONS_SORTED:
             if stem.endswith(josa) and len(stem) > len(josa):
@@ -977,7 +983,8 @@ def _extract_keywords(text: str) -> list[str]:
 async def _iter_eval_records(
     redis_conn: Any,
     key_pattern: str,
-    max_scan_iterations: int
+    max_scan_iterations: int,
+    scan_count: int = 500
 ) -> AsyncIterator[dict[str, Any]]:
     """Redis SCAN 및 JSON 파싱을 수행하는 async 제너레이터 헬퍼"""
     cursor = 0
@@ -988,7 +995,7 @@ async def _iter_eval_records(
             break
         iteration += 1
         
-        cursor, keys = await redis_conn.scan(cursor, match=key_pattern, count=500)
+        cursor, keys = await redis_conn.scan(cursor, match=key_pattern, count=scan_count)
         
         for key in keys:
             key_str = key.decode("utf-8") if isinstance(key, bytes) else str(key)
@@ -1023,7 +1030,8 @@ async def generate_eval_report() -> dict[str, Any]:
     async for parsed in _iter_eval_records(
         redis_conn=redis_client.redis,
         key_pattern=f"{_EVAL_RESULT_PREFIX}*",
-        max_scan_iterations=_EVAL_REPORT_MAX_SCAN_ITERATIONS
+        max_scan_iterations=_EVAL_REPORT_MAX_SCAN_ITERATIONS,
+        scan_count=_EVAL_REPORT_SCAN_BATCH_SIZE
     ):
         label = parsed.get("label", "uncertain")
         labels_count[label] += 1


### PR DESCRIPTION
- **[마이크로 최적화 (Micro-Optimization)]**
  - `_strip_postpositions` 내부에서 길이가 1 이하인 토큰(`stem`)에 대해 조사 룩업 무의미 반복(O(K))을 사전 차단하는 Early Guard (`len(stem) <= 1`) 선행 배치

- **[매직 넘버 하드코딩 배제 (Hardcoding Removal)]**
  - 제너레이터 깊숙이 숨겨진 `count=500` 상수값을 추출하여, 파라미터 `scan_count`로 주입
  - 최상단 모듈 레벨에서 `EVAL_REPORT_SCAN_BATCH_SIZE` 환경 변수와 연동하여 무중단 성능 튜닝이 가능하도록 구조화

🔗 Related:
- Issue [#934]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/981#pullrequestreview-4068877893)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

평가 리포트 파이프라인의 성능을 최적화하고, 환경 변수를 통해 Redis 스캔 배치 크기를 설정 가능하도록 구성합니다.

개선 사항:
- 매우 짧은 토큰에 대해 불필요한 반복 조회가 일어나지 않도록, 한국어 조사 제거 과정에 조기 종료 가드를 추가했습니다.
- 평가 리포트 생성 시 사용되는 하드코딩된 Redis SCAN count 값을 환경 기반 배치 크기 설정에 연결된 설정 가능한 파라미터로 분리했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize evaluation report pipeline performance and make Redis scan batch size configurable via environment variable.

Enhancements:
- Add an early exit guard in Korean postposition stripping to avoid unnecessary repeated lookups for very short tokens.
- Extract the hardcoded Redis SCAN count into a configurable parameter wired to an environment-based batch size setting for eval report generation.

</details>