### PR TITLE
♻️ refactor [#12.2.1]: 18차 개선 - Breaking API 호환성 검토 및 이중 로깅 폭풍 방어

### DIFF
--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -45,7 +45,7 @@ class FatalSecurityError(SystemExit):
         elif isinstance(exit_code, bool):
             # 파이썬에서 bool(True/False)은 int의 서브클래스이므로 int()에 의해 조용히 1/0으로 파싱됩니다.
             # 이와 같은 명시적인 오용(Misuse)은 Fallback으로 덮지 않고 즉각적인 TypeError로 개발자에게 피드백합니다.
-            logger.error(
+            logger.warning(
                 "[AWS][SECURITY] Boolean is implicitly castable to int, but rejected as exit_code (value=%r). Raising TypeError.",
                 exit_code
             )

--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -47,9 +47,14 @@ class FatalSecurityError(SystemExit):
             # 이와 같은 명시적인 오용(Misuse)은 Fallback으로 덮지 않고 즉각적인 TypeError로 개발자에게 피드백합니다.
             logger.warning(
                 "[AWS][SECURITY] Boolean is implicitly castable to int, but rejected as exit_code (value=%r). Raising TypeError.",
-                exit_code
+                exit_code,
+                extra={"security_violation": True, "invalid_parameter": "exit_code", "injected_value": exit_code}
             )
-            raise TypeError(f"exit_code cannot be a boolean (received: {exit_code}). Use int or SecurityExitCode.")
+            # 호명된 파라미터와 정확한 런타임 값을 문자열 시그니처에 노출하여 개발자의 디버깅을 보조합니다.
+            raise TypeError(
+                f"Configuration Error: 'exit_code' parameter rejected. "
+                f"Expected int or SecurityExitCode, but explicitly got bool with value: {exit_code}."
+            )
         else:
             try:
                 raw_code = int(exit_code)


### PR DESCRIPTION
- **[Breaking Change 호환성 무결점(Zero-impact) 검증]**
  - `exit_code` 파라미터가 `bool`일 경우 `TypeError`로 런타임 Crash를 발생시키는 변경점에 대해, 전체 코드베이스의 모든 호출자를 정적 분석(`grep_search`) 검토 완료.
  - 외부나 다른 모듈에서 `bool` 인자를 전달하는 레거시 코드가 전혀 존재하지 않음을 확인하여 운영 환경의 무정지(Zero-downtime) 보장.

- **[이중 장애 리포팅(Double Error Reporting) 안티패턴 제거]**
  - Exception을 던지기(raise) 직전에 `logger.error`를 남기는 안티패턴을 교정하여, `logger.warning` 수준으로 다운그레이드.
  - Sentry/Datadog 과 같은 APM 시스템에서 동일 트랜잭션 내에 에러 로그가 2개로 증식(Duplicate)하여 알럿 폭풍(Alert Storm)이 발생하는 것을 아키텍처 수준에서 차단.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1151#pullrequestreview-4133545817)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

버그 수정:
- 부울 `exit_code`로 인해 `TypeError`가 발생하는 경우, 로그 심각도를 낮춰 보안 관련 실패가 이중으로 보고되지 않도록 방지했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent double-reporting of security-related failures by lowering log severity when a boolean exit_code triggers a TypeError.

</details>