### PR TITLE
⚡️ perf [#12.1.5]: 2차 개선 - 피드백 스캔 파이프라이닝 최적화 및 타임스탬프 통계 방어

### DIFF
--- a/backend/services/finetune_service.py
+++ b/backend/services/finetune_service.py
@@ -628,35 +628,47 @@ async def get_model_performance_comparison() -> dict:
     
     while True:
         cursor, keys = await redis_client.redis.scan(cursor, match=f"{FEEDBACK_KEY_PREFIX}*", count=100)
-        for key in keys:
-            hash_data = await redis_client.redis.hgetall(key)
-            for _, meta_raw in hash_data.items():
-                meta_str = _decode(meta_raw)
-                if not meta_str: continue
-                try:
-                    meta = json.loads(meta_str)
-                    rating = meta.get("rating")
-                    raw_ts = meta.get("timestamp")
-                    
-                    if rating not in (RATING_UP, RATING_DOWN):
-                        continue
+        
+        if keys:
+            # Pipelining HGETALL calls to significantly reduce network roundtrips
+            pipeline = redis_client.redis.pipeline()
+            for key in keys:
+                pipeline.hgetall(key)
+            batch_results = await pipeline.execute()
+            
+            for hash_data in batch_results:
+                if not hash_data: continue
+                # Redis-py 3.x/4.x 버전에 따라 dict 형식이 반환됩니다
+                for _, meta_raw in hash_data.items():
+                    meta_str = _decode(meta_raw)
+                    if not meta_str: continue
+                    try:
+                        meta = json.loads(meta_str)
+                        rating = meta.get("rating")
+                        raw_ts = meta.get("timestamp")
                         
-                    if isinstance(raw_ts, (int, float, str)) and not isinstance(raw_ts, bool):
-                        ts = _to_timestamp(raw_ts)
-                    else:
-                        continue
-                        
-                    # deployed_ts가 0.0이면, Hot-swap 한 번도 안 일어났으므로 모든 것을 현재 모델로 분류
-                    if deployed_ts == 0.0 or ts >= deployed_ts:
-                        if rating == RATING_UP: curr_up += 1
-                        else: curr_down += 1
-                    # deployed_ts 기록은 있지만 이전 기록이 없거나, 이전 기록 시간 이상인 경우
-                    elif prev_deployed_ts == 0.0 or ts >= prev_deployed_ts:
-                        if rating == RATING_UP: prev_up += 1
-                        else: prev_down += 1
-                        
-                except (json.JSONDecodeError, ValueError, TypeError) as e:
-                    logger.debug("[OBS] Failed to parse feedback entry for performance comparison: %s", e)
+                        if rating not in (RATING_UP, RATING_DOWN):
+                            continue
+                            
+                        ts = 0.0
+                        if isinstance(raw_ts, (int, float, str)) and not isinstance(raw_ts, bool):
+                            ts = _to_timestamp(raw_ts)
+                            
+                        # 유효하지 않은 타임스탬프는 맹목적으로 누적하지 않고 생략하여 통계 오염 방지
+                        if ts <= 0.0:
+                            continue
+                            
+                        # deployed_ts가 0.0이면, Hot-swap 한 번도 안 일어났으므로 모든 것을 현재 모델로 분류
+                        if deployed_ts == 0.0 or ts >= deployed_ts:
+                            if rating == RATING_UP: curr_up += 1
+                            else: curr_down += 1
+                        # deployed_ts 기록은 있지만 이전 기록이 없거나, 이전 기록 시간 이상인 경우
+                        elif prev_deployed_ts == 0.0 or ts >= prev_deployed_ts:
+                            if rating == RATING_UP: prev_up += 1
+                            else: prev_down += 1
+                            
+                    except (json.JSONDecodeError, ValueError, TypeError) as e:
+                        logger.debug("[OBS] Failed to parse feedback entry for performance comparison: %s", e)
         if int(cursor) == 0:
             break
             

--- a/backend/services/finetune_service.py
+++ b/backend/services/finetune_service.py
@@ -626,12 +626,14 @@ async def get_model_performance_comparison() -> dict:
     from backend.api.models.shared import RATING_UP, RATING_DOWN
     import json
     
+    # 불필요한 MULTI/EXEC 오버헤드 방지를 위해 transaction=False 설정 (읽기 전용이므로 안전)
+    pipeline = redis_client.redis.pipeline(transaction=False)
+    
     while True:
         cursor, keys = await redis_client.redis.scan(cursor, match=f"{FEEDBACK_KEY_PREFIX}*", count=100)
         
         if keys:
             # Pipelining HGETALL calls to significantly reduce network roundtrips
-            pipeline = redis_client.redis.pipeline()
             for key in keys:
                 pipeline.hgetall(key)
             batch_results = await pipeline.execute()
@@ -650,9 +652,10 @@ async def get_model_performance_comparison() -> dict:
                         if rating not in (RATING_UP, RATING_DOWN):
                             continue
                             
-                        ts = 0.0
                         if isinstance(raw_ts, (int, float, str)) and not isinstance(raw_ts, bool):
                             ts = _to_timestamp(raw_ts)
+                        else:
+                            continue
                             
                         # 유효하지 않은 타임스탬프는 맹목적으로 누적하지 않고 생략하여 통계 오염 방지
                         if ts <= 0.0:


### PR DESCRIPTION
- **[성능 최적화 (Performance)]**
  - `get_model_performance_comparison`에서 O(N)만큼 발생하던 `HGETALL` 네트워크 Round-trip을 방지.
  - `redis.pipeline()`을 적용해 SCAN으로 가져온 배치 분량(최대 100개)을 단 한 번의 호출로 페치하도록 고도화하여 대규모 데이터 환경 병목 해소.

- **[결함 및 의도치 않은 데이터 오염 수정]**
  - 형태가 손상되어 파싱 실패(`0.0`)된 피드백 타임스탬프가 무조건 최신 모델(current) 실적에 반영되어 통계를 왜곡하는 현상 차단 (`ts <= 0.0` 명시적 제외 처리).

🔗 Related:
- Issue [#1045]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1092#pullrequestreview-4100300366)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Redis 피드백 해시 조회를 배치 처리하고 타임스탬프 처리를 강화하여 통계가 왜곡되지 않도록 함으로써 피드백 성능 비교를 최적화합니다.

Bug Fixes:
- 잘못된 형식이거나 0 이하인 피드백 타임스탬프를 성능 통계에서 제외하여, 현재 모델에 잘못 귀속되는 현상을 방지합니다.

Enhancements:
- SCAN 결과에 대해 파이프라이닝을 사용해 Redis `HGETALL` 연산을 배치 처리함으로써 네트워크 왕복 횟수를 줄이고 피드백 성능 비교의 성능을 향상시킵니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize feedback performance comparison by batching Redis feedback hash lookups and hardening timestamp handling to avoid skewed statistics.

Bug Fixes:
- Exclude malformed or non-positive feedback timestamps from performance statistics to prevent incorrect attribution to the current model.

Enhancements:
- Batch Redis HGETALL operations using pipelining for SCAN results to reduce network roundtrips and improve performance of feedback performance comparison.

</details>