### PR TITLE
✨ feat [#12.1.5]: 파인튜닝 이전/이후 모델 간 성능 비교 분석 자동화 (User Rating 기반)

### DIFF
--- a/backend/api/endpoints/admin.py
+++ b/backend/api/endpoints/admin.py
@@ -119,19 +119,7 @@ async def get_model_performance_endpoint(
         from backend.services.finetune_service import get_model_performance_comparison
         data = await get_model_performance_comparison()
         
-        return ModelPerformanceComparison(
-            status="success",
-            previous_model_id=data["previous_model_id"],
-            current_model_id=data["current_model_id"],
-            deployed_at=data["deployed_at"],
-            previous_up=data["previous_up"],
-            previous_down=data["previous_down"],
-            previous_score=data["previous_score"],
-            current_up=data["current_up"],
-            current_down=data["current_down"],
-            current_score=data["current_score"],
-            score_improvement=data["score_improvement"]
-        )
+        return ModelPerformanceComparison(status="success", **data)
     except Exception:
         logger.exception("[OBS] Error calculating model performance comparison")
         raise HTTPException(status_code=500, detail="Internal Server Error")

--- a/backend/api/endpoints/admin.py
+++ b/backend/api/endpoints/admin.py
@@ -90,3 +90,48 @@ async def set_active_model_endpoint(
             extra={"model_id": request.model_id}
         )
         raise HTTPException(status_code=500, detail="Internal Server Error")
+
+from backend.api.models import ModelPerformanceComparison
+
+@router.get("/models/performance", response_model=ModelPerformanceComparison, summary="이전 모델과 현행 파인튜닝 모델 간의 성능 비교 분석 자동화 (User Rating 기반)")
+async def get_model_performance_endpoint(
+    x_admin_key: Optional[str] = Header(None, description="어드민 인증 키")
+):
+    """
+    [v9.0 Phase 1] 이전 파인튜닝 모델과 최신 파인튜닝 모델의 성능을 비교 분석합니다.
+    - User Rating(Thumbs Up/Down) 기준
+    - 시간 기반(모델 배포 시간 전/후) 스코어 산출
+    """
+    admin_key = AdminConfig.get_admin_key()
+    
+    if not admin_key:
+        logger.error("[OBS] ADMIN_API_KEY is not configured in environment.")
+        raise HTTPException(status_code=500, detail="Server Configuration Error")
+        
+    provided = str(x_admin_key or "")
+    expected = str(admin_key or "")
+    
+    if not hmac.compare_digest(provided, expected):
+        logger.warning("[OBS] Unauthorized attempt to check model performance.")
+        raise HTTPException(status_code=403, detail="Forbidden: Invalid Admin Key")
+        
+    try:
+        from backend.services.finetune_service import get_model_performance_comparison
+        data = await get_model_performance_comparison()
+        
+        return ModelPerformanceComparison(
+            status="success",
+            previous_model_id=data["previous_model_id"],
+            current_model_id=data["current_model_id"],
+            deployed_at=data["deployed_at"],
+            previous_up=data["previous_up"],
+            previous_down=data["previous_down"],
+            previous_score=data["previous_score"],
+            current_up=data["current_up"],
+            current_down=data["current_down"],
+            current_score=data["current_score"],
+            score_improvement=data["score_improvement"]
+        )
+    except Exception:
+        logger.exception("[OBS] Error calculating model performance comparison")
+        raise HTTPException(status_code=500, detail="Internal Server Error")

--- a/backend/api/models/__init__.py
+++ b/backend/api/models/__init__.py
@@ -300,6 +300,24 @@ class FeedbackDetail(BaseModel):
     timestamp: str = Field(..., description="피드백 남긴 일시 (ISO 8601)")
 
 
+class ModelPerformanceComparison(BaseModel):
+    """이전 모델과 현행 모델 간의 성능 비교 분석 결과"""
+    status: ApiStatus = Field(..., description=API_STATUS_DESC)
+    previous_model_id: Optional[str] = Field(None, description="이전 모델 ID")
+    current_model_id: Optional[str] = Field(None, description="현재 활성 모델 ID")
+    deployed_at: Optional[str] = Field(None, description="현재 모델 배포(Hot-swap) 일시")
+    
+    previous_up: int = Field(0, description="이전 모델 긍정 피드백 수")
+    previous_down: int = Field(0, description="이전 모델 부정 피드백 수")
+    previous_score: float = Field(0.0, description="이전 모델 User Rating 점수 (0~100)")
+    
+    current_up: int = Field(0, description="현재 모델 긍정 피드백 수")
+    current_down: int = Field(0, description="현재 모델 부정 피드백 수")
+    current_score: float = Field(0.0, description="현재 모델 User Rating 점수 (0~100)")
+    
+    score_improvement: float = Field(0.0, description="점수 증감 (current - previous)")
+
+
 class FeedbackStatsResponse(BaseModel):
     """어드민 대시보드용 AI 피드백 통계 응답"""
     

--- a/backend/services/finetune_service.py
+++ b/backend/services/finetune_service.py
@@ -601,12 +601,18 @@ async def get_model_performance_comparison() -> dict:
 
     import datetime
     
-    def _to_timestamp(iso_str) -> float:
-        if not iso_str: return 0.0
+    def _to_timestamp(raw_ts) -> float:
+        if not raw_ts: return 0.0
+        if isinstance(raw_ts, (int, float)) and not isinstance(raw_ts, bool):
+            return float(raw_ts)
+        iso_str = str(raw_ts).strip()
         try:
             return datetime.datetime.fromisoformat(iso_str.replace("Z", "+00:00")).timestamp()
         except ValueError:
-            return 0.0
+            try:
+                return float(iso_str)
+            except ValueError:
+                return 0.0
 
     deployed_ts = _to_timestamp(deployed_at_str)
     prev_deployed_ts = _to_timestamp(prev_deployed_at_str)
@@ -636,19 +642,21 @@ async def get_model_performance_comparison() -> dict:
                         continue
                         
                     if isinstance(raw_ts, (int, float, str)) and not isinstance(raw_ts, bool):
-                        ts = _to_timestamp(str(raw_ts).strip())
+                        ts = _to_timestamp(raw_ts)
                     else:
                         continue
                         
-                    if ts >= deployed_ts and deployed_ts > 0:
+                    # deployed_ts가 0.0이면, Hot-swap 한 번도 안 일어났으므로 모든 것을 현재 모델로 분류
+                    if deployed_ts == 0.0 or ts >= deployed_ts:
                         if rating == RATING_UP: curr_up += 1
                         else: curr_down += 1
-                    elif ts >= prev_deployed_ts and ts < deployed_ts:
+                    # deployed_ts 기록은 있지만 이전 기록이 없거나, 이전 기록 시간 이상인 경우
+                    elif prev_deployed_ts == 0.0 or ts >= prev_deployed_ts:
                         if rating == RATING_UP: prev_up += 1
                         else: prev_down += 1
                         
-                except Exception:
-                    pass
+                except (json.JSONDecodeError, ValueError, TypeError) as e:
+                    logger.debug("[OBS] Failed to parse feedback entry for performance comparison: %s", e)
         if int(cursor) == 0:
             break
             

--- a/backend/services/finetune_service.py
+++ b/backend/services/finetune_service.py
@@ -247,19 +247,39 @@ async def set_active_finetune_model(fine_tuned_model_id: str) -> None:
     """
     성공적으로 완료된 파인튜닝 모델 ID를 Redis의 Active Model 키에 저장합니다.
     이 값은 Hot-swap 메커니즘에서 LangGraph 에이전트가 참조합니다.
+    성능 비교 분석(A/B 테스트)을 위해 이전 모델과 배포 시간을 기록합니다.
 
     키: {_FINETUNE_ACTIVE_MODEL_KEY} (예: "v9:finetune:current_model_id")
     """
-    if not redis_client.is_connected():
+    if not redis_client.is_connected() or not redis_client.redis:
         await redis_client.connect()
+        if not redis_client.redis:
+            raise RuntimeError("Redis connection not established.")
 
+    # 1. 기존 활성 모델의 ID와 배포 시각을 이전 모델(previous) 키에 백업
+    previous_model = await redis_client.redis.get(_FINETUNE_ACTIVE_MODEL_KEY)
+    previous_deployed_at = await redis_client.redis.get(f"{_FINETUNE_ACTIVE_MODEL_KEY}:deployed_at")
+
+    if previous_model:
+        # decode가 되어 있지 않을 경우를 대비
+        prev_model_str = previous_model.decode("utf-8") if isinstance(previous_model, bytes) else str(previous_model)
+        await redis_client.redis.set(f"{_FINETUNE_ACTIVE_MODEL_KEY}:previous", prev_model_str)
+        if previous_deployed_at:
+            prev_ts_str = previous_deployed_at.decode("utf-8") if isinstance(previous_deployed_at, bytes) else str(previous_deployed_at)
+            await redis_client.redis.set(f"{_FINETUNE_ACTIVE_MODEL_KEY}:previous_deployed_at", prev_ts_str)
+
+    # 2. 신규 파인튜닝 모델 정보 저장 (Hot-swap 적용 및 배포 시각 기록)
+    from datetime import datetime, timezone
+    now_iso = datetime.now(timezone.utc).isoformat()
     await redis_client.redis.set(_FINETUNE_ACTIVE_MODEL_KEY, fine_tuned_model_id)
+    await redis_client.redis.set(f"{_FINETUNE_ACTIVE_MODEL_KEY}:deployed_at", now_iso)
+
     logger.info(
-        "[OBS] Active fine-tuned model ID updated in Redis.",
+        "[OBS] Active fine-tuned model ID updated in Redis (Hot-swapped).",
         extra={
             "active_model_key": _FINETUNE_ACTIVE_MODEL_KEY,
-            # 모델 ID 자체는 민감 정보가 아니므로 일부만 마스킹하여 추적성 유지
             "model_id_preview": _preview_id(fine_tuned_model_id),
+            "deployed_at": now_iso,
         },
     )
 
@@ -555,3 +575,99 @@ async def get_active_finetune_model() -> Optional[str]:
 
     model_id: str = raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
     return model_id if model_id else None
+
+async def get_model_performance_comparison() -> dict:
+    """
+    이전 모델과 현재 파인튜닝 모델 간의 피드백(User Rating)을 비교하여 반환합니다.
+    """
+    if not redis_client.is_connected() or not redis_client.redis:
+        await redis_client.connect()
+        if not redis_client.redis:
+            raise RuntimeError("Redis connection not established.")
+        
+    current_model_raw = await redis_client.redis.get(_FINETUNE_ACTIVE_MODEL_KEY)
+    deployed_at_raw = await redis_client.redis.get(f"{_FINETUNE_ACTIVE_MODEL_KEY}:deployed_at")
+    previous_model_raw = await redis_client.redis.get(f"{_FINETUNE_ACTIVE_MODEL_KEY}:previous")
+    prev_deployed_at_raw = await redis_client.redis.get(f"{_FINETUNE_ACTIVE_MODEL_KEY}:previous_deployed_at")
+
+    def _decode(val) -> str | None:
+        if not val: return None
+        return val.decode("utf-8") if isinstance(val, bytes) else str(val)
+
+    current_model = _decode(current_model_raw)
+    deployed_at_str = _decode(deployed_at_raw)
+    previous_model = _decode(previous_model_raw)
+    prev_deployed_at_str = _decode(prev_deployed_at_raw)
+
+    import datetime
+    
+    def _to_timestamp(iso_str) -> float:
+        if not iso_str: return 0.0
+        try:
+            return datetime.datetime.fromisoformat(iso_str.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return 0.0
+
+    deployed_ts = _to_timestamp(deployed_at_str)
+    prev_deployed_ts = _to_timestamp(prev_deployed_at_str)
+
+    # Redis에서 피드백 데이터 스캔 (ChatHistoryService와 동일한 PREFIX)
+    cursor = 0
+    prev_up = prev_down = 0
+    curr_up = curr_down = 0
+    
+    from backend.services.chat_history_service import FEEDBACK_KEY_PREFIX
+    from backend.api.models.shared import RATING_UP, RATING_DOWN
+    import json
+    
+    while True:
+        cursor, keys = await redis_client.redis.scan(cursor, match=f"{FEEDBACK_KEY_PREFIX}*", count=100)
+        for key in keys:
+            hash_data = await redis_client.redis.hgetall(key)
+            for _, meta_raw in hash_data.items():
+                meta_str = _decode(meta_raw)
+                if not meta_str: continue
+                try:
+                    meta = json.loads(meta_str)
+                    rating = meta.get("rating")
+                    raw_ts = meta.get("timestamp")
+                    
+                    if rating not in (RATING_UP, RATING_DOWN):
+                        continue
+                        
+                    if isinstance(raw_ts, (int, float, str)) and not isinstance(raw_ts, bool):
+                        ts = _to_timestamp(str(raw_ts).strip())
+                    else:
+                        continue
+                        
+                    if ts >= deployed_ts and deployed_ts > 0:
+                        if rating == RATING_UP: curr_up += 1
+                        else: curr_down += 1
+                    elif ts >= prev_deployed_ts and ts < deployed_ts:
+                        if rating == RATING_UP: prev_up += 1
+                        else: prev_down += 1
+                        
+                except Exception:
+                    pass
+        if int(cursor) == 0:
+            break
+            
+    def _calc_score(u: int, d: int) -> float:
+        tot = u + d
+        return round((u / tot) * 100, 2) if tot > 0 else 0.0
+
+    prev_score = _calc_score(prev_up, prev_down)
+    curr_score = _calc_score(curr_up, curr_down)
+
+    return {
+        "previous_model_id": previous_model,
+        "current_model_id": current_model,
+        "deployed_at": deployed_at_str,
+        "previous_up": prev_up,
+        "previous_down": prev_down,
+        "previous_score": prev_score,
+        "current_up": curr_up,
+        "current_down": curr_down,
+        "current_score": curr_score,
+        "score_improvement": round(curr_score - prev_score, 2)
+    }


### PR DESCRIPTION
- **[성능 평가 파이프라인 엔진]**
  - 파인튜닝 핫스왑(`set_active_finetune_model`) 시 이전 모델 ID와 배포 타임스탬프를 보존(백업)하도록 로직 고도화.
  - Redis 해시 구조를 실시간 스캔(`SCAN`)하여 User Rating(up/down) 기반 시간 분할 성능(배포 전/후) 집계 함수 (`get_model_performance_comparison`) 신설.

- **[어드민 엔드포인트 신설]**
  - `GET /admin/models/performance` API를 추가하여 대시보드 단의 실시간 A/B 성능 리포트 지원.
  - `ModelPerformanceComparison` 응답 스키마를 정의하여 긍/부정 카운트 및 증감률(score_improvement) 반환.

🔗 Related: Issue [#1045]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

이전 및 현재 파인튜닝된 모델 간의 사용자 평점 기반 성능을 자동으로 비교하고, 이를 관리자용 API 엔드포인트를 통해 제공하도록 기능을 추가했습니다.

새로운 기능:
- A/B 성능 분석을 지원하기 위해 Redis에 이전 활성 파인튜닝 모델 ID와 배포 타임스탬프를 저장합니다.
- 모델 배포 전후의 사용자 평점 피드백을 집계하여 비교 성능 점수를 계산하는 서비스 함수를 도입합니다.
- 대시보드에서 사용할 수 있도록 모델 간의 실시간 성능 비교 지표를 조회하는 새로운 인증된 관리자 엔드포인트를 노출합니다.
- 모델별 피드백 횟수, 점수, 점수 향상을 포함하는 `ModelPerformanceComparison` 응답 스키마를 정의합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automated comparison of user-rating-based performance between previous and current fine-tuned models and expose it via an admin API endpoint.

New Features:
- Track previous active fine-tuned model ID and deployment timestamps in Redis to support A/B performance analysis.
- Introduce a service function that aggregates user rating feedback before and after model deployment to compute comparative performance scores.
- Expose a new authenticated admin endpoint to retrieve real-time performance comparison metrics between models for dashboard use.
- Define a ModelPerformanceComparison response schema capturing per-model feedback counts, scores, and score improvement.

</details>