### PR TITLE
♻️ refactor [#11.11.3] 20차 개선 - 수치 변환 정밀도(Precision) 보존 및 하드코딩 제거

### DIFF
--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -21,6 +21,7 @@ _MAX_DOC_CONTENT_CHARS = 1_000
 _MAX_LOG_DOC_ID_LEN = 50
 # [Observability] 로깅 시 에러 원인 추적을 위해 남기는 수치형(k) 문자열의 최대 길이 제한
 _MAX_LOG_NUMERIC_CHARS = 20
+_ELLIPSIS = "..."
 
 # API 통신 부하 및 비용 방지를 위한 외부 검색 타겟 개수 제한 (하드코딩 분리)
 _MIN_SEARCH_LIMIT = 1
@@ -40,13 +41,13 @@ def _format_numeric_safe(k: Any) -> str:
             # float 변환 가능한 수치형인 경우 과학적 표기법 등으로 정밀 제어
             val = float(k)
             s = f"{val:.10g}"
-        except Exception:
+        except (ValueError, TypeError, OverflowError):
             # 특이 수치 표현식은 단순 문자열화
             s = str(k)
             
     if len(s) > _MAX_LOG_NUMERIC_CHARS:
-        # 길이 초과 시 끝부분을 '...'으로 치환하여 하드코딩 없이 안전하게 절단
-        return s[:_MAX_LOG_NUMERIC_CHARS - 3] + "..."
+        # 길이 초과 시 끝부분을 _ELLIPSIS 로 치환하여 하드코딩 없이 안전하게 절단
+        return s[:_MAX_LOG_NUMERIC_CHARS - len(_ELLIPSIS)] + _ELLIPSIS
     return s
 
 def _build_k_logging_extra(tool_name: str, k: Any) -> Dict[str, Any]:

--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -9,6 +9,7 @@ import os
 import asyncio
 import math
 import numbers
+import decimal
 from collections.abc import Sized
 from tavily import TavilyClient
 
@@ -18,6 +19,8 @@ logger = logging.getLogger(__name__)
 _MAX_DOC_CONTENT_CHARS = 1_000
 # [Security] 로그에 포함되는 doc_id의 최대 길이 제한 (PII 경계값 명시)
 _MAX_LOG_DOC_ID_LEN = 50
+# [Observability] 로깅 시 에러 원인 추적을 위해 남기는 수치형(k) 문자열의 최대 길이 제한
+_MAX_LOG_NUMERIC_CHARS = 20
 
 # API 통신 부하 및 비용 방지를 위한 외부 검색 타겟 개수 제한 (하드코딩 분리)
 _MIN_SEARCH_LIMIT = 1
@@ -26,20 +29,25 @@ _DEFAULT_SEARCH_LIMIT = 5
 
 def _format_numeric_safe(k: Any) -> str:
     """
-    수치형 데이터를 안전하게 문자열로 변환하여 로깅 시 지수 표기법(Scientific Notation) 잘림이나 부호 유실을 방지합니다.
+    수치형 데이터를 안전하게 문자열로 변환하여 로깅 시 지수 표기법(Scientific Notation) 잘림이나 
+    거대 정수/Decimal의 정밀도 유실을 방지합니다.
     """
-    try:
-        val = float(k)
-        formatted = f"{val:.10g}"
-        if len(formatted) > 20:
-            return formatted[:17] + "..."
-        return formatted
-    except Exception:
-        # float 변환이 불가할 정도의 초거대 정수나 특이 수치 표현식은 단순 문자열화 후 안전하게 절단
+    # 정수(int, bool)와 Decimal은 float 변환 시 정밀도(precision) 손실이 발생할 수 있으므로 그대로 문자열화
+    if isinstance(k, (numbers.Integral, decimal.Decimal)):
         s = str(k)
-        if len(s) > 20:
-            return s[:17] + "..."
-        return s
+    else:
+        try:
+            # float 변환 가능한 수치형인 경우 과학적 표기법 등으로 정밀 제어
+            val = float(k)
+            s = f"{val:.10g}"
+        except Exception:
+            # 특이 수치 표현식은 단순 문자열화
+            s = str(k)
+            
+    if len(s) > _MAX_LOG_NUMERIC_CHARS:
+        # 길이 초과 시 끝부분을 '...'으로 치환하여 하드코딩 없이 안전하게 절단
+        return s[:_MAX_LOG_NUMERIC_CHARS - 3] + "..."
+    return s
 
 def _build_k_logging_extra(tool_name: str, k: Any) -> Dict[str, Any]:
     """


### PR DESCRIPTION
- **[정밀도 손실(Precision loss) 방어]**
  - _format_numeric_safe에서 모든 수치를 무조건 float()으로 변환하던 로직 수정.
  - Decimal 이나 초거대 정수(numbers.Integral)의 경우 float 변환 시 데이터가 왜곡(Loss)되거나 OverflowError가 발생할 수 있으므로 float 캐스팅을 우회하고 원본 문자열을 유지한 채 절단하도록 분기 분리.

- **[매직 넘버(Magic Number) 상수화]**
  - 숫자 로깅 절단 길이인 20, 17을 하드코딩하지 않고, _MAX_LOG_NUMERIC_CHARS 상수(20)를 도입하여 (상수 - 3) 형태로 동적으로 `...` 문자를 덧붙이도록 클린 코드화 적용.

🔗 Related:
- Issue [#935]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1031#pullrequestreview-4084376728)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

로깅을 위한 숫자 값 포매팅 시, 숫자 정밀도를 보존하고 하드코딩된 잘림 길이를 제거합니다.

개선 사항:
- 로그에 기록되는 숫자 문자열의 최대 길이를 하드코딩된 값 대신 제어하기 위해, 공통 상수 `_MAX_LOG_NUMERIC_CHARS` 를 추가합니다.
- 너무 긴 숫자 표현을 안전하게 잘라내는 동시에, 큰 정수와 `Decimal` 타입에서 정밀도 손실이 발생하지 않도록 `_format_numeric_safe` 를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve numeric precision and remove hardcoded truncation lengths when formatting numeric values for logging.

Enhancements:
- Add a shared _MAX_LOG_NUMERIC_CHARS constant to control the maximum length of logged numeric strings instead of hardcoded values.
- Update _format_numeric_safe to avoid precision loss for large integers and Decimals while still safely truncating overly long numeric representations.

</details>