### PR TITLE
📝 docs [#12.1.6]: 10차 개선 - Singleton 래퍼 제어 및 Health Registry 연동 아키텍처 고도화

### DIFF
--- a/docs/P/v9.0/v9.2_personalized_rag_tasks.md
+++ b/docs/P/v9.0/v9.2_personalized_rag_tasks.md
@@ -24,7 +24,7 @@
       - `global_pepper`: 애플리케이션 시작 시 AWS KMS 또는 HashiCorp Vault와 같은 시크릿 매니저를 통해 메모리에만 안전하게 주입 (소스 코드나 `.env` 평문 저장은 엄격히 금지)
         - **장애 조치(Edge Case)**: 애플리케이션 부트스트랩 또는 정기 키 로테이션 중 KMS/Vault 조회 실패 시 예외 원인별 동작 분리 지원:
           - 일시적 네트워크 장애 및 버스트 쓰로틀링(boto3 `EndpointConnectionError`, `ReadTimeoutError`, `ClientError` - `ThrottlingException`): 타임아웃 5초, 최대 3회 재시도 수행
-            - **알고리즘 명세**: 단일 인스턴스 패턴을 적용한 중앙 집중식 AWS 클라이언트 래퍼(예: `backend/core/aws_client.py`)에서만 Boto3 내장 재시도(Standard Mode)를 명시적으로 비활성화(`max_attempts=0`)하고, 애플리케이션 레벨의 Full Jitter 방식(Base Delay 1초, Cap 10초)을 독점 구현하여 타 컴포넌트 개발 시의 적용 누락 및 이중 증폭(Double retries) 방지
+            - **알고리즘 명세**: 단일 인스턴스 패턴을 적용한 단일 공통 AWS 클라이언트 래퍼 모듈(Single shared AWS client wrapper module)에서만 Boto3 내장 재시도(Standard Mode)를 명시적으로 비활성화(`max_attempts=0`)하고, 애플리케이션 레벨의 Full Jitter 방식(Base Delay 1초, Cap 10초)을 독점 구현하여 타 컴포넌트 개발 시의 적용 누락 및 이중 증폭(Double retries) 방지
             - 단, 계정의 영구적 하드 쿼터 초과(`LimitExceededException`) 발생 시 일시적 장애가 아니므로 즉각적인 Hard Fail-fast로 전환해 불필요한 백오프 점유 방지
           - 치명적 권한/존재 오류(boto3 `ClientError` - `AccessDeniedException`, `NotFoundException`): 재시도 없이 즉시 프로세스를 중단(Hard Fail-fast)하여 개인정보 레코드의 암호화 무단 오염 및 노출 원천 차단
 - [ ] 인덱스 수명 주기 관리: 신규 생성 / 증분 업데이트(Incremental Update) / 주기적 재구축(Compaction) 전략 수립
@@ -70,7 +70,10 @@
   - **장애 전파 범위(Blast Radius) 세분화 및 Hard Failure 원칙**: 
     - 필수 보안 설정(`STORAGE_BASE_PATH`, `PBKDF2_ITERATIONS` 등) 파싱 오류 시: 보안 오염 방지를 위해 전체 애플리케이션 기동 즉시 중단 (Global Hard Failure)
     - 선택적 부가 설정(`FAISS_COMPACTION_*`, `TOPIC_CLUSTER_CACHE_TTL` 등) 파싱 오류 시: 침묵적 폴백(Silent Fallback)은 금지하되, 전체 앱 중단 대신 해당 백그라운드 워커나 서브시스템만 비활성화(Subsystem Hard Failure)하여 핵심 REST API 생존성(Resilience) 보장
-      - **운영 가시성(Observability) 의무화**: 상태 은폐를 방지하기 위해, 장애가 난 서브시스템은 즉각 공통 상태 레지스트리(예: `HealthRegistry` 싱글톤 객체 또는 Redis State)에 결함 코드를 기록(Publish)해야 함. 중앙 `/health` 엔드포인트는 이 레지스트리를 단일 진실 공급원(SSOT)으로 취합하여 `DEGRADED` 상태 표출 및 Alert 메트릭을 연동 발송.
+      - **운영 가시성(Observability) 의무화**: 상태 은폐를 방지하기 위해, 장애가 난 서브시스템은 즉각 공통 상태 레지스트리에 결함 코드를 기록(Publish)해야 함. 중앙 `/health` 엔드포인트는 이 레지스트리를 단일 진실 공급원(SSOT)으로 쿼리하여 `DEGRADED` 상태 표출 및 Alert 메트릭을 연동 발송.
+        - **분산 상태 동기화 모델**: 배포 환경에 따른 상태 불일치(Ambiguity) 방지
+          - 단일 워커/인스턴스 구동 시: 메모리 기반 인프로세스(In-process) 싱글톤 참조
+          - 멀티 파드(Multi-pod) 분산 구동 시: Redis를 SSOT로 사용하여 스케일 아웃된 워커 간의 일관된 헬스 뷰(Consistent Health View) 보장
 
 ---
 

--- a/docs/P/v9.0/v9.2_personalized_rag_tasks.md
+++ b/docs/P/v9.0/v9.2_personalized_rag_tasks.md
@@ -24,7 +24,7 @@
       - `global_pepper`: 애플리케이션 시작 시 AWS KMS 또는 HashiCorp Vault와 같은 시크릿 매니저를 통해 메모리에만 안전하게 주입 (소스 코드나 `.env` 평문 저장은 엄격히 금지)
         - **장애 조치(Edge Case)**: 애플리케이션 부트스트랩 또는 정기 키 로테이션 중 KMS/Vault 조회 실패 시 예외 원인별 동작 분리 지원:
           - 일시적 네트워크 장애 및 버스트 쓰로틀링(boto3 `EndpointConnectionError`, `ReadTimeoutError`, `ClientError` - `ThrottlingException`): 타임아웃 5초, 최대 3회 재시도 수행
-            - **알고리즘 명세**: Boto3 자체의 내장 재시도(Standard Mode)를 명시적으로 비활성화(`max_attempts=0`)하고, 애플리케이션 레벨에서 Full Jitter 방식(Base Delay 1초, Cap 10초)을 직접 구현하여 불필요한 이중 증폭(Double retries) 방지
+            - **알고리즘 명세**: 단일 인스턴스 패턴을 적용한 중앙 집중식 AWS 클라이언트 래퍼(예: `backend/core/aws_client.py`)에서만 Boto3 내장 재시도(Standard Mode)를 명시적으로 비활성화(`max_attempts=0`)하고, 애플리케이션 레벨의 Full Jitter 방식(Base Delay 1초, Cap 10초)을 독점 구현하여 타 컴포넌트 개발 시의 적용 누락 및 이중 증폭(Double retries) 방지
             - 단, 계정의 영구적 하드 쿼터 초과(`LimitExceededException`) 발생 시 일시적 장애가 아니므로 즉각적인 Hard Fail-fast로 전환해 불필요한 백오프 점유 방지
           - 치명적 권한/존재 오류(boto3 `ClientError` - `AccessDeniedException`, `NotFoundException`): 재시도 없이 즉시 프로세스를 중단(Hard Fail-fast)하여 개인정보 레코드의 암호화 무단 오염 및 노출 원천 차단
 - [ ] 인덱스 수명 주기 관리: 신규 생성 / 증분 업데이트(Incremental Update) / 주기적 재구축(Compaction) 전략 수립
@@ -70,7 +70,7 @@
   - **장애 전파 범위(Blast Radius) 세분화 및 Hard Failure 원칙**: 
     - 필수 보안 설정(`STORAGE_BASE_PATH`, `PBKDF2_ITERATIONS` 등) 파싱 오류 시: 보안 오염 방지를 위해 전체 애플리케이션 기동 즉시 중단 (Global Hard Failure)
     - 선택적 부가 설정(`FAISS_COMPACTION_*`, `TOPIC_CLUSTER_CACHE_TTL` 등) 파싱 오류 시: 침묵적 폴백(Silent Fallback)은 금지하되, 전체 앱 중단 대신 해당 백그라운드 워커나 서브시스템만 비활성화(Subsystem Hard Failure)하여 핵심 REST API 생존성(Resilience) 보장
-      - **운영 가시성(Observability) 의무화**: 비활성화된 워커 시스템이 은폐 운영되지 않도록 앱의 `/health` 엔드포인트에서 상태를 `DEGRADED`로 즉각 노출(Surface)하고, Prometheus/Datadog 메트릭 기반의 긴급 알림(Alerting)을 발송하도록 설계
+      - **운영 가시성(Observability) 의무화**: 상태 은폐를 방지하기 위해, 장애가 난 서브시스템은 즉각 공통 상태 레지스트리(예: `HealthRegistry` 싱글톤 객체 또는 Redis State)에 결함 코드를 기록(Publish)해야 함. 중앙 `/health` 엔드포인트는 이 레지스트리를 단일 진실 공급원(SSOT)으로 취합하여 `DEGRADED` 상태 표출 및 Alert 메트릭을 연동 발송.
 
 ---
 


### PR DESCRIPTION
- **[단일 진실 공급원 (SSOT) 기반 백오프 제어]**
  - 개발자 파편화 오류로 인한 KMS 패킷 이중 증폭(Double Retry)을 근본적으로 차단하기 위해, Full Jitter 백오프 로직은 `backend/core/aws_client.py` 중앙 래퍼(Wrapper)에서 독점 제어하도록 설계 가이드 확립.

- **[결합도 낮은(Decoupled) 관제 아키텍처]**
  - HTTP 통신 기반의 `/health` 라우터가 백그라운드 워커의 상태를 일일이 추적하지 않도록, 공통 상태 레지스트리(`HealthRegistry` 싱글톤 도는 Redis)를 통한 상태 Publish 파이프라인을 채택하여 Observability 구현 구체화.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1106#pullrequestreview-4102632031)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

중앙 집중식 AWS 클라이언트 재시도 제어 및 공유 레지스트리를 통한 저하된 서브시스템의 헬스 상태 전파에 관한 문서를 명확히 합니다.

Documentation:
- 재시도 알고리즘 가이드를 업데이트하여, Boto3 재시도를 비활성화하고 Full Jitter 백오프를 구현하는 유일한 위치로 싱글톤 AWS 클라이언트 래퍼를 사용하도록 요구합니다.
- 관측 가능성(Observability) 가이드를 개선하여, 서브시스템 장애 시 상태를 공용 헬스 레지스트리에 게시하고, 중앙 `/health` 엔드포인트가 이를 소비하여 저하 상태 리포팅 및 알림에 활용하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify documentation around centralized AWS client retry control and health status propagation via a shared registry for degraded subsystems.

Documentation:
- Update retry algorithm guidance to mandate a singleton AWS client wrapper as the sole place to disable Boto3 retries and implement Full Jitter backoff.
- Refine observability guidelines so that subsystem failures publish status to a shared health registry consumed by the central /health endpoint for degraded reporting and alerting.

</details>