### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -112,12 +112,18 @@ class IndexMetadata:
         vector_count : 현재 저장된 벡터 수 (삭제된 벡터 포함 총계)
         index_path   : 파일 시스템 상의 .faiss 파일 절대 경로
                        (hashed_user_id 기반이므로 PII 미포함)
+
+    설계 원칙:
+        - 필드에 기본값을 부여하여 Redis 스키마 마이그레이션 중 구(old) 레코드와
+          신(new) 스키마가 공존할 때 서비스 장애를 방지한다 (Graceful Degradation).
+        - index_path가 Redis에 없더라도 hashed_user_id + cfg로 재계산 가능하므로
+          빈 문자열을 기본값으로 허용하고 호출자가 필요 시 재보정한다.
     """
 
-    created_at: str
-    updated_at: str
-    vector_count: int
-    index_path: str
+    created_at: str = ""
+    updated_at: str = ""
+    vector_count: int = 0
+    index_path: str = ""
 
     def to_redis_dict(self) -> dict[str, str]:
         """Redis hset에 전달할 string dict 반환."""
@@ -131,11 +137,13 @@ class IndexMetadata:
     @classmethod
     def from_redis_dict(cls, raw: dict[bytes | str, bytes | str]) -> "IndexMetadata":
         """
-        Redis hgetall 결과(bytes or str 키/값)를 IndexMetadata로 변환한다.
+        Redis hgetall 결과(bytes or str 키/값)를 IndexMetadata로 관대하게 변환한다.
 
-        첫 단계에서 모든 키·값을 str로 정규화하여 Redis 클라이언트의
-        decode_responses 설정(True/False)에 관계없이 안전하게 동작한다.
-        이후 로직은 순수 str dict으로만 처리하여 예기치 않은 KeyError를 방지한다.
+        처리 원칙:
+          1. 모든 키·값을 str로 1회 정규화 — decode_responses 설정 무관 안전 동작.
+          2. 필드 누락 시 하드 크래시 대신 데이터클래스 기본값으로 폴백하고 WARNING 로그.
+             → Redis 스키마 마이그레이션 중 구(old) 레코드와 공존 가능.
+          3. vector_count 파싱 실패(비정수) 시 0으로 폴백하고 WARNING 로그.
         """
 
         def _to_str(v: bytes | str) -> str:
@@ -144,19 +152,33 @@ class IndexMetadata:
         # 1회 정규화: 이후 코드는 str key/value만 사용 — KeyError 교차 발생 원천 차단
         normalized: dict[str, str] = {_to_str(k): _to_str(v) for k, v in raw.items()}
 
-        _REQUIRED_FIELDS = ("created_at", "updated_at", "vector_count", "index_path")
-        missing = [f for f in _REQUIRED_FIELDS if f not in normalized]
+        # 누락 필드 감지: 하드 크래시 대신 WARNING 로그 후 기본값 폴백
+        _ALL_FIELDS = ("created_at", "updated_at", "vector_count", "index_path")
+        missing = [f for f in _ALL_FIELDS if f not in normalized]
         if missing:
-            raise KeyError(
-                f"IndexMetadata.from_redis_dict: missing required fields {missing}. "
-                "Redis hash may be corrupted or schema has changed."
+            logger.warning(
+                "[PERSONALIZED_INDEX][SCHEMA] from_redis_dict: missing fields %s — "
+                "falling back to defaults. Redis hash may be from an older schema version.",
+                missing,
             )
 
+        # vector_count: 비정수인 경우 0으로 폴백 (파싱 실패가 서비스 장애로 이어지지 않도록)
+        raw_count = normalized.get("vector_count", "0")
+        try:
+            vector_count = int(raw_count)
+        except (ValueError, TypeError):
+            logger.warning(
+                "[PERSONALIZED_INDEX][SCHEMA] from_redis_dict: 'vector_count'=%r is not "
+                "a valid integer; falling back to 0.",
+                raw_count,
+            )
+            vector_count = 0
+
         return cls(
-            created_at=normalized["created_at"],
-            updated_at=normalized["updated_at"],
-            vector_count=int(normalized["vector_count"]),
-            index_path=normalized["index_path"],
+            created_at=normalized.get("created_at", ""),
+            updated_at=normalized.get("updated_at", ""),
+            vector_count=vector_count,
+            index_path=normalized.get("index_path", ""),
         )
 
 
@@ -179,6 +201,18 @@ def _build_meta_key(hashed_user_id: str) -> str:
 def _now_utc_iso() -> str:
     """현재 UTC 시각을 ISO 8601 문자열로 반환한다."""
     return datetime.now(timezone.utc).isoformat()
+
+
+async def _ensure_redis_connected() -> None:
+    """
+    Redis 연결 상태를 확인하고, 미연결 시 연결을 시도하는 내부 헬퍼.
+
+    각 비동기 함수마다 `if not redis_client.is_connected(): await redis_client.connect()`
+    패턴이 중복되는 것을 방지하기 위해 이 헬퍼를 통해 연결 관리를 중앙집중화한다.
+    연결 실패 시 예외를 상위로 전파한다.
+    """
+    if not redis_client.is_connected():
+        await redis_client.connect()
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -303,8 +337,7 @@ async def save_index_metadata(
     Raises:
         RuntimeError: Redis 연결 실패 시
     """
