### PR TITLE
♻️ refactor [#12.2.1]: 9차 개선 - 보안 상태 코드 표준화 및 Enum 도입

### DIFF
--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -4,7 +4,7 @@ import threading
 import logging
 import random
 from enum import IntEnum
-from typing import Optional, Callable, Any
+from typing import Optional, Callable, Any, Union
 from concurrent.futures import ThreadPoolExecutor
 
 import boto3
@@ -30,11 +30,19 @@ class FatalSecurityError(SystemExit):
     일반 예외(Exception) 핸들러에서 삼켜지는 것(Swallowed)을 방지하고, 
     프로세스 Fail-fast(즉시 종료)를 보장하기 위해 SystemExit을 상속받습니다.
     """
-    def __init__(self, log_message: str, exit_code: SecurityExitCode = SecurityExitCode.GENERIC_FAILURE) -> None:
+    def __init__(self, log_message: str, exit_code: Union[int, SecurityExitCode] = SecurityExitCode.GENERIC_FAILURE) -> None:
+        # 1. API 유연성: Enum 또는 원시(int) 값을 모두 수용하여 호출자의 편의를 보장
+        raw_code = exit_code.value if isinstance(exit_code, SecurityExitCode) else exit_code
+        
         # SystemExit.code 에 프로세스 종료 코드를 명시적으로 전달합니다.
-        # 기존 파이썬 예외 표준(str(e))을 깨지 않기 위해 페이로드를 별도 해제합니다.
-        super().__init__(exit_code.value)
+        super().__init__(raw_code)
         self.log_message = log_message
+        
+        # 2. 관측성 보장: 다운스트림 로거가 Enum의 풍부한 시맨틱(.name 등)을 읽을 수 있도록 보존
+        try:
+            self.exit_code_enum = SecurityExitCode(raw_code)
+        except ValueError:
+            self.exit_code_enum = None
 
     def __str__(self) -> str:
         return self.log_message

--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -3,6 +3,7 @@ import asyncio
 import threading
 import logging
 import random
+from enum import IntEnum
 from typing import Optional, Callable, Any
 from concurrent.futures import ThreadPoolExecutor
 
@@ -14,16 +15,25 @@ from backend.core.config_validator import PersonalizedRAGConfig
 
 logger = logging.getLogger(__name__)
 
+class SecurityExitCode(IntEnum):
+    """
+    FatalSecurityError 발생 시의 표준화된 프로세스 종료 코드 체계입니다.
+    무분별한 임의 숫자 사용을 방지하고, K8s 등 외부 모니터링 시스템과의 정합성을 유지합니다.
+    """
+    GENERIC_FAILURE = 1
+    # 향후 AWS IAM(액세스 거부) 또는 네트워크(타임아웃) 등 
+    # 세분화된 장애가 필요할 경우 여기에 추가 정의합니다.
+
 class FatalSecurityError(SystemExit):
     """
     치명적인 보안 관련 에러에 사용되는 예외입니다. 
     일반 예외(Exception) 핸들러에서 삼켜지는 것(Swallowed)을 방지하고, 
     프로세스 Fail-fast(즉시 종료)를 보장하기 위해 SystemExit을 상속받습니다.
     """
-    def __init__(self, log_message: str, exit_code: int = 1) -> None:
+    def __init__(self, log_message: str, exit_code: SecurityExitCode = SecurityExitCode.GENERIC_FAILURE) -> None:
         # SystemExit.code 에 프로세스 종료 코드를 명시적으로 전달합니다.
         # 기존 파이썬 예외 표준(str(e))을 깨지 않기 위해 페이로드를 별도 해제합니다.
-        super().__init__(exit_code)
+        super().__init__(exit_code.value)
         self.log_message = log_message
 
     def __str__(self) -> str:


### PR DESCRIPTION
- **[인프라 정합성(Infrastructure Consistency) 및 안전성 확보]**
  - 무분별한 매직 넘버 숫자(`exit_code: int`)가 혼입되는 것을 막기 위해 파이썬 내장 `IntEnum`을 기반으로 한 `SecurityExitCode` 표준 체계 도입.
  - `FatalSecurityError` 호출 시 아무 정수나 던질 수 없도록 파라미터 타입을 Enum으로 강제(Constraining)하여, 향후 텔레메트리(k8s, Datadog) 관측 시의 사이드 이펙트(False-positive/Unknown status)를 원천 차단.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1141#pullrequestreview-4133466601)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

IntEnum 기반 종료 코드를 사용하여 치명적인 보안 종료 처리 방식을 표준화합니다.

개선 사항:
- 보안 관련 장애에 대한 표준화된 프로세스 종료 코드를 정의하기 위해 `SecurityExitCode` IntEnum을 도입합니다.
- `FatalSecurityError`가 원시 정수 대신 `SecurityExitCode`를 필수로 사용하도록 변경하고, `SystemExit`에는 해당 Enum의 실제 값을 사용하도록 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize fatal security exit handling using an IntEnum-based exit code.

Enhancements:
- Introduce a SecurityExitCode IntEnum to define standardized process exit codes for security-related failures.
- Update FatalSecurityError to require a SecurityExitCode instead of a raw integer and use its underlying value for SystemExit.

</details>