### PR TITLE
♻️ refactor [#11.10.3]: 6차 개선 - 의존성 완전 분리 및 명시적 방어 구문 원복

### DIFF
--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -984,7 +984,7 @@ async def _iter_eval_records(
     redis_conn: Any,
     key_pattern: str,
     max_scan_iterations: int,
-    scan_count: int
+    scan_batch_size: int
 ) -> AsyncIterator[dict[str, Any]]:
     """Redis SCAN 및 JSON 파싱을 수행하는 async 제너레이터 헬퍼"""
     cursor = 0
@@ -995,7 +995,7 @@ async def _iter_eval_records(
             break
         iteration += 1
         
-        cursor, keys = await redis_conn.scan(cursor, match=key_pattern, count=scan_count)
+        cursor, keys = await redis_conn.scan(cursor, match=key_pattern, count=scan_batch_size)
         
         for key in keys:
             key_str = key.decode("utf-8") if isinstance(key, bytes) else str(key)
@@ -1031,7 +1031,7 @@ async def generate_eval_report() -> dict[str, Any]:
         redis_conn=redis_client.redis,
         key_pattern=f"{_EVAL_RESULT_PREFIX}*",
         max_scan_iterations=_EVAL_REPORT_MAX_SCAN_ITERATIONS,
-        scan_count=_EVAL_REPORT_SCAN_BATCH_SIZE
+        scan_batch_size=_EVAL_REPORT_SCAN_BATCH_SIZE
     ):
         label = parsed.get("label", "uncertain")
         labels_count[label] += 1

--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -941,7 +941,10 @@ _POSTPOSITIONS_SORTED = tuple(
 def _strip_postpositions(token: str) -> str:
     """조사(은/는/이/가/...)를 가능한 한 반복적으로 제거합니다."""
     stem = token
-    while len(stem) > 1:
+    while True:
+        if len(stem) <= 1:
+            break
+            
         stripped = False
         for josa in _POSTPOSITIONS_SORTED:
             if stem.endswith(josa) and len(stem) > len(josa):
@@ -981,7 +984,7 @@ async def _iter_eval_records(
     redis_conn: Any,
     key_pattern: str,
     max_scan_iterations: int,
-    scan_count: int = _EVAL_REPORT_SCAN_BATCH_SIZE
+    scan_count: int
 ) -> AsyncIterator[dict[str, Any]]:
     """Redis SCAN 및 JSON 파싱을 수행하는 async 제너레이터 헬퍼"""
     cursor = 0


### PR DESCRIPTION
- **[보이지 않는 결합(Hidden Coupling) 제거]**
  - `_iter_eval_records` 시그니처에서 외부 모듈 상수(`_EVAL_REPORT_SCAN_BATCH_SIZE`)를 참조하던 기본값을 삭제
  - 호출자(`generate_eval_report`)가 모든 인자를 명시적으로 투입하도록 강제하여 완벽한 순수 함수(Pure function) 형태로 격리

- **[가독성 및 명시적 제어 (Guard Clause)]**
  - `_strip_postpositions` 내부의 조건문을 다시 `while True` 로직으로 원복하고, 독립된 `if len(stem) <= 1: break` 가드 구문을 채택하여 로직의 의미 스펙(Semantics)을 원래대로 명확히 보존

🔗 Related:
- Issue [#934]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/983#pullrequestreview-4068984306)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

토큰 조사의 제거 과정에서 숨겨진 결합을 줄이고 제어 흐름을 명확히 하기 위해 평가 서비스 유틸리티를 리팩터링합니다.

개선 사항:
- 호출자가 명시적으로 스캔 횟수 인자를 전달하도록 요구하여 `_iter_eval_records` 를 외부 모듈 상수로부터 분리합니다.
- 종료 조건을 더 명확하고 읽기 쉽게 만들기 위해 `_strip_postpositions` 의 가드 로직을 복원하고 단순화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor evaluation service utilities to reduce hidden coupling and clarify control flow in token postposition stripping.

Enhancements:
- Decouple `_iter_eval_records` from external module constants by requiring an explicit scan count argument from callers.
- Restore and simplify the guard logic in `_strip_postpositions` to make termination conditions more explicit and readable.

</details>