### PR TITLE
📝 docs [#12.1.6]: 16차 개선 - OOM 스레드 제어 공식, Non-HTTP 사각지대 및 TTL 관측성(Observability) 확립

### DIFF
--- a/docs/P/v9.0/v9.2_personalized_rag_tasks.md
+++ b/docs/P/v9.0/v9.2_personalized_rag_tasks.md
@@ -25,8 +25,8 @@
         - **장애 조치(Edge Case)**: 애플리케이션 부트스트랩 또는 정기 키 로테이션 중 KMS/Vault 조회 실패 시 예외 원인별 동작 분리 지원:
           - 일시적 네트워크 장애 및 버스트 쓰로틀링(boto3 `EndpointConnectionError`, `ReadTimeoutError`, `ClientError` - `ThrottlingException`): 타임아웃 5초, 최대 3회 재시도 수행
             - **알고리즘 명세**: 단일 인스턴스 패턴을 적용한 단일 공통 AWS 클라이언트 래퍼 모듈(Single shared AWS client wrapper module)에서만 Boto3 내장 재시도(Standard Mode)를 명시적으로 비활성화(`max_attempts=0`)하고, 애플리케이션 레벨의 Full Jitter 방식(Base Delay 1초, Cap 10초)을 독점 구현하여 타 컴포넌트 개발 시의 적용 누락 및 이중 증폭(Double retries) 방지
-              - **동시성 환경에서의 스레드 안전성(Thread-Safety) 및 커넥션 풀링**: 다중 스레드/비동기 혼합 파이썬 환경에서 데드락(Deadlock)을 방지하기 위해, 동기 호출용 `threading.Lock`과 비동기 호출용 `asyncio.Lock`의 컨텍스트를 엄격히 분리함. 무거운 Boto3 초기화 연산은 이벤트 루프 블로킹을 피하도록 커스텀 `ThreadPoolExecutor`에 오프로드(Offload)하되, 고부하 환경의 OOM 방지를 위해 `max_workers=min(32, os.cpu_count() + 4)`와 같은 시스템 자원 비례 휴리스틱 공식을 도입하여 스레드 증식을 제어함.
-              - **포크 환경 안정성(Fork-Safety)**: 워커 포크 시 소켓 공유로 인한 크래시를 차단하고자, Boto3 Session 커넥션 풀은 앱 로드 시점이 아닌 프로세스 포크 이후 지연 생성(Lazy Initialization)되도록 설계. 관리 파편화를 피하기 위해, Gunicorn Post-fork 훅 대신 **FastAPI lifespan 이벤트를 최우선 HTTP 컨텍스트 생성 지점으로 일원화**하여 이중 초기화를 방지. 단, Non-HTTP 환경(예: Celery 워커, CLI 툴)에서는 Lifespan이 무시되므로, 우회 접속(Bypass) 크래시를 막기 위해 이들만을 위한 전용 초기화 훅(예: Celery `worker_process_init`)을 부차적으로 제공.
+              - **동시성 환경에서의 스레드 안전성(Thread-Safety) 및 커넥션 풀링**: 비동기 파이썬 환경에서 데드락(Deadlock)을 방지하기 위해 Boto3 초기화 연산을 커스텀 `ThreadPoolExecutor`에 오프로드(Offload)함. 단, Boto3 초기화는 CPU 기반이 아닌 네트워크 I/O 바운드 특성을 가지므로 파이썬 기본 휴리스틱(`min(32, os.cpu_count() + 4)`)을 베이스라인으로 삼되, 운영 환경의 네트워크 지연률에 맞춰 튜닝할 수 있도록 최대 워커 수를 환경 변수(`AWS_WRAPPER_MAX_WORKERS`)로 노출하여 스레드 증식 제어의 유연성을 확보함.
+              - **포크 환경 안정성(Fork-Safety)**: 워커 포크 시 소켓 공유에 따른 크래시를 차단하고자, Boto3 Session은 앱 로드 시점이 아닌 프로세스 포크 이후 지연 생성(Lazy Initialization)됨. HTTP 런타임의 경우 **FastAPI lifespan 이벤트**를, Non-HTTP 런타임(예: Celery 프로세스)의 경우 전용 훅(`worker_process_init`)을 진입점으로 각각 분리 지정하되, 이중 초기화 중복을 막기 위해 멱등성(Idempotency)이 보장되는 **공통 팩토리 함수 단일 진입점(예: `get_or_create_boto3_session()`)**만 경유하여 락(Lock)을 획득하도록 아키텍처 제약 강제.
             - 단, 계정의 영구적 하드 쿼터 초과(`LimitExceededException`) 발생 시 일시적 장애가 아니므로 즉각적인 Hard Fail-fast로 전환해 불필요한 백오프 점유 방지
           - 치명적 권한/존재 오류(boto3 `ClientError` - `AccessDeniedException`, `NotFoundException`): 재시도 없이 즉시 프로세스를 중단(Hard Fail-fast)하여 개인정보 레코드의 암호화 무단 오염 및 노출 원천 차단
 - [ ] 인덱스 수명 주기 관리: 신규 생성 / 증분 업데이트(Incremental Update) / 주기적 재구축(Compaction) 전략 수립
@@ -77,7 +77,7 @@
           - 단일 파드(Single-pod) 구동: 메모리 기반 인프로세스(In-process) 싱글톤 우선 참조
           - 멀티 파드(Multi-pod) 분산 구동: Redis를 SSOT로 사용하여 파드 간의 배포 상태 불일치 해소.
           - **CAP 정리 트레이드오프(Trade-off)**: Redis 파티션/네트워크 단절 장애 시 `/health` 다운을 지연시키기 위해, 환경 변수(`REDIS_FALLBACK_TTL_SECS`, 예: 300초)로 정의된 최대 허용 시간 내에서만 로컬 인프로세스 캐시 상태로 우아한 폴백(Graceful Fallback)을 발동. 헬스 상태의 정합성 지연(Stale State)을 일시 수용하여 시스템 오탐 셧다운(False-positive crash)을 방어하고 가용성(Availability)을 극대화함.
-            - **TTL 관측성 보장**: 부분 단위 파티션을 조기 감지할 수 있도록, 폴백 발동 중에는 남은 잔여 만료 시간을 \`redis_fallback_ttl_remaining\` 메트릭으로 노출함. 단, TTL을 초과하여 Redis가 장기 파티션될 경우 최종적으로 로컬 캐시를 무효화하고 하드 폴백 전환.
+            - **TTL 관측성 보장**: 부분 파티션 상태를 운영자가 조기 감지할 수 있도록, 폴백 발동 시 로컬 캐시에 기록된 실제 잔여 만료 시간(추정값이 아닌 엄밀한 Timestamp 차이 연산)을 초 단위(Seconds) 규격의 \`redis_fallback_ttl_remaining_seconds\` 메트릭으로 스크래핑 노출함. 단, TTL을 초과하여 Redis가 장기 파티션될 경우 최종적으로 로컬 캐시를 무효화하고 하드 폴백 전환.
         - **SSOT 통신 시퀀스 (책임 경계)**:
           1. **장애 보고(Publish)**: 에지 워커 스레드가 자체 결함 포착 시 레지스트리에 장애 코드 쓰기
           2. **취합 쿼리(Retrieve)**: 중앙 `/health` 컨트롤러가 주기적 폴링 없이, 수신된 핑(Ping) 시점에 레지스트리 상태만 Read하여 비용 최소화

--- a/docs/P/v9.0/v9.2_personalized_rag_tasks.md
+++ b/docs/P/v9.0/v9.2_personalized_rag_tasks.md
@@ -25,8 +25,8 @@
         - **장애 조치(Edge Case)**: 애플리케이션 부트스트랩 또는 정기 키 로테이션 중 KMS/Vault 조회 실패 시 예외 원인별 동작 분리 지원:
           - 일시적 네트워크 장애 및 버스트 쓰로틀링(boto3 `EndpointConnectionError`, `ReadTimeoutError`, `ClientError` - `ThrottlingException`): 타임아웃 5초, 최대 3회 재시도 수행
             - **알고리즘 명세**: 단일 인스턴스 패턴을 적용한 단일 공통 AWS 클라이언트 래퍼 모듈(Single shared AWS client wrapper module)에서만 Boto3 내장 재시도(Standard Mode)를 명시적으로 비활성화(`max_attempts=0`)하고, 애플리케이션 레벨의 Full Jitter 방식(Base Delay 1초, Cap 10초)을 독점 구현하여 타 컴포넌트 개발 시의 적용 누락 및 이중 증폭(Double retries) 방지
-              - **동시성 환경에서의 스레드 안전성(Thread-Safety) 및 커넥션 풀링**: 다중 스레드/비동기 혼합 파이썬 환경에서 데드락(Deadlock)을 방지하기 위해, 동기 호출용 `threading.Lock`과 비동기 호출용 `asyncio.Lock`의 컨텍스트를 엄격히 분리함. 또한, 무거운 Boto3 초기화 연산은 이벤트 루프 블로킹을 피하도록 OOM 방지용 제한된 크기의 커스텀 `ThreadPoolExecutor(max_workers=...)`에 `run_in_executor`로 오프로드(Offload)하여 제어를 강제.
-              - **포크 환경 안정성(Fork-Safety)**: 워커 포크 시 소켓 공유로 인한 크래시를 차단하고자, Boto3 Session 커넥션 풀은 앱 로드 시점이 아닌 프로세스 포크 이후 지연 생성(Lazy Initialization)되도록 설계. 관리 파편화를 피하기 위해, 서버 환경 종속적인 Gunicorn Post-fork 훅 대신 **프레임워크 표준인 FastAPI lifespan 이벤트를 최우선 생성 지점(Source of Initialization)으로 일원화**하여 이중 커넥션 생성을 철저히 방지.
+              - **동시성 환경에서의 스레드 안전성(Thread-Safety) 및 커넥션 풀링**: 다중 스레드/비동기 혼합 파이썬 환경에서 데드락(Deadlock)을 방지하기 위해, 동기 호출용 `threading.Lock`과 비동기 호출용 `asyncio.Lock`의 컨텍스트를 엄격히 분리함. 무거운 Boto3 초기화 연산은 이벤트 루프 블로킹을 피하도록 커스텀 `ThreadPoolExecutor`에 오프로드(Offload)하되, 고부하 환경의 OOM 방지를 위해 `max_workers=min(32, os.cpu_count() + 4)`와 같은 시스템 자원 비례 휴리스틱 공식을 도입하여 스레드 증식을 제어함.
+              - **포크 환경 안정성(Fork-Safety)**: 워커 포크 시 소켓 공유로 인한 크래시를 차단하고자, Boto3 Session 커넥션 풀은 앱 로드 시점이 아닌 프로세스 포크 이후 지연 생성(Lazy Initialization)되도록 설계. 관리 파편화를 피하기 위해, Gunicorn Post-fork 훅 대신 **FastAPI lifespan 이벤트를 최우선 HTTP 컨텍스트 생성 지점으로 일원화**하여 이중 초기화를 방지. 단, Non-HTTP 환경(예: Celery 워커, CLI 툴)에서는 Lifespan이 무시되므로, 우회 접속(Bypass) 크래시를 막기 위해 이들만을 위한 전용 초기화 훅(예: Celery `worker_process_init`)을 부차적으로 제공.
             - 단, 계정의 영구적 하드 쿼터 초과(`LimitExceededException`) 발생 시 일시적 장애가 아니므로 즉각적인 Hard Fail-fast로 전환해 불필요한 백오프 점유 방지
           - 치명적 권한/존재 오류(boto3 `ClientError` - `AccessDeniedException`, `NotFoundException`): 재시도 없이 즉시 프로세스를 중단(Hard Fail-fast)하여 개인정보 레코드의 암호화 무단 오염 및 노출 원천 차단
 - [ ] 인덱스 수명 주기 관리: 신규 생성 / 증분 업데이트(Incremental Update) / 주기적 재구축(Compaction) 전략 수립
@@ -76,7 +76,8 @@
         - **분산 상태 동기화 및 파티션 내성(Tolerance)**:
           - 단일 파드(Single-pod) 구동: 메모리 기반 인프로세스(In-process) 싱글톤 우선 참조
           - 멀티 파드(Multi-pod) 분산 구동: Redis를 SSOT로 사용하여 파드 간의 배포 상태 불일치 해소.
-          - **CAP 정리 트레이드오프(Trade-off)**: Redis 파티션/네트워크 단절 장애 시 \`/health\` 다운을 지연시키기 위해, 환경 변수(\`REDIS_FALLBACK_TTL_SECS\`, 예: 300초)로 정의된 최대 허용 시간 내에서만 로컬 인프로세스 캐시 상태로 우아한 폴백(Graceful Fallback)을 발동. 헬스 상태의 정합성 지연(Stale State)을 일시 수용하여 시스템 오탐 셧다운(False-positive crash)을 방어하고 가용성(Availability)을 극대화함. 단, TTL을 초과하여 Redis가 장기 파티션될 경우 최종적으로 로컬 캐시를 무효화하고 하드 폴백으로 전환하여 영구적인 장애 은폐를 방지.
+          - **CAP 정리 트레이드오프(Trade-off)**: Redis 파티션/네트워크 단절 장애 시 `/health` 다운을 지연시키기 위해, 환경 변수(`REDIS_FALLBACK_TTL_SECS`, 예: 300초)로 정의된 최대 허용 시간 내에서만 로컬 인프로세스 캐시 상태로 우아한 폴백(Graceful Fallback)을 발동. 헬스 상태의 정합성 지연(Stale State)을 일시 수용하여 시스템 오탐 셧다운(False-positive crash)을 방어하고 가용성(Availability)을 극대화함.
+            - **TTL 관측성 보장**: 부분 단위 파티션을 조기 감지할 수 있도록, 폴백 발동 중에는 남은 잔여 만료 시간을 \`redis_fallback_ttl_remaining\` 메트릭으로 노출함. 단, TTL을 초과하여 Redis가 장기 파티션될 경우 최종적으로 로컬 캐시를 무효화하고 하드 폴백 전환.
         - **SSOT 통신 시퀀스 (책임 경계)**:
           1. **장애 보고(Publish)**: 에지 워커 스레드가 자체 결함 포착 시 레지스트리에 장애 코드 쓰기
           2. **취합 쿼리(Retrieve)**: 중앙 `/health` 컨트롤러가 주기적 폴링 없이, 수신된 핑(Ping) 시점에 레지스트리 상태만 Read하여 비용 최소화


### PR DESCRIPTION
- **[스레드 풀 휴리스틱 컨트롤 보장]**
  - 고부하 환경에서의 무제한 스레드 증식 병목을 막기 위해, `max_workers` 설정에 `min(32, os.cpu_count() + 4)` 시스템 자원 비례 휴리스틱 공식을 도입하여 OOM(Out of Memory) 원천 차단 정책 확립.

- **[Non-HTTP 프로토콜 사각지대(Blind-spot) 방어]**
  - FastAPI Lifespan 이벤트에 종속되지 않는 Celery 워커 및 CLI 스크립트 환경의 포크 안정성 보장을 위해, 해당 환경만의 독립된 초기화 훅(예: Celery `worker_process_init`) 체계를 듀얼 구성하여 Boto3 초기화 누락/중복 차단.

- **[부분 파티션(Partial Partition) 노출 메트릭 확립]**
  - Redis 하드 폴백(DEGRADED) 진입 이전 유예 시간 중의 장애 위장 타파를 위해,  `redis_fallback_ttl_remaining` 카운트다운 메트릭을 노출하여 운영자의 관측성(Observability) 및 선제 대응력 보장.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1112#pullrequestreview-4102703272)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개인화된 RAG 작업을 위해 스레드 풀 크기 추론(heuristics), fork-안전 초기화 전략, 그리고 Redis 폴백 TTL 관측 가능성에 대한 문서를 추가합니다.

Enhancements:
- 높은 동시성 환경에서 OOM 위험을 완화하기 위해, 리소스 비례적 `ThreadPoolExecutor` 크기 추론(heuristic)을 활용한 Boto3 초기화 오프로딩 동작을 명확히 설명합니다.
- 서로 다른 환경에서 fork-안전한 Boto3 세션 설정을 보장하기 위해 HTTP 런타임과 비-HTTP 런타임에 대해 차별화된 초기화 훅을 상세히 기술합니다.
- Redis 폴백 동작을 설명하고, 부분적인 네트워크 분할(partial partition)을 더 잘 탐지하고 페일오버 처리에 도움을 주기 위해 카운트다운 스타일 TTL 메트릭을 노출하는 방법을 다룹니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document thread pool sizing heuristics, fork-safe initialization strategies, and Redis fallback TTL observability for personalized RAG tasks.

Enhancements:
- Clarify Boto3 initialization offloading with a resource-proportional ThreadPoolExecutor sizing heuristic to mitigate OOM risk under high concurrency.
- Detail differentiated initialization hooks for HTTP and Non-HTTP runtimes to ensure fork-safe Boto3 session setup across environments.
- Describe Redis fallback behavior and expose a countdown-style TTL metric to improve detection of partial partitions and guide failover handling.

</details>