-    if not redis_client.is_connected():
-        await redis_client.connect()
+    await _ensure_redis_connected()
 
     key = _build_meta_key(hashed_user_id)
     payload = metadata.to_redis_dict()
@@ -333,8 +366,7 @@ async def load_index_metadata(hashed_user_id: str) -> Optional[IndexMetadata]:
     Raises:
         RuntimeError: Redis 연결 실패 시
     """
-    if not redis_client.is_connected():
-        await redis_client.connect()
+    await _ensure_redis_connected()
 
     key = _build_meta_key(hashed_user_id)
     raw = await redis_client.redis.hgetall(key)
@@ -362,8 +394,7 @@ async def delete_index_metadata(hashed_user_id: str) -> None:
     Args:
         hashed_user_id: compute_hashed_user_id()의 반환값 (PII 미포함)
     """
-    if not redis_client.is_connected():
-        await redis_client.connect()
+    await _ensure_redis_connected()
 
     key = _build_meta_key(hashed_user_id)
     deleted = await redis_client.redis.delete(key)

--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -20,11 +20,11 @@ Path 전략:
 
 from __future__ import annotations
 
+import dataclasses
 import hashlib
-import json
 import logging
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -54,6 +54,48 @@ _HASH_ALGORITHM: str = "sha256"
 _DEFAULT_META_TTL_SECS: int = 2_592_000
 _META_TTL_MIN_SECS: int = 3_600       # 최소 1시간
 _META_TTL_MAX_SECS: int = 31_536_000  # 최대 1년
+
+# 스키마 파싱 경고 로그 레벨
+# 기본값: WARNING (일반 운영)
+# 마이그레이션 중 다량의 구(old) 레코드 처리 시 INFO로 낮춰 APM 노이즈를 억제할 수 있음:
+#   PERSONALIZED_INDEX_SCHEMA_LOG_LEVEL=INFO
+_SCHEMA_LOG_LEVEL_MAP: dict[str, int] = {
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "WARNING": logging.WARNING,
+    "ERROR": logging.ERROR,
+}
+_DEFAULT_SCHEMA_LOG_LEVEL: int = logging.WARNING
+
+
+def _load_schema_log_level() -> int:
+    """
+    PERSONALIZED_INDEX_SCHEMA_LOG_LEVEL 환경 변수를 파싱하여 로그 레벨 int를 반환한다.
+
+    - 미설정: 기본값 WARNING 사용
+    - 알 수 없는 레벨명: WARNING 로그 후 기본값으로 폴백
+
+    허용 값: DEBUG, INFO, WARNING, ERROR (대소문자 무시)
+    """
+    raw = os.environ.get("PERSONALIZED_INDEX_SCHEMA_LOG_LEVEL", "").strip().upper()
+    if not raw:
+        return _DEFAULT_SCHEMA_LOG_LEVEL
+
+    level = _SCHEMA_LOG_LEVEL_MAP.get(raw)
+    if level is None:
+        logger.warning(
+            "[PERSONALIZED_INDEX][CONFIG] 'PERSONALIZED_INDEX_SCHEMA_LOG_LEVEL'=%r is "
+            "not a valid log level (allowed: %s); falling back to WARNING.",
+            raw,
+            list(_SCHEMA_LOG_LEVEL_MAP.keys()),
+        )
+        return _DEFAULT_SCHEMA_LOG_LEVEL
+
+    return level
+
+
+# 모듈 로드 시 1회 파싱 (운영 중 환경변수 변경은 재시작 필요)
+_SCHEMA_LOG_LEVEL: int = _load_schema_log_level()
 
 
 def _load_meta_ttl() -> int:
@@ -141,9 +183,12 @@ class IndexMetadata:
 
         처리 원칙:
           1. 모든 키·값을 str로 1회 정규화 — decode_responses 설정 무관 안전 동작.
