### PR TITLE
Feature/v8 phase5 data flywheel

### DIFF
--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -941,10 +941,7 @@ _POSTPOSITIONS_SORTED = tuple(
 def _strip_postpositions(token: str) -> str:
     """조사(은/는/이/가/...)를 가능한 한 반복적으로 제거합니다."""
     stem = token
-    while True:
-        if len(stem) <= 1:
-            break
-            
+    while len(stem) > 1:
         stripped = False
         for josa in _POSTPOSITIONS_SORTED:
             if stem.endswith(josa) and len(stem) > len(josa):
@@ -984,7 +981,7 @@ async def _iter_eval_records(
     redis_conn: Any,
     key_pattern: str,
     max_scan_iterations: int,
-    scan_batch_size: int
+    scan_batch_size: int = _EVAL_REPORT_SCAN_BATCH_SIZE
 ) -> AsyncIterator[dict[str, Any]]:
     """Redis SCAN 및 JSON 파싱을 수행하는 async 제너레이터 헬퍼"""
     cursor = 0
@@ -1030,8 +1027,7 @@ async def generate_eval_report() -> dict[str, Any]:
     async for parsed in _iter_eval_records(
         redis_conn=redis_client.redis,
         key_pattern=f"{_EVAL_RESULT_PREFIX}*",
-        max_scan_iterations=_EVAL_REPORT_MAX_SCAN_ITERATIONS,
-        scan_batch_size=_EVAL_REPORT_SCAN_BATCH_SIZE
+        max_scan_iterations=_EVAL_REPORT_MAX_SCAN_ITERATIONS
     ):
         label = parsed.get("label", "uncertain")
         labels_count[label] += 1


### PR DESCRIPTION
🔖 chore [#11.10.3]: 리뷰 대응 - Sensible Defaults 복구 및 선형적 흐름 제어(Linear Control Flow) 재반영

## Summary by Sourcery

평가 보고서를 생성하기 위해 합리적인 기본값을 복원하고 평가 레코드 스캐닝을 간소화합니다.

개선 사항:
- 명확성과 유지보수성을 높이기 위해 한국어 조사 제거 루프 조건을 단순화했습니다.
- 평가 레코드 이터레이터에 기본 스캔 배치 크기 파라미터를 도입하고, 설정을 중앙집중화하기 위해 평가 보고서 생성기가 이를 사용하도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore sensible defaults and streamline evaluation record scanning for generating evaluation reports.

Enhancements:
- Simplify the Korean postposition stripping loop condition for clarity and maintainability.
- Introduce a default scan batch size parameter to the eval record iterator and rely on it from the eval report generator to centralize configuration.

</details>