### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -45,15 +45,15 @@ class FatalSecurityError(SystemExit):
         elif isinstance(exit_code, bool):
             # 파이썬에서 bool(True/False)은 int의 서브클래스이므로 int()에 의해 조용히 1/0으로 파싱됩니다.
             # 이와 같은 명시적인 오용(Misuse)은 Fallback으로 덮지 않고 즉각적인 TypeError로 개발자에게 피드백합니다.
-            logger.warning(
-                "[AWS][SECURITY] Boolean is implicitly castable to int, but rejected as exit_code (value=%r). Raising TypeError.",
-                exit_code,
-                extra={"security_violation": True, "invalid_parameter": "exit_code", "injected_value": exit_code}
+            logger.error(
+                "[AWS][SECURITY] Boolean is implicitly castable to int, but rejected as exit_code (type=%s). Raising TypeError.",
+                type(exit_code).__name__,
+                extra={"security_violation": True, "invalid_parameter": "exit_code", "injected_type": type(exit_code).__name__}
             )
-            # 호명된 파라미터와 정확한 런타임 값을 문자열 시그니처에 노출하여 개발자의 디버깅을 보조합니다.
+            # 런타임 값의 PII 유출을 방지하기 위해 값 대신 Type을 노출하여 디버깅을 지원합니다.
             raise TypeError(
                 f"Configuration Error: 'exit_code' parameter rejected. "
-                f"Expected int or SecurityExitCode, but explicitly got bool with value: {exit_code}."
+                f"Expected int or SecurityExitCode, but explicitly got type: {type(exit_code).__name__}."
             )
         else:
             try:


### PR DESCRIPTION
♻️ refactor [#12.2.1]: 20차 개선 - PII(개인정보) 유출 방지 및 보안 로그 레벨 복구

## Summary by Sourcery

AWS 클라이언트 래퍼에서 잘못된 boolean `exit_code` 사용과 관련된 보안 로깅을 강화하여, 개발자에게는 명확한 피드백을 유지하면서도 PII(개인 식별 정보) 유출을 방지합니다.

버그 수정:
- 실행 시점의 실제 값 대신 잘못된 boolean `exit_code`의 타입만 로깅하여, 보안 관련 로그에서 잠재적인 PII 유출을 방지합니다.

개선 사항:
- 잘못된 boolean `exit_code` 파라미터에 대한 보안 위반 로그의 심각도를 `warning`에서 `error`로 상향 조정하여, 설정 오류가 더 잘 드러나도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten security logging around invalid boolean exit_code usage in the AWS client wrapper to prevent PII leakage while preserving clear developer feedback.

Bug Fixes:
- Prevent potential PII leakage in security-related logs by logging only the type of invalid boolean exit_code instead of its runtime value.

Enhancements:
- Increase severity of security violation logging for invalid boolean exit_code parameters from warning to error to better surface misconfigurations.

</details>