### PR TITLE
🔧 fix [#12.1.7]: 3차 개선 - WEIGHT_SUM_TOLERANCE 환변 변수화 및 빈 해시 엣지 케이스 방어

### DIFF
--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -291,8 +291,6 @@ class PersonalizedRAGConfig:
     _FAISS_RATIO_RANGE: ClassVar[ConfigRange] = ConfigRange(min=0.0, max=1.0)
     _FAISS_THRESHOLD_RANGE: ClassVar[ConfigRange] = ConfigRange(min=100, max=100_000)
     _AWS_WORKERS_RANGE: ClassVar[ConfigRange] = ConfigRange(min=10, max=100)
-    # Weight 합계 검증 허용 오차 (에: |sum - 1.0| ≤ 0.01이면 정상)
-    _WEIGHT_SUM_TOLERANCE: ClassVar[float] = 0.01
 
     def __init__(
         self,
@@ -376,10 +374,23 @@ class PersonalizedRAGConfig:
         )
         subsystem_ok[Subsystem.HYBRID_SEARCH.value] = ok_pw and ok_gw
 
+        # 환경 변수에서 WEIGHT_SUM_TOLERANCE 파싱 (기본값 0.01)
+        raw_tolerance = os.environ.get("WEIGHT_SUM_TOLERANCE")
+        tolerance = 0.01
+        if raw_tolerance is not None:
+            try:
+                tolerance = float(raw_tolerance)
+            except ValueError:
+                logger.warning(
+                    "[CONFIG] 'WEIGHT_SUM_TOLERANCE'=%r is not a valid float; using default %.2f.",
+                    raw_tolerance,
+                    tolerance,
+                )
+
         # Weight 합계 검증: 운영자 오설정 조기 감지
         # 정규화는 Silent 수정으로 Zero Trust 원칙 위반 — WARNING 로그만 출력하고 원래 값 유지
         weight_sum = p_weight + g_weight
-        if abs(weight_sum - 1.0) > cls._WEIGHT_SUM_TOLERANCE:
+        if abs(weight_sum - 1.0) > tolerance:
             logger.warning(
                 "[CONFIG] PERSONALIZED_INDEX_WEIGHT=%.4f + GLOBAL_INDEX_WEIGHT=%.4f "
                 "= %.4f (expected ~1.0, tolerance=±%.2f). "
@@ -387,7 +398,7 @@ class PersonalizedRAGConfig:
                 p_weight,
                 g_weight,
                 weight_sum,
-                cls._WEIGHT_SUM_TOLERANCE,
+                tolerance,
             )
 
         # Redis 폴백 TTL은 인프라 설정이므로 Subsystem 비활성화 없이 기본값 적용

--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -379,7 +379,14 @@ class PersonalizedRAGConfig:
         tolerance = 0.01
         if raw_tolerance is not None:
             try:
-                tolerance = float(raw_tolerance)
+                parsed_val = float(raw_tolerance)
+                tolerance = max(0.0, min(parsed_val, 1.0))
+                if tolerance != parsed_val:
+                    logger.warning(
+                        "[CONFIG][CLAMP] 'WEIGHT_SUM_TOLERANCE'=%g is out of safe range [0.0, 1.0]; clamped to %g.",
+                        parsed_val,
+                        tolerance,
+                    )
             except ValueError:
                 logger.warning(
                     "[CONFIG] 'WEIGHT_SUM_TOLERANCE'=%r is not a valid float; using default %.2f.",

--- a/backend/core/health_registry.py
+++ b/backend/core/health_registry.py
@@ -275,6 +275,13 @@ class HealthRegistry:
         # Redis SSOT 조회 시도
         redis_state = self._fetch_from_redis()
         if redis_state is not None:
+            # Redis가 정상이나, 아직 리포트가 없어 빈 해시({})를 반환한 경우,
+            # 상태 은폐 방지를 위해 워커 로컬에 누적된 서브시스템 상태를 우선 노출합니다.
+            if not redis_state:
+                with self._state_lock:
+                    local_cache = {k: v.value for k, v in self._local_state.items()}
+                if local_cache:
+                    return local_cache
             return redis_state
 
         # Redis 파티션 — 폴백 TTL 확인

--- a/backend/core/health_registry.py
+++ b/backend/core/health_registry.py
@@ -281,6 +281,11 @@ class HealthRegistry:
                 with self._state_lock:
                     local_cache = {k: v.value for k, v in self._local_state.items()}
                 if local_cache:
+                    logger.info(
+                        "[HEALTH_REGISTRY] Redis returned empty hash. "
+                        "Falling back to local cache to expose existing subsystem states "
+                        "(startup/lag condition)."
+                    )
                     return local_cache
             return redis_state
 


### PR DESCRIPTION
- **[config_validator.py]**
  - _WEIGHT_SUM_TOLERANCE 클래스 상수 제거 및 환경변수(WEIGHT_SUM_TOLERANCE)화를 통한 동적 허용 오차 조정 체계 확립 (개방형 구성 체계)

- **[health_registry.py]**
  - get_summary: Redis가 정상이나 비어있는 상태({})를 반환할 때, 워커 로컬에 누적된 서브시스템 상태를 우선 노출하도록 보완 (Redis 기동 틈새에 발생하는 찰나의 상태 은폐 방지)

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1125#pullrequestreview-4119280233)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개인화된 RAG 가중치 검증 허용 오차를 환경 변수로 설정 가능하게 하고, Redis 상태가 비어 있을 때에도 헬스 요약이 안정적으로 동작하도록 강화합니다.

New Features:
- `WEIGHT_SUM_TOLERANCE` 환경 변수를 통해 개인화 인덱스 가중치 합 허용 오차를 설정할 수 있도록 지원합니다.

Bug Fixes:
- Redis가 빈 해시를 반환하는 경우에도 헬스 요약이 로컬 인메모리 서브시스템 상태로 폴백하도록 하여, 일시적인 상태가 가려지는 문제를 방지합니다.

Enhancements:
- 개인화 RAG 설정에 하드코딩되어 있던 가중치 합 허용 오차 상수를 제거하고, 보다 유연한 환경 변수 기반 설정으로 대체합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make personalized RAG weight validation tolerance configurable via environment and harden health summary against empty Redis state.

New Features:
- Allow configuring personalized index weight sum tolerance via the WEIGHT_SUM_TOLERANCE environment variable.

Bug Fixes:
- Ensure health summary falls back to local in-memory subsystem state when Redis returns an empty hash, avoiding transient state masking.

Enhancements:
- Remove hard-coded weight sum tolerance constant from personalized RAG configuration in favor of a more flexible, environment-driven setting.

</details>