### PR TITLE
♻️ refactor [#12.1.2] 2차 개선 - 타임아웃 관측성 및 정밀도 강화

### DIFF
--- a/backend/services/finetune_service.py
+++ b/backend/services/finetune_service.py
@@ -381,8 +381,9 @@ async def poll_finetune_job_until_done(job_id: str) -> FinetuneJobStatus:
         logger.error("[OBS] Cannot poll fine-tuning job: API client creation failed.", extra={"error": str(e)})
         return FinetuneJobStatus.FAILED
 
-    # 실제 밽시계 시간 기반으로 타임아웃 측정 (jobs.retrieve 지연 시간 포함)
-    deadline: float = time.monotonic() + _FINETUNE_POLL_TIMEOUT_SECS
+    # 실제 벽시계 시간 기반으로 타임아웃 측정 (jobs.retrieve 지연 시간 포함)
+    start_time: float = time.monotonic()
+    deadline: float = start_time + _FINETUNE_POLL_TIMEOUT_SECS
 
     logger.info(
         "[OBS] Starting fine-tuning job polling.",
@@ -397,11 +398,16 @@ async def poll_finetune_job_until_done(job_id: str) -> FinetuneJobStatus:
     # 이후 순환부터 sleep을 선행하여 불필요한 API 호출 빈도를 조절합니다.
     first_attempt = True
 
-    while time.monotonic() < deadline:
+    while True:
+        # 이터레이션 시작 시 한 번만 샘플링하여 루프 내 time.monotonic() 호출 불일치 방지
+        now: float = time.monotonic()
+        if now >= deadline:
+            break
         if not first_attempt:
             await asyncio.sleep(_FINETUNE_POLL_INTERVAL_SECS)
-            # deadline 차감 넌지 time.monotonic()으로 언제나 정확하게 확인
-            if time.monotonic() >= deadline:
+            # deadline을 차감하는 대신 time.monotonic()을 사용해 항상 정확히 확인
+            now = time.monotonic()
+            if now >= deadline:
                 break
         first_attempt = False
 
@@ -442,7 +448,7 @@ async def poll_finetune_job_until_done(job_id: str) -> FinetuneJobStatus:
             # 일시적 네트워크 오류 — 재시도 허용
             logger.warning(
                 "[OBS] Transient connection error during fine-tuning job polling. Will retry.",
-                extra={"job_id_hash": mask_pii_id(job_id), "error": str(e), "elapsed_secs": round(_FINETUNE_POLL_TIMEOUT_SECS - (deadline - time.monotonic()), 1)},
+                extra={"job_id_hash": mask_pii_id(job_id), "error": str(e), "elapsed_secs": round(max(0.0, time.monotonic() - start_time), 1)},
             )
         except APIError as e:
             status_code: int = getattr(e, "status_code", 0) or 0
@@ -466,8 +472,8 @@ async def poll_finetune_job_until_done(job_id: str) -> FinetuneJobStatus:
                     extra={"job_id_hash": mask_pii_id(job_id), "status_code": status_code, "error": str(e)},
                 )
 
-    # 타임아웃 만료: 실제 경과 시간 기록
-    actual_elapsed = _FINETUNE_POLL_TIMEOUT_SECS - (deadline - time.monotonic())
+    # 타임아웃 만료: start_time 기준으로 실제 경과 시간을 계산하고 음수가 되지 않도록 클램핑
+    actual_elapsed = max(0.0, time.monotonic() - start_time)
     logger.error(
         "[OBS] Fine-tuning job polling timed out.",
         extra={

--- a/backend/services/finetune_service.py
+++ b/backend/services/finetune_service.py
@@ -13,6 +13,7 @@ Fine-tuning Job을 생성·상태 폴링·Redis 상태 동기화까지 담당합
 import asyncio
 import logging
 import os
+import time
 from enum import Enum
 from pathlib import Path
 from typing import Optional
@@ -163,6 +164,7 @@ async def _save_job_status_to_redis(
     job_id: str,
     status: FinetuneJobStatus,
     fine_tuned_model: Optional[str] = None,
+    extra_fields: Optional[dict[str, str]] = None,
 ) -> None:
     """
     Fine-tuning Job 상태를 Redis Hash에 저장합니다.
@@ -172,6 +174,7 @@ async def _save_job_status_to_redis(
         job_id: OpenAI Fine-tuning Job ID (민감 식별자 — 로그에 원본을 남기지 않습니다.)
         status: 현재 Job 상태 (FinetuneJobStatus)
         fine_tuned_model: 성공 시 반환되는 파인튜닝된 모델 ID (Optional)
+        extra_fields: 상태 외 추가로 저장할 메타데이터 (timed_out, last_error 등)
     """
     if not redis_client.is_connected():
         await redis_client.connect()
@@ -180,6 +183,8 @@ async def _save_job_status_to_redis(
     mapping: dict[str, str] = {"status": status.value}
     if fine_tuned_model:
         mapping["fine_tuned_model"] = fine_tuned_model
+    if extra_fields:
+        mapping.update(extra_fields)
 
     await redis_client.redis.hset(redis_key, mapping=mapping)
     await redis_client.redis.expire(redis_key, _FINETUNE_REDIS_TTL_SECS)
@@ -350,7 +355,7 @@ async def upload_jsonl_and_create_finetune_job(
 async def poll_finetune_job_until_done(job_id: str) -> FinetuneJobStatus:
     """
     Fine-tuning Job 상태를 주기적으로 폴링하여 완료(succeeded/failed/cancelled)까지 대기합니다.
-    상태 변경이 발생할 때마다 Redis에 동기화하며, 완료 시 Discord 알림을 발생시킵니다.
+    상태 변경이 발생할 때마다 Redis에 동기화합니다.
 
     Args:
         job_id: OpenAI Fine-tuning Job ID
@@ -359,7 +364,9 @@ async def poll_finetune_job_until_done(job_id: str) -> FinetuneJobStatus:
         FinetuneJobStatus: 최종 종료 상태 (SUCCEEDED | FAILED | CANCELLED)
 
     Note:
-        - _FINETUNE_POLL_TIMEOUT_SECS 초과 시 RUNNING 상태를 반환하고 폴링을 종료합니다.
+        - _FINETUNE_POLL_TIMEOUT_SECS 초과 시 FAILED 상태를 Redis에 기록하고 폴링을 종료합니다.
+        - Discord 알림은 [OBS] 태그가 붙은 로그를 DiscordAlertHandler가 자동 감지하여 전송합니다.
+          (별도의 Discord API 호출은 없습니다 — backend/utils/observability.py 참조)
         - 네트워크 오류 발생 시에도 폴링을 유지하며 에러 로그만 남깁니다.
     """
     terminal_statuses = {
@@ -374,7 +381,8 @@ async def poll_finetune_job_until_done(job_id: str) -> FinetuneJobStatus:
         logger.error("[OBS] Cannot poll fine-tuning job: API client creation failed.", extra={"error": str(e)})
         return FinetuneJobStatus.FAILED
 
-    elapsed: float = 0.0
+    # 실제 밽시계 시간 기반으로 타임아웃 측정 (jobs.retrieve 지연 시간 포함)
+    deadline: float = time.monotonic() + _FINETUNE_POLL_TIMEOUT_SECS
 
     logger.info(
         "[OBS] Starting fine-tuning job polling.",
@@ -389,10 +397,12 @@ async def poll_finetune_job_until_done(job_id: str) -> FinetuneJobStatus:
     # 이후 순환부터 sleep을 선행하여 불필요한 API 호출 빈도를 조절합니다.
     first_attempt = True
 
-    while elapsed < _FINETUNE_POLL_TIMEOUT_SECS:
+    while time.monotonic() < deadline:
         if not first_attempt:
             await asyncio.sleep(_FINETUNE_POLL_INTERVAL_SECS)
-            elapsed += _FINETUNE_POLL_INTERVAL_SECS
+            # deadline 차감 넌지 time.monotonic()으로 언제나 정확하게 확인
+            if time.monotonic() >= deadline:
+                break
         first_attempt = False
 
         try:
@@ -432,7 +442,7 @@ async def poll_finetune_job_until_done(job_id: str) -> FinetuneJobStatus:
             # 일시적 네트워크 오류 — 재시도 허용
             logger.warning(
                 "[OBS] Transient connection error during fine-tuning job polling. Will retry.",
-                extra={"job_id_hash": mask_pii_id(job_id), "error": str(e), "elapsed_secs": elapsed},
+                extra={"job_id_hash": mask_pii_id(job_id), "error": str(e), "elapsed_secs": round(_FINETUNE_POLL_TIMEOUT_SECS - (deadline - time.monotonic()), 1)},
             )
         except APIError as e:
             status_code: int = getattr(e, "status_code", 0) or 0
@@ -456,15 +466,26 @@ async def poll_finetune_job_until_done(job_id: str) -> FinetuneJobStatus:
                     extra={"job_id_hash": mask_pii_id(job_id), "status_code": status_code, "error": str(e)},
                 )
 
-    # 타임아웃 만료
+    # 타임아웃 만료: 실제 경과 시간 기록
+    actual_elapsed = _FINETUNE_POLL_TIMEOUT_SECS - (deadline - time.monotonic())
     logger.error(
         "[OBS] Fine-tuning job polling timed out.",
         extra={
             "job_id_hash": mask_pii_id(job_id),
             "timeout_secs": _FINETUNE_POLL_TIMEOUT_SECS,
+            "actual_elapsed_secs": round(actual_elapsed, 1),
         },
     )
-    return FinetuneJobStatus.RUNNING
+    # 타임아웃 메타데이터를 Redis에 준영속 기록하여 다운스트림이 상태를 식별할 수 있도록 합니다.
+    await _save_job_status_to_redis(
+        job_id=job_id,
+        status=FinetuneJobStatus.FAILED,
+        extra_fields={
+            "timed_out": "true",
+            "actual_elapsed_secs": str(round(actual_elapsed, 1)),
+        },
+    )
+    return FinetuneJobStatus.FAILED
 
 
 async def get_active_finetune_model() -> Optional[str]:


### PR DESCRIPTION
- **[타임아웃 정확성 향상]**
  - 카운터 기반 `elapsed` 대신 `time.monotonic()`으로 데드라인을 관리하여 `jobs.retrieve()` 지연 시간 및 네트워크 오버헤드를 포함한 정확한 벽시계 시간 기반 타임아웃 측정.

- **[타임아웃 관측성 강화]**
  - 타임아웃 만료 시 `RUNNING` 반환 대신 `FAILED` 상태를 Redis에 기록하여 다운스트림(LangGraph 에이전트 등)이 폴링 포기 상태를 명확히 식별 가능.
  - Redis Hash에 `timed_out: true`, `actual_elapsed_secs` 메타데이터 저장.

- **[Redis 헬퍼 확장]**
  - `_save_job_status_to_redis()`에 `extra_fields` 파라미터 추가하여 상태 외 임의 메타데이터 저장 가능(확장성 확보).

- **[Docstring 정합성 수정]**
  - Discord 알림이 `[OBS]` 태그 로그를 통해 `DiscordAlertHandler`가 자동 처리함을 명시.

🔗 Related:
- Issue [#1045]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1060#pullrequestreview-4093900605)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

파인튜닝 작업 폴링 타임아웃 처리와 Redis 상태 메타데이터를 개선하여 정확성과 관측 가능성을 향상합니다.

개선 사항:
- 파인튜닝 폴링 타임아웃을 측정할 때 단조 증가 시계(monotonic clock)와 명시적인 마감 시각을 사용하여, API 및 네트워크 지연을 포함한 실제 경과 벽시계 시간(wall-clock time)을 포착합니다.
- 타임아웃이 발생한 경우 Redis에 `FAILED`로 기록하고 추가 메타데이터를 저장하여, 다운스트림 소비자들이 중단된 폴링 상태를 명확하게 감지할 수 있도록 합니다.
- 향후 확장성을 위해 Redis 작업 상태 헬퍼가 임의의 추가 메타데이터 필드를 받을 수 있도록 확장합니다.
- 타임아웃 의미론과 Discord 알림이 직접 API 호출이 아닌 관측 로그(observability logs)를 통해 어떻게 전송되는지에 대한 docstring을 명확히 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve fine-tuning job polling timeout handling and Redis status metadata for better accuracy and observability.

Enhancements:
- Measure fine-tuning polling timeouts using a monotonic clock and an explicit deadline to capture true wall-clock elapsed time including API and network delays.
- Record timeout occurrences as FAILED in Redis with additional metadata so downstream consumers can clearly detect abandoned polling states.
- Extend the Redis job status helper to accept arbitrary extra metadata fields for future extensibility.
- Clarify docstrings around timeout semantics and how Discord notifications are emitted via observability logs rather than direct API calls.

</details>