### PR TITLE
♻️ refactor [#12.2.1]: 6차 개선 - SystemExit 속성 강제 변이(Anti-pattern) 제거

### DIFF
--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -20,11 +20,14 @@ class FatalSecurityError(SystemExit):
     일반 예외(Exception) 핸들러에서 삼켜지는 것(Swallowed)을 방지하고, 
     프로세스 Fail-fast(즉시 종료)를 보장하기 위해 SystemExit을 상속받습니다.
     """
-    def __init__(self, message: str) -> None:
+    def __init__(self, log_message: str) -> None:
         # SystemExit.code 에 프로세스 종료 코드를 명시적으로 전달합니다.
-        # 사람이 읽을 수 있는 에러 메시지는 별도 속성으로 보관해 로깅 등에 활용합니다.
+        # 기존 파이썬 예외 표준(str(e))을 깨지 않기 위해 페이로드를 별도 해제합니다.
         super().__init__(1)
-        self.message = message
+        self.log_message = log_message
+
+    def __str__(self) -> str:
+        return self.log_message
 
 # Boto3 기본 재시도 비활성화 (애플리케이션 레이어 권한 통제)
 AWS_CONFIG = Config(

--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -21,8 +21,10 @@ class FatalSecurityError(SystemExit):
     프로세스 Fail-fast(즉시 종료)를 보장하기 위해 SystemExit을 상속받습니다.
     """
     def __init__(self, message: str) -> None:
-        super().__init__(message)
-        self.code = 1  # 정상 종료(0)로 오인되는 것을 방지하기 위해 강제 설정
+        # SystemExit.code 에 프로세스 종료 코드를 명시적으로 전달합니다.
+        # 사람이 읽을 수 있는 에러 메시지는 별도 속성으로 보관해 로깅 등에 활용합니다.
+        super().__init__(1)
+        self.message = message
 
 # Boto3 기본 재시도 비활성화 (애플리케이션 레이어 권한 통제)
 AWS_CONFIG = Config(


### PR DESCRIPTION
- **[Pythonic 표준화 준수]**
  - 기존 `FatalSecurityError` 생성자에서 `SystemExit`의 `.code` 속성을 강제로 문자열에서 정수(1)로 재할당하던 비표준 해킹(Anti-pattern) 제거.
  - `super().__init__(1)`을 통해 파이썬 네이티브 종료 코드 명세에 완벽히 부합하게 전달하도록 수정.
  - 사람이 읽는 에러 문구는 `self.message` 커스텀 어트리뷰트로 격리 보관하여, 향후 다른 개발자나 서드파티 로깅 통합 시 발생할 수 있는 혼란(Cognitive confusion)을 원천 차단.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1137#pullrequestreview-4133434421)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

FatalSecurityError 예외를 표준 `SystemExit` 종료 코드를 사용하도록 개선하고, 사람이 읽을 수 있는 오류 메시지를 프로세스 종료 상태와 분리합니다.

버그 수정:
- `SystemExit` 코드 값을 명시적으로 `1`로 설정하여, `FatalSecurityError`가 (코드 0인) 정상 종료로 잘못 해석되는 문제를 방지합니다.

개선 사항:
- 숫자 종료 코드를 `SystemExit`에 전달하고, 오류 텍스트를 전용 메시지 속성에 저장함으로써 `FatalSecurityError`가 Python 관례를 따르도록 정렬합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the FatalSecurityError exception to use a standard SystemExit exit code and separate the human-readable error message from the process exit status.

Bug Fixes:
- Prevent misinterpretation of FatalSecurityError as a successful (code 0) process exit by explicitly setting the SystemExit code to 1.

Enhancements:
- Align FatalSecurityError with Python conventions by passing a numeric exit code to SystemExit and storing the error text in a dedicated message attribute.

</details>