### PR TITLE
Feature/v8 phase5 data flywheel

### DIFF
--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -984,7 +984,7 @@ async def _iter_eval_records(
     redis_conn: Any,
     key_pattern: str,
     max_scan_iterations: int,
-    scan_count: int
+    scan_batch_size: int
 ) -> AsyncIterator[dict[str, Any]]:
     """Redis SCAN 및 JSON 파싱을 수행하는 async 제너레이터 헬퍼"""
     cursor = 0
@@ -995,7 +995,7 @@ async def _iter_eval_records(
             break
         iteration += 1
         
-        cursor, keys = await redis_conn.scan(cursor, match=key_pattern, count=scan_count)
+        cursor, keys = await redis_conn.scan(cursor, match=key_pattern, count=scan_batch_size)
         
         for key in keys:
             key_str = key.decode("utf-8") if isinstance(key, bytes) else str(key)
@@ -1031,7 +1031,7 @@ async def generate_eval_report() -> dict[str, Any]:
         redis_conn=redis_client.redis,
         key_pattern=f"{_EVAL_RESULT_PREFIX}*",
         max_scan_iterations=_EVAL_REPORT_MAX_SCAN_ITERATIONS,
-        scan_count=_EVAL_REPORT_SCAN_BATCH_SIZE
+        scan_batch_size=_EVAL_REPORT_SCAN_BATCH_SIZE
     ):
         label = parsed.get("label", "uncertain")
         labels_count[label] += 1

--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -941,7 +941,10 @@ _POSTPOSITIONS_SORTED = tuple(
 def _strip_postpositions(token: str) -> str:
     """조사(은/는/이/가/...)를 가능한 한 반복적으로 제거합니다."""
     stem = token
-    while len(stem) > 1:
+    while True:
+        if len(stem) <= 1:
+            break
+            
         stripped = False
         for josa in _POSTPOSITIONS_SORTED:
             if stem.endswith(josa) and len(stem) > len(josa):
@@ -981,7 +984,7 @@ async def _iter_eval_records(
     redis_conn: Any,
     key_pattern: str,
     max_scan_iterations: int,
-    scan_count: int = _EVAL_REPORT_SCAN_BATCH_SIZE
+    scan_count: int
 ) -> AsyncIterator[dict[str, Any]]:
     """Redis SCAN 및 JSON 파싱을 수행하는 async 제너레이터 헬퍼"""
     cursor = 0


### PR DESCRIPTION
♻️ refactor [#11.10.3]: 6차 개선 - 의존성 완전 분리 및 명시적 방어 구문 원복 
🔖 chore [#11.10.3]: 7차 개선 - 명시적 구문 원복 및 변수 네이밍 일관성 확보

## Summary by Sourcery

평가 서비스 헬퍼들을 다듬어 명시적인 방어 로직을 복원하고 Redis 스캔 설정을 더 명확히 합니다.

개선 사항:
- 보다 명확한 방어적 동작을 위해 조사 제거(helper)에서 명시적인 루프 종료 검사를 복원했습니다.
- Redis 평가 레코드 이터레이터의 scan 파라미터 이름을 배치 크기 의미가 드러나도록 변경하고, 호출부에도 이 새 이름을 반영했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine evaluation service helpers to restore explicit defensive logic and clarify Redis scan configuration.

Enhancements:
- Restore an explicit loop termination check in the postposition-stripping helper for clearer defensive behavior.
- Rename the Redis evaluation record iterator's scan parameter to emphasize batch size semantics and propagate the new name to its call site.

</details>