### PR TITLE
♻️ refactor [#11.11.3] 17차 개선 - 로깅 헬퍼 분리 및 PII 로그 유출 원천 방어

### DIFF
--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -16,13 +16,31 @@ logger = logging.getLogger(__name__)
 _MAX_DOC_CONTENT_CHARS = 1_000
 # [Security] 로그에 포함되는 doc_id의 최대 길이 제한 (PII 경계값 명시)
 _MAX_LOG_DOC_ID_LEN = 50
-# [Observability] 로깅 시 에러 원인 추적을 위해 남기는 원본 값 k의 최대 노출 길이 제한
-_MAX_LOG_RAW_K_CHARS = 50
 
 # API 통신 부하 및 비용 방지를 위한 외부 검색 타겟 개수 제한 (하드코딩 분리)
 _MIN_SEARCH_LIMIT = 1
 _MAX_SEARCH_LIMIT = 10
 _DEFAULT_SEARCH_LIMIT = 5
+
+def _build_k_logging_extra(tool_name: str, k: Any) -> Dict[str, Any]:
+    """
+    [Security/Observability] k 파라미터 로깅 시 중복을 제거하고,
+    PII나 비밀 데이터 유출을 방어하기 위해 컨테이너 타입은 값 대신 메타데이터(길이)만 남깁니다.
+    """
+    extra: Dict[str, Any] = {
+        "tool_name": tool_name,
+        "invalid_k_type": type(k).__name__,
+    }
+    # 숫자형(int, float, bool)은 PII 위험이 없으므로 값 자체가 로깅에 유용함
+    if isinstance(k, (int, float, bool)):
+        extra["raw_k_value"] = k
+    else:
+        # 그 외 문자열이나 구조화된 데이터는 PII 유출 우려가 있으므로 값 대신 길이만 보존
+        try:
+            extra["raw_k_length"] = len(k)
+        except TypeError:
+            extra["raw_k_length"] = "unknown"
+    return extra
 
 def _sanitize_search_limit(k: Any, tool_name: str) -> int:
     """
@@ -39,7 +57,7 @@ def _sanitize_search_limit(k: Any, tool_name: str) -> int:
     if isinstance(k, bool):
         logger.warning(
             f"[Tool] {tool_name} - bool 타입 k 입력 감지. 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
-            extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": repr(k)[:_MAX_LOG_RAW_K_CHARS]}
+            extra=_build_k_logging_extra(tool_name, k)
         )
         return _DEFAULT_SEARCH_LIMIT
 
@@ -51,14 +69,14 @@ def _sanitize_search_limit(k: Any, tool_name: str) -> int:
             # 명확한 의미 전달을 위해 여기서 먼저 차단
             logger.warning(
                 f"[Tool] {tool_name} - NaN/inf float k 감지. 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
-                extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": repr(k)[:_MAX_LOG_RAW_K_CHARS]}
+                extra=_build_k_logging_extra(tool_name, k)
             )
             return _DEFAULT_SEARCH_LIMIT
 
         if not k.is_integer():
             logger.warning(
                 f"[Tool] {tool_name} - float 타입 k 감지. 소수점 이하를 절단하여 처리합니다. (의도된 경우 int 타입으로 전달 권장)",
-                extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": repr(k)[:_MAX_LOG_RAW_K_CHARS]}
+                extra=_build_k_logging_extra(tool_name, k)
             )
         # 경고 후 int()로 절단 → 클램핑 계속 진행
 
@@ -69,7 +87,7 @@ def _sanitize_search_limit(k: Any, tool_name: str) -> int:
     except (ValueError, TypeError, OverflowError):
         logger.warning(
             f"[Tool] {tool_name} - k 파라미터 타입 파싱 실패, 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
-            extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": repr(k)[:_MAX_LOG_RAW_K_CHARS]}
+            extra=_build_k_logging_extra(tool_name, k)
         )
         return _DEFAULT_SEARCH_LIMIT
 


### PR DESCRIPTION
- **[보안(Security) 취약점 해결]**
  - LLM이 잘못 파싱된 거대한 문자열(PII 포함 가능), 리스트 등을 주입할 때 `repr(k)`를 통해 운영 로그에 민감 데이터가 유출되는 것을 차단.
  - _build_k_logging_extra 헬퍼를 도입하여 문자열/구조체는 '값' 대신 '길이(raw_k_length)'만 안전하게 메타데이터로 남기도록 로깅 정책 구조화.
  - 숫자형(int, float, bool)은 PII 위험이 없으므로 raw_k_value로 로깅하여 원래 목적이던 디버깅 용이성 유지.

- **[코드 중복 제거(DRY)]**
  - 분기마다 중복되던 _sanitize_search_limit 로그의 extra 딕셔너리 구축 로직 일원화.

🔗 Related:
- Issue [#935]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1027#pullrequestreview-4084229030)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

PII 노출을 방지하면서 잘못된 `k` 값에 대한 로깅 메타데이터 구성을 중앙집중화하도록 도구 파라미터 로깅을 개선합니다.

버그 수정:
- 숫자가 아닌 타입의 `k` 값에 대해 원시 값을 직접 로깅하는 대신 길이 기반 메타데이터로 대체하여, `k`에 포함될 수 있는 잠재적인 PII나 대용량 구조화 값이 로그에 기록되지 않도록 합니다.

개선 사항:
- `_sanitize_search_limit` 전반에서 잘못된 `k` 값에 대한 로깅 메타데이터를 표준화하기 위해 공용 헬퍼 `_build_k_logging_extra`를 도입합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine tool parameter logging to prevent PII leakage while centralizing logging metadata construction for invalid `k` values.

Bug Fixes:
- Prevent potential PII or large structured values in `k` from being logged by replacing raw value logging with length-based metadata for non-numeric types.

Enhancements:
- Introduce a shared `_build_k_logging_extra` helper to standardize logging metadata for invalid `k` values across `_sanitize_search_limit`.

</details>