### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -28,13 +28,13 @@ MIN_OS_EXIT_CODE = 1
 MAX_OS_EXIT_CODE = 255
 
 class FatalSecurityError(SystemExit):
-    """
+    f"""
     치명적인 보안 관련 에러에 사용되는 예외입니다. 
     일반 예외(Exception) 핸들러에서 삼켜지는 것(Swallowed)을 방지하고, 
     프로세스 Fail-fast(즉시 종료)를 보장하기 위해 SystemExit을 상속받습니다.
     
     [종료 코드 정규화 정책]
-    임의의 exit_code 입력은 안전한 OS 종료 코드 범위(1~255)로 정규화됩니다.
+    임의의 exit_code 입력은 안전한 OS 종료 코드 범위({MIN_OS_EXIT_CODE}~{MAX_OS_EXIT_CODE})로 정규화됩니다.
     정상 종료로 오인되는 0이나 허용 범위를 넘어서는 값, 혹은 Int 캐스팅이 불가능한 타입이 주입될 경우,
     안전성을 위해 SecurityExitCode.GENERIC_FAILURE 로 자동 폴백(Fallback) 처리됩니다.
     """
@@ -42,14 +42,22 @@ class FatalSecurityError(SystemExit):
         # 1. API 유연성 및 타입 안전성: Enum/int 수용 및 명시적 정규화
         if isinstance(exit_code, SecurityExitCode):
             raw_code = exit_code.value
+        elif isinstance(exit_code, bool):
+            # 파이썬에서 bool(True/False)은 int의 서브클래스이므로 int()에 의해 조용히 1/0으로 파싱됩니다.
+            # 이러한 오작동을 사전에 필터링합니다.
+            raw_code = SecurityExitCode.GENERIC_FAILURE.value
+            logger.warning(
+                "[AWS][SECURITY] Boolean is implicitly castable to int, but rejected as exit_code (value=%r). Falling back to GENERIC_FAILURE.",
+                exit_code
+            )
         else:
             try:
                 raw_code = int(exit_code)
             except (ValueError, TypeError):
                 raw_code = SecurityExitCode.GENERIC_FAILURE.value
                 logger.warning(
-                    "[AWS][SECURITY] Invalid exit_code type provided: %s. Falling back to GENERIC_FAILURE.",
-                    type(exit_code).__name__
+                    "[AWS][SECURITY] Invalid exit_code type provided: %s (value=%r). Falling back to GENERIC_FAILURE.",
+                    type(exit_code).__name__, exit_code
                 )
                 
         # OS Exit Code 바운더리 검증


### PR DESCRIPTION
♻️ refactor [#12.2.1]: 15차 개선 - 파이썬 Bool/Int 상속 맹점 방어 및 DRY 정책 문서화

## Summary by Sourcery

AWS 클라이언트 래퍼에서 보안 관련 종료 처리(Exit Handling)를 강화하기 위해, 종료 코드 정규화 방식을 더 엄격하게 하고 정책 문서를 보다 정확하게 명시했습니다.

버그 수정:
- Python의 bool 값이 조용히 허용된 뒤 정수 종료 코드로 캐스팅되는 문제를 방지하기 위해, bool 값을 잘못된 입력으로 처리하고 일반적인 실패 코드로 대체하도록 했습니다.

개선 사항:
- `FatalSecurityError`의 docstring에서 문서화된 OS 종료 코드 정규화 범위를, 설정된 최소/최대 상수 값을 반영하도록 명확히 하고 파라미터화했습니다.
- 잘못된 `exit_code` 입력에 대해 경고 로그에 타입과 원시 값(raw value)을 모두 포함하여 로깅을 개선했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden security-related exit handling in the AWS client wrapper by tightening exit code normalization and documenting the policy more precisely.

Bug Fixes:
- Prevent Python bool values from being silently accepted and cast to integer exit codes by treating them as invalid and falling back to a generic failure code.

Enhancements:
- Clarify and parameterize the documented OS exit code normalization range in the FatalSecurityError docstring to reflect the configured min/max constants.
- Improve logging for invalid exit_code inputs by including both the type and the raw value in warning messages.

</details>