### PR TITLE
♻️ refactor [#11.11.3] 16차 개선 - 파싱 예외 로깅의 Observability 강화 및 상수화

### DIFF
--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 _MAX_DOC_CONTENT_CHARS = 1_000
 # [Security] 로그에 포함되는 doc_id의 최대 길이 제한 (PII 경계값 명시)
 _MAX_LOG_DOC_ID_LEN = 50
+# [Observability] 로깅 시 에러 원인 추적을 위해 남기는 원본 값 k의 최대 노출 길이 제한
+_MAX_LOG_RAW_K_CHARS = 50
 
 # API 통신 부하 및 비용 방지를 위한 외부 검색 타겟 개수 제한 (하드코딩 분리)
 _MIN_SEARCH_LIMIT = 1
@@ -37,7 +39,7 @@ def _sanitize_search_limit(k: Any, tool_name: str) -> int:
     if isinstance(k, bool):
         logger.warning(
             f"[Tool] {tool_name} - bool 타입 k 입력 감지. 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
-            extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__}
+            extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": repr(k)[:_MAX_LOG_RAW_K_CHARS]}
         )
         return _DEFAULT_SEARCH_LIMIT
 
@@ -49,14 +51,14 @@ def _sanitize_search_limit(k: Any, tool_name: str) -> int:
             # 명확한 의미 전달을 위해 여기서 먼저 차단
             logger.warning(
                 f"[Tool] {tool_name} - NaN/inf float k 감지. 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
-                extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": repr(k)[:50]}
+                extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": repr(k)[:_MAX_LOG_RAW_K_CHARS]}
             )
             return _DEFAULT_SEARCH_LIMIT
 
         if not k.is_integer():
             logger.warning(
                 f"[Tool] {tool_name} - float 타입 k 감지. 소수점 이하를 절단하여 처리합니다. (의도된 경우 int 타입으로 전달 권장)",
-                extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": repr(k)[:50]}
+                extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": repr(k)[:_MAX_LOG_RAW_K_CHARS]}
             )
         # 경고 후 int()로 절단 → 클램핑 계속 진행
 
@@ -67,7 +69,7 @@ def _sanitize_search_limit(k: Any, tool_name: str) -> int:
     except (ValueError, TypeError, OverflowError):
         logger.warning(
             f"[Tool] {tool_name} - k 파라미터 타입 파싱 실패, 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
-            extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__}
+            extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": repr(k)[:_MAX_LOG_RAW_K_CHARS]}
         )
         return _DEFAULT_SEARCH_LIMIT
 


### PR DESCRIPTION
- **[트러블슈팅 가시성 극대화]**
  - 마지막 파싱 실패(ValueError, TypeError, OverflowError) 및 bool 타입 식별 블록의 경고 로그에도 raw_k 값을 추가하여, 도구 호출 실패 시 LLM이 넘긴 비정상 원본 데이터를 운영 로그에서 즉시 확인할 수 있도록 보완.
- **[매직 넘버 상수화]**
  - 로그 노출 길이 제한용으로 쓰인 매직 넘버 50을 상수(_MAX_LOG_RAW_K_CHARS)로 분리하여, 향후 로깅 길이 정책 조정 시 대응하기 쉽도록 유지보수성 향상.

🔗 Related:
- Issue [#935]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1025#pullrequestreview-4084175026)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

도구 파라미터 파싱 실패에 대한 가시성을 향상하고, 원시 입력 값에 대한 로그 길이 설정을 중앙에서 관리하도록 개선합니다.

개선 사항:
- 도구 호출 디버깅을 돕기 위해, 유효하지 않거나 파싱할 수 없는 k 파라미터에 대해 경고 로그에 `raw_k` 값을 추가합니다.
- 인라인 매직 넘버 대신, `raw_k` 값의 로그 길이를 제한하기 위한 전용 상수를 도입합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve observability of tool parameter parsing failures and centralize logging length configuration for raw input values.

Enhancements:
- Add raw_k value to warning logs for invalid or unparsable k parameters to aid debugging of tool invocations.
- Introduce a dedicated constant for limiting the logged length of raw_k values instead of using an inline magic number.

</details>