### PR TITLE
🔧 fix [#12.1.7]: 2차 개선 - Redis 초기 상태 오판 수정, 가중치 합계 검증 및 로그 하드코딩 제거

### DIFF
--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -233,7 +233,7 @@ def _parse_int_clamped(
     except (ValueError, TypeError):
         logger.warning(
             "[CONFIG][CLAMP] '%s'=%r is not a valid integer; "
-            "falling back to heuristic default %d (min(32, os.cpu_count() + 4)).",
+            "falling back to default %d provided by default_factory.",
             env_key,
             raw,
             default,
@@ -291,6 +291,8 @@ class PersonalizedRAGConfig:
     _FAISS_RATIO_RANGE: ClassVar[ConfigRange] = ConfigRange(min=0.0, max=1.0)
     _FAISS_THRESHOLD_RANGE: ClassVar[ConfigRange] = ConfigRange(min=100, max=100_000)
     _AWS_WORKERS_RANGE: ClassVar[ConfigRange] = ConfigRange(min=10, max=100)
+    # Weight 합계 검증 허용 오차 (에: |sum - 1.0| ≤ 0.01이면 정상)
+    _WEIGHT_SUM_TOLERANCE: ClassVar[float] = 0.01
 
     def __init__(
         self,
@@ -373,6 +375,20 @@ class PersonalizedRAGConfig:
             subsystem=Subsystem.HYBRID_SEARCH,
         )
         subsystem_ok[Subsystem.HYBRID_SEARCH.value] = ok_pw and ok_gw
+
+        # Weight 합계 검증: 운영자 오설정 조기 감지
+        # 정규화는 Silent 수정으로 Zero Trust 원칙 위반 — WARNING 로그만 출력하고 원래 값 유지
+        weight_sum = p_weight + g_weight
+        if abs(weight_sum - 1.0) > cls._WEIGHT_SUM_TOLERANCE:
+            logger.warning(
+                "[CONFIG] PERSONALIZED_INDEX_WEIGHT=%.4f + GLOBAL_INDEX_WEIGHT=%.4f "
+                "= %.4f (expected ~1.0, tolerance=±%.2f). "
+                "Verify weights are configured correctly.",
+                p_weight,
+                g_weight,
+                weight_sum,
+                cls._WEIGHT_SUM_TOLERANCE,
+            )
 
         # Redis 폴백 TTL은 인프라 설정이므로 Subsystem 비활성화 없이 기본값 적용
         redis_ttl, _ = _parse_int_subsystem(

--- a/backend/core/health_registry.py
+++ b/backend/core/health_registry.py
@@ -301,6 +301,9 @@ class HealthRegistry:
 
         KEYS *를 O(N) 블로킹 명령 실행 없이 HGETALL로 맨점 방지.
         실패 시 None 반환 (In-process 폴백 전환).
+        빈 dict {}는 "Redis 정상, 아직 보고된 서브시스템 없음"을 의미하므로,
+        None과 동일하게 취급하지 않음. 빈 hash를 None으로 반환하면 정상 Redis를
+        파티션 상황으로 오판하는 버그가 발생함.
         """
         client = self._get_redis()
         if client is None:
@@ -310,8 +313,8 @@ class HealthRegistry:
             result: Dict[str, str] = client.hgetall(self._REDIS_HASH_KEY)
             self._redis_available = True
             self._redis_unavailable_since = None
-            # Hash가 비어있으면 None 반환 (In-process 폴백 전환)
-            return result or None
+            # 빈 dict {}도 유효한 결과 — None으로 변환하지 않음
+            return result
         except Exception:
             self._on_redis_failure()
             return None


### PR DESCRIPTION
- **[health_registry.py]**
  - _fetch_from_redis: 빈 해시({}) 반환 시 None으로 변환하지 않도록 수정 (정상 상태 오판 방지)
  - docstring 오타 수정 및 폴백 시나리오 명확화

- **[config_validator.py]**
  - _parse_int_clamped: 로그 메시지 내 하드코딩된 휴리스틱 공식 제거 (제네릭 default_factory 언급으로 변경)
  - PersonalizedRAGConfig: INDEX_WEIGHT 합계 검증(tolerance=0.01) 및 WARNING 로그 추가

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1124#pullrequestreview-4119230639)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Redis 상태 처리 및 구성 로깅을 조정하여 잘못된 분류를 방지하고 운영자 피드백을 개선합니다.

버그 수정:
- 비어 있는 Redis 해시가 None으로 처리되지 않도록 하여, 상태 점검에서 잘못된 파티션 감지를 방지합니다.

개선 사항:
- 개인화 인덱스 가중치와 전역 인덱스 가중치의 합이 대략 1.0이 아닐 경우 검증 및 경고 로그를 추가합니다.
- 구성 클램프 경고 메시지를 수정하여, 하드코딩된 휴리스틱 공식 대신 일반적인 기본 팩토리를 참조하도록 명확히 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust Redis health handling and configuration logging to avoid misclassification and improve operator feedback.

Bug Fixes:
- Prevent empty Redis hashes from being treated as None, avoiding false partition detection in health checks.

Enhancements:
- Add validation and warning logs when personalized and global index weights do not sum to approximately 1.0.
- Clarify configuration clamp warning message to reference a generic default factory instead of a hard-coded heuristic formula.

</details>