### PR TITLE
☘️ refactor [#11.11.1]: 2차 개선 - 자료구조 불변성 확보 및 타입 정밀도 강화

### DIFF
--- a/backend/services/chat_history_service.py
+++ b/backend/services/chat_history_service.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 import logging
 from json import JSONDecodeError
-from typing import Any, Dict, List, NoReturn, Optional
+from typing import Any, Dict, List, NoReturn, Optional, Tuple
 from datetime import datetime, timezone
 from backend.services.redis_pubsub import redis_client  # type: ignore[import]
 from backend.api.models import ChatMessage  # type: ignore[import]
@@ -714,7 +714,7 @@ class ChatHistoryService:
                             pass
                 return 0.0
             
-            feedbacks_with_keys: List[tuple[float, FeedbackEntry]] = []
+            feedbacks_with_keys: List[Tuple[float, FeedbackEntry]] = []
             for msg_id_raw, meta_raw in feedback_hash.items():
                 msg_id = _decode_str(msg_id_raw)
                 meta_str = _decode_str(meta_raw)
@@ -728,7 +728,7 @@ class ChatHistoryService:
                             ts_str = ""
                             
                         raw_rating = meta.get("rating")
-                        rating = str(raw_rating).lower().strip() if raw_rating else "none"
+                        rating = str(raw_rating).lower().strip() if raw_rating is not None else "none"
                         if rating not in {"up", "down", "none"}:
                             rating = "none"
                             

--- a/backend/services/chat_history_service.py
+++ b/backend/services/chat_history_service.py
@@ -10,6 +10,7 @@ from backend.services.redis_pubsub import redis_client  # type: ignore[import]
 from backend.api.models import ChatMessage  # type: ignore[import]
 from backend.api.models.shared import FeedbackRating  # type: ignore[import]
 from backend.utils import mask_pii_id  # type: ignore[import]
+from backend.agent.chat.state import FeedbackEntry  # type: ignore[import, import-untyped]
 
 logger = logging.getLogger(__name__)
 
@@ -682,7 +683,7 @@ class ChatHistoryService:
                 e,
             )
 
-    async def get_session_feedback(self, session_id: str, limit: int = 3) -> List[Dict[str, Any]]:
+    async def get_session_feedback(self, session_id: str, limit: int = 3) -> List[FeedbackEntry]:
         """특정 세션의 최근 피드백 이력을 조회합니다.
         
         Raises:
@@ -713,7 +714,7 @@ class ChatHistoryService:
                             pass
                 return 0.0
             
-            feedbacks: List[Dict[str, Any]] = []
+            feedbacks_with_keys: List[tuple[float, FeedbackEntry]] = []
             for msg_id_raw, meta_raw in feedback_hash.items():
                 msg_id = _decode_str(msg_id_raw)
                 meta_str = _decode_str(meta_raw)
@@ -726,24 +727,24 @@ class ChatHistoryService:
                         else:
                             ts_str = ""
                             
-                        feedbacks.append({
+                        raw_rating = meta.get("rating")
+                        rating = str(raw_rating).lower().strip() if raw_rating else "none"
+                        if rating not in {"up", "down", "none"}:
+                            rating = "none"
+                            
+                        entry: FeedbackEntry = {
                             "message_id": msg_id,
-                            "rating": str(meta.get("rating", "none")),
+                            "rating": rating,
                             "text": str(meta.get("text")) if meta.get("text") else None,
                             "timestamp": ts_str,
-                            "_sort_key": _parse_timestamp(raw_ts)
-                        })
+                        }
+                        feedbacks_with_keys.append((_parse_timestamp(raw_ts), entry))
                 except (JSONDecodeError, ValueError, TypeError):
                     continue
                     
-            # 최신순 정렬 (숫자형 우선, 내림차순) 후 제한된 개수만 잘라서 반환 (_sort_key 제거)
-            feedbacks.sort(key=lambda x: x["_sort_key"], reverse=True)
-            result = []
-            for f in feedbacks[:limit]:
-                del f["_sort_key"]
-                result.append(f)
-                
-            return result
+            # 최신순 정렬 (숫자형 우선, 내림차순) 및 원본 자료형(FeedbackEntry) 리스트로 반환 (Mutation 방지)
+            feedbacks_with_keys.sort(key=lambda x: x[0], reverse=True)
+            return [entry for _, entry in feedbacks_with_keys[:limit]]
 
         except Exception as e:
             _log_and_reraise_generic(

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -31,6 +31,7 @@ from backend.services.chat_history_service import (  # type: ignore[import, impo
 )
 from backend.api.models import ChatMessage  # type: ignore[import, import-untyped, reportMissingImports]
 from backend.utils import mask_pii_id  # type: ignore[import, import-untyped, reportMissingImports]
+from backend.agent.chat.state import FeedbackEntry  # type: ignore[import, import-untyped]
 
 logger = logging.getLogger(__name__)
 
@@ -402,7 +403,7 @@ Standalone Question:"""
 
         # 0. 히스토리 로드 및 질의 재구성
         history: List[ChatMessage] = []
