### PR TITLE
Feature/v8 phase5 data flywheel

### DIFF
--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -289,6 +289,25 @@ If you used any document from the context, YOU MUST use inline citations in the 
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+def should_fallback(state: AgentState) -> str:
+    """
+    피드백 기반 Fallback 분기 라우터:
+    최근 3개의 피드백 중 'down'이 2개 이상이면 fallback_search, 아니면 standard_rag 반환.
+    """
+    feedback_history = state.get("feedback_history", [])
+    recent_feedbacks = feedback_history[-3:]  # 최근 3개
+    negative_count = sum(1 for f in recent_feedbacks if f.get("rating") == "down")
+    
+    if negative_count >= 2:
+        logger.warning(
+            "[Router] 연속 실패 감지 (부정적 피드백 2개 이상). fallback_search 실행.",
+            extra={"negative_count": negative_count}
+        )
+        return "fallback_search"
+    
+    return "standard_rag"
+
+
 def router_edge(state: AgentState) -> Literal["planner", "responder"]:
     """
     조건부 엣지(Conditional Edge):

--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -10,6 +10,7 @@ from langchain_core.messages import AIMessage, SystemMessage, BaseMessage  # typ
 from backend.agent.chat.state import AgentState  # type: ignore[import, import-untyped, reportMissingImports]
 from backend.agent.chat.tools import search_documents_tool  # type: ignore[import, import-untyped, reportMissingImports]
 from backend.services.chat_service import get_chat_service  # type: ignore[import, import-untyped, reportMissingImports]
+from backend.api.models.shared import RATING_DOWN  # type: ignore[import, import-untyped, reportMissingImports]
 
 logger = logging.getLogger(__name__)
 
@@ -296,11 +297,11 @@ def should_fallback(state: AgentState) -> str:
     """
     feedback_history = state.get("feedback_history", [])
     recent_feedbacks = feedback_history[-3:]  # 최근 3개
-    negative_count = sum(1 for f in recent_feedbacks if f.get("rating") == "down")
+    negative_count = sum(1 for f in recent_feedbacks if f.get("rating") == RATING_DOWN)
     
     if negative_count >= 2:
         logger.warning(
-            "[Router] 연속 실패 감지 (부정적 피드백 2개 이상). fallback_search 실행.",
+            "[Router] 최근 3개 중 부정적 피드백 2개 이상 감지. fallback_search 실행.",
             extra={"negative_count": negative_count}
         )
         return "fallback_search"

--- a/backend/api/models/shared.py
+++ b/backend/api/models/shared.py
@@ -10,6 +10,9 @@ SuccessStatus = Literal[
     "success"
 ]  # API가 항상 성공 객체만 반환하는 명시적 응답 컨트랙트용
 FeedbackRating = Literal["up", "down", "none"]
+RATING_UP: FeedbackRating = "up"
+RATING_DOWN: FeedbackRating = "down"
+RATING_NONE: FeedbackRating = "none"
 
 # ---------------------------------------------------------
 # OpenAPI/Swagger Field Descriptions


### PR DESCRIPTION
✨ feat [#11.11.2]: phase3의 2단계 ➀ - 연속 실패 감지 라우터(should_fallback) 구현 
🐛 fix [#11.11.2]: 1차 리뷰 - Fallback 라우터 조건식 하드코딩 및 로깅 불일치 문제 해결

## Summary by Sourcery

최근 부정적인 피드백이 임계값을 초과할 경우 채팅을 폴백 검색 플로우로 라우팅하는 피드백 기반 라우팅 메커니즘을 구현하고, 코드베이스 전반에서 재사용할 수 있도록 피드백 평점 리터럴을 중앙에서 관리합니다.

New Features:
- 최근 부정적인 피드백 이력을 기준으로 표준 채팅 플로우와 폴백 채팅 플로우 중 하나를 선택하는 `should_fallback` 라우터를 추가합니다.

Enhancements:
- 시스템 전반에서 일관되게 사용할 수 있도록 공용 API 모델에 타입이 지정된 피드백 평점 상수를 노출합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a feedback-based routing mechanism that directs chats to a fallback search flow when recent negative feedback exceeds a threshold and centralize feedback rating literals for reuse across the codebase.

New Features:
- Add a should_fallback router that chooses between standard and fallback chat flows based on recent negative feedback history.

Enhancements:
- Expose typed feedback rating constants in the shared API models for consistent use throughout the system.

</details>