### PR TITLE
♻️ refactor [#11.11.3] 10차 개선 - 중복 경고 제거 및 절단 가시성 개선

### DIFF
--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -396,13 +396,17 @@ def _resolve_base_context(state: AgentState, override: Any) -> str:
     # 컨텍스트를 과도하게 차지(Bloat)하거나 PII가 유출되는 것을 제한.
     context_str = str(override)
     if len(context_str) > _MAX_SEARCH_CONTEXT_CHARS:
+        # max(0, ...) 로 safe_slice_len이 음수가 되는 엣지케이스 방지
+        safe_slice_len = max(0, _MAX_SEARCH_CONTEXT_CHARS - len(_TRUNCATION_SUFFIX))
+        truncated_length = safe_slice_len + len(_TRUNCATION_SUFFIX)
         logger.warning(
             "[Router] _resolve_base_context: 강제 변환된 문자열이 너무 길어 잘림 처리됩니다.",
-            extra={"original_length": len(context_str), "limit": _MAX_SEARCH_CONTEXT_CHARS}
+            extra={
+                "original_length": len(context_str),
+                "limit": _MAX_SEARCH_CONTEXT_CHARS,
+                "truncated_length": truncated_length,
+            }
         )
-        # max(0, ...) 로 safe_slice_len이 음수가 되는 엣지케이스 방지
-        # (limit가 접미사보다 작더라도 빈 문자열 + 접미사로 안전하게 처리)
-        safe_slice_len = max(0, _MAX_SEARCH_CONTEXT_CHARS - len(_TRUNCATION_SUFFIX))
         context_str = context_str[:safe_slice_len] + _TRUNCATION_SUFFIX
         
     return context_str

--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -25,6 +25,9 @@ def _sanitize_search_limit(k: Any, tool_name: str) -> int:
     """
     들어온 k 파라미터를 파싱하고 제한 구역 내로 클램프합니다.
     [Comment 반영] 공통 헬퍼로 분리하여 로깅 및 검증 규칙 단일화.
+    - bool 타입: 파이썬에서 int의 하위 클래스이므로 명시적으로 먼저 차단.
+    - 나머지 비정상 타입(list, dict 등): int() 시도 후 실패 시 기본값 반환.
+      numpy.int64, Decimal 같은 int 유사 타입은 int()를 통해 정상 동작.
     """
     # [Bug Fix] bool은 파이썬에서 int의 하위 클래스이므로 int(True)==1 같은 암묵적 변환을
     # 허용하지 않고, 명시적으로 기본값으로 되돌립니다.
@@ -35,15 +38,8 @@ def _sanitize_search_limit(k: Any, tool_name: str) -> int:
         )
         return _DEFAULT_SEARCH_LIMIT
 
-    # int/str 이외의 비정상 타입은 즉시 기본값 반환 (중복 경고 방지)
-    if not isinstance(k, (int, str)):
-        logger.warning(
-            f"[Tool] {tool_name} - 비정상적인 k 타입({type(k).__name__}) 주입 시도. 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
-            extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__}
-        )
-        return _DEFAULT_SEARCH_LIMIT
-
-    # int 또는 str만 이 아래로 도달
+    # bool 이외의 모든 타입은 int() 변환 시도에 위임
+    # (numpy.int64, Decimal 등 int 유사 타입 호환성 유지)
     try:
         return max(_MIN_SEARCH_LIMIT, min(int(k), _MAX_SEARCH_LIMIT))
     except (ValueError, TypeError):

--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -35,13 +35,15 @@ def _sanitize_search_limit(k: Any, tool_name: str) -> int:
         )
         return _DEFAULT_SEARCH_LIMIT
 
-    # int/str 이외의 비정상 타입도 경고 후 그대로 try/except에 위임
+    # int/str 이외의 비정상 타입은 즉시 기본값 반환 (중복 경고 방지)
     if not isinstance(k, (int, str)):
         logger.warning(
-            f"[Tool] {tool_name} - 비정상적인 k 타입({type(k).__name__}) 주입 시도. 잠재적 버그를 유발할 수 있습니다.",
+            f"[Tool] {tool_name} - 비정상적인 k 타입({type(k).__name__}) 주입 시도. 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
             extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__}
         )
+        return _DEFAULT_SEARCH_LIMIT
 
+    # int 또는 str만 이 아래로 도달
     try:
         return max(_MIN_SEARCH_LIMIT, min(int(k), _MAX_SEARCH_LIMIT))
     except (ValueError, TypeError):


### PR DESCRIPTION
- **[중복 경고 노이즈 제거]**
  - `_sanitize_search_limit`에서 비정상 타입(non-int/str) 감지 시 경고 후 즉시 기본값 반환. 기존에는 경고 → `int(k)` 실패 → 2번째 경고로 이중 노이즈 발생하던 구조 해소.

- **[절단 로그 가시성 개선]**
  - `_resolve_base_context` 절단 경고에 `truncated_length` 필드 추가. `safe_slice_len`을 로깅 전에 먼저 계산하여 실제 잘린 결과 길이를 observability 로그에 명시적으로 포함.

🔗 Related:
- Issue [#935]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1019#pullrequestreview-4083919482)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

검색 제한(srch limit) 정규화와 기본 컨텍스트 잘림(truncation) 동작 주변의 로깅 방식을 개선하여, 불필요한 경고를 줄이고 잘림 현상에 대한 관측 가능성을 높입니다.

버그 수정:
- 검색 제한 값으로 int/str 이 아닌 값이 전달될 때 즉시 기본값으로 되돌아가도록 하여, 중복 경고가 발생하지 않도록 합니다.
- 잘림(truncation)에 안전한 슬라이스 길이를 로깅 전에 계산하고, 더 나은 진단을 위해 잘림 경고 메타데이터에 실제 잘린 길이를 포함하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve logging behavior around search limit sanitization and base context truncation to reduce noisy warnings and increase observability of truncation.

Bug Fixes:
- Prevent duplicate warnings when non-int/str values are passed as search limits by immediately falling back to the default value.
- Ensure truncation-safe slicing length is computed before logging, and expose the resulting truncated length in the truncation warning metadata for better diagnostics.

</details>