### PR TITLE
♻️ refactor [#11.11.2]: 4차 리뷰 - 라우터 보호 구문(Invariant) 추가 및 식별자 상수화

### DIFF
--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -30,6 +30,15 @@ _MAX_SEARCH_CONTEXT_CHARS: int = 8_000
 FALLBACK_WINDOW_SIZE: int = 3
 FALLBACK_THRESHOLD: int = 2
 
+# 구성 오류 방지를 위한 불변 조건(Invariant): threshold는 window size를 초과할 수 없음
+assert (
+    FALLBACK_THRESHOLD <= FALLBACK_WINDOW_SIZE
+), "Invalid fallback configuration: FALLBACK_THRESHOLD must be <= FALLBACK_WINDOW_SIZE"
+
+# 라우트 타겟 식별자 식별자(Route Target Identifiers) - 오타 방지 및 단일 진실 공급원
+ROUTE_FALLBACK_SEARCH: Literal["fallback_search"] = "fallback_search"
+ROUTE_STANDARD_RAG: Literal["standard_rag"] = "standard_rag"
+
 # 모듈 로드 시 한글 인사말 조합 생성 (O(1) 탐색, 합성어 오탐 차단)
 _KOREAN_GREETING_FORMS = {
     base + suffix for base in _SIMPLE_KOREAN_GREETINGS for suffix in _KOREAN_SUFFIXES
@@ -297,7 +306,8 @@ If you used any document from the context, YOU MUST use inline citations in the 
 def should_fallback(state: AgentState) -> Literal["fallback_search", "standard_rag"]:
     """
     피드백 기반 Fallback 분기 라우터:
-    엄격한 시간적 윈도우(최근 3회 세션) 내에서 'down'이 기준치 이상이면 fallback_search, 아니면 standard_rag 반환.
+    엄격한 시간적 윈도우(최근 FALLBACK_WINDOW_SIZE 회 세션) 내에서 
+    'down'이 기준치(FALLBACK_THRESHOLD) 이상이면 fallback_search, 아니면 standard_rag 반환.
     """
     feedback_history = state.get("feedback_history", [])
     
@@ -312,12 +322,12 @@ def should_fallback(state: AgentState) -> Literal["fallback_search", "standard_r
     
     if negative_count >= FALLBACK_THRESHOLD:
         logger.warning(
-            f"[Router] 최근 {FALLBACK_WINDOW_SIZE}개 중 부정적 피드백 {FALLBACK_THRESHOLD}개 이상 감지. fallback_search 실행.",
+            f"[Router] 최근 {FALLBACK_WINDOW_SIZE}개 중 부정적 피드백 {FALLBACK_THRESHOLD}개 이상 감지. {ROUTE_FALLBACK_SEARCH} 실행.",
             extra={"negative_count": negative_count}
         )
-        return "fallback_search"
+        return ROUTE_FALLBACK_SEARCH
     
-    return "standard_rag"
+    return ROUTE_STANDARD_RAG
 
 
 def router_edge(state: AgentState) -> Literal["planner", "responder"]:

--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -31,13 +31,16 @@ FALLBACK_WINDOW_SIZE: int = 3
 FALLBACK_THRESHOLD: int = 2
 
 # 구성 오류 방지를 위한 불변 조건(Invariant): threshold는 window size를 초과할 수 없음
-assert (
-    FALLBACK_THRESHOLD <= FALLBACK_WINDOW_SIZE
-), "Invalid fallback configuration: FALLBACK_THRESHOLD must be <= FALLBACK_WINDOW_SIZE"
+if FALLBACK_THRESHOLD > FALLBACK_WINDOW_SIZE:
+    raise ValueError(
+        f"Invalid fallback configuration: FALLBACK_THRESHOLD ({FALLBACK_THRESHOLD}) "
+        f"must be <= FALLBACK_WINDOW_SIZE ({FALLBACK_WINDOW_SIZE})"
+    )
 
 # 라우트 타겟 식별자 식별자(Route Target Identifiers) - 오타 방지 및 단일 진실 공급원
-ROUTE_FALLBACK_SEARCH: Literal["fallback_search"] = "fallback_search"
-ROUTE_STANDARD_RAG: Literal["standard_rag"] = "standard_rag"
+FallbackRoute = Literal["fallback_search", "standard_rag"]
+ROUTE_FALLBACK_SEARCH: FallbackRoute = "fallback_search"
+ROUTE_STANDARD_RAG: FallbackRoute = "standard_rag"
 
 # 모듈 로드 시 한글 인사말 조합 생성 (O(1) 탐색, 합성어 오탐 차단)
 _KOREAN_GREETING_FORMS = {
@@ -303,7 +306,7 @@ If you used any document from the context, YOU MUST use inline citations in the 
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def should_fallback(state: AgentState) -> Literal["fallback_search", "standard_rag"]:
+def should_fallback(state: AgentState) -> FallbackRoute:
     """
     피드백 기반 Fallback 분기 라우터:
     엄격한 시간적 윈도우(최근 FALLBACK_WINDOW_SIZE 회 세션) 내에서 


### PR DESCRIPTION
- **[Configuration 오류 원천 차단]**
  - `FALLBACK_THRESHOLD`가 `FALLBACK_WINDOW_SIZE`를 초과하여 라우터가 데드코드(비활성화)가 되는 수학적 모순을 방지하기 위해 로드시점 `assert` 불변성(Invariant) 검증 추가.

- **[라우팅 식별자 하드코딩 제거]**
  - 문자열 리터럴로 분산되어 있던 반환값(`"fallback_search"`, `"standard_rag"`)을 `ROUTE_FALLBACK_SEARCH` 등 명시적 상수로 분리하여 휴먼 에러 차단 및 단일 진실 공급원(SSOT) 확립.

- **[주석(Docstring) 동기화]**
  - 코드 로직과 문서의 불일치(Drift)를 해소하기 위해 주석 내에 하드코딩된 매직 넘버(3회 등)를 실제 설정된 상수명으로 교체.

🔗 Related:
- Issue [#935]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1007#pullrequestreview-4076346810)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

피드백 기반 폴백 라우터에 대한 설정 불변 조건을 강제하고, 라우팅 식별자를 상수로 중앙 관리합니다.

개선 사항:
- 라우팅 로직이 비활성화되는 잘못된 폴백 윈도우/임계값 설정을 방지하기 위해 모듈 로드 시점에 애서션을 추가했습니다.
- 오타를 방지하고 라우트 식별자의 단일 진실 공급원(Single Source of Truth)을 확립하기 위해, 하드코딩된 라우팅 문자열 리터럴을 명명된 상수로 대체했습니다.
- 문서가 런타임 동작과 일치하도록, 라우터의 도크스트링 내용을 설정 상수와 정렬했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce configuration invariants for the feedback-based fallback router and centralize routing identifiers as constants.

Enhancements:
- Add a module-load assertion to prevent invalid fallback window/threshold configurations that would disable routing logic.
- Replace hard-coded routing string literals with named constants to avoid typos and establish a single source of truth for route identifiers.
- Align router docstring text with configuration constants to keep documentation in sync with runtime behavior.

</details>