### PR TITLE
♻️ refactor [#12.2.1]: 4차 개선 - 재시도 인지 부하 해소 및 Fail-fast 보안 회귀 방어

### DIFF
--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -20,7 +20,9 @@ class FatalSecurityError(SystemExit):
     일반 예외(Exception) 핸들러에서 삼켜지는 것(Swallowed)을 방지하고, 
     프로세스 Fail-fast(즉시 종료)를 보장하기 위해 SystemExit을 상속받습니다.
     """
-    pass
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.code = 1  # 정상 종료(0)로 오인되는 것을 방지하기 위해 강제 설정
 
 # Boto3 기본 재시도 비활성화 (애플리케이션 레이어 권한 통제)
 AWS_CONFIG = Config(
@@ -76,7 +78,7 @@ async def fetch_global_pepper() -> str:
     base_delay = 1.0
     cap_delay = 10.0
 
-    for attempt in range(max_retries + 1):
+    for retry_index in range(max_retries + 1):
         try:
             response = await asyncio.to_thread(
                 client.get_parameter,
@@ -111,14 +113,14 @@ async def fetch_global_pepper() -> str:
             logger.critical("[AWS][SECURITY] Unexpected error fetching pepper: %s", type(e).__name__)
             raise FatalSecurityError("Fatal Security Error: Unexpected exception during pepper retrieval.") from e
 
-        if attempt == max_retries:
+        if retry_index == max_retries:
             logger.error("[AWS][RETRY] Max retries reached for transient error: %s", error_code)
-            raise FatalSecurityError(f"Max retries reached: {error_code}")
+            raise FatalSecurityError(f"Max retries reached: {error_code}") from e
 
-        delay = min(cap_delay, base_delay * (2**attempt))
+        delay = min(cap_delay, base_delay * (2**retry_index))
         jitter = random.uniform(0, delay)
         
-        current_retry = attempt + 1
+        current_retry = retry_index + 1
         logger.warning(
             "[AWS][RETRY] Transient error %s. Retrying in %.2fs (Retry %d/%d).",
             error_code,

--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -14,8 +14,12 @@ from backend.core.config_validator import PersonalizedRAGConfig
 
 logger = logging.getLogger(__name__)
 
-class FatalSecurityError(Exception):
-    """치명적인 보안 관련 에러에 사용되는 예외"""
+class FatalSecurityError(SystemExit):
+    """
+    치명적인 보안 관련 에러에 사용되는 예외입니다. 
+    일반 예외(Exception) 핸들러에서 삼켜지는 것(Swallowed)을 방지하고, 
+    프로세스 Fail-fast(즉시 종료)를 보장하기 위해 SystemExit을 상속받습니다.
+    """
     pass
 
 # Boto3 기본 재시도 비활성화 (애플리케이션 레이어 권한 통제)
@@ -113,11 +117,13 @@ async def fetch_global_pepper() -> str:
 
         delay = min(cap_delay, base_delay * (2**attempt))
         jitter = random.uniform(0, delay)
+        
+        current_retry = attempt + 1
         logger.warning(
-            "[AWS][RETRY] Transient error %s. Retrying in %.2fs (Attempt %d/%d).",
+            "[AWS][RETRY] Transient error %s. Retrying in %.2fs (Retry %d/%d).",
             error_code,
             jitter,
-            attempt + 1,
+            current_retry,
             max_retries,
         )
         await asyncio.sleep(jitter)


### PR DESCRIPTION
- **[보안 강제종료 보장 (Security Fail-fast Guarantees)]**
  - `FatalSecurityError`의 부모 클래스를 일반 `Exception`이 아닌 `SystemExit`으로 상향 조정.
  - Caller 모듈에서 무분별한 `except Exception`에 의해 보안 에러가 삼켜지고(Swallowed) 앱이 불안정한 상태로 지속 실행되는 취약점을 원천 차단하여, 이전 래퍼의 하드 종료 보장을 복구함.

- **[인지 부하(Cognitive Load) 해소]**
  - `fetch_global_pepper` 내의 Jitter 지연 로그를 `Attempt`에서 `Retry`로 단어를 교체.
  - `max_retries` 변수의 의미론과 로그 텍스트를 정확히 일치시켜 오프-바이-원(Off-by-one) 현상에 대한 개발자 독해 오류 가능성을 제거.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1135#pullrequestreview-4133403882)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

치명적인 보안 오류에 대해 즉시 실패(fail-fast) 동작을 보장하고, 일시적인 AWS 장애에 대한 재시도 로그 의미를 더 명확히 합니다.

버그 수정:
- 광범위한 `Exception` 핸들러에 의해 치명적인 보안 오류가 삼켜지는 것을 방지하고, 그러한 오류가 발생하면 프로세스를 즉시 종료하도록 합니다.

개선 사항:
- 전역 페퍼(global pepper) 조회에서 재시도 경고 로그를 재시도 관점의 문구와 일관된 카운터를 사용하도록 조정하여, 개발자의 인지 부담을 줄입니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guarantee fail-fast behavior for critical security errors and clarify retry logging semantics for transient AWS failures.

Bug Fixes:
- Prevent critical security errors from being swallowed by broad Exception handlers by making them terminate the process immediately.

Enhancements:
- Adjust retry warning logs in global pepper fetching to use retry-based wording and consistent counters to reduce cognitive load for developers.

</details>