### PR TITLE
✨ feat [#11.11.1]: phase3의 1단계 - LangGraph State 피드백 컨텍스트 주입

### DIFF
--- a/backend/agent/chat/state.py
+++ b/backend/agent/chat/state.py
@@ -45,3 +45,6 @@ class AgentState(TypedDict):
 
     # 검색된 원본 문서 목록(SSE 'sources' 전송용)
     source_documents: NotRequired[Optional[list[dict]]]
+
+    # 과거 피드백 이력 컨텍스트 (최근 n개)
+    feedback_history: NotRequired[list[dict]]

--- a/backend/agent/chat/state.py
+++ b/backend/agent/chat/state.py
@@ -9,6 +9,15 @@ import operator
 # =================================================================
 
 
+class FeedbackEntry(TypedDict):
+    """피드백 개별 항목의 타입 스키마"""
+
+    message_id: str
+    rating: str  # e.g., "up", "down", "none"
+    text: Optional[str]
+    timestamp: str
+
+
 class AgentState(TypedDict):
     """
     채팅 특화 멀티 에이전트를 위한 상태(State) 스키마
@@ -47,4 +56,4 @@ class AgentState(TypedDict):
     source_documents: NotRequired[Optional[list[dict]]]
 
     # 과거 피드백 이력 컨텍스트 (최근 n개)
-    feedback_history: NotRequired[list[dict]]
+    feedback_history: NotRequired[list[FeedbackEntry]]

--- a/backend/services/chat_history_service.py
+++ b/backend/services/chat_history_service.py
@@ -697,6 +697,22 @@ class ChatHistoryService:
             key = self._feedback_key(session_id)
             feedback_hash = await redis_client.redis.hgetall(key)
             
+            def _parse_timestamp(ts: Any) -> float:
+                if isinstance(ts, (int, float)) and not isinstance(ts, bool):
+                    return float(ts)
+                if isinstance(ts, str):
+                    ts_str = ts.strip()
+                    try:
+                        # ISO 8601 parsing fallback
+                        return datetime.fromisoformat(ts_str.replace("Z", "+00:00")).timestamp()
+                    except ValueError:
+                        try:
+                            # Numeric string fallback
+                            return float(ts_str)
+                        except ValueError:
+                            pass
+                return 0.0
+            
             feedbacks: List[Dict[str, Any]] = []
             for msg_id_raw, meta_raw in feedback_hash.items():
                 msg_id = _decode_str(msg_id_raw)
@@ -704,18 +720,30 @@ class ChatHistoryService:
                 try:
                     meta = json.loads(meta_str)
                     if isinstance(meta, dict):
+                        raw_ts = meta.get("timestamp")
+                        if isinstance(raw_ts, (int, float, str)) and not isinstance(raw_ts, bool):
+                            ts_str = str(raw_ts).strip()
+                        else:
+                            ts_str = ""
+                            
                         feedbacks.append({
                             "message_id": msg_id,
-                            "rating": meta.get("rating"),
-                            "text": meta.get("text"),
-                            "timestamp": meta.get("timestamp")
+                            "rating": str(meta.get("rating", "none")),
+                            "text": str(meta.get("text")) if meta.get("text") else None,
+                            "timestamp": ts_str,
+                            "_sort_key": _parse_timestamp(raw_ts)
                         })
                 except (JSONDecodeError, ValueError, TypeError):
                     continue
                     
-            # 최신순 정렬 후 제한된 개수만 반환
-            feedbacks.sort(key=lambda x: str(x.get("timestamp", "")), reverse=True)
-            return feedbacks[:limit]
+            # 최신순 정렬 (숫자형 우선, 내림차순) 후 제한된 개수만 잘라서 반환 (_sort_key 제거)
+            feedbacks.sort(key=lambda x: x["_sort_key"], reverse=True)
+            result = []
+            for f in feedbacks[:limit]:
+                del f["_sort_key"]
+                result.append(f)
+                
+            return result
 
         except Exception as e:
             _log_and_reraise_generic(

--- a/backend/services/chat_history_service.py
+++ b/backend/services/chat_history_service.py
@@ -682,7 +682,49 @@ class ChatHistoryService:
                 e,
             )
 
+    async def get_session_feedback(self, session_id: str, limit: int = 3) -> List[Dict[str, Any]]:
+        """특정 세션의 최근 피드백 이력을 조회합니다.
+        
+        Raises:
+            ValueError: session_id 누락.
+            RedisUnavailableError: Redis 연결 불가.
+        """
+        if not session_id or not session_id.strip():
+            raise ValueError("session_id is required to get session feedback.")
+
+        try:
+            await self._ensure_connected("get_session_feedback")
+            key = self._feedback_key(session_id)
+            feedback_hash = await redis_client.redis.hgetall(key)
+            
+            feedbacks: List[Dict[str, Any]] = []
+            for msg_id_raw, meta_raw in feedback_hash.items():
+                msg_id = _decode_str(msg_id_raw)
+                meta_str = _decode_str(meta_raw)
+                try:
+                    meta = json.loads(meta_str)
+                    if isinstance(meta, dict):
+                        feedbacks.append({
+                            "message_id": msg_id,
+                            "rating": meta.get("rating"),
+                            "text": meta.get("text"),
+                            "timestamp": meta.get("timestamp")
+                        })
+                except (JSONDecodeError, ValueError, TypeError):
+                    continue
+                    
+            # 최신순 정렬 후 제한된 개수만 반환
+            feedbacks.sort(key=lambda x: str(x.get("timestamp", "")), reverse=True)
+            return feedbacks[:limit]
+
+        except Exception as e:
+            _log_and_reraise_generic(
+                "Failed to get session feedback",
+                {"session_id_hash": mask_pii_id(session_id), "error": str(e)},
+                e,
+            )
 
 
 def get_chat_history_service() -> ChatHistoryService:
     return ChatHistoryService()
+

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -402,11 +402,13 @@ Standalone Question:"""
 
         # 0. 히스토리 로드 및 질의 재구성
         history: List[ChatMessage] = []
+        feedback_history: List[Dict[str, Any]] = []
         effective_query = query
         rephrase_duration = 0.0
 
         if session_id:
             history = await self.chat_history_service.get_history(session_id)
+            feedback_history = await self.chat_history_service.get_session_feedback(session_id, limit=3)
             if history:
                 rephrase_start = time.perf_counter()
                 effective_query = await self._rephrase_query(query, history)
@@ -427,6 +429,7 @@ Standalone Question:"""
             "messages": langchain_history,
             "user_id": user_id,
             "session_id": session_id,
+            "feedback_history": feedback_history,
         }
 
         # 2. workflow 컴파일 및 의존성 주입

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -406,7 +406,7 @@ Standalone Question:"""
         effective_query = query
         rephrase_duration = 0.0
 
-        if session_id:
+        if session_id and session_id.strip():
             history = await self.chat_history_service.get_history(session_id)
             feedback_history = await self.chat_history_service.get_session_feedback(session_id, limit=3)
             if history:


### PR DESCRIPTION
- **[GraphState 속성 추가]**
  - `AgentState` TypedDict에 `feedback_history: NotRequired[list[dict]]` 필드를 추가하여, 다중 턴(MTurn) 기반의 피드백 인식형 AI 응답 체계의 기반을 마련함.
  - 기존 `planner_node`와 `responder_node`에서는 선택적(Optional)으로 작동하도록 `NotRequired` 속성으로 설계해 기존 로직과의 100% 하위 호환성 확보 및 무사고 검증 완료.

- **[피드백 이력 추출 및 주입 구현]**
  - `ChatHistoryService` 내에 `get_session_feedback` 메서드를 신설하여 해당 세션의 최근(최대 3개) 피드백 이력을 안전하게 로드(JSON Parsing & Type-checking)하고 최신순 정렬 반환.
  - `ChatService.stream_chat` 진입부에서 이전 대화(History) 로딩 시 피드백 이력도 함께 조회하여, 완성된 `feedback_history` 데이터를 LangGraph `initial_state`에 온전하게 주입 처리.

🔗 Related: Issue [#935]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

최근 사용자 피드백 히스토리를 챗 에이전트 상태에 주입하여 멀티 턴 응답에서 활용하도록 합니다.

New Features:
- LangGraph 워크플로 전체에서 최근 피드백 컨텍스트를 전달하기 위해 `AgentState`에 `feedback_history` 필드를 추가합니다.
- 세션의 최근 피드백 항목을 로드하고 정제(sanitize)하기 위해 `ChatHistoryService`에 `get_session_feedback`를 노출합니다.
- 다운스트림 노드들이 활용할 수 있도록 `stream_chat`에서 챗 상태를 초기화할 때 세션 피드백을 포함합니다.

Enhancements:
- 컨텍스트 크기를 제한하고 관련성을 보장하기 위해 세션 피드백 레코드를 정렬하고, 가장 최근 항목들로 개수를 제한합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Inject recent user feedback history into the chat agent state for use in multi-turn responses.

New Features:
- Add feedback_history field to AgentState to carry recent feedback context through the LangGraph workflow.
- Expose get_session_feedback on ChatHistoryService to load and sanitize recent feedback entries for a session.
- Include session feedback when initializing chat state in stream_chat so downstream nodes can consume it.

Enhancements:
- Sort and cap session feedback records to the most recent items to limit context size and ensure relevance.

</details>