-          2. 필드 누락 시 하드 크래시 대신 데이터클래스 기본값으로 폴백하고 WARNING 로그.
-             → Redis 스키마 마이그레이션 중 구(old) 레코드와 공존 가능.
-          3. vector_count 파싱 실패(비정수) 시 0으로 폴백하고 WARNING 로그.
+          2. 필드 목록은 dataclasses.fields(cls)에서 동적으로 파생 — 하드코딩 금지.
+             스키마 변경 시 데이터클래스 정의 한 곳만 수정하면 자동 반영 (SSOT).
+          3. 필드 누락 시 하드 크래시 대신 데이터클래스 기본값으로 폴백하고
+             _SCHEMA_LOG_LEVEL(환경변수 PERSONALIZED_INDEX_SCHEMA_LOG_LEVEL) 레벨로 로그.
+             → 마이그레이션 중 다량의 구(old) 레코드 처리 시 INFO로 낮춰 APM 노이즈 억제 가능.
+          4. vector_count 파싱 실패(비정수) 시 0으로 폴백하고 동일 레벨로 로그.
         """
 
         def _to_str(v: bytes | str) -> str:
@@ -152,13 +197,15 @@ class IndexMetadata:
         # 1회 정규화: 이후 코드는 str key/value만 사용 — KeyError 교차 발생 원천 차단
         normalized: dict[str, str] = {_to_str(k): _to_str(v) for k, v in raw.items()}
 
-        # 누락 필드 감지: 하드 크래시 대신 WARNING 로그 후 기본값 폴백
-        _ALL_FIELDS = ("created_at", "updated_at", "vector_count", "index_path")
-        missing = [f for f in _ALL_FIELDS if f not in normalized]
+        # 필드 목록을 데이터클래스 정의에서 동적 파생 — _ALL_FIELDS 하드코딩 제거 (SSOT)
+        all_field_names = [f.name for f in dataclasses.fields(cls)]
+        missing = [name for name in all_field_names if name not in normalized]
         if missing:
-            logger.warning(
+            logger.log(
+                _SCHEMA_LOG_LEVEL,
                 "[PERSONALIZED_INDEX][SCHEMA] from_redis_dict: missing fields %s — "
-                "falling back to defaults. Redis hash may be from an older schema version.",
+                "falling back to defaults. Redis hash may be from an older schema version. "
+                "(Adjust 'PERSONALIZED_INDEX_SCHEMA_LOG_LEVEL' env var to suppress during migration.)",
                 missing,
             )
 
@@ -167,18 +214,18 @@ class IndexMetadata:
         try:
             vector_count = int(raw_count)
         except (ValueError, TypeError):
-            logger.warning(
+            logger.log(
+                _SCHEMA_LOG_LEVEL,
                 "[PERSONALIZED_INDEX][SCHEMA] from_redis_dict: 'vector_count'=%r is not "
-                "a valid integer; falling back to 0.",
+                "a valid integer; falling back to 0. "
+                "(Adjust 'PERSONALIZED_INDEX_SCHEMA_LOG_LEVEL' env var to suppress during migration.)",
                 raw_count,
             )
             vector_count = 0
 
         return cls(
-            created_at=normalized.get("created_at", ""),
-            updated_at=normalized.get("updated_at", ""),
+            **{name: normalized.get(name, "") for name in all_field_names if name != "vector_count"},
             vector_count=vector_count,
-            index_path=normalized.get("index_path", ""),
         )
 
 


### PR DESCRIPTION
☘️ refactor [#12.2.2]: 2차 개선 - IndexMetadata 스키마 관대한 파싱 및 Redis 연결 로직 중앙화
☘️ refactor [#12.2.2]: 3차 개선 - from_redis_dict SSOT 강화 및 스키마 로그 레벨 외부화

## Summary by Sourcery

개인화된 인덱스 메타데이터 작업을 위해 IndexMetadata Redis 스키마 처리 방식을 완화하고, Redis 연결 관리를 중앙집중화합니다.

개선 사항:
- 스키마 마이그레이션 중 누락되었거나 레거시 필드가 있어도 허용할 수 있도록, IndexMetadata 필드에 안전한 기본값을 허용하고 Redis 해시를 관대하게 파싱합니다.
- Redis 직렬화/역직렬화를 단일 소스 오브 트루스로 유지하기 위해, dataclass 정의에서 IndexMetadata 필드를 동적으로 유도합니다.
- 마이그레이션 중 발생하는 노이즈를 제어할 수 있도록, PERSONALIZED_INDEX_SCHEMA_LOG_LEVEL을 통해 스키마 파싱 경고에 대한 설정 가능한 로그 레벨을 도입합니다.
- 중복을 줄이고 연결 처리 방식을 표준화하기 위해, 메타데이터 CRUD 함수에서 사용하는 공용 헬퍼로 Redis 연결 검사 로직을 중앙집중화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax IndexMetadata Redis schema handling and centralize Redis connection management for personalized index metadata operations.

Enhancements:
- Allow IndexMetadata fields to have safe defaults and parse Redis hashes leniently to tolerate missing or legacy fields during schema migrations.
- Derive IndexMetadata fields dynamically from the dataclass definition to keep Redis serialization/deserialization in sync as a single source of truth.
- Introduce configurable log level for schema parsing warnings via PERSONALIZED_INDEX_SCHEMA_LOG_LEVEL to control noise during migrations.
- Centralize Redis connection checks into a shared helper used by metadata CRUD functions to reduce duplication and standardize connection handling.

</details>