### PR TITLE
♻️ refactor [#11.11.3] 14차 개선 - float 절단 경고 정밀화 및 repr 안전 로깅

### DIFF
--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -40,11 +40,12 @@ def _sanitize_search_limit(k: Any, tool_name: str) -> int:
         )
         return _DEFAULT_SEARCH_LIMIT
 
-    # float 타입: int()로 소수점이 조용히 절단되므로 가시성 확보를 위해 경고 후 진행
-    if isinstance(k, float):
+    # float 타입: int()로 소수점이 조용히 절단되므로 가시성 확보를 위해 경고 후 진행.
+    # k.is_integer()가 True인 경우(예: 5.0)는 절단 손실이 없으므로 경고 생략하여 로그 노이즈 방지.
+    if isinstance(k, float) and not k.is_integer():
         logger.warning(
             f"[Tool] {tool_name} - float 타입 k 감지. 소수점 이하를 절단하여 처리합니다. (의도된 경우 int 타입으로 전달 권장)",
-            extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": float(k)}
+            extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": repr(k)}
         )
         # 경고 후 int()로 절단 → 클램핑 계속 진행
 

--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -7,6 +7,7 @@ from backend.services.hybrid_search_service import get_hybrid_search_service  # 
 
 import os
 import asyncio
+import math
 from tavily import TavilyClient
 
 logger = logging.getLogger(__name__)
@@ -40,20 +41,30 @@ def _sanitize_search_limit(k: Any, tool_name: str) -> int:
         )
         return _DEFAULT_SEARCH_LIMIT
 
-    # float 타입: int()로 소수점이 조용히 절단되므로 가시성 확보를 위해 경고 후 진행.
-    # k.is_integer()가 True인 경우(예: 5.0)는 절단 손실이 없으므로 경고 생략하여 로그 노이즈 방지.
-    if isinstance(k, float) and not k.is_integer():
-        logger.warning(
-            f"[Tool] {tool_name} - float 타입 k 감지. 소수점 이하를 절단하여 처리합니다. (의도된 경우 int 타입으로 전달 권장)",
-            extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": repr(k)}
-        )
+    # float 타입: NaN/inf 먼저 차단 후 소수점 절단 가시화
+    # k.is_integer()가 True인 경우(예: 5.0)는 절단 손실 없으므로 경고 생략
+    if isinstance(k, float):
+        if not math.isfinite(k):
+            # int(inf) → OverflowError, int(nan) → ValueError: 모두 except에 위임 가능하나
+            # 명확한 의미 전달을 위해 여기서 먼저 차단
+            logger.warning(
+                f"[Tool] {tool_name} - NaN/inf float k 감지. 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
+                extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": repr(k)[:50]}
+            )
+            return _DEFAULT_SEARCH_LIMIT
+
+        if not k.is_integer():
+            logger.warning(
+                f"[Tool] {tool_name} - float 타입 k 감지. 소수점 이하를 절단하여 처리합니다. (의도된 경우 int 타입으로 전달 권장)",
+                extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": repr(k)[:50]}
+            )
         # 경고 후 int()로 절단 → 클램핑 계속 진행
 
     # bool/float 이외의 모든 타입은 int() 변환 시도에 위임
     # (numpy.int64, Decimal 등 int 유사 타입 호환성 유지)
     try:
         return max(_MIN_SEARCH_LIMIT, min(int(k), _MAX_SEARCH_LIMIT))
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, OverflowError):
         logger.warning(
             f"[Tool] {tool_name} - k 파라미터 타입 파싱 실패, 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
             extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__}


### PR DESCRIPTION
- float 경고 조건을 not k.is_integer()로 좁혀 5.0처럼 손실 없는 정수 float의 불필요한 경고를 제거하여 로그 노이즈 방지.
- raw_k 로그값을 float(k) 에서 repr(k)로 변경하여 numpy.float64 등 비표준 float 유사 타입의 변환 오류를 방지하고 정밀도 손실 없이 기록.

🔗 Related:
- Issue [#935]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1023#pullrequestreview-4084044137)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

float 입력에 대한 검색 제한(sanitization) 로깅을 개선하여 불필요한 로그를 줄이고 변환 문제를 방지합니다.

버그 수정:
- `float`로 캐스팅하지 않고 `repr`로 원시 값을 기록하도록 하여, 비표준 float 유사 타입을 로깅할 때 발생하는 변환 오류를 피합니다.

개선 사항:
- 5.0처럼 정수와 동등한 float 값에 대해 불필요한 로그 노이즈가 생기지 않도록, float 잘림(truncation) 경고를 비정수 float 값에만 한정합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine search limit sanitization logging for float inputs to reduce noise and avoid conversion issues.

Bug Fixes:
- Avoid conversion errors when logging non-standard float-like types by recording the raw value with repr instead of casting to float.

Enhancements:
- Narrow float truncation warnings to only non-integer float values to prevent unnecessary log noise for integer-equivalent floats like 5.0.

</details>