### PR TITLE
♻️ refactor [#12.2.1]: 8차 개선 - 확장성 확보 및 하드코딩(매직 넘버) 제거

### DIFF
--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -20,10 +20,10 @@ class FatalSecurityError(SystemExit):
     일반 예외(Exception) 핸들러에서 삼켜지는 것(Swallowed)을 방지하고, 
     프로세스 Fail-fast(즉시 종료)를 보장하기 위해 SystemExit을 상속받습니다.
     """
-    def __init__(self, log_message: str) -> None:
+    def __init__(self, log_message: str, exit_code: int = 1) -> None:
         # SystemExit.code 에 프로세스 종료 코드를 명시적으로 전달합니다.
         # 기존 파이썬 예외 표준(str(e))을 깨지 않기 위해 페이로드를 별도 해제합니다.
-        super().__init__(1)
+        super().__init__(exit_code)
         self.log_message = log_message
 
     def __str__(self) -> str:


### PR DESCRIPTION
- **[유연성(Flexibility) 강화 및 하드코딩 배제]**
  - `FatalSecurityError` 생성자 내부의 `super().__init__(1)`에서 하드코딩된 '1'을 제거.
  - `exit_code: int = 1` 형태의 기본 매개변수(Default parameter)를 도입하여 기존 동작의 하위 호환성을 100% 유지.
  - 이를 통해 향후 호출자(Caller) 측에서 에러 유형(IAM 권한, KMS 만료 등)에 따라 세분화된 비표준 종료 코드(Exit 2, Exit 3 등)를 직접 주입할 수 있도록 제어 역전(Inversion of Control)을 실현함.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1139#pullrequestreview-4133458786)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Enhancements:
- 기존 기본 동작을 유지하면서, `FatalSecurityError`가 설정 가능한 종료 코드를 받을 수 있도록 허용했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Allow FatalSecurityError to accept a configurable exit code while preserving the existing default behavior.

</details>