### PR TITLE
✨ refactor [#12.1.7]: 5차 개선 - Float Clamping 헬퍼 모듈화 및 로그 스팸 가드 도입

### DIFF
--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -258,6 +258,48 @@ def _parse_int_clamped(
     return clamped
 
 
+def _parse_float_clamped(
+    env_key: str,
+    *,
+    default: float,
+    range_: ConfigRange,
+) -> float:
+    """
+    범위 기반 float 환경 변수를 파싱한다 (Graceful Fallback / Clamping).
+    """
+    raw = os.environ.get(env_key)
+
+    if raw is None:
+        return default
+
+    try:
+        value = float(raw)
+    except (ValueError, TypeError):
+        logger.warning(
+            "[CONFIG][CLAMP] '%s'=%r is not a valid float; "
+            "falling back to default %g.",
+            env_key,
+            raw,
+            default,
+        )
+        return default
+
+    clamped = _clamp(value, range_)
+    if clamped != value:
+        reason = "범위 미만 보정" if value < range_.min else "범위 초과 보정"
+        logger.warning(
+            "[CONFIG][CLAMP] '%s'=%g is outside safe range [%g, %g]; "
+            "clamped to %g (%s).",
+            env_key,
+            value,
+            range_.min,
+            range_.max,
+            clamped,
+            reason,
+        )
+    return clamped
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Phase 2 통합 설정 클래스
 # ─────────────────────────────────────────────────────────────────────────────
@@ -291,6 +333,8 @@ class PersonalizedRAGConfig:
     _FAISS_RATIO_RANGE: ClassVar[ConfigRange] = ConfigRange(min=0.0, max=1.0)
     _FAISS_THRESHOLD_RANGE: ClassVar[ConfigRange] = ConfigRange(min=100, max=100_000)
     _AWS_WORKERS_RANGE: ClassVar[ConfigRange] = ConfigRange(min=10, max=100)
+    
+    _DEFAULT_WEIGHT_SUM_TOLERANCE: ClassVar[float] = 0.01
 
     def __init__(
         self,
@@ -374,25 +418,11 @@ class PersonalizedRAGConfig:
         )
         subsystem_ok[Subsystem.HYBRID_SEARCH.value] = ok_pw and ok_gw
 
-        # 환경 변수에서 WEIGHT_SUM_TOLERANCE 파싱 (기본값 0.01)
-        raw_tolerance = os.environ.get("WEIGHT_SUM_TOLERANCE")
-        tolerance = 0.01
-        if raw_tolerance is not None:
-            try:
-                parsed_val = float(raw_tolerance)
-                tolerance = max(0.0, min(parsed_val, 1.0))
-                if tolerance != parsed_val:
-                    logger.warning(
-                        "[CONFIG][CLAMP] 'WEIGHT_SUM_TOLERANCE'=%g is out of safe range [0.0, 1.0]; clamped to %g.",
-                        parsed_val,
-                        tolerance,
-                    )
-            except ValueError:
-                logger.warning(
-                    "[CONFIG] 'WEIGHT_SUM_TOLERANCE'=%r is not a valid float; using default %.2f.",
-                    raw_tolerance,
-                    tolerance,
-                )
+        tolerance = _parse_float_clamped(
+            "WEIGHT_SUM_TOLERANCE",
+            default=cls._DEFAULT_WEIGHT_SUM_TOLERANCE,
+            range_=ConfigRange(min=0.0, max=1.0),
+        )
 
         # Weight 합계 검증: 운영자 오설정 조기 감지
         # 정규화는 Silent 수정으로 Zero Trust 원칙 위반 — WARNING 로그만 출력하고 원래 값 유지

--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -335,6 +335,7 @@ class PersonalizedRAGConfig:
     _AWS_WORKERS_RANGE: ClassVar[ConfigRange] = ConfigRange(min=10, max=100)
     
     _DEFAULT_WEIGHT_SUM_TOLERANCE: ClassVar[float] = 0.01
+    _WEIGHT_SUM_TOLERANCE_RANGE: ClassVar[ConfigRange] = ConfigRange(min=0.0, max=1.0)
 
     def __init__(
         self,
@@ -421,7 +422,7 @@ class PersonalizedRAGConfig:
         tolerance = _parse_float_clamped(
             "WEIGHT_SUM_TOLERANCE",
             default=cls._DEFAULT_WEIGHT_SUM_TOLERANCE,
-            range_=ConfigRange(min=0.0, max=1.0),
+            range_=cls._WEIGHT_SUM_TOLERANCE_RANGE,
         )
 
         # Weight 합계 검증: 운영자 오설정 조기 감지

--- a/backend/core/health_registry.py
+++ b/backend/core/health_registry.py
@@ -99,6 +99,7 @@ class HealthRegistry:
         # Redis 폴백 추적
         self._redis_available: bool = True
         self._redis_unavailable_since: Optional[float] = None  # monotonic timestamp
+        self._logged_empty_hash_fallback: bool = False  # 로그 스팸 방지 가드
 
         # Redis 클라이언트 (지연 초기화, fork-safe)
         self._redis_client = None
@@ -281,12 +282,17 @@ class HealthRegistry:
                 with self._state_lock:
                     local_cache = {k: v.value for k, v in self._local_state.items()}
                 if local_cache:
-                    logger.info(
-                        "[HEALTH_REGISTRY] Redis returned empty hash. "
-                        "Falling back to local cache to expose existing subsystem states "
-                        "(startup/lag condition)."
-                    )
+                    if not self._logged_empty_hash_fallback:
+                        logger.info(
+                            "[HEALTH_REGISTRY] Redis returned empty hash. "
+                            "Falling back to local cache to expose existing subsystem states "
+                            "(startup/lag condition)."
+                        )
+                        self._logged_empty_hash_fallback = True
                     return local_cache
+            # 정상적으로 데이터를 수신하면 가드 리셋
+            elif self._logged_empty_hash_fallback:
+                self._logged_empty_hash_fallback = False
             return redis_state
 
         # Redis 파티션 — 폴백 TTL 확인

--- a/backend/core/health_registry.py
+++ b/backend/core/health_registry.py
@@ -281,18 +281,20 @@ class HealthRegistry:
             if not redis_state:
                 with self._state_lock:
                     local_cache = {k: v.value for k, v in self._local_state.items()}
-                if local_cache:
-                    if not self._logged_empty_hash_fallback:
-                        logger.info(
-                            "[HEALTH_REGISTRY] Redis returned empty hash. "
-                            "Falling back to local cache to expose existing subsystem states "
-                            "(startup/lag condition)."
-                        )
-                        self._logged_empty_hash_fallback = True
-                    return local_cache
+                    if local_cache:
+                        if not self._logged_empty_hash_fallback:
+                            logger.info(
+                                "[HEALTH_REGISTRY] Redis returned empty hash. "
+                                "Falling back to local cache to expose existing subsystem states "
+                                "(startup/lag condition)."
+                            )
+                            self._logged_empty_hash_fallback = True
+                        return local_cache
             # 정상적으로 데이터를 수신하면 가드 리셋
-            elif self._logged_empty_hash_fallback:
-                self._logged_empty_hash_fallback = False
+            else:
+                with self._state_lock:
+                    if self._logged_empty_hash_fallback:
+                        self._logged_empty_hash_fallback = False
             return redis_state
 
         # Redis 파티션 — 폴백 TTL 확인


### PR DESCRIPTION
- **[config_validator.py]**
  - _parse_float_clamped 헬퍼 함수 개설 (코드 재사용성 향상 및 from_env 비대화 해소)
  - _DEFAULT_WEIGHT_SUM_TOLERANCE 단위 상수화를 통해 매직넘버(0.01) 하드코딩 완전 제거

- **[health_registry.py]**
  - get_summary: Redis Empty Hash 조우로 인한 로컬 리턴 시, 헬스체크 핑에 의한 로그 스팸 난사를 방어하는 1회성 인지 가드(_logged_empty_hash_fallback) 적용

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1127#pullrequestreview-4127768363)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

구성에서의 float 파싱 로직을 재사용 가능한 클램핑(clamping) 헬퍼로 리팩터링하고, 헬스 레지스트리에서 Redis 빈 해시(empty-hash) 폴백에 대한 로그 스팸 방지 기능을 추가합니다.

New Features:
- 설정된 범위 내에서 float 환경 변수를 파싱하고 클램핑하는 재사용 가능한 헬퍼를 도입합니다.

Enhancements:
- 인라인 매직 넘버 대신, `WEIGHT_SUM_TOLERANCE` 기본값을 클래스 수준 상수로 중앙집중화합니다.
- 헬스 레지스트리에서 Redis 빈 해시 폴백 로깅을 보호하여, 빈 해시가 발생하는 한 에피소드 동안 info 로그를 한 번만 출력하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor configuration float parsing into a reusable clamping helper and add log spam protection for Redis empty-hash fallbacks in the health registry.

New Features:
- Introduce a reusable helper to parse and clamp float environment variables within a configured range.

Enhancements:
- Centralize the WEIGHT_SUM_TOLERANCE default value as a class-level constant instead of an inline magic number.
- Guard Redis empty-hash fallback logging in the health registry to emit the info log only once per empty-hash episode.

</details>