### PR TITLE
♻️ refactor [#12.2.1]: 23차 개선 - SIEM 구조화 로깅의 Granularity(세분화) 병합 충돌 해결

### DIFF
--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -41,7 +41,7 @@ class FatalSecurityError(SystemExit):
     def __init__(self, log_message: str, exit_code: int | SecurityExitCode = SecurityExitCode.GENERIC_FAILURE) -> None:
         # 공통 로깅 메타데이터(SIEM/APM용 구조화 필드) 사전 선언
         injected_type = type(exit_code).__name__
-        sec_extra = {"security_violation": True, "invalid_parameter": "exit_code", "injected_type": injected_type}
+        base_extra = {"security_violation": True, "invalid_parameter": "exit_code", "injected_type": injected_type}
 
         # 1. API 유연성 및 타입 안전성: Enum/int 수용 및 명시적 정규화
         if isinstance(exit_code, SecurityExitCode):
@@ -56,7 +56,7 @@ class FatalSecurityError(SystemExit):
             logger.error(
                 "[AWS][SECURITY] Boolean is implicitly castable to int, but rejected as exit_code (type=%s). Raising TypeError.",
                 injected_type,
-                extra=sec_extra
+                extra={**base_extra, "reason": "invalid_type"}
             )
             # 런타임 값의 PII 유출을 방지하기 위해 값 대신 Type을 노출하여 디버깅을 지원합니다.
             raise TypeError(
@@ -71,7 +71,7 @@ class FatalSecurityError(SystemExit):
                 logger.warning(
                     "[AWS][SECURITY] Invalid exit_code type provided: %s. Falling back to GENERIC_FAILURE.",
                     injected_type,
-                    extra=sec_extra
+                    extra={**base_extra, "reason": "invalid_type"}
                 )
                 
         # OS Exit Code 바운더리 검증
@@ -80,7 +80,7 @@ class FatalSecurityError(SystemExit):
             logger.warning(
                 "[AWS][SECURITY] exit_code %s is out of valid OS bounds (%d-%d). Falling back to GENERIC_FAILURE.",
                 raw_code, MIN_OS_EXIT_CODE, MAX_OS_EXIT_CODE,
-                extra=sec_extra
+                extra={**base_extra, "reason": "out_of_bounds", "out_of_bounds_value": raw_code}
             )
             raw_code = SecurityExitCode.GENERIC_FAILURE.value
         


### PR DESCRIPTION
- **[개발 최적화(DRY)와 보안 정합성(SIEM)의 상충 해소]**
  - 이전 커밋에서 단일 공유 인스턴스로 추출했던 `base_extra` 메타데이터에 파이썬 딕셔너리 언패킹(`**base_extra`) 문법을 적용.
  - 이를 통해 공통 필드(DRY)의 장점은 유지하면서도, 각 보안 예외 분기마다 구체적인 실패 원인(`"reason": "invalid_type" | "out_of_bounds"`)을 런타임에 동적 오버라이드 조립.
  - Datadog/ELK 등 로그 애널리틱스 대시보드 소비 시 에러의 발생 기원을 정확히 Group-by 할 수 있는 강력한 Granularity(입도) 확보.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1157#pullrequestreview-4133708761)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

향상 사항:
- 공통 `base_extra` 메타데이터 페이로드를 도입하고, 보안 관련 로그를 위해 `invalid_type`, `out_of_bounds`와 같은 구체적인 실패 이유를 브랜치별로 확장했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Introduce a shared base_extra metadata payload and extend it per-branch with specific failure reasons such as invalid_type and out_of_bounds for security-related logs.

</details>