### PR TITLE
🔖 chore [#11.10.3]: 8차 개선 - Sensible Defaults 복구 및 선형적 흐름 제어(Linear Control Flow) 재반영

### DIFF
--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -941,10 +941,7 @@ _POSTPOSITIONS_SORTED = tuple(
 def _strip_postpositions(token: str) -> str:
     """조사(은/는/이/가/...)를 가능한 한 반복적으로 제거합니다."""
     stem = token
-    while True:
-        if len(stem) <= 1:
-            break
-            
+    while len(stem) > 1:
         stripped = False
         for josa in _POSTPOSITIONS_SORTED:
             if stem.endswith(josa) and len(stem) > len(josa):
@@ -984,7 +981,7 @@ async def _iter_eval_records(
     redis_conn: Any,
     key_pattern: str,
     max_scan_iterations: int,
-    scan_batch_size: int
+    scan_batch_size: int = _EVAL_REPORT_SCAN_BATCH_SIZE
 ) -> AsyncIterator[dict[str, Any]]:
     """Redis SCAN 및 JSON 파싱을 수행하는 async 제너레이터 헬퍼"""
     cursor = 0
@@ -1030,8 +1027,7 @@ async def generate_eval_report() -> dict[str, Any]:
     async for parsed in _iter_eval_records(
         redis_conn=redis_client.redis,
         key_pattern=f"{_EVAL_RESULT_PREFIX}*",
-        max_scan_iterations=_EVAL_REPORT_MAX_SCAN_ITERATIONS,
-        scan_batch_size=_EVAL_REPORT_SCAN_BATCH_SIZE
+        max_scan_iterations=_EVAL_REPORT_MAX_SCAN_ITERATIONS
     ):
         label = parsed.get("label", "uncertain")
         labels_count[label] += 1


### PR DESCRIPTION
- **[개발자 생산성 복구 (Sensible Defaults)]**
  - `_iter_eval_records` 생성자 호출 시 매번 강제로 `scan_batch_size`를 꽂아넣어야 하는 강결합(Rigid constraint)을 풀고, `_EVAL_REPORT_SCAN_BATCH_SIZE`라는 타당한 기본값(Sensible default)을 보장하여 사용성을 다시 끌어올림

- **[직관적 제어 흐름 (Clear Control Flow)]**
  - 형태소 분석 루프에서 불필요한 `while True` + 내장 `break` 형태의 묘수를 제거하고, 조건 지시어 자체가 의도를 반영하는 `while len(stem) > 1:` 형태로 완전 롤백하여 가독성을 최대로 높임

🔗 Related:
- Issue [#934]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/985#pullrequestreview-4069086525)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

평가 유틸리티에서 합리적인 기본값을 복원하고 제어 흐름을 단순화합니다.

개선 사항:
- eval 레코드 이터레이터에 기본 스캔 배치 크기를 설정하여 호출부 보일러플레이트를 줄이고 합리적인 동작을 복원합니다.
- 보다 명확하고 선형적인 제어 흐름을 위해 후치사 제거 루프를 직접적인 길이 조건을 사용하는 방식으로 단순화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore sensible defaults and simplify control flow in evaluation utilities.

Enhancements:
- Set a default scan batch size for the eval record iterator to reduce call-site boilerplate and restore sensible behavior.
- Simplify the postposition-stripping loop to use a direct length condition for clearer, more linear control flow.

</details>