### PR TITLE
♻️ refactor [#11.11.3] 8차 개선 - 절단 오버플로우 수정 및 bool 타입 완전 차단

### DIFF
--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -392,13 +392,16 @@ def _resolve_base_context(state: AgentState, override: Any) -> str:
         
     # [Security/Performance] 복잡한 타입이나 거대한 객체가 그대로 문자열화되어
     # 컨텍스트를 과도하게 차지(Bloat)하거나 PII가 유출되는 것을 제한.
+    _TRUNCATION_SUFFIX = "...(truncated)"
     context_str = str(override)
     if len(context_str) > _MAX_SEARCH_CONTEXT_CHARS:
         logger.warning(
             "[Router] _resolve_base_context: 강제 변환된 문자열이 너무 길어 잘림 처리됩니다.",
-            extra={"original_length": len(context_str), "truncated_length": _MAX_SEARCH_CONTEXT_CHARS}
+            extra={"original_length": len(context_str), "limit": _MAX_SEARCH_CONTEXT_CHARS}
         )
-        context_str = context_str[:_MAX_SEARCH_CONTEXT_CHARS] + "...(truncated)"
+        # 최종 문자열이 _MAX_SEARCH_CONTEXT_CHARS를 넘지 않도록 접미사 길이를 미리 뺌
+        safe_slice_len = _MAX_SEARCH_CONTEXT_CHARS - len(_TRUNCATION_SUFFIX)
+        context_str = context_str[:safe_slice_len] + _TRUNCATION_SUFFIX
         
     return context_str
 

--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -25,6 +25,8 @@ _MAX_GREETING_LENGTH = 15
 # [Engineering Decision] 검색 결과 총합 토큰 예산 보호 (LLM 컨텍스트 윈도우 안전 범위 유지)
 # 명시적 int 타입 어노테이션 적용 → Pyre2가 Literal[8000]이아닌 int로 추론하도록 일치
 _MAX_SEARCH_CONTEXT_CHARS: int = 8_000
+# 긴 문자열 절단(Truncation) 시 끝에 붙이는 접미사 — 모듈 레벨 상수로 공유
+_TRUNCATION_SUFFIX: str = "...(truncated)"
 
 # Fallback Routing 관련 임계치 및 윈도우 사이즈
 FALLBACK_WINDOW_SIZE: int = 3
@@ -392,15 +394,15 @@ def _resolve_base_context(state: AgentState, override: Any) -> str:
         
     # [Security/Performance] 복잡한 타입이나 거대한 객체가 그대로 문자열화되어
     # 컨텍스트를 과도하게 차지(Bloat)하거나 PII가 유출되는 것을 제한.
-    _TRUNCATION_SUFFIX = "...(truncated)"
     context_str = str(override)
     if len(context_str) > _MAX_SEARCH_CONTEXT_CHARS:
         logger.warning(
             "[Router] _resolve_base_context: 강제 변환된 문자열이 너무 길어 잘림 처리됩니다.",
             extra={"original_length": len(context_str), "limit": _MAX_SEARCH_CONTEXT_CHARS}
         )
-        # 최종 문자열이 _MAX_SEARCH_CONTEXT_CHARS를 넘지 않도록 접미사 길이를 미리 뺌
-        safe_slice_len = _MAX_SEARCH_CONTEXT_CHARS - len(_TRUNCATION_SUFFIX)
+        # max(0, ...) 로 safe_slice_len이 음수가 되는 엣지케이스 방지
+        # (limit가 접미사보다 작더라도 빈 문자열 + 접미사로 안전하게 처리)
+        safe_slice_len = max(0, _MAX_SEARCH_CONTEXT_CHARS - len(_TRUNCATION_SUFFIX))
         context_str = context_str[:safe_slice_len] + _TRUNCATION_SUFFIX
         
     return context_str

--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -30,8 +30,8 @@ def _sanitize_search_limit(k: Any, tool_name: str) -> int:
     # 허용하지 않고, 명시적으로 기본값으로 되돌립니다.
     if isinstance(k, bool):
         logger.warning(
-            f"[Tool] {tool_name} - bool 타입 k 입력({k!r}) 감지. 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
-            extra={"tool_name": tool_name, "invalid_k": str(k)[:50]}
+            f"[Tool] {tool_name} - bool 타입 k 입력 감지. 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
+            extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__}
         )
         return _DEFAULT_SEARCH_LIMIT
 
@@ -39,7 +39,7 @@ def _sanitize_search_limit(k: Any, tool_name: str) -> int:
     if not isinstance(k, (int, str)):
         logger.warning(
             f"[Tool] {tool_name} - 비정상적인 k 타입({type(k).__name__}) 주입 시도. 잠재적 버그를 유발할 수 있습니다.",
-            extra={"tool_name": tool_name, "invalid_k": str(k)[:50]}
+            extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__}
         )
 
     try:
