### PR TITLE
Feature/v8 phase5 data flywheel

### DIFF
--- a/backend/agent/chat/graph.py
+++ b/backend/agent/chat/graph.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from langgraph.graph.state import CompiledStateGraph
 
 from backend.agent.chat.state import AgentState
-from backend.agent.chat.nodes import router_edge, planner_node, responder_node
+from backend.agent.chat.nodes import router_edge, standard_rag_node, fallback_search_node, responder_node
 from backend.agent.checkpointer import get_checkpointer
 
 
@@ -26,24 +26,27 @@ def create_chat_workflow(checkpointer: Optional["BaseCheckpointSaver"] = None) -
     
     # 2. 노드(Nodes) 추가
     # 각 노드는 AgentState를 입력받아, 변동될 속성의 딕셔너리를 반환합니다.
-    workflow.add_node("planner", planner_node)
+    workflow.add_node("standard_rag", standard_rag_node)
+    workflow.add_node("fallback_search", fallback_search_node)
     workflow.add_node("responder", responder_node)
     
     # 3. 라우팅 (조건부 진입점)
     # 시작점(START)에서 사용자의 메시지를 받아, 조건부 엣지(router_edge)를 통해 
-    # 복잡한 검색이 필요한 planner를 거칠지, 단순 인사말인 responder로 직행할지 결정합니다.
+    # 검색 방식(standard_rag, fallback_search)을 선택하거나 단순 인사말인 responder로 직행할지 결정합니다.
     workflow.add_conditional_edges(
         START,
         router_edge,
         {
-            "planner": "planner",
+            "standard_rag": "standard_rag",
+            "fallback_search": "fallback_search",
             "responder": "responder"
         }
     )
     
     # 4. 방향 엣지(Edges) 연결
-    # Planner 작업(검색 및 도구 호출)이 끝나면 무조건 Responder로 넘어와서 최종 텍스트 답변을 구성합니다.
-    workflow.add_edge("planner", "responder")
+    # 검색 작업(내부 문서 검색 혹은 타빌리 웹 검색)이 끝나면 무조건 Responder로 넘어와서 최종 텍스트 답변을 구성합니다.
+    workflow.add_edge("standard_rag", "responder")
+    workflow.add_edge("fallback_search", "responder")
     
     # Responder가 최종 응답을 생성하면 에이전트 그래프 모방을 종료(END)합니다.
     workflow.add_edge("responder", END)

