### PR TITLE
✨ feat [#12.1.7]: phase 5 - ➄ Global Config Validation Policy 및 HealthRegistry 구현

### DIFF
--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -1,0 +1,414 @@
+# backend/core/config_validator.py
+
+"""
+Global Configuration Validation Policy — v9.0 Phase 2 (Personalized RAG)
+=========================================================================
+
+장애 전파 범위(Blast Radius) 정책:
+
+  [Global Hard Failure]
+    필수 보안 설정(STORAGE_BASE_PATH, PBKDF2_ITERATIONS 등) 파싱 오류 시
+    → 보안 오염 방지를 위해 SystemExit(1)으로 전체 애플리케이션 기동 즉시 중단.
+
+  [Subsystem Hard Failure]
+    선택적 부가 설정(FAISS_COMPACTION_*, TOPIC_CLUSTER_CACHE_TTL 등) 파싱 오류 시
+    → Silent Fallback 금지. 해당 서브시스템만 비활성화하고 핵심 REST API는 유지.
+    → HealthRegistry를 통해 DEGRADED 상태를 노출하여 상태 은폐 방지.
+
+  [Graceful Fallback / Clamping]
+    범위 기반 설정(AWS_WRAPPER_MAX_WORKERS 등) 값이 10 미만(< 10) 또는 100 초과(> 100)인 경우
+    → 크래시 없이 안전 범위 내로 자율 보정(Clamp) + WARNING 로그 (환경변수명, 원래값, 보정값, 이유 포함).
+    → 비정수/미설정 시 heuristic 기본값으로 폴백 + WARNING 로그.
+
+이 모듈은 하나의 프로세스에서 한 번만 초기화됩니다 (bootstrap 단계).
+민감 정보(시크릿, 키, 경로값)는 절대 로그에 기록하지 않습니다.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from enum import Enum
+from typing import ClassVar, Dict
+
+# 프로젝트 공통 유틸 재사용 — 중복 구현 금지
+from backend.config import ConfigRange, _clamp
+
+logger = logging.getLogger(__name__)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 서브시스템 식별자
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class Subsystem(str, Enum):
+    """서브시스템 식별자 (HealthRegistry 키로 사용)."""
+
+    FAISS_COMPACTION = "faiss_compaction"
+    TOPIC_CLUSTERING = "topic_clustering"
+    HYBRID_SEARCH = "hybrid_search"
+    PERSONALIZED_INDEX = "personalized_index"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 내부 파서 헬퍼 (모듈 내부 전용)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _parse_str_critical(env_key: str) -> str:
+    """
+    필수 문자열 환경 변수를 파싱한다.
+    미설정 또는 빈 값이면 CRITICAL 로그 후 SystemExit(1) — Global Hard Failure.
+
+    주의: 값 자체(경로, 식별자)는 보안상 로그에 기록하지 않는다.
+    """
+    raw = os.environ.get(env_key, "").strip()
+    if not raw:
+        logger.critical(
+            "[CONFIG][GLOBAL HARD FAILURE] '%s' is required but not set or empty. "
+            "Application startup aborted to prevent security contamination.",
+            env_key,
+        )
+        raise SystemExit(1)
+    return raw
+
+
+def _parse_int_critical(env_key: str, *, min_val: int | None = None) -> int:
+    """
+    필수 정수 환경 변수를 파싱한다.
+    파싱 실패 또는 min_val 미달 시 CRITICAL 로그 후 SystemExit(1) — Global Hard Failure.
+    """
+    raw = os.environ.get(env_key)
+    if raw is None:
+        logger.critical(
+            "[CONFIG][GLOBAL HARD FAILURE] '%s' is required but not set. "
+            "Application startup aborted.",
+            env_key,
+        )
+        raise SystemExit(1)
+
+    try:
+        value = int(raw)
+    except (ValueError, TypeError):
+        logger.critical(
+            "[CONFIG][GLOBAL HARD FAILURE] '%s' must be an integer, got type=%s. "
+            "Application startup aborted.",
+            env_key,
+            type(raw).__name__,
+        )
+        raise SystemExit(1)
+
+    if min_val is not None and value < min_val:
+        logger.critical(
+            "[CONFIG][GLOBAL HARD FAILURE] '%s'=%d is below minimum required value %d. "
+            "Application startup aborted.",
+            env_key,
+            value,
+            min_val,
+        )
+        raise SystemExit(1)
+
+    return value
+
+
+def _parse_int_subsystem(
+    env_key: str,
+    *,
+    default: int,
+    range_: ConfigRange | None = None,
+    subsystem: Subsystem,
+) -> tuple[int, bool]:
+    """
+    선택적 정수 환경 변수를 파싱한다 (서브시스템 설정용).
+
+    Returns:
+        (value, ok): ok=False → 해당 서브시스템 비활성화 (Subsystem Hard Failure).
+    """
+    raw = os.environ.get(env_key)
+    if raw is None:
+        # 미설정은 기본값 사용 — 실패가 아님
+        return default, True
+
+    try:
+        value = int(raw)
+    except (ValueError, TypeError):
+        logger.error(
+            "[CONFIG][SUBSYSTEM HARD FAILURE][%s] '%s' must be an integer, got type=%s. "
+            "Subsystem disabled. Core REST API remains operational.",
+            subsystem.value,
+            env_key,
+            type(raw).__name__,
+        )
+        return default, False
+
+    if range_ is not None:
+        clamped = _clamp(value, range_)
+        if clamped != value:
+            logger.warning(
+                "[CONFIG][CLAMP] '%s'=%d is out of range [%d, %d]; clamped to %d.",
+                env_key,
+                value,
+                range_.min,
+                range_.max,
+                clamped,
+            )
+        return clamped, True
+
+    return value, True
+
+
+def _parse_float_subsystem(
+    env_key: str,
+    *,
+    default: float,
+    range_: ConfigRange | None = None,
+    subsystem: Subsystem,
+) -> tuple[float, bool]:
+    """
+    선택적 float 환경 변수를 파싱한다 (서브시스템 설정용).
+
+    Returns:
+        (value, ok): ok=False → 해당 서브시스템 비활성화 (Subsystem Hard Failure).
+    """
+    raw = os.environ.get(env_key)
+    if raw is None:
+        return default, True
+
+    try:
+        value = float(raw)
+    except (ValueError, TypeError):
+        logger.error(
+            "[CONFIG][SUBSYSTEM HARD FAILURE][%s] '%s' must be a float, got type=%s. "
+            "Subsystem disabled. Core REST API remains operational.",
+            subsystem.value,
+            env_key,
+            type(raw).__name__,
+        )
+        return default, False
+
+    if range_ is not None:
+        clamped = _clamp(value, range_)
+        if clamped != value:
+            logger.warning(
+                "[CONFIG][CLAMP] '%s'=%g is out of range [%g, %g]; clamped to %g.",
+                env_key,
+                value,
+                range_.min,
+                range_.max,
+                clamped,
+            )
+        return clamped, True
+
+    return value, True
+
+
+def _parse_int_clamped(
+    env_key: str,
+    *,
+    default_factory,
+    range_: ConfigRange,
+) -> int:
+    """
+    범위 기반 정수 환경 변수를 파싱한다 (Graceful Fallback / Clamping).
+
+    - 미설정 또는 비정수: heuristic 기본값으로 폴백 + WARNING 로그
+    - 값이 10 미만(< 10) 또는 100 초과(> 100): 경계로 보정 + WARNING 로그
+      (10과 100은 유효한 경계값으로 보정 대상 제외)
+    - 환경변수명·원래값·보정값·폴백 이유를 모두 WARNING 로그에 포함
+    """
+    default = default_factory()
+    raw = os.environ.get(env_key)
+
+    if raw is None:
+        logger.warning(
+            "[CONFIG][CLAMP] '%s' is not set; using heuristic default %d.",
+            env_key,
+            default,
+        )
+        return default
+
+    try:
+        value = int(raw)
+    except (ValueError, TypeError):
+        logger.warning(
+            "[CONFIG][CLAMP] '%s'=%r is not a valid integer; "
+            "falling back to heuristic default %d (min(32, os.cpu_count() + 4)).",
+            env_key,
+            raw,
+            default,
+        )
+        return default
+
+    clamped = _clamp(value, range_)
+    if clamped != value:
+        reason = "범위 미만 보정" if value < range_.min else "범위 초과 보정"
+        logger.warning(
+            "[CONFIG][CLAMP] '%s'=%d is outside safe range [%d, %d]; "
+            "clamped to %d (%s). "
+            "Adjust '%s' to suppress this warning.",
+            env_key,
+            value,
+            range_.min,
+            range_.max,
+            clamped,
+            reason,
+            env_key,
+        )
+    return clamped
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 2 통합 설정 클래스
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class PersonalizedRAGConfig:
+    """
+    v9.0 Phase 2 Personalized RAG 전용 검증 설정 클래스.
+
+    사용법:
+        cfg = PersonalizedRAGConfig.from_env()  # bootstrap 단계에서 1회 호출
+
+    필수 환경 변수 (미설정 시 애플리케이션 기동 불가):
+        STORAGE_BASE_PATH       - 사용자 데이터 루트 경로
+        PBKDF2_ITERATIONS       - 키 파생 반복 횟수 (보안 최소값: 600,000)
+
+    선택적 환경 변수 (파싱 오류 시 해당 서브시스템만 비활성화):
+        FAISS_COMPACTION_VECTOR_THRESHOLD   (int, 기본: 500, 최소: 100)
+        FAISS_COMPACTION_DELETE_RATIO       (float, 기본: 0.15, 범위: 0.0~1.0)
+        TOPIC_CLUSTER_CACHE_TTL             (int, 초 단위, 기본: 3600)
+        REDIS_FALLBACK_TTL_SECS             (int, 초 단위, 기본: 300)
+        PERSONALIZED_INDEX_WEIGHT           (float, 기본: 0.6, 범위: 0.0~1.0)
+        GLOBAL_INDEX_WEIGHT                 (float, 기본: 0.4, 범위: 0.0~1.0)
+
+    범위 보정(Clamping) 환경 변수:
+        AWS_WRAPPER_MAX_WORKERS (int, 기본: heuristic, 권장 범위: 10~100)
+    """
+
+    # 공유 ConfigRange 상수
+    _WEIGHT_RANGE: ClassVar[ConfigRange] = ConfigRange(min=0.0, max=1.0)
+    _FAISS_RATIO_RANGE: ClassVar[ConfigRange] = ConfigRange(min=0.0, max=1.0)
+    _FAISS_THRESHOLD_RANGE: ClassVar[ConfigRange] = ConfigRange(min=100, max=100_000)
+    _AWS_WORKERS_RANGE: ClassVar[ConfigRange] = ConfigRange(min=10, max=100)
+
+    def __init__(
+        self,
+        *,
+        # Critical
+        storage_base_path: str,
+        pbkdf2_iterations: int,
+        # Optional subsystem
+        faiss_compaction_vector_threshold: int,
+        faiss_compaction_delete_ratio: float,
+        topic_cluster_cache_ttl: int,
+        redis_fallback_ttl_secs: int,
+        personalized_index_weight: float,
+        global_index_weight: float,
+        # Clamped
+        aws_wrapper_max_workers: int,
+        # Subsystem health map
+        subsystem_ok: Dict[str, bool],
+    ) -> None:
+        self.storage_base_path = storage_base_path
+        self.pbkdf2_iterations = pbkdf2_iterations
+        self.faiss_compaction_vector_threshold = faiss_compaction_vector_threshold
+        self.faiss_compaction_delete_ratio = faiss_compaction_delete_ratio
+        self.topic_cluster_cache_ttl = topic_cluster_cache_ttl
+        self.redis_fallback_ttl_secs = redis_fallback_ttl_secs
+        self.personalized_index_weight = personalized_index_weight
+        self.global_index_weight = global_index_weight
+        self.aws_wrapper_max_workers = aws_wrapper_max_workers
+        # 서브시스템 가동 여부 맵 (True=활성, False=비활성)
+        self.subsystem_ok: Dict[str, bool] = subsystem_ok
+
+    @classmethod
+    def from_env(cls) -> "PersonalizedRAGConfig":
+        """
+        환경 변수에서 설정을 파싱하여 PersonalizedRAGConfig 인스턴스를 반환한다.
+        Critical 설정 파싱 실패 시 SystemExit(1) — Global Hard Failure.
+        """
+        # ── 1. Critical 설정 (Global Hard Failure) ────────────────────────
+        storage_base_path = _parse_str_critical("STORAGE_BASE_PATH")
+        pbkdf2_iterations = _parse_int_critical(
+            "PBKDF2_ITERATIONS", min_val=600_000
+        )
+
+        # ── 2. 서브시스템 설정 (Subsystem Hard Failure) ───────────────────
+        subsystem_ok: Dict[str, bool] = {}
+
+        faiss_threshold, ok_ft = _parse_int_subsystem(
+            "FAISS_COMPACTION_VECTOR_THRESHOLD",
+            default=500,
+            range_=cls._FAISS_THRESHOLD_RANGE,
+            subsystem=Subsystem.FAISS_COMPACTION,
+        )
+        faiss_ratio, ok_fr = _parse_float_subsystem(
+            "FAISS_COMPACTION_DELETE_RATIO",
+            default=0.15,
+            range_=cls._FAISS_RATIO_RANGE,
+            subsystem=Subsystem.FAISS_COMPACTION,
+        )
+        # 두 설정 중 하나라도 실패하면 FAISS Compaction 서브시스템 비활성화
+        subsystem_ok[Subsystem.FAISS_COMPACTION] = ok_ft and ok_fr
+
+        topic_ttl, ok_ttl = _parse_int_subsystem(
+            "TOPIC_CLUSTER_CACHE_TTL",
+            default=3600,
+            subsystem=Subsystem.TOPIC_CLUSTERING,
+        )
+        subsystem_ok[Subsystem.TOPIC_CLUSTERING] = ok_ttl
+
+        p_weight, ok_pw = _parse_float_subsystem(
+            "PERSONALIZED_INDEX_WEIGHT",
+            default=0.6,
+            range_=cls._WEIGHT_RANGE,
+            subsystem=Subsystem.HYBRID_SEARCH,
+        )
+        g_weight, ok_gw = _parse_float_subsystem(
+            "GLOBAL_INDEX_WEIGHT",
+            default=0.4,
+            range_=cls._WEIGHT_RANGE,
+            subsystem=Subsystem.HYBRID_SEARCH,
+        )
+        subsystem_ok[Subsystem.HYBRID_SEARCH] = ok_pw and ok_gw
+
+        # Redis 폴백 TTL은 인프라 설정이므로 Subsystem 비활성화 없이 기본값 적용
+        redis_ttl, _ = _parse_int_subsystem(
+            "REDIS_FALLBACK_TTL_SECS",
+            default=300,
+            subsystem=Subsystem.PERSONALIZED_INDEX,
+        )
+
+        # ── 3. 범위 보정(Clamping) 설정 ───────────────────────────────────
+        def _cpu_heuristic() -> int:
+            cpu = os.cpu_count() or 1
+            return min(32, cpu + 4)
+
+        aws_workers = _parse_int_clamped(
+            "AWS_WRAPPER_MAX_WORKERS",
+            default_factory=_cpu_heuristic,
+            range_=cls._AWS_WORKERS_RANGE,
+        )
+
+        # ── 4. 비활성화된 서브시스템 운영 가시성 로깅 ────────────────────
+        for sub, ok in subsystem_ok.items():
+            if not ok:
+                logger.error(
+                    "[CONFIG][SUBSYSTEM DISABLED] '%s' subsystem is DISABLED due to "
+                    "invalid configuration. Register via HealthRegistry for /health exposure.",
+                    sub,
+                )
+
+        return cls(
+            storage_base_path=storage_base_path,
+            pbkdf2_iterations=pbkdf2_iterations,
+            faiss_compaction_vector_threshold=faiss_threshold,
+            faiss_compaction_delete_ratio=faiss_ratio,
+            topic_cluster_cache_ttl=topic_ttl,
+            redis_fallback_ttl_secs=redis_ttl,
+            personalized_index_weight=p_weight,
+            global_index_weight=g_weight,
+            aws_wrapper_max_workers=aws_workers,
+            subsystem_ok=subsystem_ok,
+        )

--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import logging
 import os
 from enum import Enum
-from typing import ClassVar, Dict
+from typing import Callable, ClassVar, Dict
 
 # 프로젝트 공통 유틸 재사용 — 중복 구현 금지
 from backend.config import ConfigRange, _clamp
@@ -206,7 +206,7 @@ def _parse_float_subsystem(
 def _parse_int_clamped(
     env_key: str,
     *,
-    default_factory,
+    default_factory: Callable[[], int],
     range_: ConfigRange,
 ) -> int:
     """
@@ -335,6 +335,7 @@ class PersonalizedRAGConfig:
         )
 
         # ── 2. 서브시스템 설정 (Subsystem Hard Failure) ───────────────────
