### PR TITLE
♻️ refactor [#12.1.4]: 12차 개선 - Redis 키 빈 문자열 방어 및 경고 로그 진단성 강화

### DIFF
--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -21,7 +21,8 @@ DEFAULT_MODEL_NAME: str = os.getenv("GPT4O_MODEL", "gpt-4o")
 
 # Hot-swap 활성 모델을 저장하는 Redis 키 (finetune_service._FINETUNE_ACTIVE_MODEL_KEY와 동일한 환경 변수 참조)
 # finetune_service의 상수가 모듈-프라이빗(_)이므로 직접 임포트 대신 동일한 환경 변수를 공유 진실 공급원으로 사용합니다.
-_ACTIVE_MODEL_REDIS_KEY: str = os.getenv("FINETUNE_ACTIVE_MODEL_KEY", "v9:finetune:current_model_id")
+# `or` 패턴을 사용하여 FINETUNE_ACTIVE_MODEL_KEY=""(빈 문자열)로 설정된 경우에돈 쨴 Redis 키 사용을 방지합니다.
+_ACTIVE_MODEL_REDIS_KEY: str = os.getenv("FINETUNE_ACTIVE_MODEL_KEY") or "v9:finetune:current_model_id"
 
 # 로거 설정
 logger = logging.getLogger(__name__)
@@ -71,18 +72,19 @@ async def resolve_active_model() -> str:
     보장하기 위한 설계 결정입니다. (광범위한 Exception 캐치는 버그 마스킹 위험이 있습니다.)
     """
     try:
-        raw_model = await get_active_finetune_model()
+        raw_active_model = await get_active_finetune_model()
         # 공백 전용 문자열('   ')은 Truthy이지만 유효하지 않으므로 strip()으로 정규화
         # (반환 타입이 Optional[str]이므로 str 이외의 타입 방어는 불요)
-        active_model = raw_model.strip() if isinstance(raw_model, str) else raw_model
+        active_model = raw_active_model.strip() if isinstance(raw_active_model, str) else raw_active_model
         # strip() 후 빈 문자열이 됐다면 → 원본이 빈 문자열이거나 공백 전용 문자열이었음 (Redis 데이터 오염)
         # isinstance() 로 None(정상 미등록 케이스)을 제외하고, 빈 문자열("")과 공백(" ") 모두 경고 대상에 포함
-        if isinstance(raw_model, str) and not active_model:
+        if isinstance(raw_active_model, str) and not active_model:
             logger.warning(
-                "resolve_active_model: Redis returned an empty or whitespace-only model name. "
+                "resolve_active_model: Redis returned an empty or whitespace-only model name %r. "
                 "Falling back to %s. Check Redis key '%s' for data corruption.",
+                raw_active_model,  # 실제 오염 값을 포함하여 운영 진단성 강화 (%r 포맷으로 표시)
                 DEFAULT_MODEL_NAME,
-                _ACTIVE_MODEL_REDIS_KEY,  # 환경 변수 기반 상수 사용 — finetune_service와 동일한 SSOT
+                _ACTIVE_MODEL_REDIS_KEY,
             )
         return active_model or DEFAULT_MODEL_NAME
     # 아래 예외만 캐치 (NameError/TypeError 등 프로그래밍 버그는 의도적으로 통과시킴 → Fail Fast)

--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -21,7 +21,7 @@ DEFAULT_MODEL_NAME: str = os.getenv("GPT4O_MODEL", "gpt-4o")
 
 # Hot-swap 활성 모델을 저장하는 Redis 키 (finetune_service._FINETUNE_ACTIVE_MODEL_KEY와 동일한 환경 변수 참조)
 # finetune_service의 상수가 모듈-프라이빗(_)이므로 직접 임포트 대신 동일한 환경 변수를 공유 진실 공급원으로 사용합니다.
-# `or` 패턴을 사용하여 FINETUNE_ACTIVE_MODEL_KEY=""(빈 문자열)로 설정된 경우에돈 쨴 Redis 키 사용을 방지합니다.
+# `or` 패턴을 사용하여 FINETUNE_ACTIVE_MODEL_KEY=""(빈 문자열)로 설정된 경우에도 잘못된 Redis 키 사용을 방지합니다.
 _ACTIVE_MODEL_REDIS_KEY: str = os.getenv("FINETUNE_ACTIVE_MODEL_KEY") or "v9:finetune:current_model_id"
 
 # 로거 설정


### PR DESCRIPTION
- **[엣지케이스 방어 강화]**
  - `_ACTIVE_MODEL_REDIS_KEY`를 `os.getenv(..., default)` 에서 `os.getenv(...) or default` 패턴으로 변경하여, 환경 변수가 빈 문자열("")로 잘못 설정된 경우에도 유효한 Redis 키 기본값이 적용되도록 방어.

- **[운영 진단성(Observability) 강화]**
  - 경고 로그에 Redis에서 읽어온 실제 오염 값(`raw_active_model`)을 `%r` 포맷으로 포함하여, 빈 문자열("")인지 공백 전용("   ")인지 운영 로그에서 즉각 구분 가능하도록 개선.

- **[가독성 개선]**
  - 변수명 `raw_model` → `raw_active_model`로 변경하여 Redis Active Model 조회 결과임을 변수명 수준에서 명확히 표현.

🔗 Related:
- Issue [#1045]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1086#pullrequestreview-4095309431)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Redis 활성 모델 키 처리 방식을 강화하고, 손상되었거나 잘못된 값이 반환될 때 관측 가능성을 개선합니다.

버그 수정:
- `FINETUNE_ACTIVE_MODEL_KEY`가 빈 문자열로 설정된 경우에도 올바른 기본 Redis 키가 사용되도록 하여, 활성 모델 조회에 잘못된 키가 사용되는 문제를 방지합니다.

개선 사항:
- 경고 로그에 Redis 활성 모델의 원시 값을 포함하여, 비어 있는 값과 공백 문자만 있는 값을 구분하고 데이터 손상 사례 진단을 개선합니다.
- Redis 활성 모델 값과 관련된 변수 이름을 명확히 하여 그 목적이 더 잘 전달되도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden Redis active model key handling and improve observability when corrupted or invalid values are returned.

Bug Fixes:
- Ensure a valid default Redis key is used when FINETUNE_ACTIVE_MODEL_KEY is set to an empty string, preventing use of an invalid key for the active model lookup.

Enhancements:
- Include the raw Redis active model value in warning logs to distinguish empty from whitespace-only values and improve diagnosis of data corruption cases.
- Clarify variable naming around the Redis active model value to better convey its purpose.

</details>