### PR TITLE
♻️ refactor [#11.11.3] 18차 개선 - 로깅 헬퍼 성능 및 견고성 완결

### DIFF
--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -8,6 +8,7 @@ from backend.services.hybrid_search_service import get_hybrid_search_service  # 
 import os
 import asyncio
 import math
+import numbers
 from collections.abc import Sized
 from tavily import TavilyClient
 
@@ -23,6 +24,23 @@ _MIN_SEARCH_LIMIT = 1
 _MAX_SEARCH_LIMIT = 10
 _DEFAULT_SEARCH_LIMIT = 5
 
+def _format_numeric_safe(k: Any) -> str:
+    """
+    수치형 데이터를 안전하게 문자열로 변환하여 로깅 시 지수 표기법(Scientific Notation) 잘림이나 부호 유실을 방지합니다.
+    """
+    try:
+        val = float(k)
+        formatted = f"{val:.10g}"
+        if len(formatted) > 20:
+            return formatted[:17] + "..."
+        return formatted
+    except Exception:
+        # float 변환이 불가할 정도의 초거대 정수나 특이 수치 표현식은 단순 문자열화 후 안전하게 절단
+        s = str(k)
+        if len(s) > 20:
+            return s[:17] + "..."
+        return s
+
 def _build_k_logging_extra(tool_name: str, k: Any) -> Dict[str, Any]:
     """
     [Security/Observability] k 파라미터 로깅 시 중복을 제거하고,
@@ -34,10 +52,10 @@ def _build_k_logging_extra(tool_name: str, k: Any) -> Dict[str, Any]:
     }
     if isinstance(k, bool):
         extra["raw_k_value"] = k
-    elif isinstance(k, (int, float)):
-        # 극한의 수치(예: 1e100, 초거대 정수)에 의한 로그 부하 및 노이즈 방지를 위해 문자열 변환 후 20자 제한.
-        # 숫자 타입이므로 PII 위험은 없지만 시스템 관측성을 안전하게 유지하기 위함.
-        extra["raw_k_value"] = str(k)[:20]
+    elif isinstance(k, numbers.Number):
+        # 숫자형(int, float, Decimal, numpy 스칼라 등)은 
+        # 극한의 수치에 의한 로그 부하 방지 및 지수 표기법 유지를 위해 헬퍼로 포맷팅
+        extra["raw_k_value"] = _format_numeric_safe(k)
     else:
         # 그 외 문자열이나 구조화된 데이터는 PII 유출 우려가 있으므로 값 대신 길이만 보존
         # Sized 구현체인지 명시적으로 검사하여 제너레이터 등에서 예외 발생 오버헤드 방지

--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -8,6 +8,7 @@ from backend.services.hybrid_search_service import get_hybrid_search_service  # 
 import os
 import asyncio
 import math
+from collections.abc import Sized
 from tavily import TavilyClient
 
 logger = logging.getLogger(__name__)
@@ -31,14 +32,18 @@ def _build_k_logging_extra(tool_name: str, k: Any) -> Dict[str, Any]:
         "tool_name": tool_name,
         "invalid_k_type": type(k).__name__,
     }
-    # 숫자형(int, float, bool)은 PII 위험이 없으므로 값 자체가 로깅에 유용함
-    if isinstance(k, (int, float, bool)):
+    if isinstance(k, bool):
         extra["raw_k_value"] = k
+    elif isinstance(k, (int, float)):
+        # 극한의 수치(예: 1e100, 초거대 정수)에 의한 로그 부하 및 노이즈 방지를 위해 문자열 변환 후 20자 제한.
+        # 숫자 타입이므로 PII 위험은 없지만 시스템 관측성을 안전하게 유지하기 위함.
+        extra["raw_k_value"] = str(k)[:20]
     else:
         # 그 외 문자열이나 구조화된 데이터는 PII 유출 우려가 있으므로 값 대신 길이만 보존
-        try:
+        # Sized 구현체인지 명시적으로 검사하여 제너레이터 등에서 예외 발생 오버헤드 방지
+        if isinstance(k, Sized):
             extra["raw_k_length"] = len(k)
-        except TypeError:
+        else:
             extra["raw_k_length"] = "unknown"
     return extra
 


### PR DESCRIPTION
- **[로깅 성능(오버헤드) 최적화]**
  - 길이를 알 수 없는 커스텀/반복자(iterator) 객체가 헬퍼에 들어왔을 때, 단순 TypeError에 의존하지 않고 collections.abc.Sized 구현체인지 사전 검증(isinstance)하여 안전하고 가볍게 len()을 호출하도록 최적화.
- **[숫자형 로그 블로트(Bloat) 차단]**
  - 실수나 악의로 초거대 수치값(예: 1e100, 거대 정수)이 k로 유입되었을 때, 노이즈가 그대로 로깅되지 않도록 str(k)[:20]으로 클램핑(Clamping) 제한 추가.
  - 관측 가능성(Observability)과 시스템 안정성을 동시에 충족.

🔗 Related:
- Issue [#935]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1029#pullrequestreview-4084288456)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

잘못된 도구 파라미터 값에 대한 로깅 헬퍼 동작을 최적화하여 성능을 개선하고 불필요한 수치 로그를 줄였습니다.

개선 사항:
- 관측 가능성을 유지하면서도, 지나치게 큰 정수나 부동소수점 수로 인해 로그가 비대해지는 것을 막기 위해, 기록되는 숫자 값을 최대 20자 길이의 문자열로 제한(clamp)합니다.
- 숫자가 아닌 값에 대해 길이를 로깅할 때 `len()` 사용으로 인한 TypeError 오버헤드를 피하기 위해, 먼저 해당 값이 `Sized`인지 명시적으로 확인하고, 그렇지 않은 경우에는 길이를 "unknown"으로 기록하도록 처리합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize logging helper behavior for invalid tool parameter values to improve performance and reduce noisy numeric logs.

Enhancements:
- Clamp logged numeric values to a 20-character string to avoid log bloat from extremely large integers or floats while preserving observability.
- Avoid len() TypeError overhead by explicitly checking whether non-numeric values are Sized before logging their length, falling back to an "unknown" length when not.

</details>