### PR TITLE
♻️ refactor [#12.2.1]: 2차 개선 - AWS 래퍼 예외 처리 위임 및 간접 참조(Indirection) 제거

### DIFF
--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -14,6 +14,10 @@ from backend.core.config_validator import PersonalizedRAGConfig
 
 logger = logging.getLogger(__name__)
 
+class FatalSecurityError(Exception):
+    """치명적인 보안 관련 에러에 사용되는 예외"""
+    pass
+
 # Boto3 기본 재시도 비활성화 (애플리케이션 레이어 권한 통제)
 AWS_CONFIG = Config(
     retries={'max_attempts': 0, 'mode': 'standard'}
@@ -26,15 +30,14 @@ _boto_session: Optional[boto3.Session] = None
 def get_boto3_session() -> boto3.Session:
     """
     동기(Synchronous) Boto3 Session 싱글톤 팩토리.
-    이중 확인 락킹(Double-checked locking) 패턴으로 프로세스/포크 내 유일성을 보장 (Thread-Safe & Fork-Safe).
+    단일 공용 Lock을 사용하여 초기화 스레드 안전성을 보장합니다.
     """
     global _boto_session
-    if _boto_session is None:
-        with _session_lock:
-            if _boto_session is None:
-                logger.info("[AWS] Initializing shared Boto3 Session (Lazy Initialization)")
-                _boto_session = boto3.Session()
-    return _boto_session
+    with _session_lock:
+        if _boto_session is None:
+            logger.info("[AWS] Initializing shared Boto3 Session (Lazy Initialization)")
+            _boto_session = boto3.Session()
+        return _boto_session
 
 
 async def get_boto3_session_async() -> boto3.Session:
@@ -42,11 +45,6 @@ async def get_boto3_session_async() -> boto3.Session:
     비동기 파이썬 환경에서 데드락(Deadlock)을 방지하기 위해 
     Boto3 초기화 연산을 기본 이벤트 루프 스레드 풀에 오프로드(Offload)합니다.
     """
-    global _boto_session
-    
-    if _boto_session is not None:
-        return _boto_session
-        
     return await asyncio.to_thread(get_boto3_session)
 
 
@@ -58,55 +56,6 @@ FATAL_CLIENT_ERRORS = {
     "ParameterNotFound",
 }
 
-async def _invoke_with_full_jitter(func: Callable[[], Any]) -> Any:
-    """
-    명시적 Full Jitter 기반 앱 레벨 재시도 알고리즘 (Base Delay 1s, Cap 10s, Max 3 Retries).
-    이중 증폭(Double retries) 방지를 위해 boto3 설정에서 max_attempts=0 지정 시에만 사용 권장.
-    """
-    max_retries = 3
-    base_delay = 1.0
-    cap_delay = 10.0
-    
-    for attempt in range(max_retries + 1):
-        try:
-            return await asyncio.to_thread(func)
-            
-        except (EndpointConnectionError, ReadTimeoutError) as e:
-            is_transient = True
-            error_code = type(e).__name__
-            
-        except ClientError as e:
-            error_code = e.response.get("Error", {}).get("Code", "Unknown")
-            
-            if error_code in FATAL_CLIENT_ERRORS:
-                logger.critical(
-                    "[AWS][HARD-FAIL] Fatal ClientError: %s. Aborting immediately without retries.",
-                    error_code
-                )
-                raise
-            
-            is_transient = error_code in TRANSIENT_CLIENT_ERRORS
-            
-            if not is_transient:
-                logger.error("[AWS] Unhandled ClientError: %s", error_code)
-                raise
-                
-        else:
-            # loop exited via return; unreachable
-            break
-            
-        if attempt == max_retries:
-            logger.error("[AWS][RETRY] Max retries reached for transient error: %s", error_code)
-            raise
-            
-        delay = min(cap_delay, base_delay * (2 ** attempt))
-        jitter = random.uniform(0, delay)
-        logger.warning(
-            "[AWS][RETRY] Transient error %s. Retrying in %.2fs (Attempt %d/%d).",
-            error_code, jitter, attempt + 1, max_retries
-        )
-        await asyncio.sleep(jitter)
-
 
 async def fetch_global_pepper() -> str:
     """
@@ -114,26 +63,58 @@ async def fetch_global_pepper() -> str:
     global_pepper를 안전하게 메모리로만 페치합니다. (KMS 자동 복호화 포함)
     """
     session = await get_boto3_session_async()
-    
-    def _fetch() -> str:
-        # Boto3 기본 재시도를 비활성화하고 독점 Full Jitter 사용
-        client = session.client('ssm', config=AWS_CONFIG)
-        response = client.get_parameter(
-            Name='/v9/security/global_pepper',
-            WithDecryption=True
+    client = session.client('ssm', config=AWS_CONFIG)
+
+    max_retries = 3
+    base_delay = 1.0
+    cap_delay = 10.0
+
+    for attempt in range(max_retries + 1):
+        try:
+            response = await asyncio.to_thread(
+                client.get_parameter,
+                Name="/v9/security/global_pepper",
+                WithDecryption=True,
+            )
+            pepper = response["Parameter"]["Value"]
+            if not pepper:
+                raise ValueError("SSM returned empty string for global_pepper")
+            return pepper
+
+        except (EndpointConnectionError, ReadTimeoutError) as e:
+            error_code = type(e).__name__
+            is_transient = True
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "Unknown")
+
+            if error_code in FATAL_CLIENT_ERRORS:
+                logger.critical(
+                    "[AWS][HARD-FAIL] Fatal ClientError: %s. Aborting immediately without retries.",
+                    error_code,
+                )
+                raise FatalSecurityError(f"Fatal Security Error: {error_code}")
+
+            is_transient = error_code in TRANSIENT_CLIENT_ERRORS
+            if not is_transient:
+                logger.error("[AWS] Unhandled ClientError: %s", error_code)
+                raise FatalSecurityError(f"Unhandled AWS exception: {error_code}")
+                
+        except Exception as e:
+            logger.critical("[AWS][SECURITY] Unexpected error fetching pepper: %s", type(e).__name__)
+            raise FatalSecurityError("Fatal Security Error: Unexpected exception during pepper retrieval.")
+
+        if attempt == max_retries:
+            logger.error("[AWS][RETRY] Max retries reached for transient error: %s", error_code)
+            raise FatalSecurityError(f"Max retries reached: {error_code}")
+
+        delay = min(cap_delay, base_delay * (2**attempt))
+        jitter = random.uniform(0, delay)
+        logger.warning(
+            "[AWS][RETRY] Transient error %s. Retrying in %.2fs (Attempt %d/%d).",
+            error_code,
+            jitter,
+            attempt + 1,
+            max_retries,
         )
-        return response['Parameter']['Value']
-        
-    try:
-        pepper = await _invoke_with_full_jitter(_fetch)
-        if not pepper:
-            raise ValueError("SSM returned empty string for global_pepper")
-        return pepper
-    except ClientError as e:
-        error_code = e.response.get('Error', {}).get('Code', 'Unknown')
-        logger.critical("[AWS][SECURITY] Failed to fetch global_pepper: %s", error_code)
-        # 암호화 무단 오염 및 노출 방지를 위한 프로세스 중단 (Hard Fail-fast)
-        raise SystemExit("Fatal Security Error: Cannot retrieve global_pepper. Process aborted to protect data integrity.")
-    except Exception as e:
-        logger.critical("[AWS][SECURITY] Unexpected error fetching pepper: %s", type(e).__name__)
-        raise SystemExit("Fatal Security Error: Cannot retrieve global_pepper. Process aborted to protect data integrity.")
+        await asyncio.sleep(jitter)

--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -45,6 +45,9 @@ async def get_boto3_session_async() -> boto3.Session:
     비동기 파이썬 환경에서 데드락(Deadlock)을 방지하기 위해 
     Boto3 초기화 연산을 기본 이벤트 루프 스레드 풀에 오프로드(Offload)합니다.
     """
+    global _boto_session
+    if _boto_session is not None:
+        return _boto_session
     return await asyncio.to_thread(get_boto3_session)
 
 
@@ -93,16 +96,16 @@ async def fetch_global_pepper() -> str:
                     "[AWS][HARD-FAIL] Fatal ClientError: %s. Aborting immediately without retries.",
                     error_code,
                 )
-                raise FatalSecurityError(f"Fatal Security Error: {error_code}")
+                raise FatalSecurityError(f"Fatal Security Error: {error_code}") from e
 
             is_transient = error_code in TRANSIENT_CLIENT_ERRORS
             if not is_transient:
                 logger.error("[AWS] Unhandled ClientError: %s", error_code)
-                raise FatalSecurityError(f"Unhandled AWS exception: {error_code}")
+                raise FatalSecurityError(f"Unhandled AWS exception: {error_code}") from e
                 
         except Exception as e:
             logger.critical("[AWS][SECURITY] Unexpected error fetching pepper: %s", type(e).__name__)
-            raise FatalSecurityError("Fatal Security Error: Unexpected exception during pepper retrieval.")
+            raise FatalSecurityError("Fatal Security Error: Unexpected exception during pepper retrieval.") from e
 
         if attempt == max_retries:
             logger.error("[AWS][RETRY] Max retries reached for transient error: %s", error_code)


### PR DESCRIPTION
- **[예외 처리 책임 위임 (Delegation)]**
  - 라이브러리 레벨에서의 하드코딩된 강제 종료(`SystemExit`)를 금지하고, 전용 커스텀 예외인 `FatalSecurityError`를 신설하여 상위 Caller가 제어권을 가지도록 유연성 확보.

- **[코드 직관성 향상 (Readability)]**
  - 불필요한 `Double-checked locking`을 Single 락 방식으로 간소화하여 시각적 노이즈 제거.
  - `fetch_global_pepper` 내부에 Full Jitter 재시도 로직을 전면 인라이닝(Inlining)하여, 도달할 수 없는 데드 코드(`else: break`)를 없애고 제어 흐름 추적 용이성 극대화.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1133#pullrequestreview-4133379468)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

치명적인 AWS 보안 실패를 호출자에게 새로운 커스텀 예외를 통해 위임하고, 세션/페퍼 조회 로직을 단순화합니다.

New Features:
- 복구 불가능한 보안 관련 AWS 실패를 표현하기 위한 `FatalSecurityError` 예외를 도입합니다.

Enhancements:
- 스레드 안정성을 위해 단일 공유 락을 사용하는 방식으로 `boto3` 세션 싱글턴 초기화를 단순화합니다.
- 간접 호출 및 도달 불가능한 코드를 제거하기 위해, 전역 페퍼(global pepper) 조회 로직에 풀 지터(full-jitter) 재시도 로직을 직접 인라인합니다.
- 일시적인 AWS 오류와 치명적인 AWS 오류를 구분하면서, 전역 페퍼 조회 시 프로세스를 종료하는 대신 일관되게 `FatalSecurityError`를 발생시키도록 보장합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Delegate fatal AWS security failures to callers via a new custom exception and simplify session/pepper retrieval logic.

New Features:
- Introduce a FatalSecurityError exception to represent unrecoverable security-related AWS failures.

Enhancements:
- Simplify boto3 session singleton initialization to use a single shared lock for thread safety.
- Inline the full-jitter retry logic directly into global pepper fetching to remove indirection and unreachable code.
- Ensure global pepper retrieval consistently raises FatalSecurityError instead of terminating the process, while distinguishing transient and fatal AWS errors.

</details>