@@ -47,7 +47,7 @@ def _sanitize_search_limit(k: Any, tool_name: str) -> int:
     except (ValueError, TypeError):
         logger.warning(
             f"[Tool] {tool_name} - k 파라미터 타입 파싱 실패, 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
-            extra={"invalid_k": str(k)[:50], "tool_name": tool_name}
+            extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__}
         )
         return _DEFAULT_SEARCH_LIMIT
 

--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -26,11 +26,20 @@ def _sanitize_search_limit(k: Any, tool_name: str) -> int:
     들어온 k 파라미터를 파싱하고 제한 구역 내로 클램프합니다.
     [Comment 반영] 공통 헬퍼로 분리하여 로깅 및 검증 규칙 단일화.
     """
-    # 파이썬 특성상 bool은 int의 하위 클래스이므로 명시적으로 먼저 차단/경고
-    if isinstance(k, bool) or not isinstance(k, (int, str)):
+    # [Bug Fix] bool은 파이썬에서 int의 하위 클래스이므로 int(True)==1 같은 암묵적 변환을
+    # 허용하지 않고, 명시적으로 기본값으로 되돌립니다.
+    if isinstance(k, bool):
+        logger.warning(
+            f"[Tool] {tool_name} - bool 타입 k 입력({k!r}) 감지. 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
+            extra={"tool_name": tool_name, "invalid_k": str(k)[:50]}
+        )
+        return _DEFAULT_SEARCH_LIMIT
+
+    # int/str 이외의 비정상 타입도 경고 후 그대로 try/except에 위임
+    if not isinstance(k, (int, str)):
         logger.warning(
             f"[Tool] {tool_name} - 비정상적인 k 타입({type(k).__name__}) 주입 시도. 잠재적 버그를 유발할 수 있습니다.",
-            extra={"tool_name": tool_name}
+            extra={"tool_name": tool_name, "invalid_k": str(k)[:50]}
         )
 
     try:


### PR DESCRIPTION
- **[Truncation Off-by-one 버그 수정]**
  - `_resolve_base_context`에서 슬라이스 넘버링 실수를 수정: `str[:MAX] + suffix`→총 길이가 MAX를 초과하는 버그 패치.
  - 접미사(_TRUNCATION_SUFFIX) 길이를 먼저 빼고 슬라이스하여 최종 문자열 `_MAX_SEARCH_CONTEXT_CHARS`를 절대 초과하지 않도록 보장.

- **[bool 타입 k 조용한 버그 완전 차단]**
  - `_sanitize_search_limit`에서 bool 감지 시 단순 경고에 머무르지 않고 즉시 `_DEFAULT_SEARCH_LIMIT`으로 반환.
  - `int(True)==1` 처럼 검색 결과를 의도치 않게 1개로 제한하는 파이썬 암묵적 형변환 버그 원천 차단.

- **[경고 로그 스키마 일관화]**
  - bool 및 비정상 타입 경고 모두 `extra`에 `invalid_k` 필드 추가하여 두 경고 간 로그 스키마 완전 통일.

🔗 Related:
- Issue [#935]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1017#pullrequestreview-4083810091)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

도구 검색 파라미터의 정제 및 컨텍스트 잘라내기 로직을 개선하여 미묘한 버그를 방지하고 로깅 일관성을 향상합니다.

버그 수정:
- 잘린 컨텍스트 문자열이 잘림 접미사를 포함하더라도 허용되는 최대 길이를 절대 초과하지 않도록 보장합니다.
- 검색 제한 값 `k`에 전달된 bool 값이 암묵적으로 정수로 취급되지 않도록, 항상 기본 제한값을 사용하도록 합니다.
- int/str 이외의 타입이 검색 제한으로 전달될 때 핵심 동작을 변경하지 않고, 일관된 메타데이터를 로깅하도록 처리 방식을 개선합니다.

개선 사항:
- 잘못된 검색 제한 값에 대한 경고 로그 스키마를 통합하여, 문제가 되는 값을 전용 필드에 포함하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine tool search parameter sanitization and context truncation to prevent subtle bugs and improve logging consistency.

Bug Fixes:
- Ensure truncated context strings, including the truncation suffix, never exceed the maximum allowed length.
- Prevent bool values passed as search limit k from being implicitly treated as integers by always falling back to the default limit.
- Improve handling of non-int/str search limit types by logging consistent metadata without altering core behavior.

Enhancements:
- Unify warning log schema for invalid search limit values by including the offending value in a dedicated field.

</details>