+        # subsystem_ok 키는 항상 str (Subsystem.value) 로 통일 — HealthRegistry 경계와 일치
         subsystem_ok: Dict[str, bool] = {}
 
         faiss_threshold, ok_ft = _parse_int_subsystem(
@@ -350,14 +351,14 @@ class PersonalizedRAGConfig:
             subsystem=Subsystem.FAISS_COMPACTION,
         )
         # 두 설정 중 하나라도 실패하면 FAISS Compaction 서브시스템 비활성화
-        subsystem_ok[Subsystem.FAISS_COMPACTION] = ok_ft and ok_fr
+        subsystem_ok[Subsystem.FAISS_COMPACTION.value] = ok_ft and ok_fr
 
         topic_ttl, ok_ttl = _parse_int_subsystem(
             "TOPIC_CLUSTER_CACHE_TTL",
             default=3600,
             subsystem=Subsystem.TOPIC_CLUSTERING,
         )
-        subsystem_ok[Subsystem.TOPIC_CLUSTERING] = ok_ttl
+        subsystem_ok[Subsystem.TOPIC_CLUSTERING.value] = ok_ttl
 
         p_weight, ok_pw = _parse_float_subsystem(
             "PERSONALIZED_INDEX_WEIGHT",
@@ -371,7 +372,7 @@ class PersonalizedRAGConfig:
             range_=cls._WEIGHT_RANGE,
             subsystem=Subsystem.HYBRID_SEARCH,
         )
