### PR TITLE
Feature/v8 phase5 data flywheel

### DIFF
--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -16,13 +16,31 @@ logger = logging.getLogger(__name__)
 _MAX_DOC_CONTENT_CHARS = 1_000
 # [Security] 로그에 포함되는 doc_id의 최대 길이 제한 (PII 경계값 명시)
 _MAX_LOG_DOC_ID_LEN = 50
-# [Observability] 로깅 시 에러 원인 추적을 위해 남기는 원본 값 k의 최대 노출 길이 제한
-_MAX_LOG_RAW_K_CHARS = 50
 
 # API 통신 부하 및 비용 방지를 위한 외부 검색 타겟 개수 제한 (하드코딩 분리)
 _MIN_SEARCH_LIMIT = 1
 _MAX_SEARCH_LIMIT = 10
 _DEFAULT_SEARCH_LIMIT = 5
+
+def _build_k_logging_extra(tool_name: str, k: Any) -> Dict[str, Any]:
+    """
+    [Security/Observability] k 파라미터 로깅 시 중복을 제거하고,
+    PII나 비밀 데이터 유출을 방어하기 위해 컨테이너 타입은 값 대신 메타데이터(길이)만 남깁니다.
+    """
+    extra: Dict[str, Any] = {
+        "tool_name": tool_name,
+        "invalid_k_type": type(k).__name__,
+    }
+    # 숫자형(int, float, bool)은 PII 위험이 없으므로 값 자체가 로깅에 유용함
+    if isinstance(k, (int, float, bool)):
+        extra["raw_k_value"] = k
+    else:
+        # 그 외 문자열이나 구조화된 데이터는 PII 유출 우려가 있으므로 값 대신 길이만 보존
+        try:
+            extra["raw_k_length"] = len(k)
+        except TypeError:
+            extra["raw_k_length"] = "unknown"
+    return extra
 
 def _sanitize_search_limit(k: Any, tool_name: str) -> int:
     """
@@ -39,7 +57,7 @@ def _sanitize_search_limit(k: Any, tool_name: str) -> int:
     if isinstance(k, bool):
         logger.warning(
             f"[Tool] {tool_name} - bool 타입 k 입력 감지. 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
-            extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": repr(k)[:_MAX_LOG_RAW_K_CHARS]}
+            extra=_build_k_logging_extra(tool_name, k)
         )
         return _DEFAULT_SEARCH_LIMIT
 
@@ -51,14 +69,14 @@ def _sanitize_search_limit(k: Any, tool_name: str) -> int:
             # 명확한 의미 전달을 위해 여기서 먼저 차단
             logger.warning(
                 f"[Tool] {tool_name} - NaN/inf float k 감지. 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
-                extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": repr(k)[:_MAX_LOG_RAW_K_CHARS]}
+                extra=_build_k_logging_extra(tool_name, k)
             )
             return _DEFAULT_SEARCH_LIMIT
 
         if not k.is_integer():
             logger.warning(
                 f"[Tool] {tool_name} - float 타입 k 감지. 소수점 이하를 절단하여 처리합니다. (의도된 경우 int 타입으로 전달 권장)",
-                extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": repr(k)[:_MAX_LOG_RAW_K_CHARS]}
+                extra=_build_k_logging_extra(tool_name, k)
             )
         # 경고 후 int()로 절단 → 클램핑 계속 진행
 
@@ -69,7 +87,7 @@ def _sanitize_search_limit(k: Any, tool_name: str) -> int:
     except (ValueError, TypeError, OverflowError):
         logger.warning(
             f"[Tool] {tool_name} - k 파라미터 타입 파싱 실패, 기본값({_DEFAULT_SEARCH_LIMIT})으로 폴백합니다.",
-            extra={"tool_name": tool_name, "invalid_k_type": type(k).__name__, "raw_k": repr(k)[:_MAX_LOG_RAW_K_CHARS]}
+            extra=_build_k_logging_extra(tool_name, k)
         )
         return _DEFAULT_SEARCH_LIMIT
 


### PR DESCRIPTION
♻️ refactor [#11.11.3] 17차 개선 - 로깅 헬퍼 분리 및 PII 로그 유출 원천 방어

## Summary by Sourcery

검색 제한값 정규화를 강화하기 위해, k 로깅 동작을 중앙집중화하고 로그에 잠재적으로 민감한 데이터가 노출되는 범위를 줄였습니다.

Bug Fixes:
- 도구 검색 제한을 위한 비숫자형 k 값의 원본을 더 이상 로그에 남기지 않도록 하여, 잠재적인 PII 또는 비밀 데이터 누출을 방지합니다.

Enhancements:
- k 파라미터를 위한 공용 로깅 헬퍼를 도입했습니다. 숫자형 값은 그대로 로그에 기록하되, 컨테이너나 문자열과 유사한 타입은 메타데이터(길이)만 기록하도록 하여, 개인정보 보호를 유지하면서도 관측 가능성을 향상합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden tool parameter logging for search limit sanitization by centralizing k logging behavior and reducing exposure of potentially sensitive data in logs.

Bug Fixes:
- Prevent potential PII or secret data leakage by no longer logging raw non-numeric k values for tool search limits.

Enhancements:
- Introduce a shared logging helper for k parameters that logs numeric values directly but only metadata (length) for container or string-like types to improve observability while preserving privacy.

</details>