### PR TITLE
📝 docs [#12.1.6]: 4차 개선 - 환경 변수 타입 컨벤션 및 Fail-fast 엣지 케이스 명세

### DIFF
--- a/docs/P/v9.0/v9.2_personalized_rag_tasks.md
+++ b/docs/P/v9.0/v9.2_personalized_rag_tasks.md
@@ -22,9 +22,10 @@
     - **해시 전략**: `SHA-256(user_id + per_user_salt + global_pepper)` 구조를 사용하여 결정론적 경로 생성을 보장하되 무차별 대입(Brute-force) 역추적에 강인하도록 설계
       - `per_user_salt`: DB의 사용자 레코드에 일반 평문으로 저장 (보안성보다는 고유성 목적)
       - `global_pepper`: 애플리케이션 시작 시 AWS KMS 또는 HashiCorp Vault와 같은 시크릿 매니저를 통해 메모리에만 안전하게 주입 (소스 코드나 `.env` 평문 저장은 엄격히 금지)
+        - **장애 조치(Edge Case)**: 애플리케이션 부트스트랩 또는 정기 키 로테이션 시 KMS/Vault 조회 실패 시, 개인정보 규제 위반 및 암호화 오염을 막기 위해 애플리케이션 시작을 즉시 중단(Fail-fast 및 CrashLoopBackOff 유도) 처리
 - [ ] 인덱스 수명 주기 관리: 신규 생성 / 증분 업데이트(Incremental Update) / 주기적 재구축(Compaction) 전략 수립
   - **컴팩션 트리거 예시**: 서브-인덱스 내 누적 벡터 개수가 500개를 초과하거나, 잔여 벡터 대비 삭제된 벡터의 비율(`deleted/total`)이 15%를 초과할 경우 백그라운드 워커에서 인덱스 재생성(Rebuild) 수행
-    - 다양한 워크로드 확장에 원활하게 대비하기 위해 해당 임계값은 환경 변수(`FAISS_COMPACTION_VECTOR_THRESHOLD=500`, `FAISS_COMPACTION_DELETE_RATIO=0.15`)로 외부화하여 동적 튜닝이 가능하도록 설계
+    - 다양한 워크로드 확장에 원활하게 대비하기 위해 해당 임계값은 환경 변수(`FAISS_COMPACTION_VECTOR_THRESHOLD` [int, 기본값: 500], `FAISS_COMPACTION_DELETE_RATIO` [float, 기본값: 0.15])로 외부화하여 동적 튜닝이 가능하도록 설계
 - [ ] 인덱스 메타데이터(생성일, 최종 업데이트, 벡터 수) Redis 캐시 저장
 
 ### 2-2. 사용자 관심 토픽 클러스터링
@@ -38,7 +39,7 @@
 
 ### 2-3. 개인화 컨텍스트 가중치 라우팅
 - [ ] `backend/services/hybrid_search_service.py` 확장: 개인 인덱스(60%) + 전역 인덱스(40%) 혼합 검색 라우터 구현
-  - 추천 혼합 비율은 환경 변수 `PERSONALIZED_INDEX_WEIGHT=0.6` / `GLOBAL_INDEX_WEIGHT=0.4`로 오버라이드 가능 (단, 콜드 스타트 조건 부합 시 즉시 전역 100% 편향 로직 적용)
+  - 추천 혼합 비율은 환경 변수 `PERSONALIZED_INDEX_WEIGHT` [float, 기본값: 0.6] 및 `GLOBAL_INDEX_WEIGHT` [float, 기본값: 0.4]로 오버라이드 가능 (단, 콜드 스타트 조건 부합 시 즉시 전역 100% 편향 로직 적용)
 - [ ] LangGraph 에이전트 `retrieve_node`에서 개인화 서브-인덱스 우선 참조하도록 수정
 - [ ] 개인 인덱스 검색 결과와 전역 인덱스 결과 간의 RRF(Reciprocal Rank Fusion) 병합 로직 구현
 

--- a/docs/P/v9.0/v9.2_personalized_rag_tasks.md
+++ b/docs/P/v9.0/v9.2_personalized_rag_tasks.md
@@ -22,10 +22,10 @@
     - **해시 전략**: `SHA-256(user_id + per_user_salt + global_pepper)` 구조를 사용하여 결정론적 경로 생성을 보장하되 무차별 대입(Brute-force) 역추적에 강인하도록 설계
       - `per_user_salt`: DB의 사용자 레코드에 일반 평문으로 저장 (보안성보다는 고유성 목적)
       - `global_pepper`: 애플리케이션 시작 시 AWS KMS 또는 HashiCorp Vault와 같은 시크릿 매니저를 통해 메모리에만 안전하게 주입 (소스 코드나 `.env` 평문 저장은 엄격히 금지)
-        - **장애 조치(Edge Case)**: 애플리케이션 부트스트랩 또는 정기 키 로테이션 시 KMS/Vault 조회 실패 시, 개인정보 규제 위반 및 암호화 오염을 막기 위해 애플리케이션 시작을 즉시 중단(Fail-fast 및 CrashLoopBackOff 유도) 처리
+        - **장애 조치(Edge Case)**: 애플리케이션 부트스트랩 또는 정기 키 로테이션 중 KMS/Vault 조회 실패 시, 네트워크 일시 지연 여부를 확인(타임아웃 5초, 최대 3회 재시도)한 후 최종 실패할 경우 개인정보 규제 위반 및 데이터 오염을 막기 위해 프로세스를 즉시 중단(Fail-fast 및 CrashLoopBackOff 유도) 처리
 - [ ] 인덱스 수명 주기 관리: 신규 생성 / 증분 업데이트(Incremental Update) / 주기적 재구축(Compaction) 전략 수립
   - **컴팩션 트리거 예시**: 서브-인덱스 내 누적 벡터 개수가 500개를 초과하거나, 잔여 벡터 대비 삭제된 벡터의 비율(`deleted/total`)이 15%를 초과할 경우 백그라운드 워커에서 인덱스 재생성(Rebuild) 수행
-    - 다양한 워크로드 확장에 원활하게 대비하기 위해 해당 임계값은 환경 변수(`FAISS_COMPACTION_VECTOR_THRESHOLD` [int, 기본값: 500], `FAISS_COMPACTION_DELETE_RATIO` [float, 기본값: 0.15])로 외부화하여 동적 튜닝이 가능하도록 설계
+    - 다양한 워크로드 확장에 원활하게 대비하기 위해 해당 임계값은 환경 변수(`FAISS_COMPACTION_VECTOR_THRESHOLD` [int, 기본값: 500, 최소값: 100], `FAISS_COMPACTION_DELETE_RATIO` [float, 기본값: 0.15, 유효 범위: 0.0~1.0])로 외부화하여 동적 튜닝이 가능하도록 설계
 - [ ] 인덱스 메타데이터(생성일, 최종 업데이트, 벡터 수) Redis 캐시 저장
 
 ### 2-2. 사용자 관심 토픽 클러스터링
@@ -39,7 +39,7 @@
 
 ### 2-3. 개인화 컨텍스트 가중치 라우팅
 - [ ] `backend/services/hybrid_search_service.py` 확장: 개인 인덱스(60%) + 전역 인덱스(40%) 혼합 검색 라우터 구현
-  - 추천 혼합 비율은 환경 변수 `PERSONALIZED_INDEX_WEIGHT` [float, 기본값: 0.6] 및 `GLOBAL_INDEX_WEIGHT` [float, 기본값: 0.4]로 오버라이드 가능 (단, 콜드 스타트 조건 부합 시 즉시 전역 100% 편향 로직 적용)
+  - 추천 혼합 비율은 환경 변수 `PERSONALIZED_INDEX_WEIGHT` [float, 기본값: 0.6, 유효 범위: 0.0~1.0] 및 `GLOBAL_INDEX_WEIGHT` [float, 기본값: 0.4, 유효 범위: 0.0~1.0]로 오버라이드 가능 (단, 콜드 스타트 조건 부합 시 즉시 전역 100% 편향 로직 적용)
 - [ ] LangGraph 에이전트 `retrieve_node`에서 개인화 서브-인덱스 우선 참조하도록 수정
 - [ ] 개인 인덱스 검색 결과와 전역 인덱스 결과 간의 RRF(Reciprocal Rank Fusion) 병합 로직 구현
 


### PR DESCRIPTION
- **[인프라 정합성 보호 (Configuration Types)]**
  - 환경 변수로 외부화한 컴팩션 및 RAG 혼합 가중치 설정값들에 대하여 `[int]`, `[float]` 등 데이터 캐스팅 타입을 명시하여 배포 시 파싱 오류 방지 보강.

- **[보안 엣지 케이스 정책 수립 (Resilience/Edge Case)]**
  - `global_pepper` 의 런타임 메모리 주입 시점(KMS/Vault)에서 통신 장애나 키 조회가 실패할 경우, 데이터 오염 및 보안 위반을 막기 위해 애플리케이션 기동을 즉시 중지시키는 `Fail-fast` 장애 조치 룰 확립.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1100#pullrequestreview-4102553182)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개인화된 RAG 작업에서 비밀값(secret) 조회 실패 시의 즉시 실패(fail-fast) 동작 및 환경 변수 타입 규칙을 문서화합니다.

Documentation:
- FAISS 압축 임계값과 personalized/global 인덱스 가중치가 문서화된 기본값을 가진 타입 지정 환경 변수를 통해 설정된다는 점을 명확히 합니다.
- 부트스트랩 또는 키 로테이션 중 `global_pepper`에 대한 KMS/Vault 조회가 실패할 경우 애플리케이션이 즉시 종료(fail-fast)된다는 동작을 명시합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document environment variable type conventions and fail-fast behavior for secret retrieval failures in personalized RAG tasks.

Documentation:
- Clarify that FAISS compaction thresholds and personalized/global index weights are configured via typed environment variables with documented defaults.
- Specify fail-fast application shutdown behavior when KMS/Vault retrieval of global_pepper fails during bootstrap or key rotation.

</details>