### PR TITLE
♻️ refactor [#12.2.1]: 16차 개선 - 정적 분석 호환성 확보 및 명시적 실패(Fail-loud) 적용

### DIFF
--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -28,13 +28,13 @@ MIN_OS_EXIT_CODE = 1
 MAX_OS_EXIT_CODE = 255
 
 class FatalSecurityError(SystemExit):
-    f"""
+    """
     치명적인 보안 관련 에러에 사용되는 예외입니다. 
     일반 예외(Exception) 핸들러에서 삼켜지는 것(Swallowed)을 방지하고, 
     프로세스 Fail-fast(즉시 종료)를 보장하기 위해 SystemExit을 상속받습니다.
     
     [종료 코드 정규화 정책]
-    임의의 exit_code 입력은 안전한 OS 종료 코드 범위({MIN_OS_EXIT_CODE}~{MAX_OS_EXIT_CODE})로 정규화됩니다.
+    임의의 exit_code 입력은 안전한 OS 종료 코드 범위(MIN_OS_EXIT_CODE ~ MAX_OS_EXIT_CODE)로 정규화됩니다.
     정상 종료로 오인되는 0이나 허용 범위를 넘어서는 값, 혹은 Int 캐스팅이 불가능한 타입이 주입될 경우,
     안전성을 위해 SecurityExitCode.GENERIC_FAILURE 로 자동 폴백(Fallback) 처리됩니다.
     """
@@ -44,12 +44,8 @@ class FatalSecurityError(SystemExit):
             raw_code = exit_code.value
         elif isinstance(exit_code, bool):
             # 파이썬에서 bool(True/False)은 int의 서브클래스이므로 int()에 의해 조용히 1/0으로 파싱됩니다.
-            # 이러한 오작동을 사전에 필터링합니다.
-            raw_code = SecurityExitCode.GENERIC_FAILURE.value
-            logger.warning(
-                "[AWS][SECURITY] Boolean is implicitly castable to int, but rejected as exit_code (value=%r). Falling back to GENERIC_FAILURE.",
-                exit_code
-            )
+            # 이와 같은 명시적인 오용(Misuse)은 Fallback으로 덮지 않고 즉각적인 TypeError로 개발자에게 피드백합니다.
+            raise TypeError(f"exit_code cannot be a boolean (received: {exit_code}). Use int or SecurityExitCode.")
         else:
             try:
                 raw_code = int(exit_code)

--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -34,7 +34,7 @@ class FatalSecurityError(SystemExit):
     프로세스 Fail-fast(즉시 종료)를 보장하기 위해 SystemExit을 상속받습니다.
     
     [종료 코드 정규화 정책]
-    임의의 exit_code 입력은 안전한 OS 종료 코드 범위(MIN_OS_EXIT_CODE ~ MAX_OS_EXIT_CODE)로 정규화됩니다.
+    임의의 exit_code 입력은 안전한 OS 종료 코드 범위(허용 한계치는 MIN_OS_EXIT_CODE 및 MAX_OS_EXIT_CODE 상수 참조)로 정규화됩니다.
     정상 종료로 오인되는 0이나 허용 범위를 넘어서는 값, 혹은 Int 캐스팅이 불가능한 타입이 주입될 경우,
     안전성을 위해 SecurityExitCode.GENERIC_FAILURE 로 자동 폴백(Fallback) 처리됩니다.
     """
@@ -45,6 +45,10 @@ class FatalSecurityError(SystemExit):
         elif isinstance(exit_code, bool):
             # 파이썬에서 bool(True/False)은 int의 서브클래스이므로 int()에 의해 조용히 1/0으로 파싱됩니다.
             # 이와 같은 명시적인 오용(Misuse)은 Fallback으로 덮지 않고 즉각적인 TypeError로 개발자에게 피드백합니다.
+            logger.error(
+                "[AWS][SECURITY] Boolean is implicitly castable to int, but rejected as exit_code (value=%r). Raising TypeError.",
+                exit_code
+            )
             raise TypeError(f"exit_code cannot be a boolean (received: {exit_code}). Use int or SecurityExitCode.")
         else:
             try:


### PR DESCRIPTION
- **[정적 분석(Sphinx) 호환성 보장]**
  - 클래스 Docstring(`__doc__`)에 사용된 동적 보간(f-string) 문법을 제거하고 순수 문자열(Literal) 명칭으로 치환.
  - 이를 통해 모듈 로드 시점의 동적 평가에 의존하지 않고, 외부 문서 자동화 도구나 린터(Linter)가 텍스트를 파싱할 때 발생할 수 있는 안티패턴 제거.

- **[오용 방지를 위한 명시적 실패(Fail-Loud) 체계 도입]**
  - 개발자가 명백하게 코드를 잘못 작성하여 `bool`을 `exit_code`로 넘긴 경우, 더 이상 조용히(Silent) `GENERIC_FAILURE`로 덮어주지(Masking) 않음.
  - 가차 없이 즉시 `TypeError`를 뿜어냄으로써(Fail-Loud), 개발 파이프라인(테스트) 단계에서 해당 오용 징후가 빠르게 폭로될 수 있도록 시스템 엔지니어링 원칙 강화.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1149#pullrequestreview-4133532410)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

보안 종료 처리 및 문서를 개선하여 정적 분석 도구와의 호환성을 높이고, 잘못된 종료 코드에 대해 명확하게 실패(fail-loud)하도록 동작을 강화합니다.

버그 수정:
- `exit_code`로 전달된 불리언 값은 일반적인 실패 코드로 조용히 정규화하지 않고, `TypeError`를 발생시켜 거부합니다.

개선 사항:
- `FatalSecurityError`의 docstring에서 런타임 f-string 보간을 제거하고, 종료 코드 범위 설명에 대해 정적인 리터럴 텍스트를 사용하도록 업데이트했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine security exit handling and documentation to improve static analysis compatibility and enforce fail-loud behavior on invalid exit codes.

Bug Fixes:
- Reject boolean values passed as exit_code by raising a TypeError instead of silently normalizing them to a generic failure code.

Enhancements:
- Update FatalSecurityError docstring to remove runtime f-string interpolation and use static literal text for exit code range description.

</details>