### PR TITLE
♻️ refactor [#11.11.3]: 2차 리뷰 - 검색 오케스트레이션 동기화 및 Fallback 컨텍스트 격리

### DIFF
--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -378,21 +378,30 @@ def router_edge(state: AgentState) -> Literal["standard_rag", "fallback_search",
     return route
 
 
+_USE_STATE_CONTEXT = object()
+
 def _orchestrate_search_flow(
     state: AgentState,
     system_prompt: str,
-    base_context_override: Optional[str] = None
+    base_context_override: Any = _USE_STATE_CONTEXT
 ) -> tuple[List[BaseMessage], str]:
     """
     공통 검색 오케스트레이션 헬퍼:
     - 메시지를 추출하고,
     - base_context 를 계산한 뒤,
     - 시스템 프롬프트를 선행 메시지로 추가합니다.
+
+    Args:
+        state: AgentState 객체.
+        system_prompt: 주입할 시스템 프롬프트.
+        base_context_override: 명시적으로 값을 주입할 경우 이 값을 사용하며,
+                               기본값(_USE_STATE_CONTEXT 센티널 객체)인 경우 state 내부의 
+                               'search_context'를 로드합니다. 빈 컨텍스트("") 전달과 완전히 구분됩니다.
     """
     messages = state.get("messages", [])
     
-    if base_context_override is not None:
-        base_context = base_context_override
+    if base_context_override is not _USE_STATE_CONTEXT:
+        base_context = str(base_context_override)
     else:
         base_context = str(state.get("search_context", "") or "")
 

--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -4,7 +4,7 @@ import re
 import logging
 import numbers
 from itertools import islice
-from typing import Dict, Any, Literal, cast, List, TypedDict
+from typing import Dict, Any, Literal, cast, List, TypedDict, Optional
 from langchain_core.messages import AIMessage, SystemMessage, BaseMessage  # type: ignore[import, import-untyped, reportMissingImports]
 
 from backend.agent.chat.state import AgentState  # type: ignore[import, import-untyped, reportMissingImports]
@@ -372,14 +372,16 @@ def router_edge(state: AgentState) -> Literal["standard_rag", "fallback_search",
         logger.info("[Router] 단순 대화 감지 -> responder", extra=router_log_extra)
         return "responder"
 
-    router_log_extra["target"] = "search"
-    logger.info("[Router] 검색/추론 도구 필요 판단 -> should_fallback 분기로 전달", extra=router_log_extra)
-    return should_fallback(state)
+    route = should_fallback(state)
+    router_log_extra["target"] = route
+    logger.info(f"[Router] 검색/추론 도구 필요 판단 -> {route} 분기로 전달", extra=router_log_extra)
+    return route
 
 
-async def _orchestrate_standard_search_flow(
+def _orchestrate_search_flow(
     state: AgentState,
     system_prompt: str,
+    base_context_override: Optional[str] = None
 ) -> tuple[List[BaseMessage], str]:
     """
     공통 검색 오케스트레이션 헬퍼:
@@ -388,7 +390,11 @@ async def _orchestrate_standard_search_flow(
     - 시스템 프롬프트를 선행 메시지로 추가합니다.
     """
     messages = state.get("messages", [])
-    base_context = str(state.get("search_context", "") or "")
+    
+    if base_context_override is not None:
+        base_context = base_context_override
+    else:
+        base_context = str(state.get("search_context", "") or "")
 
     system_message = SystemMessage(content=system_prompt)
     orchestrated_messages: List[BaseMessage] = [system_message, *messages]
@@ -417,7 +423,7 @@ async def standard_rag_node(state: AgentState) -> PlannerResult:
         "단순 안부 이외의 대부분의 사실 확인은 이 도구를 통해 컨텍스트를 얻는 것이 안전합니다."
     )
 
-    plan_messages, base_context = await _orchestrate_standard_search_flow(
+    plan_messages, base_context = _orchestrate_search_flow(
         state=state,
         system_prompt=system_prompt,
     )
@@ -452,9 +458,11 @@ async def fallback_search_node(state: AgentState) -> PlannerResult:
         "질문에 답하기 위해 최신 뉴스, 외부 트렌드, 정보가 필요하다면 즉시 'deep_web_search_tool'을 호출하세요."
     )
 
-    plan_messages, base_context = await _orchestrate_standard_search_flow(
+    # Fallback 플로우에서는 기존 RAG의 search_context가 오염되지 않도록 base_context를 빈 값으로 덮어씌움
+    plan_messages, base_context = _orchestrate_search_flow(
         state=state,
         system_prompt=system_prompt,
+        base_context_override=""
     )
 
     result = await _run_search_agent(plan_messages, base_context, deep_web_search_tool, "deep_web_search_tool")

--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -221,7 +221,14 @@ async def deep_web_search_tool(query: str, k: int = 5) -> dict:
         k (int): 검색할 최대 문서 수 (기본값: 5).
     """
     # [Comment 3 반영] 안전한 범위로 k를 검증/제한하여 예기치 않은 부하나 비용 방지
-    k = max(1, min(int(k), 10))
+    try:
+        k = max(1, min(int(k), 10))
+    except (ValueError, TypeError):
+        logger.warning(
+            "[Tool] k 파라미터 타입 캐스팅 실패, 기본값(5)으로 폴백합니다.",
+            extra={"invalid_k": str(k)[:50]}
+        )
+        k = 5
 
     logger.info(
         "[Tool] deep_web_search_tool 실행",

--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -220,6 +220,9 @@ async def deep_web_search_tool(query: str, k: int = 5) -> dict:
         query (str): 검색할 핵심 질의어, 키워드 또는 전체 문장.
         k (int): 검색할 최대 문서 수 (기본값: 5).
     """
+    # [Comment 3 반영] 안전한 범위로 k를 검증/제한하여 예기치 않은 부하나 비용 방지
+    k = max(1, min(int(k), 10))
+
     logger.info(
         "[Tool] deep_web_search_tool 실행",
         extra={"query_length": len(query), "k": k}


### PR DESCRIPTION
- **[공통 헬퍼 동기화 및 범용성 개선]**
  - 불필요한 비동기 컨텍스트 스위칭 구조를 제거하기 위해 `_orchestrate_search_flow`를 완전한 동기(Sync) 일반 함수로 전환하여 이벤트 루프 부하 절감.

- **[Fallback 오염 타겟팅 및 라우팅 명확화]**
  - 기존 내부 문서(RAG) 검색 실패로 넘어온 `search_context` 찌꺼기가 후속 Web 검색용 프롬프트와 섞이지 않도록 `base_context_override`를 도입하여 컨텍스트 청결 유지(Bug Risk 대응).
  - `router_edge` 로깅 시 추상적인 `"search"` 대신 `standard_rag` 혹은 `fallback_search` 중 실제로 결정된 구체적 타겟(Route)을 정확히 남기도록 개선.

- **[Tavily Search Tool 파라미터 방어막 적용]**
  - LLM 추론 오류로 인해 `k`값이 비정상적으로 높게 들어오는 것을 차단하기 위해 `k`를 1~10 안전 범위로 강제 클램프(Clamp) 조치하여 API 비용 폭발 및 메모리 과부하 사전 예방.

🔗 Related:
- Issue [#935]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1011#pullrequestreview-4083543158)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

에이전트 채팅 플로우를 위해 검색 라우팅, 오케스트레이션, 웹 검색 안전 한도를 개선합니다.

버그 수정:
- 폴백 웹 검색 프롬프트를 위한 명시적인 빈 기본 컨텍스트를 허용하여, RAG 검색 컨텍스트가 폴백 웹 검색 프롬프트로 유출되지 않도록 방지합니다.

개선 사항:
- 공용 검색 오케스트레이션 헬퍼를 동기 함수로 정리하고, 검색 경로 전반에서의 재사용성을 높이기 위해 선택적인 기본 컨텍스트 재정의 기능을 추가합니다.
- 일반적인 검색 대상 대신 구체적인 경로 이름(`standard_rag` 또는 `fallback_search`)을 기록하여 라우터 로깅을 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine search routing, orchestration, and web search safety limits for the agent chat flow.

Bug Fixes:
- Prevent RAG search context from leaking into fallback web search prompts by allowing an explicit empty base context for fallback flows.

Enhancements:
- Synchronize the shared search orchestration helper as a synchronous function and add optional base context overriding for greater reuse across search paths.
- Improve router logging by recording the concrete route name (standard_rag or fallback_search) instead of a generic search target.

</details>