### PR TITLE
♻️ refactor [#11.10.4]: 4차 개선 - 데이터 정규화 및 레이아웃 안정성(Robustness) 강화

### DIFF
--- a/web_ui/src/app/[locale]/(admin)/admin/_components/bar-segment.tsx
+++ b/web_ui/src/app/[locale]/(admin)/admin/_components/bar-segment.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import './bar-pct.css';
 
 interface BarSegmentProps {
-  percentage: number;
+  percentage?: number;
   className: string;
 }
 
@@ -12,8 +12,9 @@ interface BarSegmentProps {
  * 이를 통해 모든 IDE 차원의 인라인 스타일 경고를 원천적으로 차단합니다.
  */
 export function BarSegment({ percentage, className }: BarSegmentProps) {
-  // [Review 991 반영] NaN, undefined 등에 대한 방어 코드 및 0~100 범위 클램핑
-  const safePct = isNaN(percentage) ? 0 : Math.max(0, Math.min(100, Math.round(percentage)));
+  // [Review 991/992 반영] NaN, undefined 등에 대한 방어 코드 및 0~100 범위 클램핑 (strict Number.isNaN 사용)
+  const basePct = percentage ?? 0;
+  const safePct = Number.isNaN(basePct) ? 0 : Math.max(0, Math.min(100, Math.round(basePct)));
 
   // [Review 991 반영] 0%일 때도 null을 반환하지 않고 렌더링을 유지하여 DOM 구조(라운드 처리 등)의 일관성 확보
   const pctClass = `bar-pct-${safePct}`;

--- a/web_ui/src/app/[locale]/(admin)/admin/_components/bar-segment.tsx
+++ b/web_ui/src/app/[locale]/(admin)/admin/_components/bar-segment.tsx
@@ -12,10 +12,11 @@ interface BarSegmentProps {
  * 이를 통해 모든 IDE 차원의 인라인 스타일 경고를 원천적으로 차단합니다.
  */
 export function BarSegment({ percentage, className }: BarSegmentProps) {
-  if (percentage <= 0) return null;
+  // [Review 991 반영] NaN, undefined 등에 대한 방어 코드 및 0~100 범위 클램핑
+  const safePct = isNaN(percentage) ? 0 : Math.max(0, Math.min(100, Math.round(percentage)));
 
-  // 0~100 사이의 올바른 클래스 이름 생성 (Math.round로 안전하게 반올림)
-  const pctClass = `bar-pct-${Math.max(0, Math.min(100, Math.round(percentage)))}`;
+  // [Review 991 반영] 0%일 때도 null을 반환하지 않고 렌더링을 유지하여 DOM 구조(라운드 처리 등)의 일관성 확보
+  const pctClass = `bar-pct-${safePct}`;
 
   return (
     <div className={`${pctClass} ${className}`} />

--- a/web_ui/src/app/[locale]/(admin)/admin/analytics/actions.ts
+++ b/web_ui/src/app/[locale]/(admin)/admin/analytics/actions.ts
@@ -35,7 +35,8 @@ export interface FeedbackStatsResponse {
 export interface EvalReportResponse {
   status: string;
   total_evaluated: number;
-  label_distribution: Record<string, number> & Partial<Record<EvalLabel, number>>;
+  label_distribution: Record<EvalLabel, number>;
+  additional_labels?: Record<string, number>;
   top_failing_topics: Array<{ keyword: string; count: number }>;
   failed_query_count: number;
   timestamp: string;
@@ -153,7 +154,33 @@ export async function fetchEvalReport(): Promise<EvalReportResponse> {
       throw new Error(`Backend returned status ${res.status}`);
     }
 
-    const data: EvalReportResponse = await res.json();
+    // [Review 991 반영] 백엔드에서 온 동적 레코드를 정규화하여 타입 안정성을 확보합니다.
+    const rawData = await res.json();
+    const rawDist = rawData.label_distribution || {};
+    
+    // 코어 라벨 분류
+    const label_distribution: Record<EvalLabel, number> = {
+      hallucination: rawDist.hallucination || 0,
+      rag_retrieval_failure: rawDist.rag_retrieval_failure || 0,
+      uncertain: rawDist.uncertain || 0,
+    };
+    
+    // 나머지는 additional_labels로 분리 (accidental access 방지)
+    const knownKeys = new Set(['hallucination', 'rag_retrieval_failure', 'uncertain']);
+    const additional_labels: Record<string, number> = {};
+    
+    Object.keys(rawDist).forEach(key => {
+      if (!knownKeys.has(key)) {
+        additional_labels[key] = rawDist[key];
+      }
+    });
+
+    const data: EvalReportResponse = {
+      ...rawData,
+      label_distribution,
+      additional_labels: Object.keys(additional_labels).length > 0 ? additional_labels : undefined
+    };
+
     return data;
     
   } catch (error) {

--- a/web_ui/src/app/[locale]/(admin)/admin/analytics/actions.ts
+++ b/web_ui/src/app/[locale]/(admin)/admin/analytics/actions.ts
@@ -22,7 +22,8 @@ export interface FeedbackDetail {
   timestamp: string;
 }
 
-export type EvalLabel = 'hallucination' | 'rag_retrieval_failure' | 'uncertain';
+export const EVAL_LABELS = ['hallucination', 'rag_retrieval_failure', 'uncertain'] as const;
+export type EvalLabel = (typeof EVAL_LABELS)[number];
 
 export interface FeedbackStatsResponse {
   status: string;
@@ -160,18 +161,22 @@ export async function fetchEvalReport(): Promise<EvalReportResponse> {
     
     // 코어 라벨 분류
     const label_distribution: Record<EvalLabel, number> = {
-      hallucination: rawDist.hallucination || 0,
-      rag_retrieval_failure: rawDist.rag_retrieval_failure || 0,
-      uncertain: rawDist.uncertain || 0,
+      hallucination: Number(rawDist.hallucination) || 0,
+      rag_retrieval_failure: Number(rawDist.rag_retrieval_failure) || 0,
+      uncertain: Number(rawDist.uncertain) || 0,
     };
     
-    // 나머지는 additional_labels로 분리 (accidental access 방지)
-    const knownKeys = new Set(['hallucination', 'rag_retrieval_failure', 'uncertain']);
+    // [Review 992 반영] EvalLabel에서 자동으로 knownKeys 집합을 파생하여 SSOT 보장
+    const knownKeys = new Set<string>(EVAL_LABELS);
     const additional_labels: Record<string, number> = {};
     
     Object.keys(rawDist).forEach(key => {
       if (!knownKeys.has(key)) {
-        additional_labels[key] = rawDist[key];
+        // [Review 992 반영] 비정상적인 데이터(문자열, null 등)가 섞여 있어도 수치 안정성을 유지하도록 유효성 검증
+        const numericValue = Number(rawDist[key]);
+        if (!Number.isFinite(numericValue)) return;
+        
+        additional_labels[key] = numericValue;
       }
     });
 


### PR DESCRIPTION
- **[Normalization: 백엔드 응답 데이터의 엄격한 분리 및 정규화]**
  - `label_distribution`의 키 공간을 코어 레이블(3종)로 한정하고, 가변 레이블은 `additional_labels`로 격리하여 타입 안정성 극대화
  - `fetchEvalReport` 액션 내 정규화 파이프라인을 구축하여 예상치 못한 데이터 유입 시에도 UI 불변성 확보

- **[Robustness: 비정상 데이터 방어 및 레이아웃 무결성 확보]**
  - `BarSegment` 내 `NaN`, `undefined` 대응 클램핑 로직을 추가하여 CSS 클래스 생성 과정의 런타임 안정성 향상
  - 0% 세그먼트의 DOM 렌더링을 유지하여 `:first-child/:last-child` 등 레이아웃 의미론(Semantics) 및 시각적 일관성 보호

- **[Hygiene: CSS 유틸리티 관리 체계 명확화]**
  - `bar-pct.css`를 '생성된 레이어'로 정의하고 유지보수 가이드 주석을 추가하여 수동 관리의 위험성 제거

🔗 Related:
- Issue [#934]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/991#pullrequestreview-4069621158)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

애널리틱스 평가(report) 데이터 형식을 정규화하고, 잘못되었거나 엣지 케이스에 해당하는 입력 값에 대해서도 막대 차트 세그먼트 렌더링이 안전하게 동작하도록 강화합니다.

Bug Fixes:
- 잘못되었거나 허용 범위를 벗어난 퍼센트 값들을 클램핑(clamping)하고, 레이아웃 일관성을 위해 0% 세그먼트를 DOM에 유지함으로써 막대 세그먼트 렌더링에서 발생하는 런타임 문제를 방지합니다.

Enhancements:
- eval report 라벨 분포를 고정된 핵심 라벨 집합으로 정규화하고, 추가 라벨은 분리하여 백엔드 응답을 더 안전하게 처리할 수 있도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize analytics evaluation report data and harden bar chart segment rendering against invalid or edge-case input values.

Bug Fixes:
- Prevent runtime issues in bar segment rendering by clamping invalid or out-of-range percentage values and keeping 0% segments in the DOM for consistent layout.

Enhancements:
- Normalize eval report label distribution into fixed core labels with additional labels separated for safer backend response handling.

</details>