### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -24,11 +24,19 @@ class SecurityExitCode(Enum):
     # 향후 AWS IAM(액세스 거부) 또는 네트워크(타임아웃) 등 
     # 세분화된 장애가 필요할 경우 여기에 추가 정의합니다.
 
+MIN_OS_EXIT_CODE = 1
+MAX_OS_EXIT_CODE = 255
+
 class FatalSecurityError(SystemExit):
     """
     치명적인 보안 관련 에러에 사용되는 예외입니다. 
     일반 예외(Exception) 핸들러에서 삼켜지는 것(Swallowed)을 방지하고, 
     프로세스 Fail-fast(즉시 종료)를 보장하기 위해 SystemExit을 상속받습니다.
+    
+    [종료 코드 정규화 정책]
+    임의의 exit_code 입력은 안전한 OS 종료 코드 범위(1~255)로 정규화됩니다.
+    정상 종료로 오인되는 0이나 허용 범위를 넘어서는 값, 혹은 Int 캐스팅이 불가능한 타입이 주입될 경우,
+    안전성을 위해 SecurityExitCode.GENERIC_FAILURE 로 자동 폴백(Fallback) 처리됩니다.
     """
     def __init__(self, log_message: str, exit_code: int | SecurityExitCode = SecurityExitCode.GENERIC_FAILURE) -> None:
         # 1. API 유연성 및 타입 안전성: Enum/int 수용 및 명시적 정규화
@@ -44,12 +52,12 @@ class FatalSecurityError(SystemExit):
                     type(exit_code).__name__
                 )
                 
-        # OS Exit Code 바운더리 검증 (1 ~ 255)
-        # 0은 정상 종료인 false-positive를 유발하므로 허용하지 않으며, 255 초과는 Unix에서 모듈로 연산됨
-        if not (1 <= raw_code <= 255):
+        # OS Exit Code 바운더리 검증
+        # 0은 정상 종료인 false-positive를 유발하므로 허용하지 않으며, MAX 초과는 Unix에서 모듈로 연산됨
+        if not (MIN_OS_EXIT_CODE <= raw_code <= MAX_OS_EXIT_CODE):
             logger.warning(
-                "[AWS][SECURITY] exit_code %s is out of valid OS bounds (1-255). Falling back to GENERIC_FAILURE.",
-                raw_code
+                "[AWS][SECURITY] exit_code %s is out of valid OS bounds (%d-%d). Falling back to GENERIC_FAILURE.",
+                raw_code, MIN_OS_EXIT_CODE, MAX_OS_EXIT_CODE
             )
             raw_code = SecurityExitCode.GENERIC_FAILURE.value
         

--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -39,7 +39,19 @@ class FatalSecurityError(SystemExit):
                 raw_code = int(exit_code)
             except (ValueError, TypeError):
                 raw_code = SecurityExitCode.GENERIC_FAILURE.value
-                logger.error("[AWS][SECURITY] Invalid exit_code type provided: %s. Falling back to GENERIC_FAILURE.", type(exit_code).__name__)
+                logger.warning(
+                    "[AWS][SECURITY] Invalid exit_code type provided: %s. Falling back to GENERIC_FAILURE.",
+                    type(exit_code).__name__
+                )
+                
+        # OS Exit Code 바운더리 검증 (1 ~ 255)
+        # 0은 정상 종료인 false-positive를 유발하므로 허용하지 않으며, 255 초과는 Unix에서 모듈로 연산됨
+        if not (1 <= raw_code <= 255):
+            logger.warning(
+                "[AWS][SECURITY] exit_code %s is out of valid OS bounds (1-255). Falling back to GENERIC_FAILURE.",
+                raw_code
+            )
+            raw_code = SecurityExitCode.GENERIC_FAILURE.value
         
         # SystemExit.code 에 프로세스 종료 코드를 명시적으로 전달합니다.
         super().__init__(raw_code)


### PR DESCRIPTION
♻️ refactor [#12.2.1]: 13차 개선 - OS 레벨 종료 코드 경계 검증 및 시맨틱 보존 
♻️ refactor [#12.2.1]: 14차 개선 - OS 종료 코드 매직 넘버 분리 및 공식 정책 문서화

## Summary by Sourcery

보안 관련 치명적 오류에 대한 프로세스 종료 코드를 정규화하고 검증하여, 해당 코드가 항상 안전한 OS 수준 범위 내에 머물도록 하고, 유효하지 않은 경우 일반적인 실패 코드로 대체되도록 합니다.

Enhancements:
- 명시적인 OS 종료 코드 범위를 도입하고, `FatalSecurityError`에서 사용자 정의 종료 코드에 대한 정규화를 강제합니다.
- 잘못된 `exit_code` 타입에 대한 로깅 심각도를 완화하고, 범위를 벗어난 OS 종료 코드가 일반적인 실패 코드로 강제 변환(coerce)될 때 경고를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize and validate process exit codes for security-related fatal errors to ensure they stay within safe OS-level bounds and fall back to a generic failure code when invalid.

Enhancements:
- Introduce explicit OS exit code bounds and enforce normalization of custom exit codes in FatalSecurityError.
- Relax logging severity for invalid exit_code types and add warnings for out-of-range OS exit codes that are coerced to a generic failure.

</details>