--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -377,6 +377,25 @@ def router_edge(state: AgentState) -> Literal["standard_rag", "fallback_search",
     return should_fallback(state)
 
 
+async def _orchestrate_standard_search_flow(
+    state: AgentState,
+    system_prompt: str,
+) -> tuple[List[BaseMessage], str]:
+    """
+    공통 검색 오케스트레이션 헬퍼:
+    - 메시지를 추출하고,
+    - base_context 를 계산한 뒤,
+    - 시스템 프롬프트를 선행 메시지로 추가합니다.
+    """
+    messages = state.get("messages", [])
+    base_context = str(state.get("search_context", "") or "")
+
+    system_message = SystemMessage(content=system_prompt)
+    orchestrated_messages: List[BaseMessage] = [system_message, *messages]
+
+    return orchestrated_messages, base_context
+
+
 async def standard_rag_node(state: AgentState) -> PlannerResult:
     """
     기존 RAG (Standard RAG) 노드 — Thin Orchestrator:
@@ -384,8 +403,7 @@ async def standard_rag_node(state: AgentState) -> PlannerResult:
     """
     logger.info("[Standard RAG Node] 실행 중... (도구 호출 및 검색 활용 계획)")
 
-    messages = state.get("messages", [])
-    if not messages:
+    if not state.get("messages", []):
         return {
             "search_context": "",
             "planner_failed": False,
@@ -393,16 +411,16 @@ async def standard_rag_node(state: AgentState) -> PlannerResult:
             "source_documents": [],
         }
 
-    base_context = str(state.get("search_context", "") or "")
-
-    sys_prompt = SystemMessage(
-        content=(
-            "당신은 사용자의 질문을 분석하고 외부 지식이 필요한 경우 적절한 도구를 실행하여 정보를 수집하는 Planner입니다.\n"
-            "질문에 답하기 위해 프로젝트 내부 문서, 규정, 특정 지식 확인이 필요하다면 즉시 'search_documents_tool'을 호출하세요.\n"
-            "단순 안부 이외의 대부분의 사실 확인은 이 도구를 통해 컨텍스트를 얻는 것이 안전합니다."
-        )
+    system_prompt = (
+        "당신은 사용자의 질문을 분석하고 외부 지식이 필요한 경우 적절한 도구를 실행하여 정보를 수집하는 Planner입니다.\n"
+        "질문에 답하기 위해 프로젝트 내부 문서, 규정, 특정 지식 확인이 필요하다면 즉시 'search_documents_tool'을 호출하세요.\n"
+        "단순 안부 이외의 대부분의 사실 확인은 이 도구를 통해 컨텍스트를 얻는 것이 안전합니다."
     )
-    plan_messages = [sys_prompt] + messages
+
+    plan_messages, base_context = await _orchestrate_standard_search_flow(
+        state=state,
+        system_prompt=system_prompt,
+    )
 
     result = await _run_search_agent(plan_messages, base_context, search_documents_tool, "search_documents_tool")
     return {
@@ -420,8 +438,7 @@ async def fallback_search_node(state: AgentState) -> PlannerResult:
     """
     logger.info("[Fallback Search Node] 실행 중... (Tavily 연동 웹 검색 진행)")
 
-    messages = state.get("messages", [])
-    if not messages:
+    if not state.get("messages", []):
         return {
             "search_context": "",
             "planner_failed": False,
@@ -429,16 +446,16 @@ async def fallback_search_node(state: AgentState) -> PlannerResult:
             "source_documents": [],
         }
 
-    base_context = str(state.get("search_context", "") or "")
-
-    sys_prompt = SystemMessage(
-        content=(
-            "당신은 사용자의 질문을 분석하고 웹 상의 최신 지식이 필요한 경우 적절한 도구를 실행하여 정보를 수집하는 Planner입니다.\n"
-            "일반적인 내부 문서(RAG) 검색으로는 사용자를 만족시키기 어렵다고 판단되어 현재 Fallback 외부 검색(웹 검색) 라우팅을 탔습니다.\n"
-            "질문에 답하기 위해 최신 뉴스, 외부 트렌드, 정보가 필요하다면 즉시 'deep_web_search_tool'을 호출하세요."
-        )
+    system_prompt = (
+        "당신은 사용자의 질문을 분석하고 웹 상의 최신 지식이 필요한 경우 적절한 도구를 실행하여 정보를 수집하는 Planner입니다.\n"
+        "일반적인 내부 문서(RAG) 검색으로는 사용자를 만족시키기 어렵다고 판단되어 현재 Fallback 외부 검색(웹 검색) 라우팅을 탔습니다.\n"
+        "질문에 답하기 위해 최신 뉴스, 외부 트렌드, 정보가 필요하다면 즉시 'deep_web_search_tool'을 호출하세요."
     )
-    plan_messages = [sys_prompt] + messages
+
+    plan_messages, base_context = await _orchestrate_standard_search_flow(
+        state=state,
+        system_prompt=system_prompt,
+    )
 
     result = await _run_search_agent(plan_messages, base_context, deep_web_search_tool, "deep_web_search_tool")
     return {

--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -8,7 +8,7 @@ from typing import Dict, Any, Literal, cast, List, TypedDict
 from langchain_core.messages import AIMessage, SystemMessage, BaseMessage  # type: ignore[import, import-untyped, reportMissingImports]
 
 from backend.agent.chat.state import AgentState  # type: ignore[import, import-untyped, reportMissingImports]
-from backend.agent.chat.tools import search_documents_tool  # type: ignore[import, import-untyped, reportMissingImports]
+from backend.agent.chat.tools import search_documents_tool, deep_web_search_tool  # type: ignore[import, import-untyped, reportMissingImports]
 from backend.services.chat_service import get_chat_service  # type: ignore[import, import-untyped, reportMissingImports]
 from backend.api.models.shared import RATING_DOWN  # type: ignore[import, import-untyped, reportMissingImports]
 
@@ -182,16 +182,18 @@ def _safe_truncate_error_msg(e: Exception, max_chars: int = _MAX_ERROR_MSG_CHARS
     return "".join(islice(sanitized, max_chars))
 
 
-async def _run_planner_with_tools(
+async def _run_search_agent(
     plan_messages: List[BaseMessage],
     base_context: str,
+    search_tool: Any,
+    expected_tool_name: str,
 ) -> PlannerResult:
     """
     LLM에 도구 호출 권한을 부여하고, 도구를 실행하여 search_context를 반환하는 오케스트레이션 헬퍼.
     """
     chat_svc = get_chat_service()
     llm = chat_svc._get_llm(streaming=False)
-    llm_with_tools = llm.bind_tools([search_documents_tool])
+    llm_with_tools = llm.bind_tools([search_tool])
 
     ctx_parts: List[str] = [base_context] if base_context else []
     planner_failed = False
@@ -229,7 +231,7 @@ async def _run_planner_with_tools(
                 else:
                     tool_args = raw_args
 
-                if tool_name != "search_documents_tool":
+                if tool_name != expected_tool_name:
                     logger.debug(
                         "[Tool Dispatch] 미지원 도구 요청 무시",
                         extra={"tool_name": tool_name},
@@ -238,10 +240,10 @@ async def _run_planner_with_tools(
 
                 query_arg = str(tool_args.get("query", ""))
                 logger.info(
-                    "[Planner] -> search_documents_tool 호출",
+                    f"[Planner] -> {expected_tool_name} 호출",
                     extra={"query_length": len(query_arg)},
                 )
-                tool_res_raw = await search_documents_tool.ainvoke(tool_args)
+                tool_res_raw = await search_tool.ainvoke(tool_args)
                 tool_res: str = ""
                 if isinstance(tool_res_raw, dict):
                     tool_res = str(tool_res_raw.get("context", ""))
@@ -333,11 +335,12 @@ def should_fallback(state: AgentState) -> FallbackRoute:
     return ROUTE_STANDARD_RAG
 
 
-def router_edge(state: AgentState) -> Literal["planner", "responder"]:
+def router_edge(state: AgentState) -> Literal["standard_rag", "fallback_search", "responder"]:
     """
     조건부 엣지(Conditional Edge):
     가장 마지막 Human 메시지의 의도를 파악하여
-    복잡한 추론/검색이 필요한지(planner), 단순 인사말인지(responder) 판별합니다.
+    단순 인사말인 경우 responder로 직행하고, 그렇지 않은 경우 
+    과거 피드백 기록에 따라 standard_rag 또는 fallback_search를 결정합니다.
     """
     messages = state.get("messages", [])
     if not messages:
@@ -369,21 +372,17 @@ def router_edge(state: AgentState) -> Literal["planner", "responder"]:
         logger.info("[Router] 단순 대화 감지 -> responder", extra=router_log_extra)
         return "responder"
 
-    router_log_extra["target"] = "planner"
-    logger.info("[Router] 검색/추론 도구 필요 판단 -> planner", extra=router_log_extra)
-    return "planner"
+    router_log_extra["target"] = "search"
+    logger.info("[Router] 검색/추론 도구 필요 판단 -> should_fallback 분기로 전달", extra=router_log_extra)
+    return should_fallback(state)
 
 
-async def planner_node(state: AgentState) -> PlannerResult:
+async def standard_rag_node(state: AgentState) -> PlannerResult:
     """
-    계획자(Planner) 노드 — Thin Orchestrator:
+    기존 RAG (Standard RAG) 노드 — Thin Orchestrator:
     - 상태를 수집하고 헬퍼를 호출하여 도구 실행 및 컨텍스트를 구성한 후 반환합니다.
-
-    [Engineering Decision - Coupling]
-    현재 시스템 내에서 LLM 결합 방식에 대한 의존성이 존재하며,
-    Phase 3 Integration 단계에서 LLM 제공자를 DI(의존성 주입)로 분리할 예정입니다.
     """
-    logger.info("[Planner Node] 실행 중... (도구 호출 및 검색 활용 계획)")
+    logger.info("[Standard RAG Node] 실행 중... (도구 호출 및 검색 활용 계획)")
 
     messages = state.get("messages", [])
     if not messages:
@@ -405,7 +404,43 @@ async def planner_node(state: AgentState) -> PlannerResult:
     )
     plan_messages = [sys_prompt] + messages
 
-    result = await _run_planner_with_tools(plan_messages, base_context)
+    result = await _run_search_agent(plan_messages, base_context, search_documents_tool, "search_documents_tool")
+    return {
+        "search_context": result["search_context"],
+        "planner_failed": result["planner_failed"],
+        "planner_error_message": result["planner_error_message"],
+        "source_documents": cast(list[dict], result.get("source_documents", [])),
+    }
+
+
+async def fallback_search_node(state: AgentState) -> PlannerResult:
+    """
+    딥웹 검출(Fallback Search) 노드 — Thin Orchestrator:
+    지속적인 부정적 피드백으로 감지되었을 때 호출되는 타빌리 검색 기반의 보완 노드입니다.
+    """
+    logger.info("[Fallback Search Node] 실행 중... (Tavily 연동 웹 검색 진행)")
+
+    messages = state.get("messages", [])
+    if not messages:
+        return {
+            "search_context": "",
+            "planner_failed": False,
+            "planner_error_message": "",
+            "source_documents": [],
+        }
+
+    base_context = str(state.get("search_context", "") or "")
+
+    sys_prompt = SystemMessage(
+        content=(
+            "당신은 사용자의 질문을 분석하고 웹 상의 최신 지식이 필요한 경우 적절한 도구를 실행하여 정보를 수집하는 Planner입니다.\n"
+            "일반적인 내부 문서(RAG) 검색으로는 사용자를 만족시키기 어렵다고 판단되어 현재 Fallback 외부 검색(웹 검색) 라우팅을 탔습니다.\n"
+            "질문에 답하기 위해 최신 뉴스, 외부 트렌드, 정보가 필요하다면 즉시 'deep_web_search_tool'을 호출하세요."
+        )
+    )
+    plan_messages = [sys_prompt] + messages
+
+    result = await _run_search_agent(plan_messages, base_context, deep_web_search_tool, "deep_web_search_tool")
     return {
         "search_context": result["search_context"],
         "planner_failed": result["planner_failed"],

--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -16,6 +16,20 @@ _MAX_DOC_CONTENT_CHARS = 1_000
 # [Security] 로그에 포함되는 doc_id의 최대 길이 제한 (PII 경계값 명시)
 _MAX_LOG_DOC_ID_LEN = 50
 
+_tavily_client: Optional[TavilyClient] = None
+
+def _get_tavily_client(api_key: str) -> TavilyClient:
+    """
+    Lazily initialize and reuse a module-level TavilyClient instance.
+
+    This avoids constructing a new client for every deep_web_search_tool call
+    while preserving the existing per-call API key validation and error handling.
+    """
+    global _tavily_client
+    if _tavily_client is None:
+        _tavily_client = TavilyClient(api_key=api_key)
+    return _tavily_client
+
 
 class SerializedDoc(TypedDict):
     """
@@ -216,7 +230,7 @@ async def deep_web_search_tool(query: str, k: int = 5) -> dict:
         return {"context": "웹 검색 연결 설정이 누락되어 검색할 수 없습니다.", "docs": []}
 
     try:
-        client = TavilyClient(api_key=api_key)
+        client = _get_tavily_client(api_key)
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(
             None,

--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -5,6 +5,10 @@ from typing import Any, Dict, Optional, TypedDict, cast
 from langchain_core.tools import tool  # type: ignore[import, import-untyped, reportMissingImports]
 from backend.services.hybrid_search_service import get_hybrid_search_service  # type: ignore[import, import-untyped, reportMissingImports]
 
+import os
+import asyncio
+from tavily import TavilyClient
+
 logger = logging.getLogger(__name__)
 
 # 도구 내 단일 문서 최대 길이 상수 (하드코딩 방지)
@@ -189,3 +193,72 @@ async def search_documents_tool(query: str, k: int = 5) -> dict:
             extra=_build_log_extra(None, error_type=type(e).__name__),
         )
         return {"context": "문서 검색 중 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.", "docs": []}
+
+
+@tool
+async def deep_web_search_tool(query: str, k: int = 5) -> dict:
+    """
+    Tavily API 기반 Deep Web Search 도구입니다.
+    기존 내부 문서 검색(RAG)으로 원하는 정보를 찾지 못했거나 부정적인 피드백이 누적되었을 때,
+    최신 외부 지식이나 광범위한 웹 문서를 검색하기 위해 이 도구를 호출하세요.
+
+    Args:
+        query (str): 검색할 핵심 질의어, 키워드 또는 전체 문장.
+        k (int): 검색할 최대 문서 수 (기본값: 5).
+    """
+    logger.info(
+        "[Tool] deep_web_search_tool 실행",
+        extra={"query_length": len(query), "k": k}
+    )
+    api_key = os.getenv("TAVILY_API_KEY")
+    if not api_key:
+        logger.error("[Tool] TAVILY_API_KEY 환경변수가 설정되지 않았습니다.")
+        return {"context": "웹 검색 연결 설정이 누락되어 검색할 수 없습니다.", "docs": []}
+
+    try:
+        client = TavilyClient(api_key=api_key)
+        loop = asyncio.get_running_loop()
+        result = await loop.run_in_executor(
+            None,
+            lambda: client.search(query=query, search_depth="advanced", max_results=k)
+        )
+
+        results = result.get("results", [])
+        if not results:
+            logger.info("[Tool] 웹 검색 결과 없음", extra={"k": k})
+            return {"context": "관련된 웹 검색 결과를 찾을 수 없습니다.", "docs": []}
+
+        formatted_results = []
+        serialized_docs = []
+
+        for i, item in enumerate(results, 1):
+            content_str = str(item.get("content", ""))
+            if len(content_str) > _MAX_DOC_CONTENT_CHARS:
+                content_str = str(content_str[:_MAX_DOC_CONTENT_CHARS]) + "...(truncated)"
+
+            source = str(item.get("url", "unknown"))
+            formatted_results.append(
+                f"--- Web Document {i} (Source: {source}) ---\n{content_str}"
+            )
+
+            safe_doc: SerializedDoc = _normalize_doc({
+                "id": source,
+                "score": float(item.get("score", 0.0) if item.get("score") is not None else 0.0),
+                "content": content_str,
+                "metadata": {"source": source, "title": item.get("title", "")}
+            })
+            serialized_docs.append(safe_doc)
+
+        final_context = "\n\n".join(formatted_results)
+        logger.info(
+            "[Tool] 웹 검색 완료",
+            extra={"doc_count": len(results), "total_length": len(final_context)}
+        )
+        return {"context": final_context, "docs": serialized_docs}
+
+    except Exception as e:
+        logger.error(
+            "[Tool] 웹 검색 중 오류 발생",
+            extra=_build_log_extra(None, error_type=type(e).__name__),
+        )
+        return {"context": "웹 검색 중 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.", "docs": []}

--- a/requirements.txt
+++ b/requirements.txt
@@ -135,3 +135,4 @@ zipp==3.23.0
 zstandard==0.25.0
 exceptiongroup>=1.0.0; python_version < '3.11'
 rank-bm25==0.2.2
+tavily-python==0.7.23


### PR DESCRIPTION
✨ feat [#11.11.3]: phase3의 2단계 ➁ - Tavily 연동 및 Fallback 라우팅 로직 연결 
♻️ refactor [#11.11.3]: 1차 리뷰 - 공통 오케스트레이션 헬퍼 패턴 도입 및 TavilyClient 최적화

## Summary by Sourcery

기존 RAG 검색과 새로운 Tavily 기반 웹 검색 폴백 사이를, 사용자 의도와 피드백 신호에 따라 라우팅하는 이중 검색 워크플로를 도입합니다.

New Features:
- 내부 RAG 결과가 부족할 때 외부 웹 검색을 수행하기 위한 Tavily 기반 `deep_web_search_tool`을 추가합니다.
- 피드백 기반 폴백 로직에 따라 딥 웹 검색을 호출하도록, 챗 워크플로에 `fallback_search` 노드와 라우팅 경로를 추가합니다.

Enhancements:
- 여러 검색 도구를 일관된 방식으로 지원하기 위해, 재사용 가능한 검색 오케스트레이션 헬퍼와 범용 검색 에이전트 러너를 추출합니다.
- 역할을 명확히 하기 위해, 기존 플래너 노드를 `standard_rag` 노드와 전담 `fallback_search` 노드로 분리하고 이름을 변경합니다.

Build:
- Tavily 웹 검색 연동을 위해 `tavily-python` 의존성을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dual search workflow that routes between existing RAG search and a new Tavily-based web search fallback based on user intent and feedback signals.

New Features:
- Add a Tavily-backed deep_web_search_tool for external web search when internal RAG results are insufficient.
- Add a fallback_search node and routing path in the chat workflow to invoke deep web search based on feedback-driven fallback logic.

Enhancements:
- Extract a reusable search orchestration helper and general search agent runner to support multiple search tools with consistent behavior.
- Rename and split the previous planner node into a standard_rag node and a dedicated fallback_search node for clearer responsibilities.

Build:
- Add tavily-python dependency for Tavily web search integration.

</details>