### PR TITLE
📝 docs [#12.1.6]: 8차 개선 - 엔터프라이즈급 SRE 예외 정책 수립 (Jitter & Blast Radius)

### DIFF
--- a/docs/P/v9.0/v9.2_personalized_rag_tasks.md
+++ b/docs/P/v9.0/v9.2_personalized_rag_tasks.md
@@ -23,7 +23,7 @@
       - `per_user_salt`: DB의 사용자 레코드에 일반 평문으로 저장 (보안성보다는 고유성 목적)
       - `global_pepper`: 애플리케이션 시작 시 AWS KMS 또는 HashiCorp Vault와 같은 시크릿 매니저를 통해 메모리에만 안전하게 주입 (소스 코드나 `.env` 평문 저장은 엄격히 금지)
         - **장애 조치(Edge Case)**: 애플리케이션 부트스트랩 또는 정기 키 로테이션 중 KMS/Vault 조회 실패 시 예외 원인별 동작 분리 지원:
-          - 일시적 네트워크 장애(boto3 `EndpointConnectionError`, `ReadTimeoutError`): 타임아웃 5초, 최대 3회 백오프 재시도 수행
+          - 일시적 네트워크 장애 및 Rate Limit(boto3 `EndpointConnectionError`, `ReadTimeoutError`, `ClientError` - `ThrottlingException`): 타임아웃 5초, 최대 3회 재시도(지터가 포함된 지수 백오프, Exponential Backoff with Jitter, 최대 지연 10초) 수행
           - 치명적 권한/존재 오류(boto3 `ClientError` - `AccessDeniedException`, `NotFoundException`): 재시도 없이 즉시 프로세스를 중단(Hard Fail-fast)하여 개인정보 레코드의 암호화 무단 오염 및 노출 원천 차단
 - [ ] 인덱스 수명 주기 관리: 신규 생성 / 증분 업데이트(Incremental Update) / 주기적 재구축(Compaction) 전략 수립
   - **컴팩션 트리거 예시**: 서브-인덱스 내 누적 벡터 개수가 500개를 초과하거나, 잔여 벡터 대비 삭제된 벡터의 비율(`deleted/total`)이 15%를 초과할 경우 백그라운드 워커에서 인덱스 재생성(Rebuild) 수행
@@ -65,7 +65,9 @@
 
 ### 2-5. [공통] 환경 변수 및 설정 검증 정책(Global Configuration Validation Policy)
 - [ ] 시스템 전반의 환경 변수(비율/가중치/임계값 등)에 대한 중앙 집중식 유효성 검사 로직(Validation) 구성
-  - **Hard Failure 원칙**: 파싱 불가능한 값(non-parsable)이거나 유효 범위를 벗어난 값이 주입될 경우, 침묵적 기본값 할당(Silent Fallback)을 엄격히 금지. 예기치 않은 아키텍처 동작을 막기 위해 애플리케이션 부트스트랩 단계에서 즉시 실행을 중단(Hard Failure)하고 인프라에 에러 전파
+  - **장애 전파 범위(Blast Radius) 세분화 및 Hard Failure 원칙**: 
+    - 필수 보안 설정(`STORAGE_BASE_PATH`, `PBKDF2_ITERATIONS` 등) 파싱 오류 시: 보안 오염 방지를 위해 전체 애플리케이션 기동 즉시 중단 (Global Hard Failure)
+    - 선택적 부가 설정(`FAISS_COMPACTION_*`, `TOPIC_CLUSTER_CACHE_TTL` 등) 파싱 오류 시: 침묵적 폴백(Silent Fallback)은 금지하되, 전체 앱 중단 대신 해당 백그라운드 워커나 서브시스템만 비활성화(Subsystem Hard Failure)하여 핵심 REST API 생존성(Resilience) 보장
 
 ---
 

--- a/docs/P/v9.0/v9.2_personalized_rag_tasks.md
+++ b/docs/P/v9.0/v9.2_personalized_rag_tasks.md
@@ -23,7 +23,9 @@
       - `per_user_salt`: DB의 사용자 레코드에 일반 평문으로 저장 (보안성보다는 고유성 목적)
       - `global_pepper`: 애플리케이션 시작 시 AWS KMS 또는 HashiCorp Vault와 같은 시크릿 매니저를 통해 메모리에만 안전하게 주입 (소스 코드나 `.env` 평문 저장은 엄격히 금지)
         - **장애 조치(Edge Case)**: 애플리케이션 부트스트랩 또는 정기 키 로테이션 중 KMS/Vault 조회 실패 시 예외 원인별 동작 분리 지원:
-          - 일시적 네트워크 장애 및 Rate Limit(boto3 `EndpointConnectionError`, `ReadTimeoutError`, `ClientError` - `ThrottlingException`): 타임아웃 5초, 최대 3회 재시도(지터가 포함된 지수 백오프, Exponential Backoff with Jitter, 최대 지연 10초) 수행
+          - 일시적 네트워크 장애 및 버스트 쓰로틀링(boto3 `EndpointConnectionError`, `ReadTimeoutError`, `ClientError` - `ThrottlingException`): 타임아웃 5초, 최대 3회 재시도 수행
+            - **알고리즘 명세**: Boto3 자체의 내장 재시도(Standard Mode)를 명시적으로 비활성화(`max_attempts=0`)하고, 애플리케이션 레벨에서 Full Jitter 방식(Base Delay 1초, Cap 10초)을 직접 구현하여 불필요한 이중 증폭(Double retries) 방지
+            - 단, 계정의 영구적 하드 쿼터 초과(`LimitExceededException`) 발생 시 일시적 장애가 아니므로 즉각적인 Hard Fail-fast로 전환해 불필요한 백오프 점유 방지
           - 치명적 권한/존재 오류(boto3 `ClientError` - `AccessDeniedException`, `NotFoundException`): 재시도 없이 즉시 프로세스를 중단(Hard Fail-fast)하여 개인정보 레코드의 암호화 무단 오염 및 노출 원천 차단
 - [ ] 인덱스 수명 주기 관리: 신규 생성 / 증분 업데이트(Incremental Update) / 주기적 재구축(Compaction) 전략 수립
   - **컴팩션 트리거 예시**: 서브-인덱스 내 누적 벡터 개수가 500개를 초과하거나, 잔여 벡터 대비 삭제된 벡터의 비율(`deleted/total`)이 15%를 초과할 경우 백그라운드 워커에서 인덱스 재생성(Rebuild) 수행
@@ -68,6 +70,7 @@
   - **장애 전파 범위(Blast Radius) 세분화 및 Hard Failure 원칙**: 
     - 필수 보안 설정(`STORAGE_BASE_PATH`, `PBKDF2_ITERATIONS` 등) 파싱 오류 시: 보안 오염 방지를 위해 전체 애플리케이션 기동 즉시 중단 (Global Hard Failure)
     - 선택적 부가 설정(`FAISS_COMPACTION_*`, `TOPIC_CLUSTER_CACHE_TTL` 등) 파싱 오류 시: 침묵적 폴백(Silent Fallback)은 금지하되, 전체 앱 중단 대신 해당 백그라운드 워커나 서브시스템만 비활성화(Subsystem Hard Failure)하여 핵심 REST API 생존성(Resilience) 보장
+      - **운영 가시성(Observability) 의무화**: 비활성화된 워커 시스템이 은폐 운영되지 않도록 앱의 `/health` 엔드포인트에서 상태를 `DEGRADED`로 즉각 노출(Surface)하고, Prometheus/Datadog 메트릭 기반의 긴급 알림(Alerting)을 발송하도록 설계
 
 ---
 


### PR DESCRIPTION
- **[회복탄력성 고도화 (Resilience & Thundering Herd Prevention)]**
  - AWS KMS 재시도 정책에 분산 시스템 모범 사례인 `지터가 포함된 지수 백오프(Exponential Backoff with Jitter)`를 명시하여 재시도 부하 분산.
  - `ThrottlingException(Rate Limit)`을 네트워크 계층 장애(Retryable) 그룹에 적절히 매핑하여 일시적 쿼터 초과 시 유연한 런타임 복구 도모.

- **[장애 격리 설계 (Fault Isolation / Blast Radius)]**
  - 기존의 단일 통합 예외 정책(Global Hard Failure)을 쪼개어 서브시스템 장애 전파(Blast Radius)를 제어하는 정책 선언.
  - 비핵심 부가 설정(컴팩션 룰 등) 파싱 에러 시에는 전체 앱을 중단하지 않고, 해당 워커만 격리하여 정지시키는 `부분 장애(Subsystem Hard Failure)` 전략을 채택하여 핵심 REST API의 생존성 보장.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1104#pullrequestreview-4102607907)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개인화된 RAG 작업에서 시크릿 조회 재시도 및 블라스트 반경 제어와 관련된 SRE 예외 및 구성 정책을 정교하게 다듬고 문서화했습니다.

New Features:
- 시크릿 조회 시 KMS/Vault 재시도 동작을, 지터가 포함된 지수 백오프(exponential backoff with jitter) 및 스로틀링(throttling) 오류에 대한 명시적 처리 방식으로 명확히 했습니다.
- 중요하지 않은 서브시스템을 격리하는 차등적 하드 실패(hard-failure) 정책을 정의하고, 동시에 중요한 보안 구성 오류 발생 시 전역 실패를 강제하도록 했습니다.

Documentation:
- KMS/Vault 접근을 위해 지터가 포함된 지수 백오프와 레이트 리미팅(rate limiting) 고려 사항을 반영하도록 복원력(resilience) 관련 문서를 업데이트했습니다.
- 블라스트 반경을 제한하면서도 코어 API 가용성을 보장할 수 있도록, 전역 하드 실패와 서브시스템 하드 실패를 구분하는 구성 검증 가이드라인을 확장했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document refined SRE exception and configuration policies for secret retrieval retries and blast radius control in personalized RAG tasks.

New Features:
- Clarify KMS/Vault retry behavior using exponential backoff with jitter and explicit handling of throttling errors in secret retrieval.
- Define differentiated hard-failure policies that isolate non-critical subsystems while enforcing global failure on critical security configuration errors.

Documentation:
- Update resilience documentation to incorporate jittered exponential backoff and rate limiting considerations for KMS/Vault access.
- Extend configuration validation guidelines to distinguish between global and subsystem hard failures to limit blast radius while preserving core API availability.

</details>