### PR TITLE
♻️ refactor [#11.11.2]: 2차 리뷰 - 타입 정밀도 강화 및 전역 하드코딩 제거

### DIFF
--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -23,7 +23,7 @@ _SIMPLE_LATIN_GREETINGS = ["hello", "hi"]
 _MAX_GREETING_LENGTH = 15
 
 # [Engineering Decision] 검색 결과 총합 토큰 예산 보호 (LLM 컨텍스트 윈도우 안전 범위 유지)
-# 名시적 int 타입 어노테이션 적용 → Pyre2가 Literal[8000]이아닌 int로 추론하도록 일치
+# 명시적 int 타입 어노테이션 적용 → Pyre2가 Literal[8000]이아닌 int로 추론하도록 일치
 _MAX_SEARCH_CONTEXT_CHARS: int = 8_000
 
 # Fallback Routing 관련 임계치 및 윈도우 사이즈
@@ -297,15 +297,18 @@ If you used any document from the context, YOU MUST use inline citations in the 
 def should_fallback(state: AgentState) -> Literal["fallback_search", "standard_rag"]:
     """
     피드백 기반 Fallback 분기 라우터:
-    설정된 크기의 윈도우(최근 피드백) 내에서 'down'이 기준치 이상이면 fallback_search, 아니면 standard_rag 반환.
+    엄격한 시간적 윈도우(최근 3회 세션) 내에서 'down'이 기준치 이상이면 fallback_search, 아니면 standard_rag 반환.
     """
     feedback_history = state.get("feedback_history", [])
     
-    # 런타임 방어: 항목이 dict인지 확증하여 f.get() 호출 시 발생할 수 있는 AttributeError 차단
-    valid_feedbacks = [f for f in feedback_history if isinstance(f, dict)]
-    recent_feedbacks = valid_feedbacks[-FALLBACK_WINDOW_SIZE:] if valid_feedbacks else []
+    # 윈도우 왜곡(Window Distortion) 방지 및 메모리 할당 최적화
+    # 전체를 검증 후 자르는 것이 아니라, 최신 N개를 먼저 확보한 뒤 내부에서 타입 가드를 수행합니다.
+    recent_feedbacks = feedback_history[-FALLBACK_WINDOW_SIZE:] if feedback_history else []
     
-    negative_count = sum(1 for f in recent_feedbacks if f.get("rating") == RATING_DOWN)
+    negative_count = sum(
+        1 for f in recent_feedbacks 
+        if isinstance(f, dict) and f.get("rating") == RATING_DOWN
+    )
     
     if negative_count >= FALLBACK_THRESHOLD:
         logger.warning(

--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -23,8 +23,12 @@ _SIMPLE_LATIN_GREETINGS = ["hello", "hi"]
 _MAX_GREETING_LENGTH = 15
 
 # [Engineering Decision] 검색 결과 총합 토큰 예산 보호 (LLM 컨텍스트 윈도우 안전 범위 유지)
-# 명시적 int 타입 어노테이션 적용 → Pyre2가 Literal[8000]이아닌 int로 추론하도록 일치
+# 名시적 int 타입 어노테이션 적용 → Pyre2가 Literal[8000]이아닌 int로 추론하도록 일치
 _MAX_SEARCH_CONTEXT_CHARS: int = 8_000
+
+# Fallback Routing 관련 임계치 및 윈도우 사이즈
+FALLBACK_WINDOW_SIZE: int = 3
+FALLBACK_THRESHOLD: int = 2
 
 # 모듈 로드 시 한글 인사말 조합 생성 (O(1) 탐색, 합성어 오탐 차단)
 _KOREAN_GREETING_FORMS = {
@@ -290,18 +294,22 @@ If you used any document from the context, YOU MUST use inline citations in the 
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def should_fallback(state: AgentState) -> str:
+def should_fallback(state: AgentState) -> Literal["fallback_search", "standard_rag"]:
     """
     피드백 기반 Fallback 분기 라우터:
-    최근 3개의 피드백 중 'down'이 2개 이상이면 fallback_search, 아니면 standard_rag 반환.
+    설정된 크기의 윈도우(최근 피드백) 내에서 'down'이 기준치 이상이면 fallback_search, 아니면 standard_rag 반환.
     """
     feedback_history = state.get("feedback_history", [])
-    recent_feedbacks = feedback_history[-3:]  # 최근 3개
+    
+    # 런타임 방어: 항목이 dict인지 확증하여 f.get() 호출 시 발생할 수 있는 AttributeError 차단
+    valid_feedbacks = [f for f in feedback_history if isinstance(f, dict)]
+    recent_feedbacks = valid_feedbacks[-FALLBACK_WINDOW_SIZE:] if valid_feedbacks else []
+    
     negative_count = sum(1 for f in recent_feedbacks if f.get("rating") == RATING_DOWN)
     
-    if negative_count >= 2:
+    if negative_count >= FALLBACK_THRESHOLD:
         logger.warning(
-            "[Router] 최근 3개 중 부정적 피드백 2개 이상 감지. fallback_search 실행.",
+            f"[Router] 최근 {FALLBACK_WINDOW_SIZE}개 중 부정적 피드백 {FALLBACK_THRESHOLD}개 이상 감지. fallback_search 실행.",
             extra={"negative_count": negative_count}
         )
         return "fallback_search"

--- a/backend/services/chat_history_service.py
+++ b/backend/services/chat_history_service.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, NoReturn, Optional, Tuple
 from datetime import datetime, timezone
 from backend.services.redis_pubsub import redis_client  # type: ignore[import]
 from backend.api.models import ChatMessage  # type: ignore[import]
-from backend.api.models.shared import FeedbackRating  # type: ignore[import]
+from backend.api.models.shared import FeedbackRating, RATING_UP, RATING_DOWN, RATING_NONE  # type: ignore[import]
 from backend.utils import mask_pii_id  # type: ignore[import]
 from backend.agent.chat.state import FeedbackEntry  # type: ignore[import, import-untyped]
 
@@ -91,7 +91,7 @@ def _process_feedback_entry(
 
     raw_rating = meta.get("rating")
     # Frontend FeedbackRating Union 타입('up' | 'down' | 'none')과 일치시키기 위한 강제 캐스팅
-    rating = raw_rating if raw_rating in ("up", "down") else "none"
+    rating = raw_rating if raw_rating in (RATING_UP, RATING_DOWN) else RATING_NONE
     
     # timestamp가 int(epoch)이거나 str(ISO)일 수 있으므로 타입을 명시적으로 검증하여 정규화
     # 주의: bool은 int의 서브클래스이므로 명시적으로 제외 (True/False가 0/1 epoch으로 처리되는 것을 방지)
@@ -102,12 +102,12 @@ def _process_feedback_entry(
         # bool·비-스칼라 값(Dict/List) 또는 None인 경우 빈 문자열로 처리하여 예기치 못한 객체 문자화 방지
         ts = ""
 
-    up_delta = 1 if rating == "up" else 0
-    down_delta = 1 if rating == "down" else 0
+    up_delta = 1 if rating == RATING_UP else 0
+    down_delta = 1 if rating == RATING_DOWN else 0
 
-    if ts and rating in ("up", "down"):
+    if ts and rating in (RATING_UP, RATING_DOWN):
         date_str = ts[:10]
-        day = trends.setdefault(date_str, {"up": 0, "down": 0})
+        day = trends.setdefault(date_str, {RATING_UP: 0, RATING_DOWN: 0})
         day[rating] += 1
 
     item = None
@@ -658,7 +658,7 @@ class ChatHistoryService:
 
             # 3. YYYY-MM-DD 정렬
             sorted_trends = [
-                {"date": d, "up": trends[d]["up"], "down": trends[d]["down"]}
+                {"date": d, "up": trends[d][RATING_UP], "down": trends[d][RATING_DOWN]}
                 for d in sorted(trends.keys())
             ]
             
@@ -728,9 +728,9 @@ class ChatHistoryService:
                             ts_str = ""
                             
                         raw_rating = meta.get("rating")
-                        rating = str(raw_rating).lower().strip() if raw_rating is not None else "none"
-                        if rating not in {"up", "down", "none"}:
-                            rating = "none"
+                        rating = str(raw_rating).lower().strip() if raw_rating is not None else RATING_NONE
+                        if rating not in {RATING_UP, RATING_DOWN, RATING_NONE}:
+                            rating = RATING_NONE
                             
                         entry: FeedbackEntry = {
                             "message_id": msg_id,

--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -34,6 +34,7 @@ from typing import Any, AsyncIterator, Literal, Optional
 
 import redis.exceptions
 
+from backend.api.models.shared import FeedbackRating, RATING_DOWN  # type: ignore[import, import-untyped, reportMissingImports]
 from backend.services.chat_history_service import (  # type: ignore[import]
     FEEDBACK_KEY_PREFIX,
     _HISTORY_PREFIX,
@@ -750,7 +751,8 @@ async def run_negative_feedback_eval_pipeline(
                     except (JSONDecodeError, ValueError):
                         continue
 
-                    if meta.get("rating") != "down":
+                    # 성능 최적화: RATING_DOWN ("down") 피드백만 처리
+                    if meta.get("rating") != RATING_DOWN:
                         continue
 
                     summary["total_negative"] += 1

--- a/backend/services/golden_dataset_service.py
+++ b/backend/services/golden_dataset_service.py
@@ -16,6 +16,7 @@ import numbers
 from dataclasses import dataclass
 from json import JSONDecodeError
 from typing import Any, Optional
+from backend.api.models.shared import RATING_UP  # type: ignore[import, import-untyped, reportMissingImports]
 
 import redis.exceptions
 
@@ -74,7 +75,7 @@ def _parse_feedback_meta(
     **책임 범위**: 이 함수는 이미 정규화된(디코딩/파싱 완료된) 타입만 입력받습니다.
     - msg_id: 호출부에서 bytes 디코딩을 완료한 str.
     - meta: 호출부에서 json.loads()를 완료한 dict.
-    - rating 게이트("up" 필터링) 책임은 전적으로 호출부 루프에 있습니다.
+    - rating 게이트(RATING_UP 필터링) 책임은 전적으로 호출부 루프에 있습니다.
 
     Args:
         msg_id: 디코딩이 완료된 message_id (str).
@@ -121,7 +122,7 @@ async def filter_positive_feedbacks(
     품질 기준을 통과한 '좋아요(Thumbs Up)' 피드백 항목을 수집합니다.
 
     품질 게이트 (Quality Gates):
-        1. rating == "up" 인 항목만 포함 (부정/없음 제외) — 호출부 루프에서 단일 처리
+        1. rating == RATING_UP 인 항목만 포함 (부정/없음 제외) — 호출부 루프에서 단일 처리
         2. timestamp가 유효한 스칼라 타입이고 비어있지 않아야 함 — _parse_feedback_meta에서 검증
         3. session_id와 message_id 모두 비어있지 않아야 함
         4. (session_id, message_id) 복합 키 기준으로 중복 제거
@@ -165,7 +166,7 @@ async def filter_positive_feedbacks(
         cursor = 0
         total_scanned_keys = 0
         total_skipped_parse = 0    # JSON 디코딩 오류 또는 timestamp 유효성 실패
-        total_skipped_rating = 0   # rating != "up" (부정/없음 평가)
+        total_skipped_rating = 0   # rating != RATING_UP (부정/없음 평가)
         total_skipped_quality = 0  # session_id/message_id 비어있음
         total_skipped_dedup = 0    # (session_id, message_id) 중복
 
@@ -209,7 +210,7 @@ async def filter_positive_feedbacks(
 
                     # [Step 2] rating 게이트: 이 루프가 유일한 rating 필터 레이어입니다.
                     # _parse_feedback_meta는 rating에 관여하지 않습니다.
-                    if meta.get("rating") != "up":
+                    if meta.get("rating") != RATING_UP:
                         total_skipped_rating += 1
                         continue
 
@@ -264,7 +265,7 @@ async def filter_positive_feedbacks(
                 "total_collected": len(results),
                 "total_scanned_keys": total_scanned_keys,
                 "skipped_parse_error": total_skipped_parse,    # 실제 파싱/타입 오류만 집계
-                "skipped_rating_gate": total_skipped_rating,   # rating != "up" 필터 수
+                "skipped_rating_gate": total_skipped_rating,   # rating != RATING_UP 필터 수
                 "skipped_quality_gate": total_skipped_quality,
                 "skipped_dedup": total_skipped_dedup,
             },


### PR DESCRIPTION
- **[라우팅 반환형 정밀화]**
  - `should_fallback` 라우터의 반환 타입을 단순 `str`에서 `Literal["fallback_search", "standard_rag"]`로 강제하여, LangGraph 분기 처리 중 휴먼 에러(오타)가 런타임 버그로 발생하지 않도록 정적 분석 기능 강화.

- **[매직넘버 제거 및 런타임 안정성 보완]**
  - 최근 피드백 분석 시 사용되던 윈도우 사이즈(3)와 임계치 값(2)을 각각 `FALLBACK_WINDOW_SIZE`, `FALLBACK_THRESHOLD` 상수로 분리하여 기획 변경에 유연히 대응.
  - `feedback_history` 리스트 요소 접근 시 명시적인 형 검사(`isinstance(f, dict)`)를 도입하여 깨진 데이터(Malformed)에 의한 `AttributeError` 500 에러를 선제 차단.

- **[코드베이스 전역 상수 통합]**
  - `shared.py`에 선언한 평가 상태 상수(`RATING_UP, DOWN, NONE`)를 `eval_service.py`, `golden_dataset_service.py`, `chat_history_service.py` 전체로 확장 적용.
  - 전역 스코프에 잔존해있던 하드코딩된 평가치 문자열 리터럴을 100% 제거 완료.

🔗 Related:
- Issue [#935]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1005#pullrequestreview-4076235437)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

피드백 기반 폴백 라우팅을 개선하고, 공통 상수를 사용해 서비스 전반의 평점 처리 방식을 통일합니다.

개선 사항:
- 폴백 라우터의 반환 타입을 명시적인 리터럴로 제한하고, 구성 가능한 윈도우 크기와 임계값 상수를 도입하며, 잘못된 형식의 피드백 이력 엔트리에 대해 방어적인 처리를 추가합니다.
- 채팅 히스토리, 골든 데이터셋, 평가 서비스 전반에서 사용되는 하드코딩된 평점 문자열 리터럴을 공통 평점 상수로 교체하고, 관련 주석 및 통계 집계 구조에도 이를 반영합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine feedback-based fallback routing and unify rating handling across services using shared constants.

Enhancements:
- Constrain the fallback router return type to explicit literals and introduce configurable window size and threshold constants with defensive handling for malformed feedback history entries.
- Replace hardcoded rating string literals with shared rating constants across chat history, golden dataset, and evaluation services, including associated comments and stats aggregation structures.

</details>