### PR TITLE
♻️ refactor [#12.1.2] 7차 개선 - 관측성(Observability) 및 알림을 위한 구조적 로깅 강화

### DIFF
--- a/backend/services/finetune_service.py
+++ b/backend/services/finetune_service.py
@@ -23,6 +23,7 @@ from openai import OpenAI, APIError, APIConnectionError
 from backend.config import ModelConfig  # type: ignore[import]
 from backend.services.redis_pubsub import redis_client  # type: ignore[import]
 from backend.utils import mask_pii_id  # type: ignore[import]
+from backend.utils.observability import ObsEvent, ObsMetaTag  # type: ignore[import]
 
 logger = logging.getLogger(__name__)
 
@@ -217,9 +218,9 @@ async def _save_job_status_to_redis(
             logger.warning(
                 "[OBS] extra_fields contained reserved Redis keys and were ignored.",
                 extra={
-                    # ELK/Datadog 등 알림 규칙 대응용 기계 판독 머커
-                    "event": "reserved_redis_keys_in_extra_fields",
-                    "intentional_warning": True,
+                    # ELK/Datadog 등 알림 규칙 대응용 기계 판독 마커 (공용 Enum 사용)
+                    "event": ObsEvent.FINETUNE_RESERVED_REDIS_KEY_VIOLATION.value,
+                    ObsMetaTag.INTENTIONAL_WARNING.value: True,
                     "skipped_reserved_redis_keys": sorted(skipped),
                     # 운영자가 어떤 Job에서 발생한 경고인지 추적할 수 있도록 마스킹 ID 포함
                     "job_id_hash": mask_pii_id(job_id),

--- a/backend/services/finetune_service.py
+++ b/backend/services/finetune_service.py
@@ -217,7 +217,10 @@ async def _save_job_status_to_redis(
             logger.warning(
                 "[OBS] extra_fields contained reserved Redis keys and were ignored.",
                 extra={
-                    "skipped_keys": sorted(skipped),
+                    # ELK/Datadog 등 알림 규칙 대응용 기계 판독 머커
+                    "event": "reserved_redis_keys_in_extra_fields",
+                    "intentional_warning": True,
+                    "skipped_reserved_redis_keys": sorted(skipped),
                     # 운영자가 어떤 Job에서 발생한 경고인지 추적할 수 있도록 마스킹 ID 포함
                     "job_id_hash": mask_pii_id(job_id),
                     "redis_key_prefix": _FINETUNE_REDIS_KEY_PREFIX,

--- a/backend/utils/observability.py
+++ b/backend/utils/observability.py
@@ -5,8 +5,26 @@ import time
 import threading
 import httpx
 from concurrent.futures import ThreadPoolExecutor
+from enum import Enum
 from typing import Dict, Optional, Any
 from backend.config import AlertConfig
+
+
+class ObsEvent(str, Enum):
+    """
+    관측성(Observability) 시스템 전반에서 사용되는 표준 이벤트 이름.
+    자유 형식의 로깅 문자열을 파싱하는 대신, ELK/Datadog 등의 대시보드와 알림 규칙(Rule Engine)이
+    명확한 기준표를 가질 수 있도록 중앙화된 구조를 제공합니다.
+    """
+    FINETUNE_RESERVED_REDIS_KEY_VIOLATION = "reserved_redis_keys_in_extra_fields"
+
+
+class ObsMetaTag(str, Enum):
+    """
+    관측성 시스템 전반에서 사용되는 메타데이터 플래그 모음.
+    네임스페이스(meta_)를 부착하여 비즈니스 데이터와 시스템 제어용 데이터를 분리합니다.
+    """
+    INTENTIONAL_WARNING = "meta_intentional_warning"
 
 
 class DiscordAlertHandler(logging.Handler):


### PR DESCRIPTION
- **[기계 판독(Machine-Readable) 태그 추가]**
  - 의도된 버그 감지용 경고(INTENTIONAL WARNING) 발생 시 기존에는 텍스트 주석만 남겼으나, Datadog/ELK 등 알림 규칙 엔진이 자유 형식의 텍스트가 아닌 정확한 Key-Value를 파싱할 수 있도록 개선.
  - `extra` 페이로드에 `"event": "reserved_redis_keys_in_extra_fields"` 와 `"intentional_warning": True` 구조화 플래그를 추가.

- **[명시적 로깅 키 네이밍]**
  - 기존 `skipped_keys` 필드명을 `skipped_reserved_redis_keys`로 변경하여, 어떤 데이터가 누락/충돌했는지 더욱 직관적이고 구체적으로 확인 가능.

🔗 Related:
- Issue [#1045]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1066#pullrequestreview-4093931797)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

파인튜닝 작업 상태를 저장할 때 예약된 Redis 키에 대한 의도적인 경고를 더 강력한 구조적 로깅으로 기록하도록 개선합니다.

새 기능:
- 예약된 Redis 키가 감지될 때, 관측 도구에서 활용할 수 있도록 `extra` 페이로드에 기계가 읽을 수 있는 `event` 및 `intentional_warning` 플래그를 추가합니다.

개선사항:
- Redis 로깅에서 무시된 추가 필드를 더 명확히 식별할 수 있도록 `skipped_keys` 로그 필드 이름을 `skipped_reserved_redis_keys`로 변경합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen structured logging for intentional warnings about reserved Redis keys in finetune job status saving.

New Features:
- Add machine-readable event and intentional_warning flags to extra payload for observability tools when reserved Redis keys are detected.

Enhancements:
- Rename the skipped_keys log field to skipped_reserved_redis_keys for clearer identification of ignored extra fields in Redis logging.

</details>