### PR TITLE
✨ feat [#12.1.4]: 모델 Hot-swap 관리자 API 및 무중단 활성 모델 적용 인프라 구축

### DIFF
--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 
 from backend.agent.state import AgentState
 from backend.agent.utils import get_llm, extract_keywords, search_similar_docs
+from backend.services.finetune_service import get_active_finetune_model
 
 # Try importing specific exceptions for better error handling
 try:
@@ -70,11 +71,18 @@ def retrieve_node(state: AgentState) -> Dict[str, Any]:
     return {"retrieved_context": context}
 
 
-def classify_node(state: AgentState) -> Dict[str, Any]:
+async def classify_node(state: AgentState) -> Dict[str, Any]:
     """
     분류 수행 노드: LLM을 사용하여 PARA 카테고리 분류
     """
-    llm = get_llm()
+    try:
+        active_model = await get_active_finetune_model()
+        model_name = active_model if active_model else "gpt-4o"
+    except Exception as e:
+        logger.error(f"Failed to fetch active model from Redis, defaulting to gpt-4o: {e}")
+        model_name = "gpt-4o"
+
+    llm = get_llm(model_name)
 
     # LLM 초기화 실패 시 Stub 반환 (안전장치)
     if not llm:

--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -42,11 +42,11 @@ except ImportError:
     CommaSeparatedListOutputParser = None  # type: ignore
 
 
-@lru_cache(maxsize=1)
-def get_llm() -> Optional["BaseChatModel"]:
+@lru_cache(maxsize=4)
+def get_llm(model_name: str = "gpt-4o") -> Optional["BaseChatModel"]:
     """
     LLM 인스턴스를 반환하는 팩토리 함수.
-    LRU Cache를 사용하여 인스턴스 재생성을 방지하고 오버헤드를 줄입니다.
+    LRU Cache를 파라미터(model_name) 기반으로 캐싱하여 모델 전환 시(Hot-swap) 연속성을 보장합니다.
     """
     if ChatOpenAI is None:
         logger.warning("langchain_openai not installed.")
@@ -59,7 +59,8 @@ def get_llm() -> Optional["BaseChatModel"]:
 
     try:
         # 분류 및 추출 작업에는 결정적인 출력을 위해 temperature=0 사용
-        return ChatOpenAI(model="gpt-4o", temperature=0)
+        logger.info(f"Initializing LLM with model: {model_name}")
+        return ChatOpenAI(model=model_name, temperature=0)
     except Exception as e:
         logger.error("Error initializing LLM", exc_info=True)
         return None

--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -59,7 +59,7 @@ def get_llm(model_name: str = "gpt-4o") -> Optional["BaseChatModel"]:
 
     try:
         # 분류 및 추출 작업에는 결정적인 출력을 위해 temperature=0 사용
-        logger.info(f"Initializing LLM with model: {model_name}")
+        logger.debug(f"Initializing LLM with model: {model_name}")
         return ChatOpenAI(model=model_name, temperature=0)
     except Exception as e:
         logger.error("Error initializing LLM", exc_info=True)

--- a/backend/api/endpoints/admin.py
+++ b/backend/api/endpoints/admin.py
@@ -8,8 +8,11 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException
 
+from pydantic import BaseModel
+
 from backend.config import AdminConfig
 from backend.services.eval_service import generate_eval_report
+from backend.services.finetune_service import set_active_finetune_model
 
 logger = logging.getLogger(__name__)
 
@@ -42,4 +45,42 @@ async def get_eval_report_endpoint(
         return report
     except Exception:
         logger.exception("[OBS] Error generating eval report")
+        raise HTTPException(status_code=500, detail="Internal Server Error")
+
+class ActiveModelRequest(BaseModel):
+    model_id: str
+
+@router.post("/models/active", summary="활성 파인튜닝 모델 수동 변경 (Hot-swap)")
+async def set_active_model_endpoint(
+    request: ActiveModelRequest,
+    x_admin_key: Optional[str] = Header(None, description="어드민 인증 키")
+):
+    """
+    [Hot-swap] 시스템 전역에서 사용할 파인튜닝 모델 ID를 수동으로 지정합니다.
+    - 입력받은 ft-model-id를 Redis 설정(v9:finetune:current_model_id)에 갱신
+    """
+    admin_key = AdminConfig.get_admin_key()
+    
+    if not admin_key:
+        logger.error("[OBS] ADMIN_API_KEY is not configured in environment.")
+        raise HTTPException(status_code=500, detail="Server Configuration Error")
+        
+    provided = str(x_admin_key or "")
+    expected = str(admin_key or "")
+    
+    if not hmac.compare_digest(provided, expected):
+        logger.warning(
+            "[OBS] Unauthorized attempt to update active model.",
+            extra={"model_id": request.model_id}
+        )
+        raise HTTPException(status_code=403, detail="Forbidden: Invalid Admin Key")
+        
+    try:
+        await set_active_finetune_model(request.model_id)
+        return {"status": "success", "active_model_id": request.model_id}
+    except Exception:
+        logger.exception(
+            "[OBS] Error setting active model",
+            extra={"model_id": request.model_id}
+        )
         raise HTTPException(status_code=500, detail="Internal Server Error")

--- a/backend/api/endpoints/admin.py
+++ b/backend/api/endpoints/admin.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from backend.config import AdminConfig
 from backend.services.eval_service import generate_eval_report
@@ -48,7 +48,13 @@ async def get_eval_report_endpoint(
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
 class ActiveModelRequest(BaseModel):
-    model_id: str
+    model_id: str = Field(
+        ...,
+        min_length=3,
+        max_length=128,
+        pattern=r"^[a-zA-Z0-9\-\.:]+$",
+        description="The ID of the model to activate (e.g., ft:gpt-4o:my-org::123 or gpt-4o)"
+    )
 
 @router.post("/models/active", summary="활성 파인튜닝 모델 수동 변경 (Hot-swap)")
 async def set_active_model_endpoint(

--- a/backend/services/finetune_service.py
+++ b/backend/services/finetune_service.py
@@ -243,7 +243,7 @@ async def _save_job_status_to_redis(
     )
 
 
-async def _set_active_model_in_redis(fine_tuned_model_id: str) -> None:
+async def set_active_finetune_model(fine_tuned_model_id: str) -> None:
     """
     성공적으로 완료된 파인튜닝 모델 ID를 Redis의 Active Model 키에 저장합니다.
     이 값은 Hot-swap 메커니즘에서 LangGraph 에이전트가 참조합니다.
@@ -470,7 +470,7 @@ async def poll_finetune_job_until_done(job_id: str) -> FinetuneJobStatus:
             if current_status in terminal_statuses:
                 if current_status == FinetuneJobStatus.SUCCEEDED and fine_tuned_model:
                     # Hot-swap: 완료된 모델 ID를 Active Model로 등록
-                    await _set_active_model_in_redis(fine_tuned_model)
+                    await set_active_finetune_model(fine_tuned_model)
                     logger.info(
                         "[OBS] Fine-tuning succeeded. New model is now active.",
                         extra={


### PR DESCRIPTION
- **[Hot-swap API 구현]**
  - POST /admin/models/active 엔드포인트 신설: 관리자 인증 기반 수동 파인튜닝 모델 전환 기능 개발
  - 설계 컨벤션 기반 네임스페이스 키(v9:finetune:current_model_id) 적용

- **[LangGraph 에이전트 수정]**
  - classify_node 비동기 전환 및 실시간 Redis 참조 로직 추가: 새 에이전트 세션 생성 시 핫스왑 모델 우선 채택

- **[세션 연속성 보장]**
  - get_llm 싱글톤 구조를 모델 파라미터 기반 캐시(lru_cache)로 리팩터링하여 기존 세션 중단 없이 캐시 스위칭

🔗 Related: Issue [#1045]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

관리자용 핫스왑 API를 도입하고, 세션 연속성을 모델 인식 LLM 캐싱을 통해 유지하면서 에이전트 파이프라인에 활성 파인튜닝 모델 선택 기능을 통합합니다.

New Features:
- Redis를 통해 시스템 전역에서 사용되는 활성 파인튜닝 모델을 수동으로 설정할 수 있는 인증된 관리자 엔드포인트를 추가합니다.

Enhancements:
- 에이전트 분류 노드를 업데이트하여 비동기적으로 활성 파인튜닝 모델을 조회하고 우선적으로 사용하되, 실패 시 기본(base) 모델로 폴백하도록 합니다.
- LLM 팩토리 캐싱을 모델 이름을 키로 사용하도록 개선하여, 기존 세션을 중단하지 않고도 매끄럽게 모델을 전환할 수 있도록 지원합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an admin hot-swap API and integrate active fine-tuned model selection into the agent pipeline while preserving session continuity via model-aware LLM caching.

New Features:
- Add an authenticated admin endpoint to manually set the active fine-tuned model used system-wide via Redis.

Enhancements:
- Update the agent classification node to asynchronously resolve and prioritize the active fine-tuned model, defaulting to a base model on failure.
- Refine LLM factory caching to key instances by model name, supporting seamless model switching without interrupting existing sessions.

</details>