### PR TITLE
Feature/v8 phase5 data flywheel

### DIFF
--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -917,10 +917,10 @@ async def run_negative_feedback_eval_pipeline(
 
 # [Step 2-3] 관리자 보고서용 Redis SCAN 상한 (요청당 최대 반복 횟수)
 # 환경변수 EVAL_REPORT_MAX_SCAN_ITERATIONS 로 조정 가능
-_EVAL_REPORT_MAX_SCAN_ITERATIONS = int(os.getenv("EVAL_REPORT_MAX_SCAN_ITERATIONS", "100"))
+_EVAL_REPORT_MAX_SCAN_ITERATIONS = max(1, int(os.getenv("EVAL_REPORT_MAX_SCAN_ITERATIONS", "100")))
 
-# [Step 2-3] Redis SCAN 1회당 조회할 키 개수 (기본 500)
-_EVAL_REPORT_SCAN_BATCH_SIZE = int(os.getenv("EVAL_REPORT_SCAN_BATCH_SIZE", "500"))
+# [Step 2-3] Redis SCAN 1회당 조회할 키 개수 (기본 500, 최소 1 이상 보장)
+_EVAL_REPORT_SCAN_BATCH_SIZE = max(1, int(os.getenv("EVAL_REPORT_SCAN_BATCH_SIZE", "500")))
 
 # [Step 2-3] 조사 제거 및 TF 계산을 위한 경량화된 한국어 불용어
 _KOREAN_STOPWORDS = {
@@ -941,10 +941,7 @@ _POSTPOSITIONS_SORTED = tuple(
 def _strip_postpositions(token: str) -> str:
     """조사(은/는/이/가/...)를 가능한 한 반복적으로 제거합니다."""
     stem = token
-    while True:
-        if len(stem) <= 1:
-            break
-            
+    while len(stem) > 1:
         stripped = False
         for josa in _POSTPOSITIONS_SORTED:
             if stem.endswith(josa) and len(stem) > len(josa):
@@ -984,7 +981,7 @@ async def _iter_eval_records(
     redis_conn: Any,
     key_pattern: str,
     max_scan_iterations: int,
-    scan_count: int = 500
+    scan_count: int = _EVAL_REPORT_SCAN_BATCH_SIZE
 ) -> AsyncIterator[dict[str, Any]]:
     """Redis SCAN 및 JSON 파싱을 수행하는 async 제너레이터 헬퍼"""
     cursor = 0

--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -919,6 +919,9 @@ async def run_negative_feedback_eval_pipeline(
 # 환경변수 EVAL_REPORT_MAX_SCAN_ITERATIONS 로 조정 가능
 _EVAL_REPORT_MAX_SCAN_ITERATIONS = int(os.getenv("EVAL_REPORT_MAX_SCAN_ITERATIONS", "100"))
 
+# [Step 2-3] Redis SCAN 1회당 조회할 키 개수 (기본 500)
+_EVAL_REPORT_SCAN_BATCH_SIZE = int(os.getenv("EVAL_REPORT_SCAN_BATCH_SIZE", "500"))
+
 # [Step 2-3] 조사 제거 및 TF 계산을 위한 경량화된 한국어 불용어
 _KOREAN_STOPWORDS = {
     "어떻게", "무엇인가요", "알려줘", "설명해줘", "어떤", "무엇", "이건", "저건", 
@@ -939,6 +942,9 @@ def _strip_postpositions(token: str) -> str:
     """조사(은/는/이/가/...)를 가능한 한 반복적으로 제거합니다."""
     stem = token
     while True:
+        if len(stem) <= 1:
+            break
+            
         stripped = False
         for josa in _POSTPOSITIONS_SORTED:
             if stem.endswith(josa) and len(stem) > len(josa):
@@ -977,7 +983,8 @@ def _extract_keywords(text: str) -> list[str]:
 async def _iter_eval_records(
     redis_conn: Any,
     key_pattern: str,
-    max_scan_iterations: int
+    max_scan_iterations: int,
+    scan_count: int = 500
 ) -> AsyncIterator[dict[str, Any]]:
     """Redis SCAN 및 JSON 파싱을 수행하는 async 제너레이터 헬퍼"""
     cursor = 0
@@ -988,7 +995,7 @@ async def _iter_eval_records(
             break
         iteration += 1
         
-        cursor, keys = await redis_conn.scan(cursor, match=key_pattern, count=500)
+        cursor, keys = await redis_conn.scan(cursor, match=key_pattern, count=scan_count)
         
         for key in keys:
             key_str = key.decode("utf-8") if isinstance(key, bytes) else str(key)
@@ -1023,7 +1030,8 @@ async def generate_eval_report() -> dict[str, Any]:
     async for parsed in _iter_eval_records(
         redis_conn=redis_client.redis,
         key_pattern=f"{_EVAL_RESULT_PREFIX}*",
-        max_scan_iterations=_EVAL_REPORT_MAX_SCAN_ITERATIONS
+        max_scan_iterations=_EVAL_REPORT_MAX_SCAN_ITERATIONS,
+        scan_count=_EVAL_REPORT_SCAN_BATCH_SIZE
     ):
         label = parsed.get("label", "uncertain")
         labels_count[label] += 1


### PR DESCRIPTION
⚡️ perf [#11.10.3]: 4차 개선 - 마이크로 성능 최적화 및 매직 넘버 하드코딩 제거 
🐛 fix [#11.10.3]: 5차 개선 - 런타임 버그 방지 및 단일 진실 공급원(SSOT) 확립

## Summary by Sourcery

Redis 기반 eval 보고서 스캔을 더 안전하고 설정 가능하게 만드는 동시에 한국어 토큰 제거를 더 엄격하게 합니다.

향상 사항:
- eval 보고서 Redis 스캔 반복 횟수와 배치 크기 환경 변수를 최소 1로 제한하고, 보고서 파이프라인 전체에서 사용되는 설정 가능한 스캔 배치 크기를 도입합니다.
- 어간 길이가 1보다 길게 유지되도록 보장하여, 한국어 조사 제거 과정에서 무한 루프가 발생하지 않도록 합니다.
- 하드코딩된 개수 대신, eval 레코드 이터레이터와 보고서 생성에서 공용 Redis 스캔 배치 크기 설정을 사용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make Redis-based eval report scanning safer and configurable while tightening Korean token stripping.

Enhancements:
- Clamp eval report Redis scan iteration and batch size environment variables to minimum 1 and introduce a configurable scan batch size used across the report pipeline.
- Prevent infinite loops when stripping Korean postpositions by ensuring the stem length must remain greater than 1 before further stripping.
- Use the shared Redis scan batch size configuration in the eval record iterator and report generation instead of a hardcoded count.

</details>