### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -233,7 +233,7 @@ def _parse_int_clamped(
     except (ValueError, TypeError):
         logger.warning(
             "[CONFIG][CLAMP] '%s'=%r is not a valid integer; "
-            "falling back to heuristic default %d (min(32, os.cpu_count() + 4)).",
+            "falling back to default %d provided by default_factory.",
             env_key,
             raw,
             default,
@@ -291,6 +291,8 @@ class PersonalizedRAGConfig:
     _FAISS_RATIO_RANGE: ClassVar[ConfigRange] = ConfigRange(min=0.0, max=1.0)
     _FAISS_THRESHOLD_RANGE: ClassVar[ConfigRange] = ConfigRange(min=100, max=100_000)
     _AWS_WORKERS_RANGE: ClassVar[ConfigRange] = ConfigRange(min=10, max=100)
+    # Weight 합계 검증 허용 오차 (에: |sum - 1.0| ≤ 0.01이면 정상)
+    _WEIGHT_SUM_TOLERANCE: ClassVar[float] = 0.01
 
     def __init__(
         self,
@@ -373,6 +375,20 @@ class PersonalizedRAGConfig:
             subsystem=Subsystem.HYBRID_SEARCH,
         )
         subsystem_ok[Subsystem.HYBRID_SEARCH.value] = ok_pw and ok_gw
+
+        # Weight 합계 검증: 운영자 오설정 조기 감지
+        # 정규화는 Silent 수정으로 Zero Trust 원칙 위반 — WARNING 로그만 출력하고 원래 값 유지
+        weight_sum = p_weight + g_weight
+        if abs(weight_sum - 1.0) > cls._WEIGHT_SUM_TOLERANCE:
+            logger.warning(
+                "[CONFIG] PERSONALIZED_INDEX_WEIGHT=%.4f + GLOBAL_INDEX_WEIGHT=%.4f "
+                "= %.4f (expected ~1.0, tolerance=±%.2f). "
+                "Verify weights are configured correctly.",
+                p_weight,
+                g_weight,
+                weight_sum,
+                cls._WEIGHT_SUM_TOLERANCE,
+            )
 
         # Redis 폴백 TTL은 인프라 설정이므로 Subsystem 비활성화 없이 기본값 적용
         redis_ttl, _ = _parse_int_subsystem(

--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -291,8 +291,6 @@ class PersonalizedRAGConfig:
     _FAISS_RATIO_RANGE: ClassVar[ConfigRange] = ConfigRange(min=0.0, max=1.0)
     _FAISS_THRESHOLD_RANGE: ClassVar[ConfigRange] = ConfigRange(min=100, max=100_000)
     _AWS_WORKERS_RANGE: ClassVar[ConfigRange] = ConfigRange(min=10, max=100)
-    # Weight 합계 검증 허용 오차 (에: |sum - 1.0| ≤ 0.01이면 정상)
-    _WEIGHT_SUM_TOLERANCE: ClassVar[float] = 0.01
 
     def __init__(
         self,
@@ -376,10 +374,23 @@ class PersonalizedRAGConfig:
         )
         subsystem_ok[Subsystem.HYBRID_SEARCH.value] = ok_pw and ok_gw
 
+        # 환경 변수에서 WEIGHT_SUM_TOLERANCE 파싱 (기본값 0.01)
+        raw_tolerance = os.environ.get("WEIGHT_SUM_TOLERANCE")
+        tolerance = 0.01
+        if raw_tolerance is not None:
+            try:
+                tolerance = float(raw_tolerance)
+            except ValueError:
+                logger.warning(
+                    "[CONFIG] 'WEIGHT_SUM_TOLERANCE'=%r is not a valid float; using default %.2f.",
+                    raw_tolerance,
+                    tolerance,
+                )
+
         # Weight 합계 검증: 운영자 오설정 조기 감지
         # 정규화는 Silent 수정으로 Zero Trust 원칙 위반 — WARNING 로그만 출력하고 원래 값 유지
         weight_sum = p_weight + g_weight
-        if abs(weight_sum - 1.0) > cls._WEIGHT_SUM_TOLERANCE:
+        if abs(weight_sum - 1.0) > tolerance:
             logger.warning(
                 "[CONFIG] PERSONALIZED_INDEX_WEIGHT=%.4f + GLOBAL_INDEX_WEIGHT=%.4f "
                 "= %.4f (expected ~1.0, tolerance=±%.2f). "
@@ -387,7 +398,7 @@ class PersonalizedRAGConfig:
                 p_weight,
                 g_weight,
                 weight_sum,
-                cls._WEIGHT_SUM_TOLERANCE,
+                tolerance,
             )
 
         # Redis 폴백 TTL은 인프라 설정이므로 Subsystem 비활성화 없이 기본값 적용

--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -379,7 +379,14 @@ class PersonalizedRAGConfig:
         tolerance = 0.01
         if raw_tolerance is not None:
             try:
-                tolerance = float(raw_tolerance)
+                parsed_val = float(raw_tolerance)
+                tolerance = max(0.0, min(parsed_val, 1.0))
+                if tolerance != parsed_val:
+                    logger.warning(
+                        "[CONFIG][CLAMP] 'WEIGHT_SUM_TOLERANCE'=%g is out of safe range [0.0, 1.0]; clamped to %g.",
+                        parsed_val,
+                        tolerance,
+                    )
             except ValueError:
                 logger.warning(
                     "[CONFIG] 'WEIGHT_SUM_TOLERANCE'=%r is not a valid float; using default %.2f.",

--- a/backend/core/health_registry.py
+++ b/backend/core/health_registry.py
@@ -275,6 +275,13 @@ class HealthRegistry:
         # Redis SSOT 조회 시도
         redis_state = self._fetch_from_redis()
         if redis_state is not None:
+            # Redis가 정상이나, 아직 리포트가 없어 빈 해시({})를 반환한 경우,
+            # 상태 은폐 방지를 위해 워커 로컬에 누적된 서브시스템 상태를 우선 노출합니다.
+            if not redis_state:
+                with self._state_lock:
+                    local_cache = {k: v.value for k, v in self._local_state.items()}
+                if local_cache:
+                    return local_cache
             return redis_state
 
         # Redis 파티션 — 폴백 TTL 확인

--- a/backend/core/health_registry.py
+++ b/backend/core/health_registry.py
@@ -281,6 +281,11 @@ class HealthRegistry:
                 with self._state_lock:
                     local_cache = {k: v.value for k, v in self._local_state.items()}
                 if local_cache:
+                    logger.info(
+                        "[HEALTH_REGISTRY] Redis returned empty hash. "
+                        "Falling back to local cache to expose existing subsystem states "
+                        "(startup/lag condition)."
+                    )
                     return local_cache
             return redis_state
 

--- a/backend/core/health_registry.py
+++ b/backend/core/health_registry.py
@@ -301,6 +301,9 @@ class HealthRegistry:
 
         KEYS *를 O(N) 블로킹 명령 실행 없이 HGETALL로 맨점 방지.
         실패 시 None 반환 (In-process 폴백 전환).
+        빈 dict {}는 "Redis 정상, 아직 보고된 서브시스템 없음"을 의미하므로,
+        None과 동일하게 취급하지 않음. 빈 hash를 None으로 반환하면 정상 Redis를
+        파티션 상황으로 오판하는 버그가 발생함.
         """
         client = self._get_redis()
         if client is None:
@@ -310,8 +313,8 @@ class HealthRegistry:
             result: Dict[str, str] = client.hgetall(self._REDIS_HASH_KEY)
             self._redis_available = True
             self._redis_unavailable_since = None
-            # Hash가 비어있으면 None 반환 (In-process 폴백 전환)
-            return result or None
+            # 빈 dict {}도 유효한 결과 — None으로 변환하지 않음
+            return result
         except Exception:
             self._on_redis_failure()
             return None


### PR DESCRIPTION
🔧 fix [#12.1.7]: 2차 개선 - Redis 초기 상태 오판 수정, 가중치 합계 검증 및 로그 하드코딩 제거
🔧 fix [#12.1.7]: 3차 개선 - WEIGHT_SUM_TOLERANCE 환변 변수화 및 빈 해시 엣지 케이스 방어 
🔧 fix [#12.1.7]: 4차 개선 - Tolerance Clamping 및 Redis Empty Hash 로깅 추가

## Summary by Sourcery

구성 가능한 허용 오차에 따라 개인화/글로벌 인덱스 가중치 설정을 검증하고, 비어 있는 Redis 해시 처리 시 상태 관리 방식을 개선합니다.

개선 사항:
- 개인화/글로벌 가중치가 기대되는 합에서 벗어날 경우, 클램핑(clamping) 및 로깅을 수행하도록 구성 가능한 `WEIGHT_SUM_TOLERANCE`를 추가.
- 구성 클램핑 관련 로그 메시지를 휴리스틱 기본값이 아니라, 제공된 기본 팩토리를 참조하도록 명확화.
- 비어 있는 Redis 상태 해시를 유효한 상태로 취급하고, 로컬 캐시로 폴백하여 정상적인 Redis를 파티션된 상태로 잘못 분류하는 것을 방지.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate personalized/global index weight configuration against a configurable tolerance and improve Redis-based health state handling for empty hashes.

Enhancements:
- Add configurable WEIGHT_SUM_TOLERANCE with clamping and logging when personalized/global weights deviate from the expected sum.
- Clarify config clamping log messaging to reference the provided default factory instead of a heuristic default.
- Treat empty Redis health hashes as valid states and fall back to local cache to avoid misclassifying healthy Redis as partitioned.

</details>