### PR TITLE
♻️ refactor [#11.11.3] 4차 개선 - 파라미터 타입 강제 및 컨텍스트 예외 처리 강화

### DIFF
--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -380,6 +380,24 @@ def router_edge(state: AgentState) -> Literal["standard_rag", "fallback_search",
 
 _USE_STATE_CONTEXT = object()
 
+def _resolve_base_context(state: AgentState, override: Any) -> str:
+    """
+    base_context_override 파라미터의 센티널 확인, None 폴백 및 타입 검증을 수행하는 헬퍼 함수입니다.
+    """
+    if override is _USE_STATE_CONTEXT:
+        return str(state.get("search_context", "") or "")
+    
+    if override is None:
+        return ""
+        
+    if isinstance(override, str):
+        return override
+        
+    raise TypeError(
+        f"base_context_override must be of type str or None, "
+        f"got {type(override).__name__}"
+    )
+
 def _orchestrate_search_flow(
     state: AgentState,
     system_prompt: str,
@@ -403,19 +421,7 @@ def _orchestrate_search_flow(
         tuple[List[BaseMessage], str]: 시스템 메시지가 주입된 최종 메시지 리스트와 검색 컨텍스트 문자열.
     """
     messages = state.get("messages", [])
-    
-    if base_context_override is _USE_STATE_CONTEXT:
-        base_context = str(state.get("search_context", "") or "")
-    else:
-        if base_context_override is None:
-            base_context = ""
-        elif isinstance(base_context_override, str):
-            base_context = base_context_override
-        else:
-            raise TypeError(
-                f"base_context_override must be of type str or None, "
-                f"got {type(base_context_override).__name__}"
-            )
+    base_context = _resolve_base_context(state, base_context_override)
 
     system_message = SystemMessage(content=system_prompt)
     orchestrated_messages: List[BaseMessage] = [system_message, *messages]

--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -396,14 +396,26 @@ def _orchestrate_search_flow(
         system_prompt: 주입할 시스템 프롬프트.
         base_context_override: 명시적으로 값을 주입할 경우 이 값을 사용하며,
                                기본값(_USE_STATE_CONTEXT 센티널 객체)인 경우 state 내부의 
-                               'search_context'를 로드합니다. 빈 컨텍스트("") 전달과 완전히 구분됩니다.
+                               'search_context'를 로드합니다. 
+                               None은 "컨텍스트 없음"을 의미하며 빈 문자열("")로 취급됩니다.
+
+    Returns:
+        tuple[List[BaseMessage], str]: 시스템 메시지가 주입된 최종 메시지 리스트와 검색 컨텍스트 문자열.
     """
     messages = state.get("messages", [])
     
-    if base_context_override is not _USE_STATE_CONTEXT:
-        base_context = str(base_context_override)
-    else:
+    if base_context_override is _USE_STATE_CONTEXT:
         base_context = str(state.get("search_context", "") or "")
+    else:
+        if base_context_override is None:
+            base_context = ""
+        elif isinstance(base_context_override, str):
+            base_context = base_context_override
+        else:
+            raise TypeError(
+                f"base_context_override must be of type str or None, "
+                f"got {type(base_context_override).__name__}"
+            )
 
     system_message = SystemMessage(content=system_prompt)
     orchestrated_messages: List[BaseMessage] = [system_message, *messages]

--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -150,7 +150,7 @@ def _normalize_doc(doc: Any) -> SerializedDoc:
 
 
 @tool
-async def search_documents_tool(query: str, k: int = 5) -> dict:
+async def search_documents_tool(query: str, k: int = _DEFAULT_SEARCH_LIMIT) -> dict:
     """
     RAG 기반 사내 문서 검색 도구입니다.
     사용자의 질문이나 분석 의도와 관련된 지식 베이스 문서를 검색합니다.
@@ -158,8 +158,18 @@ async def search_documents_tool(query: str, k: int = 5) -> dict:
 
     Args:
         query (str): 검색할 핵심 질의어, 키워드 또는 전체 문장.
-        k (int): 검색할 최대 문서 수 (기본값: 5).
+        k (int): 검색할 최대 문서 수. (예기치 않은 부하 방지를 위해 제한 구역 내로 클램프되며, 유효하지 않은 값이면 기본값이 사용됩니다).
     """
+    # 안전한 범위로 k를 검증/제한하여 예기치 않은 부하나 비용 방지
+    try:
+        k = max(_MIN_SEARCH_LIMIT, min(int(k), _MAX_SEARCH_LIMIT))
+    except (ValueError, TypeError):
+        logger.warning(
+            f"[Tool] search_documents_tool k 파라미터 타입 캐스팅 실패, 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
+            extra={"invalid_k": str(k)[:50]}
+        )
+        k = _DEFAULT_SEARCH_LIMIT
+
     # [Comment 1 반영] PII 보호: query 원문 대신 길이(비민감 메타데이터)만 로깅
     logger.info(
         "[Tool] search_documents_tool 실행",

--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -16,6 +16,11 @@ _MAX_DOC_CONTENT_CHARS = 1_000
 # [Security] 로그에 포함되는 doc_id의 최대 길이 제한 (PII 경계값 명시)
 _MAX_LOG_DOC_ID_LEN = 50
 
+# API 통신 부하 및 비용 방지를 위한 외부 검색 타겟 개수 제한 (하드코딩 분리)
+_MIN_SEARCH_LIMIT = 1
+_MAX_SEARCH_LIMIT = 10
+_DEFAULT_SEARCH_LIMIT = 5
+
 _tavily_client: Optional[TavilyClient] = None
 
 def _get_tavily_client(api_key: str) -> TavilyClient:
@@ -210,7 +215,7 @@ async def search_documents_tool(query: str, k: int = 5) -> dict:
 
 
 @tool
-async def deep_web_search_tool(query: str, k: int = 5) -> dict:
+async def deep_web_search_tool(query: str, k: int = _DEFAULT_SEARCH_LIMIT) -> dict:
     """
     Tavily API 기반 Deep Web Search 도구입니다.
     기존 내부 문서 검색(RAG)으로 원하는 정보를 찾지 못했거나 부정적인 피드백이 누적되었을 때,
@@ -218,17 +223,17 @@ async def deep_web_search_tool(query: str, k: int = 5) -> dict:
 
     Args:
         query (str): 검색할 핵심 질의어, 키워드 또는 전체 문장.
-        k (int): 검색할 최대 문서 수 (기본값: 5).
+        k (int): 검색할 최대 문서 수. (예기치 않은 부하 방지를 위해 제한 구역 내로 클램프되며, 유효하지 않은 값이면 기본값이 사용됩니다).
     """
     # [Comment 3 반영] 안전한 범위로 k를 검증/제한하여 예기치 않은 부하나 비용 방지
     try:
-        k = max(1, min(int(k), 10))
+        k = max(_MIN_SEARCH_LIMIT, min(int(k), _MAX_SEARCH_LIMIT))
     except (ValueError, TypeError):
         logger.warning(
-            "[Tool] k 파라미터 타입 캐스팅 실패, 기본값(5)으로 폴백합니다.",
+            f"[Tool] k 파라미터 타입 캐스팅 실패, 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
             extra={"invalid_k": str(k)[:50]}
         )
-        k = 5
+        k = _DEFAULT_SEARCH_LIMIT
 
     logger.info(
         "[Tool] deep_web_search_tool 실행",


### PR DESCRIPTION
- **[Sentinel Override 버그 수정 및 타입 검증 강화]**
  - `_orchestrate_search_flow`에서 `None`을 오버라이드 값으로 주입했을 때, 무조건적인 `str()` 캐스팅으로 인해 진리값(Truthy)인 문자열 `"None"`으로 변환되던 Bug Risk 수정.
  - 명시적 `None`은 `""`로 처리하고, `str`이 아닌 비정상적인 타입 주입 시 `TypeError`를 발생시키도록 보호 로직 격상.
  - `Returns:` 블록 등 호출부 명세를 돕기 위한 Docstring 업데이트.

- **[Tool 파라미터 제약 상수로 분리 (하드코딩 제거)]**
  - `deep_web_search_tool` 내부의 `k` 클램핑 제한 범위를 `_MIN_SEARCH_LIMIT`, `_MAX_SEARCH_LIMIT` 등 상수로 도출하여 중앙 통제 및 튜닝 용이성 강화.
  - Docstring에 클램프 제약 사항 및 예외 시 기본값(`5`) 작동 명세 포함.

🔗 Related:
- Issue [#935]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1013#pullrequestreview-4083657812)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

검색 플로우 컨텍스트 처리 강화 및 딥 웹 검색 파라미터 제한 중앙화.

버그 수정:
- 검색 플로우에서 `None` 오버라이드를 잘못 처리하여, 참값으로 평가되는 문자열 `'None'`을 생성하던 문제를 수정했습니다.

개선 사항:
- 검색 컨텍스트 오버라이드에 대한 엄격한 타입 검증을 적용하여, `None`은 빈 컨텍스트로 처리하고 문자열이 아닌 타입은 명확한 에러와 함께 거부하도록 했습니다.
- 딥 웹 검색 결과 제한 및 기본값에 대해 명명된 상수를 도입하고, 이에 맞게 값 클램핑 로직과 메시지를 업데이트했습니다.

문서화:
- 딥 웹 검색 파라미터 제약 및 폴백 동작을 포함하여, 검색 플로우 컨텍스트 동작과 반환 타입을 docstring에서 더 명확히 설명했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen search flow context handling and centralize deep web search parameter limits.

Bug Fixes:
- Fix incorrect handling of None overrides in search flow that previously produced a truthy 'None' string.

Enhancements:
- Enforce strict type validation for search context overrides, treating None as empty context and rejecting non-string types with clear errors.
- Introduce named constants for deep web search result limits and default value, updating clamping logic and messaging accordingly.

Documentation:
- Clarify search flow context behavior and return types in docstrings, including deep web search parameter constraints and fallback behavior.

</details>