### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/services/finetune_service.py
+++ b/backend/services/finetune_service.py
@@ -132,7 +132,9 @@ def _preview_id(value: str, length: int = 20) -> str:
 
 def _elapsed(start: float) -> float:
     """
-    폴링 시작 시점(start_time)으로부터 현재까지 경과한 실제 벽시계 시간(초)을 반환합니다.
+    폴링 시작 시점(start)으로부터 현재까지 경과한 시간(초)을 반환합니다.
+    time.monotonic()을 사용하기 때문에 NTP 조정이나 시스템 시간 변경에 영향받지 않는
+    단조 증가(단조롭, monotonic) 경과 시간을 측정합니다. 실제 암/시간과는 일치하지 않을 수 있습니다.
     결과는 항상 0 이상으로 클램핑되어 음수 값 발생을 방지합니다.
     시간 측정 로직을 단일 지점으로 중앙화하여 일관성을 보장합니다(DRY 원칙).
 
@@ -140,7 +142,7 @@ def _elapsed(start: float) -> float:
         start: 기준 시작 시간 (time.monotonic() 반환값)
 
     Returns:
-        경과 시간 (초), 항상 >= 0.0
+        단조 경과 시간 (초), 항상 >= 0.0
     """
     return max(0.0, time.monotonic() - start)
 
@@ -206,11 +208,17 @@ async def _save_job_status_to_redis(
     if extra_fields:
         # 핵심 키(status, fine_tuned_model)가 오버라이드되지 않도록 예약 키를 필터링합니다.
         safe_extra = {k: v for k, v in extra_fields.items() if k not in _RESERVED_REDIS_KEYS}
-        skipped = set(extra_fields) - set(safe_extra)
+        # 집합 교집(∩)으로 충돌한 예약 키를 직접 하이라이팅하여 의도를 명확히 표현합니다.
+        skipped = set(extra_fields) & _RESERVED_REDIS_KEYS
         if skipped:
             logger.warning(
                 "[OBS] extra_fields contained reserved Redis keys and were ignored.",
-                extra={"skipped_keys": sorted(skipped)},
+                extra={
+                    "skipped_keys": sorted(skipped),
+                    # 운영자가 어떤 Job에서 발생한 경고인지 추적할 수 있도록 마스킹 ID 포함
+                    "job_id_hash": mask_pii_id(job_id),
+                    "redis_key_prefix": _FINETUNE_REDIS_KEY_PREFIX,
+                },
             )
         if safe_extra:
             mapping.update(safe_extra)

--- a/backend/services/finetune_service.py
+++ b/backend/services/finetune_service.py
@@ -130,6 +130,26 @@ def _preview_id(value: str, length: int = 20) -> str:
     return value[:length] + "..." if len(value) > length else value
 
 
+def _elapsed(start: float) -> float:
+    """
+    폴링 시작 시점(start_time)으로부터 현재까지 경과한 실제 벽시계 시간(초)을 반환합니다.
+    결과는 항상 0 이상으로 클램핑되어 음수 값 발생을 방지합니다.
+    시간 측정 로직을 단일 지점으로 중앙화하여 일관성을 보장합니다(DRY 원칙).
+
+    Args:
+        start: 기준 시작 시간 (time.monotonic() 반환값)
+
+    Returns:
+        경과 시간 (초), 항상 >= 0.0
+    """
+    return max(0.0, time.monotonic() - start)
+
+
+# Redis Hash에서 타측에서 교체할 수 없는 핵심 피드 키 목록
+# extra_fields에 이 키가 포함되어도 저장에서 제외(필터링)됩니다.
+_RESERVED_REDIS_KEYS: frozenset[str] = frozenset({"status", "fine_tuned_model"})
+
+
 # ─────────────────────────────────────────────────────────────
 # 내부 헬퍼: OpenAI 클라이언트 생성
 # ─────────────────────────────────────────────────────────────
@@ -184,7 +204,16 @@ async def _save_job_status_to_redis(
     if fine_tuned_model:
         mapping["fine_tuned_model"] = fine_tuned_model
     if extra_fields:
-        mapping.update(extra_fields)
+        # 핵심 키(status, fine_tuned_model)가 오버라이드되지 않도록 예약 키를 필터링합니다.
+        safe_extra = {k: v for k, v in extra_fields.items() if k not in _RESERVED_REDIS_KEYS}
+        skipped = set(extra_fields) - set(safe_extra)
+        if skipped:
+            logger.warning(
+                "[OBS] extra_fields contained reserved Redis keys and were ignored.",
+                extra={"skipped_keys": sorted(skipped)},
+            )
+        if safe_extra:
+            mapping.update(safe_extra)
 
     await redis_client.redis.hset(redis_key, mapping=mapping)
     await redis_client.redis.expire(redis_key, _FINETUNE_REDIS_TTL_SECS)
@@ -448,7 +477,7 @@ async def poll_finetune_job_until_done(job_id: str) -> FinetuneJobStatus:
             # 일시적 네트워크 오류 — 재시도 허용
             logger.warning(
                 "[OBS] Transient connection error during fine-tuning job polling. Will retry.",
-                extra={"job_id_hash": mask_pii_id(job_id), "error": str(e), "elapsed_secs": round(max(0.0, time.monotonic() - start_time), 1)},
+                extra={"job_id_hash": mask_pii_id(job_id), "error": str(e), "elapsed_secs": round(_elapsed(start_time), 1)},
             )
         except APIError as e:
             status_code: int = getattr(e, "status_code", 0) or 0
@@ -473,7 +502,7 @@ async def poll_finetune_job_until_done(job_id: str) -> FinetuneJobStatus:
                 )
 
     # 타임아웃 만료: start_time 기준으로 실제 경과 시간을 계산하고 음수가 되지 않도록 클램핑
-    actual_elapsed = max(0.0, time.monotonic() - start_time)
+    actual_elapsed = _elapsed(start_time)
     logger.error(
         "[OBS] Fine-tuning job polling timed out.",
         extra={


### PR DESCRIPTION
♻️ refactor [#12.1.2] 4차 개선 - Redis 핵심 키 보호 및 경과 시간 계산 중앙화 
♻️ refactor [#12.1.2] 5차 개선 - 독스트링 정밀도 및 경고 로그 추적성 강화

## Summary by Sourcery

파인튜닝 작업의 경과 시간 계산을 중앙화하고, 예약된 Redis 상태 키가 추가 필드에 의해 덮어쓰이지 않도록 보호합니다.

버그 수정:
- 파인튜닝 작업 상태를 저장할 때 `status`, `fine_tuned_model`과 같은 Redis 해시 예약 키가 덮어써지지 않도록 방지합니다.

개선사항:
- 파인튜닝 작업 폴링에서 시간 측정을 표준화하고 범위를 제한(clamp)하기 위해, 단조 증가하는(monotonic) 경과 시간 계산을 위한 재사용 가능한 헬퍼를 도입합니다.
- 추가 Redis 필드에 예약 키가 포함되어 있을 때 구조화된 경고 로그를 추가하여, 운영자가 관찰 가능성과 추적 가능성을 높일 수 있도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize finetuning job elapsed-time calculation and protect reserved Redis status keys from being overwritten by extra fields.

Bug Fixes:
- Prevent reserved Redis hash keys such as status and fine_tuned_model from being overridden when saving finetuning job status.

Enhancements:
- Introduce a reusable helper for monotonic elapsed-time calculation to standardize and clamp timing measurements in finetuning job polling.
- Add structured warning logging when extra Redis fields include reserved keys, improving observability and traceability for operators.

</details>