### PR TITLE
♻️ refactor [#12.1.4]: 10차 개선 - Redis 키 환경 변수 기반 SSOT 확보 및 공백 감지 조건 가독성 개선

### DIFF
--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -19,6 +19,10 @@ load_dotenv()
 # 이 상수를 수정하면 resolve_active_model() 폴백, get_llm() 기본값이 모두 함께 바뀝니다.
 DEFAULT_MODEL_NAME: str = os.getenv("GPT4O_MODEL", "gpt-4o")
 
+# Hot-swap 활성 모델을 저장하는 Redis 키 (finetune_service._FINETUNE_ACTIVE_MODEL_KEY와 동일한 환경 변수 참조)
+# finetune_service의 상수가 모듈-프라이빗(_)이므로 직접 임포트 대신 동일한 환경 변수를 공유 진실 공급원으로 사용합니다.
+_ACTIVE_MODEL_REDIS_KEY: str = os.getenv("FINETUNE_ACTIVE_MODEL_KEY", "v9:finetune:current_model_id")
+
 # 로거 설정
 logger = logging.getLogger(__name__)
 
@@ -67,18 +71,17 @@ async def resolve_active_model() -> str:
     보장하기 위한 설계 결정입니다. (광범위한 Exception 캐치는 버그 마스킹 위험이 있습니다.)
     """
     try:
-        active_model = await get_active_finetune_model()
-        # 공백 전용 문자열('   ')은 Truthy이지만 유효하지 않으므로 strip()으로 정규화 후 검증
-        # (get_active_finetune_model()의 반환 타입이 Optional[str]이므로 str 이외의 타입 방어는 불요)
-        if isinstance(active_model, str):
-            active_model = active_model.strip()
-        if not active_model and active_model is not None:
-            # None이 아니라 공백 문자열이 들어온 경우 → Redis 데이터 오염 가능성 알림
+        raw_model = await get_active_finetune_model()
+        # 공백 전용 문자열('   ')은 Truthy이지만 유효하지 않으므로 strip()으로 정규화
+        # (반환 타입이 Optional[str]이므로 str 이외의 타입 방어는 불요)
+        active_model = raw_model.strip() if isinstance(raw_model, str) else raw_model
+        # strip() 후 빈 문자열이 됐다면 → 원본이 공백 전용 문자열이었음 (Redis 데이터 오염)
+        if raw_model and not active_model:
             logger.warning(
                 "resolve_active_model: Redis returned a whitespace-only model name. "
                 "Falling back to %s. Check Redis key '%s' for data corruption.",
                 DEFAULT_MODEL_NAME,
-                "v9:finetune:current_model_id",  # 키 이름은 finetune_service 상수와 동일
+                _ACTIVE_MODEL_REDIS_KEY,  # 환경 변수 기반 상수 사용 — finetune_service와 동일한 SSOT
             )
         return active_model or DEFAULT_MODEL_NAME
     # 아래 예외만 캐치 (NameError/TypeError 등 프로그래밍 버그는 의도적으로 통과시킴 → Fail Fast)

--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -75,10 +75,11 @@ async def resolve_active_model() -> str:
         # 공백 전용 문자열('   ')은 Truthy이지만 유효하지 않으므로 strip()으로 정규화
         # (반환 타입이 Optional[str]이므로 str 이외의 타입 방어는 불요)
         active_model = raw_model.strip() if isinstance(raw_model, str) else raw_model
-        # strip() 후 빈 문자열이 됐다면 → 원본이 공백 전용 문자열이었음 (Redis 데이터 오염)
-        if raw_model and not active_model:
+        # strip() 후 빈 문자열이 됐다면 → 원본이 빈 문자열이거나 공백 전용 문자열이었음 (Redis 데이터 오염)
+        # isinstance() 로 None(정상 미등록 케이스)을 제외하고, 빈 문자열("")과 공백(" ") 모두 경고 대상에 포함
+        if isinstance(raw_model, str) and not active_model:
             logger.warning(
-                "resolve_active_model: Redis returned a whitespace-only model name. "
+                "resolve_active_model: Redis returned an empty or whitespace-only model name. "
                 "Falling back to %s. Check Redis key '%s' for data corruption.",
                 DEFAULT_MODEL_NAME,
                 _ACTIVE_MODEL_REDIS_KEY,  # 환경 변수 기반 상수 사용 — finetune_service와 동일한 SSOT


### PR DESCRIPTION
- **[단일 진실 공급원(SSOT) 확보]**
  - 로그 메시지에 하드코딩되어 있던 Redis 키 문자열을 제거하고 `_ACTIVE_MODEL_REDIS_KEY = os.getenv("FINETUNE_ACTIVE_MODEL_KEY", "v9:finetune:current_model_id")` 모듈 상수로 교체.
  - `finetune_service._FINETUNE_ACTIVE_MODEL_KEY`가 모듈-프라이빗(`_`)이어서 직접 임포트 불가한 설계를 존중하면서, 동일한 환경 변수를 공유 SSOT로 삼아 키 변경 시 env 수정 한 번으로 양쪽에 자동 반영되도록 구성.

- **[조건 로직 가독성 개선]**
  - `active_model is not None` 패턴을 `raw_model`/`active_model` 두 변수로 역할 분리하여 "strip() 전 원본이 존재했으나 strip() 후 비어있다" 조건을 `if raw_model and not ctive_model:`로 의도를 즉각 파악할 수 있도록 재작성.

🔗 Related:
- Issue [#1045]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1084#pullrequestreview-4095271136)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

환경 기반 설정과 활성 모델 Redis 키 처리 방식을 정렬하고, 공백만으로 이루어진 모델 감지 로직의 가독성을 개선합니다.

Enhancements:
- 모듈 전반에서 하드코딩된 문자열을 피하고 단일 진실 공급원(SSOT)을 보장하기 위해, 활성 모델 Redis 키에 대해 환경 변수 기반으로 공유되는 상수를 도입합니다.
- 공백만으로 이루어진 Redis 엔트리를 감지할 때, 원본 값과 공백 제거(strip)된 값을 명확히 구분할 수 있도록 활성 모델 해석 로직을 다듬습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align active model Redis key handling with environment-based configuration and improve readability of whitespace-only model detection logic.

Enhancements:
- Introduce a shared environment-driven constant for the active model Redis key to avoid hardcoded strings and ensure SSOT across modules.
- Refine active model resolution logic to clearly distinguish between raw and stripped values when detecting whitespace-only Redis entries.

</details>