### PR TITLE
✨ feat [#11.11.2]: phase3의 2단계 ➀ - 연속 실패 감지 라우터(should_fallback) 구현

### DIFF
--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -289,6 +289,25 @@ If you used any document from the context, YOU MUST use inline citations in the 
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+def should_fallback(state: AgentState) -> str:
+    """
+    피드백 기반 Fallback 분기 라우터:
+    최근 3개의 피드백 중 'down'이 2개 이상이면 fallback_search, 아니면 standard_rag 반환.
+    """
+    feedback_history = state.get("feedback_history", [])
+    recent_feedbacks = feedback_history[-3:]  # 최근 3개
+    negative_count = sum(1 for f in recent_feedbacks if f.get("rating") == "down")
+    
+    if negative_count >= 2:
+        logger.warning(
+            "[Router] 연속 실패 감지 (부정적 피드백 2개 이상). fallback_search 실행.",
+            extra={"negative_count": negative_count}
+        )
+        return "fallback_search"
+    
+    return "standard_rag"
+
+
 def router_edge(state: AgentState) -> Literal["planner", "responder"]:
     """
     조건부 엣지(Conditional Edge):

--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -10,6 +10,7 @@ from langchain_core.messages import AIMessage, SystemMessage, BaseMessage  # typ
 from backend.agent.chat.state import AgentState  # type: ignore[import, import-untyped, reportMissingImports]
 from backend.agent.chat.tools import search_documents_tool  # type: ignore[import, import-untyped, reportMissingImports]
 from backend.services.chat_service import get_chat_service  # type: ignore[import, import-untyped, reportMissingImports]
+from backend.api.models.shared import RATING_DOWN  # type: ignore[import, import-untyped, reportMissingImports]
 
 logger = logging.getLogger(__name__)
 
@@ -296,11 +297,11 @@ def should_fallback(state: AgentState) -> str:
     """
     feedback_history = state.get("feedback_history", [])
     recent_feedbacks = feedback_history[-3:]  # 최근 3개
-    negative_count = sum(1 for f in recent_feedbacks if f.get("rating") == "down")
+    negative_count = sum(1 for f in recent_feedbacks if f.get("rating") == RATING_DOWN)
     
     if negative_count >= 2:
         logger.warning(
-            "[Router] 연속 실패 감지 (부정적 피드백 2개 이상). fallback_search 실행.",
+            "[Router] 최근 3개 중 부정적 피드백 2개 이상 감지. fallback_search 실행.",
             extra={"negative_count": negative_count}
         )
         return "fallback_search"

--- a/backend/api/models/shared.py
+++ b/backend/api/models/shared.py
@@ -10,6 +10,9 @@ SuccessStatus = Literal[
     "success"
 ]  # API가 항상 성공 객체만 반환하는 명시적 응답 컨트랙트용
 FeedbackRating = Literal["up", "down", "none"]
+RATING_UP: FeedbackRating = "up"
+RATING_DOWN: FeedbackRating = "down"
+RATING_NONE: FeedbackRating = "none"
 
 # ---------------------------------------------------------
 # OpenAPI/Swagger Field Descriptions


### PR DESCRIPTION
- **[라우터 로직 신설]**
  - `backend/agent/chat/nodes.py`에 `should_fallback` 라우터 함수 추가.
  - 최신 3개의 피드백 데이터를 조회하여, 사용자가 '싫어요(down)'를 2회 이상 누른 경우 일반 RAG(`standard_rag`) 대신 딥웹 기반의 타빌리 검색(`fallback_search`)으로 분기되도록 기준을 설정함.

- **[안정성 확보]**
  - `NotRequired`로 설계된 상태 값에 접근 시 발생할 수 있는 `KeyError` 방지를 위해 `state.get()` 방식으로 구현.
  - 로거(Logger)를 적용하여 라우팅 발동 시 디버깅이 용이하도록 처리함.

🔗 Related: Issue [#935]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

새로운 기능:
- 최근 피드백의 마지막 세 항목 중에서 최소 두 개의 부정적인 평가가 있을 경우, `fallback_search`로 전환하는 `should_fallback` 라우터를 도입했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce a should_fallback router that switches to fallback_search when recent feedback contains at least two negative ratings within the last three entries.

</details>