### PR TITLE
♻️ refactor [#12.1.4]: 14차 개선 - 환경 변수 공백 전용 값 방어 추가

### DIFF
--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -21,8 +21,9 @@ DEFAULT_MODEL_NAME: str = os.getenv("GPT4O_MODEL", "gpt-4o")
 
 # Hot-swap 활성 모델을 저장하는 Redis 키 (finetune_service._FINETUNE_ACTIVE_MODEL_KEY와 동일한 환경 변수 참조)
 # finetune_service의 상수가 모듈-프라이빗(_)이므로 직접 임포트 대신 동일한 환경 변수를 공유 진실 공급원으로 사용합니다.
-# `or` 패턴을 사용하여 FINETUNE_ACTIVE_MODEL_KEY=""(빈 문자열)로 설정된 경우에도 잘못된 Redis 키 사용을 방지합니다.
-_ACTIVE_MODEL_REDIS_KEY: str = os.getenv("FINETUNE_ACTIVE_MODEL_KEY") or "v9:finetune:current_model_id"
+# strip() 후 or 패턴으로 빈 문자열("") 및 공백 전용("   ") 환경 변수 값도 올바르게 기본값으로 대체합니다.
+_raw_active_model_redis_key = os.getenv("FINETUNE_ACTIVE_MODEL_KEY", "").strip()
+_ACTIVE_MODEL_REDIS_KEY: str = _raw_active_model_redis_key or "v9:finetune:current_model_id"
 
 # 로거 설정
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
- FINETUNE_ACTIVE_MODEL_KEY 환경 변수가 공백 전용 문자열("   ")인 경우
  이전 or 패턴에서는 유효한 키로 통과되던 문제를 수정.
- strip() 후 or 패턴으로 빈 문자열, 공백 전용 값 모두 기본값으로 대체.

🔗 Related:
- Issue [#1045]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1088#pullrequestreview-4095340177)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

버그 수정:
- 공백만으로 이루어진 `FINETUNE_ACTIVE_MODEL_KEY` 값은 유효하지 않은 값으로 처리하고, 기본 Redis 키로 대체하도록 수정했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Treat whitespace-only FINETUNE_ACTIVE_MODEL_KEY values as invalid and replace them with the default Redis key.

</details>