### PR TITLE
♻️ refactor [#12.2.1]: 13차 개선 - OS 레벨 종료 코드 경계 검증 및 시맨틱 보존

### DIFF
--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -24,11 +24,19 @@ class SecurityExitCode(Enum):
     # 향후 AWS IAM(액세스 거부) 또는 네트워크(타임아웃) 등 
     # 세분화된 장애가 필요할 경우 여기에 추가 정의합니다.
 
+MIN_OS_EXIT_CODE = 1
+MAX_OS_EXIT_CODE = 255
+
 class FatalSecurityError(SystemExit):
     """
     치명적인 보안 관련 에러에 사용되는 예외입니다. 
     일반 예외(Exception) 핸들러에서 삼켜지는 것(Swallowed)을 방지하고, 
     프로세스 Fail-fast(즉시 종료)를 보장하기 위해 SystemExit을 상속받습니다.
+    
+    [종료 코드 정규화 정책]
+    임의의 exit_code 입력은 안전한 OS 종료 코드 범위(1~255)로 정규화됩니다.
+    정상 종료로 오인되는 0이나 허용 범위를 넘어서는 값, 혹은 Int 캐스팅이 불가능한 타입이 주입될 경우,
+    안전성을 위해 SecurityExitCode.GENERIC_FAILURE 로 자동 폴백(Fallback) 처리됩니다.
     """
     def __init__(self, log_message: str, exit_code: int | SecurityExitCode = SecurityExitCode.GENERIC_FAILURE) -> None:
         # 1. API 유연성 및 타입 안전성: Enum/int 수용 및 명시적 정규화
@@ -44,12 +52,12 @@ class FatalSecurityError(SystemExit):
                     type(exit_code).__name__
                 )
                 
-        # OS Exit Code 바운더리 검증 (1 ~ 255)
-        # 0은 정상 종료인 false-positive를 유발하므로 허용하지 않으며, 255 초과는 Unix에서 모듈로 연산됨
-        if not (1 <= raw_code <= 255):
+        # OS Exit Code 바운더리 검증
+        # 0은 정상 종료인 false-positive를 유발하므로 허용하지 않으며, MAX 초과는 Unix에서 모듈로 연산됨
+        if not (MIN_OS_EXIT_CODE <= raw_code <= MAX_OS_EXIT_CODE):
             logger.warning(
-                "[AWS][SECURITY] exit_code %s is out of valid OS bounds (1-255). Falling back to GENERIC_FAILURE.",
-                raw_code
+                "[AWS][SECURITY] exit_code %s is out of valid OS bounds (%d-%d). Falling back to GENERIC_FAILURE.",
+                raw_code, MIN_OS_EXIT_CODE, MAX_OS_EXIT_CODE
             )
             raw_code = SecurityExitCode.GENERIC_FAILURE.value
         

--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -39,7 +39,19 @@ class FatalSecurityError(SystemExit):
                 raw_code = int(exit_code)
             except (ValueError, TypeError):
                 raw_code = SecurityExitCode.GENERIC_FAILURE.value
-                logger.error("[AWS][SECURITY] Invalid exit_code type provided: %s. Falling back to GENERIC_FAILURE.", type(exit_code).__name__)
+                logger.warning(
+                    "[AWS][SECURITY] Invalid exit_code type provided: %s. Falling back to GENERIC_FAILURE.",
+                    type(exit_code).__name__
+                )
+                
+        # OS Exit Code 바운더리 검증 (1 ~ 255)
+        # 0은 정상 종료인 false-positive를 유발하므로 허용하지 않으며, 255 초과는 Unix에서 모듈로 연산됨
+        if not (1 <= raw_code <= 255):
+            logger.warning(
+                "[AWS][SECURITY] exit_code %s is out of valid OS bounds (1-255). Falling back to GENERIC_FAILURE.",
+                raw_code
+            )
+            raw_code = SecurityExitCode.GENERIC_FAILURE.value
         
         # SystemExit.code 에 프로세스 종료 코드를 명시적으로 전달합니다.
         super().__init__(raw_code)


### PR DESCRIPTION
- **[OS System Limits 방어 프로그래밍]**
  - Caller가 넘긴 `exit_code`가 유닉스 표준 종료 코드 범위(1~255)를 벗어나거나, 혹은 비정상적인 `SystemExit(999)` 등으로 인해 OS 레벨에서 잘못 래핑(Wrapping)되는 문제를 미연에 차단.
  - `0`이 주입되어 보안 에러임에도 불구하고 정상적인(Clean) 종료로 오인(False-positive)되는 치명적 회귀 취약점 방어.

- **[로그 정책(Log Severity) 최적화]**
  - 단순 파라미터 타입 오류 등으로 발생한 내부 Fallback 동작의 로깅 레벨을 `ERROR`에서 `WARNING`으로 하향 조정.
  - 시스템적 치명타가 아닌 단순 개발/예외 처리 단계에서의 자가 복구 상황임을 명시하여, 불필요한 APM 알럿 스팸 억제.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1145#pullrequestreview-4133497543)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

AWS 클라이언트 래퍼에서 보안 관련 프로세스 종료 처리 방식을 개선하여 OS 종료 코드 범위를 준수하고, 중요하지 않은 폴백(fallback) 시나리오에 대해 로깅 심각도를 조정합니다.

버그 수정:
- 잘못되었거나 범위를 벗어난 종료 코드가 OS로 전파되지 않도록, 이를 일반적인 실패 코드로 정규화합니다.
- 0을 유효한 종료 코드로 허용하지 않음으로써, 보안 관련 실패가 정상 종료로 오분류되는 것을 방지합니다.

개선 사항:
- 불필요한 경고를 줄이기 위해, 내부 폴백 동작을 트리거하는 잘못된 `exit_code` 타입에 대한 로깅 심각도를 오류(error)에서 경고(warning)로 낮춥니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine security-related process exit handling in the AWS client wrapper to respect OS exit code bounds and adjust logging severity for non-critical fallback scenarios.

Bug Fixes:
- Prevent invalid or out-of-range exit codes from propagating to the OS by normalizing them to a generic failure code.
- Avoid misclassifying security-related failures as successful exits by disallowing zero as an effective exit code.

Enhancements:
- Downgrade logging severity from error to warning for invalid exit_code types that trigger internal fallback behavior to reduce unnecessary alerts.

</details>