-        subsystem_ok[Subsystem.HYBRID_SEARCH] = ok_pw and ok_gw
+        subsystem_ok[Subsystem.HYBRID_SEARCH.value] = ok_pw and ok_gw
 
         # Redis 폴백 TTL은 인프라 설정이므로 Subsystem 비활성화 없이 기본값 적용
         redis_ttl, _ = _parse_int_subsystem(

--- a/backend/core/health_registry.py
+++ b/backend/core/health_registry.py
@@ -74,9 +74,9 @@ class HealthRegistry:
         ttl_remaining = registry.get_fallback_ttl_remaining_seconds()
     """
 
-    # Redis 키 프리픽스 — 사용자 정보 미포함
-    _REDIS_KEY_PREFIX = "flownote:health:"
-    _REDIS_SUMMARY_KEY = "flownote:health:summary"
+    # Redis 상태를 단일 Hash에 저장하여 HGETALL 한 번으로 전체 조회 (KEYS 살포 O(N) 블로킹 제거)
+    _REDIS_HASH_KEY = "flownote:health:summary"  # 불변 summary hash key
+    # TTL: Hash 전체에 적용 (개별 필드 만료 없음)
 
     def __init__(
         self,
@@ -133,6 +133,37 @@ class HealthRegistry:
                         redis_fallback_ttl_secs=redis_fallback_ttl_secs,
                         redis_url=redis_url,
                     )
+        else:
+            # 이미 생성된 싱글턴이 있을 때 다른 설정으로 호용되면 경고를 남김.
+            # Redis URL 값 자체는 credential 포함 가능성이 있으므로 절대 로그에 기록하지 않음.
+            try:
+                inst = _registry_instance
+                configured_ttl = getattr(inst, "_redis_fallback_ttl_secs", None)
+                configured_redis = getattr(inst, "_redis_url", None)
+                ttl_mismatch = (
+                    redis_fallback_ttl_secs != configured_ttl
+                )
+                redis_mismatch = (
+                    redis_url is not None
+                    and redis_url != configured_redis
+                )
+                if ttl_mismatch or redis_mismatch:
+                    logger.warning(
+                        "[HEALTH_REGISTRY] get_instance called with config that "
+                        "differs from existing singleton "
+                        "(redis_enabled_current=%s, redis_fallback_ttl_current=%r; "
+                        "redis_enabled_requested=%s, redis_fallback_ttl_requested=%r). "
+                        "Existing singleton configuration will be used.",
+                        configured_redis is not None,
+                        configured_ttl,
+                        redis_url is not None,
+                        redis_fallback_ttl_secs,
+                    )
+            except Exception:
+                logger.exception(
+                    "[HEALTH_REGISTRY] Failed to compare singleton configuration "
+                    "in get_instance."
+                )
         return _registry_instance
 
     # ── Redis 클라이언트 지연 초기화 (Fork-safe) ─────────────────────────
@@ -202,14 +233,21 @@ class HealthRegistry:
         self._publish_to_redis(subsystem, status)
 
     def _publish_to_redis(self, subsystem: str, status: SubsystemStatus) -> None:
-        """Redis에 상태를 게시한다. 실패 시 폴백 타이머 시작."""
+        """
+        Redis Hash에 서브시스템 상태를 HSET으로 게시한다.
+
+        단일 Hash(_REDIS_HASH_KEY)에 모든 서브시스템 상태를 field로 저장하며,
+        GET N회 대신 HGETALL 1회로 전체 조회 가능 (라운드트립 1회로 축소).
+        실패 시 TTL 타이머 시작.
+        """
         client = self._get_redis()
         if client is None:
             return
 
-        key = f"{self._REDIS_KEY_PREFIX}{subsystem}"
         try:
-            client.set(key, status.value, ex=self._redis_fallback_ttl_secs * 2)
+            client.hset(self._REDIS_HASH_KEY, subsystem, status.value)
+            # Hash 전체에 TTL 적용 (서브시스템 보고 없으면 자동 만료)
+            client.expire(self._REDIS_HASH_KEY, self._redis_fallback_ttl_secs * 2)
             if not self._redis_available:
                 logger.info(
                     "[HEALTH_REGISTRY] Redis connection restored. "
@@ -258,28 +296,22 @@ class HealthRegistry:
             return {k: v.value for k, v in self._local_state.items()}
 
     def _fetch_from_redis(self) -> Optional[Dict[str, str]]:
-        """Redis에서 전체 상태를 조회한다. 실패 시 None 반환."""
+        """
+        Redis Hash에서 HGETALL로 전체 상태를 단일 Round-trip으로 조회한다.
+
+        KEYS *를 O(N) 블로킹 명령 실행 없이 HGETALL로 맨점 방지.
+        실패 시 None 반환 (In-process 폴백 전환).
+        """
         client = self._get_redis()
         if client is None:
             return None
 
         try:
-            keys = client.keys(f"{self._REDIS_KEY_PREFIX}*")
-            if not keys:
-                # Redis 연결은 OK이지만 키가 없음 — 로컬 상태 참조
-                return None
-
-            result = {}
-            for key in keys:
-                subsystem = key.replace(self._REDIS_KEY_PREFIX, "")
-                value = client.get(key)
-                if value is not None:
-                    result[subsystem] = value
-
+            result: Dict[str, str] = client.hgetall(self._REDIS_HASH_KEY)
             self._redis_available = True
             self._redis_unavailable_since = None
+            # Hash가 비어있으면 로컈 상태 참조
             return result if result else None
-
         except Exception:
             self._on_redis_failure()
             return None

--- a/backend/core/health_registry.py
+++ b/backend/core/health_registry.py
@@ -134,7 +134,7 @@ class HealthRegistry:
                         redis_url=redis_url,
                     )
         else:
-            # 이미 생성된 싱글턴이 있을 때 다른 설정으로 호용되면 경고를 남김.
+            # 이미 생성된 싱글턴이 있을 때 다른 설정으로 허용되면 경고를 남김.
             # Redis URL 값 자체는 credential 포함 가능성이 있으므로 절대 로그에 기록하지 않음.
             try:
                 inst = _registry_instance

--- a/backend/core/health_registry.py
+++ b/backend/core/health_registry.py
@@ -1,0 +1,339 @@
+# backend/core/health_registry.py
+
+"""
+HealthRegistry — 단일 진실 공급원(SSOT) 기반 서브시스템 상태 레지스트리
+==========================================================================
+
+아키텍처 원칙:
+  - 단일 파드: 모듈 스코프 싱글톤(In-process) 우선 참조
+  - 멀티 파드: Redis를 SSOT로 사용, 파드 간 배포 상태 불일치 해소
+  - CAP 트레이드오프: Redis 파티션 시 REDIS_FALLBACK_TTL_SECS 내에서
+    로컬 캐시로 Graceful Fallback, TTL 초과 시 Hard Fallback
+  - Intra-process Lock: threading.Lock은 동일 프로세스 내 단일 세션
+    초기화만 보장. Inter-process 조율은 별도 메커니즘(파일 락 등) 필요.
+
+SSOT 통신 시퀀스:
+  1. Publish: 에지 워커 → registry.report(subsystem, status)
+  2. Retrieve: /health 컨트롤러 → registry.get_summary() (폴링 없음)
+  3. Alert: DEGRADED 전환 시 HTTP 503 응답 + Prometheus 메트릭 노출
+
+보안 원칙:
+  - 민감 정보(연결 문자열, 키)는 절대 로그에 기록하지 않음
+  - Redis 키에 사용자 식별 정보 포함 금지
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from enum import Enum
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 서브시스템 상태 열거형
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class SubsystemStatus(str, Enum):
+    """서브시스템 운영 상태."""
+
+    HEALTHY = "healthy"      # 정상 운영 중
+    DEGRADED = "degraded"    # 설정 오류 등으로 비활성화 (서비스는 유지)
+    FAILED = "failed"        # 런타임 장애 감지 (복구 시도 가능)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 모듈 스코프 싱글톤 락 — Double-checked locking 패턴용
+# 이 Lock은 동일 프로세스 내(Intra-process) 스레드 간 단일 세션 초기화만 보장.
+# 프로세스 간(Inter-process) 동기화는 OS 레벨 파일 락(단일 서버 표준) 또는
+# Redis 분산 락(다중 서버/컨테이너 환경)을 별도로 도입해야 함.
+# ─────────────────────────────────────────────────────────────────────────────
+_REGISTRY_LOCK = threading.Lock()
+_registry_instance: Optional["HealthRegistry"] = None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# HealthRegistry
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class HealthRegistry:
+    """
+    서브시스템 상태 레지스트리 싱글톤.
+
+    사용법:
+        registry = HealthRegistry.get_instance(
+            redis_fallback_ttl_secs=300,
+            redis_url="redis://localhost:6379",   # 선택: 멀티 파드 환경
+        )
+        registry.report("faiss_compaction", SubsystemStatus.DEGRADED)
+        summary = registry.get_summary()
+        ttl_remaining = registry.get_fallback_ttl_remaining_seconds()
+    """
+
+    # Redis 키 프리픽스 — 사용자 정보 미포함
+    _REDIS_KEY_PREFIX = "flownote:health:"
+    _REDIS_SUMMARY_KEY = "flownote:health:summary"
+
+    def __init__(
+        self,
+        redis_fallback_ttl_secs: int = 300,
+        redis_url: Optional[str] = None,
+    ) -> None:
+        """
+        Args:
+            redis_fallback_ttl_secs: Redis 파티션 시 로컬 캐시 허용 최대 시간(초).
+            redis_url: Redis 연결 URL (미지정 시 단일 파드 In-process 모드).
+                       보안상 이 값은 절대 로그에 기록하지 않음.
+        """
+        self._redis_fallback_ttl_secs = redis_fallback_ttl_secs
+        self._redis_url = redis_url
+
+        # In-process 상태 저장소
+        self._local_state: Dict[str, SubsystemStatus] = {}
+        self._state_lock = threading.Lock()
+
+        # Redis 폴백 추적
+        self._redis_available: bool = True
+        self._redis_unavailable_since: Optional[float] = None  # monotonic timestamp
+
+        # Redis 클라이언트 (지연 초기화, fork-safe)
+        self._redis_client = None
+        self._redis_init_lock = threading.Lock()
+
+    # ── 싱글톤 팩토리 ─────────────────────────────────────────────────────
+
+    @classmethod
+    def get_instance(
+        cls,
+        redis_fallback_ttl_secs: int = 300,
+        redis_url: Optional[str] = None,
+    ) -> "HealthRegistry":
+        """
+        Double-checked locking 패턴으로 프로세스 내 단일 인스턴스를 반환한다.
+
+        동시성 보장:
+          - 모듈 스코프 _REGISTRY_LOCK을 통해 Intra-process 스레드 간 race condition 방지.
+          - 각 워커 프로세스는 포크 이후 독립적인 인스턴스를 가짐 (프로세스별 단일 세션).
+        """
+        global _registry_instance
+        if _registry_instance is None:
+            with _REGISTRY_LOCK:
+                # 락 획득 후 이중 확인 (Double-checked locking)
+                if _registry_instance is None:
+                    logger.info(
+                        "[HEALTH_REGISTRY] Initializing singleton instance "
+                        "(redis=%s).",
+                        "enabled" if redis_url else "disabled (single-pod mode)",
+                    )
+                    _registry_instance = cls(
+                        redis_fallback_ttl_secs=redis_fallback_ttl_secs,
+                        redis_url=redis_url,
+                    )
+        return _registry_instance
+
+    # ── Redis 클라이언트 지연 초기화 (Fork-safe) ─────────────────────────
+
+    def _get_redis(self):
+        """
+        Redis 클라이언트를 지연 초기화하여 반환한다 (Fork-safe Lazy Initialization).
+        프로세스 포크 이후에만 연결을 생성하여 소켓 공유 크래시를 방지.
+        연결 실패 시 None을 반환하며 In-process 폴백 모드로 전환.
+        """
+        if self._redis_url is None:
+            return None
+
+        if self._redis_client is not None:
+            return self._redis_client
+
+        with self._redis_init_lock:
+            if self._redis_client is not None:
+                return self._redis_client
+            try:
+                import redis  # type: ignore
+
+                client = redis.from_url(
+                    self._redis_url,
+                    socket_connect_timeout=2,
+                    socket_timeout=2,
+                    decode_responses=True,
+                )
+                client.ping()
+                self._redis_client = client
+                logger.info("[HEALTH_REGISTRY] Redis connection established.")
+            except Exception:
+                # Redis URL은 보안상 로그에 기록하지 않음
+                logger.warning(
+                    "[HEALTH_REGISTRY] Redis connection failed. "
+                    "Falling back to in-process state (single-pod mode)."
+                )
+                self._redis_client = None
+
+        return self._redis_client
+
+    # ── 상태 보고 (Publish) ───────────────────────────────────────────────
+
+    def report(self, subsystem: str, status: SubsystemStatus) -> None:
+        """
+        서브시스템 상태를 레지스트리에 기록한다.
+
+        [에지 워커 스레드] → report() 호출 → 레지스트리 상태 갱신.
+
+        Args:
+            subsystem: 서브시스템 식별자 (예: "faiss_compaction")
+            status: SubsystemStatus 열거값
+        """
+        with self._state_lock:
+            prev = self._local_state.get(subsystem)
+            self._local_state[subsystem] = status
+
+        if prev != status:
+            logger.info(
+                "[HEALTH_REGISTRY] '%s': %s → %s",
+                subsystem,
+                prev.value if prev else "unknown",
+                status.value,
+            )
+
+        # Redis SSOT 동기화 시도 (멀티 파드 모드)
+        self._publish_to_redis(subsystem, status)
+
+    def _publish_to_redis(self, subsystem: str, status: SubsystemStatus) -> None:
+        """Redis에 상태를 게시한다. 실패 시 폴백 타이머 시작."""
+        client = self._get_redis()
+        if client is None:
+            return
+
+        key = f"{self._REDIS_KEY_PREFIX}{subsystem}"
+        try:
+            client.set(key, status.value, ex=self._redis_fallback_ttl_secs * 2)
+            if not self._redis_available:
+                logger.info(
+                    "[HEALTH_REGISTRY] Redis connection restored. "
+                    "Resuming SSOT synchronization."
+                )
+            self._redis_available = True
+            self._redis_unavailable_since = None
+        except Exception:
+            self._on_redis_failure()
+
+    # ── 상태 조회 (Retrieve) ──────────────────────────────────────────────
+
+    def get_summary(self) -> Dict[str, str]:
+        """
+        모든 서브시스템의 현재 상태를 반환한다.
+        /health 컨트롤러는 주기적 폴링 없이 핑(Ping) 수신 시에만 이 메서드를 호출한다.
+
+        Redis 가용 시: Redis SSOT 참조.
+        Redis 파티션 시: REDIS_FALLBACK_TTL_SECS 내 → 로컬 캐시 반환 (Stale State 허용).
+                         TTL 초과 → 로컬 캐시 무효화 후 Hard Fallback (FAILED 처리).
+
+        Returns:
+            {"subsystem_name": "healthy"|"degraded"|"failed", ...}
+        """
+        # Redis SSOT 조회 시도
+        redis_state = self._fetch_from_redis()
+        if redis_state is not None:
+            return redis_state
+
+        # Redis 파티션 — 폴백 TTL 확인
+        if self._redis_unavailable_since is not None:
+            elapsed = time.monotonic() - self._redis_unavailable_since
+            if elapsed > self._redis_fallback_ttl_secs:
+                logger.error(
+                    "[HEALTH_REGISTRY] Redis fallback TTL (%ds) exceeded (elapsed=%.1fs). "
+                    "Invalidating local cache. Hard fallback activated.",
+                    self._redis_fallback_ttl_secs,
+                    elapsed,
+                )
+                # 로컬 캐시를 무효화: 모든 서브시스템을 FAILED로 처리
+                with self._state_lock:
+                    return {k: SubsystemStatus.FAILED.value for k in self._local_state}
+
+        # TTL 내 로컬 캐시 정상 반환 (Graceful Fallback)
+        with self._state_lock:
+            return {k: v.value for k, v in self._local_state.items()}
+
+    def _fetch_from_redis(self) -> Optional[Dict[str, str]]:
+        """Redis에서 전체 상태를 조회한다. 실패 시 None 반환."""
+        client = self._get_redis()
+        if client is None:
+            return None
+
+        try:
+            keys = client.keys(f"{self._REDIS_KEY_PREFIX}*")
+            if not keys:
+                # Redis 연결은 OK이지만 키가 없음 — 로컬 상태 참조
+                return None
+
+            result = {}
+            for key in keys:
+                subsystem = key.replace(self._REDIS_KEY_PREFIX, "")
+                value = client.get(key)
+                if value is not None:
+                    result[subsystem] = value
+
+            self._redis_available = True
+            self._redis_unavailable_since = None
+            return result if result else None
+
+        except Exception:
+            self._on_redis_failure()
+            return None
+
+    def _on_redis_failure(self) -> None:
+        """Redis 장애 발생 시 폴백 타이머를 시작한다."""
+        if self._redis_available:
+            self._redis_available = False
+            self._redis_unavailable_since = time.monotonic()
+            logger.warning(
+                "[HEALTH_REGISTRY] Redis became unavailable. "
+                "Graceful fallback activated (TTL=%ds). "
+                "Monitor 'redis_fallback_ttl_remaining_seconds' metric.",
+                self._redis_fallback_ttl_secs,
+            )
+
+    # ── Prometheus 메트릭 ─────────────────────────────────────────────────
+
+    def get_fallback_ttl_remaining_seconds(self) -> float:
+        """
+        Redis 폴백 잔여 TTL을 초 단위(Seconds)로 반환한다.
+
+        메트릭명: redis_fallback_ttl_remaining_seconds
+        계산 방식: 엄밀한 Timestamp 차이 연산 (추정값 아님)
+        노출 대상: Prometheus 스크래핑 엔드포인트 (/metrics)
+
+        Returns:
+            잔여 TTL(초). Redis 정상 시 full TTL 값 반환.
+            0.0 이하 시 TTL 초과 상태.
+        """
+        if self._redis_unavailable_since is None:
+            return float(self._redis_fallback_ttl_secs)
+
+        elapsed = time.monotonic() - self._redis_unavailable_since
+        remaining = self._redis_fallback_ttl_secs - elapsed
+        return max(0.0, remaining)
+
+    # ── 전체 상태 판정 (/health 응답용) ──────────────────────────────────
+
+    def is_healthy(self) -> bool:
+        """
+        시스템 전체 상태가 HEALTHY인지 반환한다.
+        하나라도 FAILED/DEGRADED 서브시스템이 있으면 False.
+        /health 컨트롤러에서 HTTP 200 vs 503 분기에 사용.
+        """
+        summary = self.get_summary()
+        return all(
+            v == SubsystemStatus.HEALTHY.value for v in summary.values()
+        )
+
+    def get_http_status_code(self) -> int:
+        """
+        /health 응답 코드를 반환한다.
+          - 200: 모든 서브시스템 HEALTHY
+          - 503: 하나 이상 DEGRADED/FAILED (AWS ALB/K8s 트래픽 차단 신호)
+        """
+        return 200 if self.is_healthy() else 503

--- a/backend/core/health_registry.py
+++ b/backend/core/health_registry.py
@@ -310,8 +310,8 @@ class HealthRegistry:
             result: Dict[str, str] = client.hgetall(self._REDIS_HASH_KEY)
             self._redis_available = True
             self._redis_unavailable_since = None
-            # Hash가 비어있으면 로컈 상태 참조
-            return result if result else None
+            # Hash가 비어있으면 None 반환 (In-process 폴백 전환)
+            return result or None
         except Exception:
             self._on_redis_failure()
             return None


### PR DESCRIPTION
- **[Global Configuration Validation Policy]** backend/core/config_validator.py 신설
  - 필수 보안 설정(STORAGE_BASE_PATH, PBKDF2_ITERATIONS) 파싱 오류 시 `SystemExit(1) — Global Hard Failure` (보안 오염 방지)
  - 부가 설정(FAISS_COMPACTION_*, TOPIC_CLUSTER_CACHE_TTL) 파싱 오류 시 해당 서브시스템만 비활성화 — Subsystem Hard Failure (핵심 REST API 생존)
  - AWS_WRAPPER_MAX_WORKERS: 비정수/미설정 시 heuristic 폴백, 범위 위반(< 10 또는 > 100) 시 자율 보정(Clamp) + 상세 WARNING 로그
  - 기존 `ConfigRange` / `_clamp` 재사용으로 중복 구현 방지

- **[HealthRegistry SSOT]** backend/core/health_registry.py 신설
  - 모듈 스코프 `threading.Lock` + `Double-checked locking` 패턴으로 `Intra-process` 단일 세션 초기화 보장
  - 단일 파드: In-process 싱글톤, 멀티 파드: Redis SSOT
  - `REDIS_FALLBACK_TTL_SECS` 기반 `Graceful Fallback` + `Hard Fallback`
  - `redis_fallback_ttl_remaining_seconds` 메트릭 (Timestamp 차이 연산)
  - `DEGRADED` 전환 시 `HTTP 503` 응답 (ALB/K8s 트래픽 차단)

🔗 Related: Issue [#1046]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개인맞춤형 RAG 하위 시스템을 위해 중앙집중식 구성 검증 및 상태(헬스) 레지스트리를 도입합니다.

새 기능:
- 중요한 및 선택적 환경 기반 설정을 명확한 실패 정책과 함께 검증하는 `PersonalizedRAGConfig` 로더를 추가합니다.
- 하위 시스템 상태를 추적하고, 선택적인 Redis 기반 SSOT를 통합하며, `/health` 및 HTTP 응답을 위해 전체 시스템 상태를 노출하는 `HealthRegistry` 싱글톤을 도입합니다.

개선 사항:
- 안전한 운영 범위를 유지하면서도 크래시를 방지하기 위해 AWS 워커 설정에 범위 기반 클램핑과 휴리스틱 기본값을 적용합니다.
- 구성 파싱 결과에 기반한 하위 시스템 활성/비활성 의미를 표준화하고, 구조화된 로깅 및 상태(헬스) 노출 훅을 제공합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce centralized configuration validation and health status registry for Personalized RAG subsystems.

New Features:
- Add a PersonalizedRAGConfig loader that validates critical and optional environment-based configuration with clear failure policies.
- Introduce a HealthRegistry singleton to track subsystem health, integrate optional Redis-based SSOT, and expose overall system status for /health and HTTP responses.

Enhancements:
- Apply range-based clamping and heuristic defaults for AWS worker configuration to avoid crashes while keeping safe operational bounds.
- Standardize subsystem enable/disable semantics based on configuration parsing results, with structured logging and health exposure hooks.

</details>