### PR TITLE
♻️ refactor [#12.1.4]: 8차 개선 - Redis 공백 문자열 데이터 오염 방어 로직 추가

### DIFF
--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -69,8 +69,17 @@ async def resolve_active_model() -> str:
     try:
         active_model = await get_active_finetune_model()
         # 공백 전용 문자열('   ')은 Truthy이지만 유효하지 않으므로 strip()으로 정규화 후 검증
+        # (get_active_finetune_model()의 반환 타입이 Optional[str]이므로 str 이외의 타입 방어는 불요)
         if isinstance(active_model, str):
             active_model = active_model.strip()
+        if not active_model and active_model is not None:
+            # None이 아니라 공백 문자열이 들어온 경우 → Redis 데이터 오염 가능성 알림
+            logger.warning(
+                "resolve_active_model: Redis returned a whitespace-only model name. "
+                "Falling back to %s. Check Redis key '%s' for data corruption.",
+                DEFAULT_MODEL_NAME,
+                "v9:finetune:current_model_id",  # 키 이름은 finetune_service 상수와 동일
+            )
         return active_model or DEFAULT_MODEL_NAME
     # 아래 예외만 캐치 (NameError/TypeError 등 프로그래밍 버그는 의도적으로 통과시킴 → Fail Fast)
     except (redis.exceptions.RedisError, asyncio.TimeoutError, ValueError, UnicodeDecodeError) as e:

--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -68,7 +68,10 @@ async def resolve_active_model() -> str:
     """
     try:
         active_model = await get_active_finetune_model()
-        return active_model if active_model else DEFAULT_MODEL_NAME
+        # 공백 전용 문자열('   ')은 Truthy이지만 유효하지 않으므로 strip()으로 정규화 후 검증
+        if isinstance(active_model, str):
+            active_model = active_model.strip()
+        return active_model or DEFAULT_MODEL_NAME
     # 아래 예외만 캐치 (NameError/TypeError 등 프로그래밍 버그는 의도적으로 통과시킴 → Fail Fast)
     except (redis.exceptions.RedisError, asyncio.TimeoutError, ValueError, UnicodeDecodeError) as e:
         logger.exception(


### PR DESCRIPTION
- **[데이터 무결성 검증 강화]**
  - `resolve_active_model()`에서 Redis가 반환한 값이 공백 전용 문자열(`'   '`)일 경우 기존 `if active_model` 조건이 Truthy로 통과시켜 LLM에 유효하지 않은 model_name이 전달되는 잠재적 버그 차단.
  - `isinstance(active_model, str)` 타입 가드 + `strip()` 정규화 후 `or DEFAULT_MODEL_NAME`
로 폴백하여, 관리자 오입력 등 Redis 데이터 오염 시나리오에도 서비스 가용성 보장.

🔗 Related:
- Issue [#1045]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1082#pullrequestreview-4095254892)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Redis에서 가져온 활성 모델 이름을 정규화하고 검증하여 공백만 포함된 잘못된 값이 전파되지 않도록 방지하면서, 오류 발생 시나 값이 비어 있을 경우 기존과 동일하게 기본 모델로 폴백하는 동작을 유지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize and validate the active model name resolved from Redis to prevent invalid whitespace-only values from propagating, while preserving the existing fallback to the default model on errors or empty values.

</details>