### PR TITLE
📝 docs [#12.1.6]: 14차 개선 - 비동기 데드락(Deadlock) 차단 설계 및 Redis TTL 기반 무결성 방어 도입

### DIFF
--- a/docs/P/v9.0/v9.2_personalized_rag_tasks.md
+++ b/docs/P/v9.0/v9.2_personalized_rag_tasks.md
@@ -25,7 +25,8 @@
         - **장애 조치(Edge Case)**: 애플리케이션 부트스트랩 또는 정기 키 로테이션 중 KMS/Vault 조회 실패 시 예외 원인별 동작 분리 지원:
           - 일시적 네트워크 장애 및 버스트 쓰로틀링(boto3 `EndpointConnectionError`, `ReadTimeoutError`, `ClientError` - `ThrottlingException`): 타임아웃 5초, 최대 3회 재시도 수행
             - **알고리즘 명세**: 단일 인스턴스 패턴을 적용한 단일 공통 AWS 클라이언트 래퍼 모듈(Single shared AWS client wrapper module)에서만 Boto3 내장 재시도(Standard Mode)를 명시적으로 비활성화(`max_attempts=0`)하고, 애플리케이션 레벨의 Full Jitter 방식(Base Delay 1초, Cap 10초)을 독점 구현하여 타 컴포넌트 개발 시의 적용 누락 및 이중 증폭(Double retries) 방지
-              - **스레드 안전성(Thread-Safety) 및 커넥션 풀링**: 해당 래퍼 모듈은 다중 스레드 환경을 위해 프로세스 레벨 락(`threading.Lock` / `asyncio.Lock`)을 통한 스레드-세이프 초기화를 보장함. 단, 멀티-프로세싱(Gunicorn/Uvicorn 등) 배포 환경에서는 Fork-safety 이슈(소켓 공유 충돌) 방지를 위해 전역 락 스코프를 '개별 프로세스(Worker) 단위'로 엄격히 격리하고 독립적인 Boto3 Session 커넥션 풀(Connection Pooling)을 생성하여 리소스 충돌을 차단하도록 설계
+              - **동시성 환경에서의 스레드 안전성(Thread-Safety) 및 커넥션 풀링**: 다중 스레드/비동기 혼합 파이썬 환경에서 데드락(Deadlock)을 방지하기 위해, 동기 호출용 `threading.Lock`과 비동기 호출용 `asyncio.Lock`의 컨텍스트를 엄격히 분리하고 동기화된 Boto3 초기화 연산은 이벤트 루프 블로킹(Event Loop Blocking)을 피하도록 스레드 풀(`run_in_executor`)로 위임(Offload)하는 래퍼 호출 패턴을 강제함.
+              - **포크 환경 안정성(Fork-Safety)**: Gunicorn/Uvicorn 등 멀티-프로세싱 워커 구동 시 부모 프로세스의 소켓 공유로 인한 크래시를 원천 차단하고자, Boto3 Session 커넥션 풀은 앱 로드 시점이 아닌 **프로세스 포크(Fork) 이후 단계(Post-fork 훅 또는 FastAPI lifespan)**에서 워커 단위로 지연 생성(Lazy Initialization)되도록 이격 설계
             - 단, 계정의 영구적 하드 쿼터 초과(`LimitExceededException`) 발생 시 일시적 장애가 아니므로 즉각적인 Hard Fail-fast로 전환해 불필요한 백오프 점유 방지
           - 치명적 권한/존재 오류(boto3 `ClientError` - `AccessDeniedException`, `NotFoundException`): 재시도 없이 즉시 프로세스를 중단(Hard Fail-fast)하여 개인정보 레코드의 암호화 무단 오염 및 노출 원천 차단
 - [ ] 인덱스 수명 주기 관리: 신규 생성 / 증분 업데이트(Incremental Update) / 주기적 재구축(Compaction) 전략 수립
@@ -75,11 +76,11 @@
         - **분산 상태 동기화 및 파티션 내성(Tolerance)**:
           - 단일 파드(Single-pod) 구동: 메모리 기반 인프로세스(In-process) 싱글톤 우선 참조
           - 멀티 파드(Multi-pod) 분산 구동: Redis를 SSOT로 사용하여 파드 간의 배포 상태 불일치 해소.
-          - **CAP 정리 트레이드오프(Trade-off)**: Redis 파티션/네트워크 단절 장애 시 \`/health\` 다운을 막기 위해 로컬 인프로세스 캐시 상태로 우아한 폴백(Graceful Fallback)을 발동. 이 경우 헬스 상태의 정합성 저하/지연(Stale State)이 일시적으로 발생할 수 있으나, 시스템 오탐으로 인한 연쇄 셧다운(False-positive crash)을 방지하고 상태 가용성(Availability)을 우선시하는 아키텍처적 결단을 수용함.
+          - **CAP 정리 트레이드오프(Trade-off)**: Redis 파티션/네트워크 단절 차단 시 \`/health\` 다운을 지연시키기 위해 최대 허용 시간(TTL, 예: 5분) 내에서만 로컬 인프로세스 캐시 상태로 우아한 폴백(Graceful Fallback)을 발동. 이 경우 헬스 상태의 정합성 지연(Stale State)을 일시 수용하여 오탐 셧다운(False-positive crash)을 방어하고 가용성(Availability)을 극대화함. 단, TTL을 초과하여 Redis가 장기 파티션될 경우 최종적으로 `DEGRADED` 하드 폴백을 발동하여 영구적인 장애 은폐 방지
         - **SSOT 통신 시퀀스 (책임 경계)**:
           1. **장애 보고(Publish)**: 에지 워커 스레드가 자체 결함 포착 시 레지스트리에 장애 코드 쓰기
           2. **취합 쿼리(Retrieve)**: 중앙 `/health` 컨트롤러가 주기적 폴링 없이, 수신된 핑(Ping) 시점에 레지스트리 상태만 Read하여 비용 최소화
-          3. **발송(Alerting)**: 수집된 상태 코드를 기반으로 `DEGRADED` Http 코드 응답 및 Datadog/Prometheus 메트릭 노출
+          3. **발송(Alerting)**: 수집된 상태 코드를 기반으로 `DEGRADED` HTTP 코드 응답 및 Datadog/Prometheus 메트릭 노출
 
 ---
 

--- a/docs/P/v9.0/v9.2_personalized_rag_tasks.md
+++ b/docs/P/v9.0/v9.2_personalized_rag_tasks.md
@@ -25,8 +25,8 @@
         - **장애 조치(Edge Case)**: 애플리케이션 부트스트랩 또는 정기 키 로테이션 중 KMS/Vault 조회 실패 시 예외 원인별 동작 분리 지원:
           - 일시적 네트워크 장애 및 버스트 쓰로틀링(boto3 `EndpointConnectionError`, `ReadTimeoutError`, `ClientError` - `ThrottlingException`): 타임아웃 5초, 최대 3회 재시도 수행
             - **알고리즘 명세**: 단일 인스턴스 패턴을 적용한 단일 공통 AWS 클라이언트 래퍼 모듈(Single shared AWS client wrapper module)에서만 Boto3 내장 재시도(Standard Mode)를 명시적으로 비활성화(`max_attempts=0`)하고, 애플리케이션 레벨의 Full Jitter 방식(Base Delay 1초, Cap 10초)을 독점 구현하여 타 컴포넌트 개발 시의 적용 누락 및 이중 증폭(Double retries) 방지
-              - **동시성 환경에서의 스레드 안전성(Thread-Safety) 및 커넥션 풀링**: 다중 스레드/비동기 혼합 파이썬 환경에서 데드락(Deadlock)을 방지하기 위해, 동기 호출용 `threading.Lock`과 비동기 호출용 `asyncio.Lock`의 컨텍스트를 엄격히 분리하고 동기화된 Boto3 초기화 연산은 이벤트 루프 블로킹(Event Loop Blocking)을 피하도록 스레드 풀(`run_in_executor`)로 위임(Offload)하는 래퍼 호출 패턴을 강제함.
-              - **포크 환경 안정성(Fork-Safety)**: Gunicorn/Uvicorn 등 멀티-프로세싱 워커 구동 시 부모 프로세스의 소켓 공유로 인한 크래시를 원천 차단하고자, Boto3 Session 커넥션 풀은 앱 로드 시점이 아닌 **프로세스 포크(Fork) 이후 단계(Post-fork 훅 또는 FastAPI lifespan)**에서 워커 단위로 지연 생성(Lazy Initialization)되도록 이격 설계
+              - **동시성 환경에서의 스레드 안전성(Thread-Safety) 및 커넥션 풀링**: 다중 스레드/비동기 혼합 파이썬 환경에서 데드락(Deadlock)을 방지하기 위해, 동기 호출용 `threading.Lock`과 비동기 호출용 `asyncio.Lock`의 컨텍스트를 엄격히 분리함. 또한, 무거운 Boto3 초기화 연산은 이벤트 루프 블로킹을 피하도록 OOM 방지용 제한된 크기의 커스텀 `ThreadPoolExecutor(max_workers=...)`에 `run_in_executor`로 오프로드(Offload)하여 제어를 강제.
+              - **포크 환경 안정성(Fork-Safety)**: 워커 포크 시 소켓 공유로 인한 크래시를 차단하고자, Boto3 Session 커넥션 풀은 앱 로드 시점이 아닌 프로세스 포크 이후 지연 생성(Lazy Initialization)되도록 설계. 관리 파편화를 피하기 위해, 서버 환경 종속적인 Gunicorn Post-fork 훅 대신 **프레임워크 표준인 FastAPI lifespan 이벤트를 최우선 생성 지점(Source of Initialization)으로 일원화**하여 이중 커넥션 생성을 철저히 방지.
             - 단, 계정의 영구적 하드 쿼터 초과(`LimitExceededException`) 발생 시 일시적 장애가 아니므로 즉각적인 Hard Fail-fast로 전환해 불필요한 백오프 점유 방지
           - 치명적 권한/존재 오류(boto3 `ClientError` - `AccessDeniedException`, `NotFoundException`): 재시도 없이 즉시 프로세스를 중단(Hard Fail-fast)하여 개인정보 레코드의 암호화 무단 오염 및 노출 원천 차단
 - [ ] 인덱스 수명 주기 관리: 신규 생성 / 증분 업데이트(Incremental Update) / 주기적 재구축(Compaction) 전략 수립
@@ -76,11 +76,11 @@
         - **분산 상태 동기화 및 파티션 내성(Tolerance)**:
           - 단일 파드(Single-pod) 구동: 메모리 기반 인프로세스(In-process) 싱글톤 우선 참조
           - 멀티 파드(Multi-pod) 분산 구동: Redis를 SSOT로 사용하여 파드 간의 배포 상태 불일치 해소.
-          - **CAP 정리 트레이드오프(Trade-off)**: Redis 파티션/네트워크 단절 차단 시 \`/health\` 다운을 지연시키기 위해 최대 허용 시간(TTL, 예: 5분) 내에서만 로컬 인프로세스 캐시 상태로 우아한 폴백(Graceful Fallback)을 발동. 이 경우 헬스 상태의 정합성 지연(Stale State)을 일시 수용하여 오탐 셧다운(False-positive crash)을 방어하고 가용성(Availability)을 극대화함. 단, TTL을 초과하여 Redis가 장기 파티션될 경우 최종적으로 `DEGRADED` 하드 폴백을 발동하여 영구적인 장애 은폐 방지
+          - **CAP 정리 트레이드오프(Trade-off)**: Redis 파티션/네트워크 단절 장애 시 \`/health\` 다운을 지연시키기 위해, 환경 변수(\`REDIS_FALLBACK_TTL_SECS\`, 예: 300초)로 정의된 최대 허용 시간 내에서만 로컬 인프로세스 캐시 상태로 우아한 폴백(Graceful Fallback)을 발동. 헬스 상태의 정합성 지연(Stale State)을 일시 수용하여 시스템 오탐 셧다운(False-positive crash)을 방어하고 가용성(Availability)을 극대화함. 단, TTL을 초과하여 Redis가 장기 파티션될 경우 최종적으로 로컬 캐시를 무효화하고 하드 폴백으로 전환하여 영구적인 장애 은폐를 방지.
         - **SSOT 통신 시퀀스 (책임 경계)**:
           1. **장애 보고(Publish)**: 에지 워커 스레드가 자체 결함 포착 시 레지스트리에 장애 코드 쓰기
           2. **취합 쿼리(Retrieve)**: 중앙 `/health` 컨트롤러가 주기적 폴링 없이, 수신된 핑(Ping) 시점에 레지스트리 상태만 Read하여 비용 최소화
-          3. **발송(Alerting)**: 수집된 상태 코드를 기반으로 `DEGRADED` HTTP 코드 응답 및 Datadog/Prometheus 메트릭 노출
+          3. **발송(Alerting)**: 수집된 상태 코드를 기반으로 `DEGRADED` 전환 시 `HTTP 503 Service Unavailable` 코드 응답(AWS ALB/K8s 트래픽 차단용) 및 Datadog/Prometheus 메트릭 노출
 
 ---
 


### PR DESCRIPTION
- **[이벤트 루프 데드락(Deadlock) 블로킹 방어]**
  - Boto3 AWS 래퍼 초기화 시 Sync/Async 락 컨텍스트 혼용으로 인한 데드락 방지를 위해, 스레드 풀(`run_in_executor`) 기반의 오프로딩(Offload) 패턴을 아키텍처 표준으로 강제.

- **[Fork-safety 지연 초기화(Lazy Init) 스코프 명세]**
  - Gunicorn 배포 시 소켓 공유 크래시 결함을 가장 완벽히 막기 위해, Connection Pooling 생성 시점을 앱 로드가 아닌 명시적인 `Post-fork 훅` 단계로 지연 초기화하도록 문서화.

- **[무결성 가드레일 (Stale State TTL)]**
  - Redis 우아한 폴백(Graceful Fallback) 전환 시 무한한 상태 지연을 방어하기 위해, 최대 허용 임계치(TTL, 예: 5분)를 초과할 경우 최종 DEGRADED 하드 폴백으로 전환하여 영구 장기 파티션을 은폐하지 않도록 안정성 확보.
- 일반적인 오탈자 및 프로토콜 규격(`HTTP`) 대소문자 정규화.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1110#pullrequestreview-4102679040)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개인화된 RAG 태스크 문서에서 동시성, 포크 안전성, 그리고 헬스 체크 일관성 보장에 대해 더 명확히 설명합니다.

문서화:
- 블로킹 초기화 작업을 명시적으로 오프로딩하는 방식으로, 동기/비동기 환경이 혼재된 상황에서 교착 상태를 방지하는 AWS Boto3 래퍼 사용법을 문서화합니다.
- 멀티 워커 배포 환경에서 프로세스 포크 이후 Boto3 커넥션 풀을 포크 안전하게 지연 초기화(lazy initialization)하는 방법을 설명합니다.
- 무한정으로 오래된 상태가 숨겨지는 것을 방지하기 위해, 제한된 TTL과 최종 DEGRADED 상태를 사용하는 Redis 기반 헬스 체크 폴백 동작을 명시합니다.
- 헬스 상태 알림 문서에서 HTTP 용어와 표현을 정규화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify concurrency, fork-safety, and health-check consistency guarantees in the personalized RAG tasks documentation.

Documentation:
- Document deadlock-safe AWS Boto3 wrapper usage in mixed sync/async environments with explicit offloading of blocking initialization work.
- Describe fork-safe lazy initialization of Boto3 connection pools after process forking for multi-worker deployments.
- Specify Redis-backed health-check fallback behavior with a bounded TTL and final DEGRADED state to avoid indefinite stale status masking.
- Normalize HTTP terminology and wording in health status alerting documentation.

</details>