-        feedback_history: List[Dict[str, Any]] = []
+        feedback_history: List[FeedbackEntry] = []
         effective_query = query
         rephrase_duration = 0.0
 


### PR DESCRIPTION
- **[타입 시스템 일관성 강화]**
  - `get_session_feedback` 반환 타입 및 `stream_chat` 내부 `feedback_history` 변수 타입을 추상적인 `List[Dict[str, Any]]`에서 구체적인 `List[FeedbackEntry]` 타입 스키마로 전면 교체하여 정적 검사 및 코드 가독성 향상.

- **[자료 구조 불변성(Immutability) 보장]**
  - 정렬을 위해 딕셔너리를 변형(mutate: `_sort_key` 추가 후 `del`)하던 안티 패턴을 제거.
  - `(정렬 키, FeedbackEntry)` 쌍의 투플 리스트로 매핑한 뒤, 정렬 후 언패킹하여 원본 스키마 구조의 변형 없이 순수성(Pure)을 보장하도록 리팩토링 수행.

- **[타입 암묵적 캐스팅 버그 방어]**
  - `meta.get('rating')`이 명시적으로 `None`일 때 `str(None)` 연산으로 인해 의도치 않은 `"None"` 문자열이 발생하는 파이썬 문자 캐스팅 버그 차단.
  - 사전에 `['up', 'down', 'none']` 화이트리스트 검사 기반의 폴백 처리 최적화를 통해 프론트엔드 Union 타입과의 100% 호환성 확보.

🔗 Related:
- Issue [#935]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1001#pullrequestreview-4075985996)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

피드백 처리 로직의 타입을 더 엄격하게 하고, 피드백 조회 방식을 불변(immutable)이며 스키마와 일관되도록 리팩터링하여 모든 채팅 서비스에서 동일하게 동작하도록 강화합니다.

Bug Fixes:
- 피드백 평점 값을 사용하기 전에 정규화하고 허용된 값만 화이트리스트로 관리하여, 의도치 않은 `"None"` 평점 문자열이 생성되는 문제를 방지합니다.

Enhancements:
- 느슨하게 타이핑된 피드백 컬렉션을 `FeedbackEntry` 구체 스키마로 교체하여, 피드백 조회 및 스트리밍 채팅 히스토리에 일관된 타입을 적용합니다.
- 피드백 항목을 변경하지 않고(불변성 유지) 보조 정렬 키를 사용하는 방식으로 피드백 정렬 로직을 리팩터링하여, 데이터의 불변성과 코드의 명확성을 향상합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen feedback handling by tightening types and refactoring feedback retrieval to be immutable and schema-consistent across chat services.

Bug Fixes:
- Prevent unintended "None" rating strings by normalizing and whitelisting feedback rating values before use.

Enhancements:
- Replace loosely typed feedback collections with the concrete FeedbackEntry schema in feedback retrieval and streaming chat history.
- Refactor feedback sorting to use auxiliary sort keys without mutating feedback entries, preserving data immutability and clarity.

</details>