### PR TITLE
☘️ refactor [#12.2.2]: 4차 개선 - `from_redis_dict 기본값 SSOT` 완성 (dataclass 기본값 동적 파생)

### DIFF
--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -197,36 +197,63 @@ class IndexMetadata:
         # 1회 정규화: 이후 코드는 str key/value만 사용 — KeyError 교차 발생 원천 차단
         normalized: dict[str, str] = {_to_str(k): _to_str(v) for k, v in raw.items()}
 
-        # 필드 목록을 데이터클래스 정의에서 동적 파생 — _ALL_FIELDS 하드코딩 제거 (SSOT)
-        all_field_names = [f.name for f in dataclasses.fields(cls)]
-        missing = [name for name in all_field_names if name not in normalized]
+        # 필드 메타데이터를 데이터클래스 정의에서 동적 파생 — 이름·기본값 모두 SSOT
+        cls_fields = dataclasses.fields(cls)
+
+        # 각 필드의 실제 기본값을 읽어 fallback 딕셔너리를 구성한다.
+        # - field.default         : 리터럴 기본값 (e.g. "", 0, False)
+        # - field.default_factory : 팩토리 함수 기반 기본값 (e.g. list, dict)
+        # - dataclasses.MISSING   : 기본값이 없는 필수 필드 → 이 클래스에서는 허용하지 않으므로 경고
+        def _get_field_default(f: dataclasses.Field) -> object:
+            """dataclasses.Field에서 실제 사용 가능한 기본값을 반환한다."""
+            if f.default is not dataclasses.MISSING:
+                return f.default
+            if f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
+                return f.default_factory()  # type: ignore[misc]
+            # 기본값 없는 필드: 데이터 없이 인스턴스 생성 불가 → None 반환 후 호출자가 처리
+            logger.error(
+                "[PERSONALIZED_INDEX][SCHEMA] Field '%s' has no default value in IndexMetadata. "
+                "Redis data must always supply this field.",
+                f.name,
+            )
+            return None
+
+        field_defaults: dict[str, object] = {f.name: _get_field_default(f) for f in cls_fields}
+
+        # 누락 필드 감지: 하드 크래시 대신 _SCHEMA_LOG_LEVEL 레벨 로그 후 dataclass 기본값 폴백
+        missing = [name for name in field_defaults if name not in normalized]
         if missing:
             logger.log(
                 _SCHEMA_LOG_LEVEL,
                 "[PERSONALIZED_INDEX][SCHEMA] from_redis_dict: missing fields %s — "
-                "falling back to defaults. Redis hash may be from an older schema version. "
+                "falling back to dataclass defaults. Redis hash may be from an older schema version. "
                 "(Adjust 'PERSONALIZED_INDEX_SCHEMA_LOG_LEVEL' env var to suppress during migration.)",
                 missing,
             )
 
-        # vector_count: 비정수인 경우 0으로 폴백 (파싱 실패가 서비스 장애로 이어지지 않도록)
-        raw_count = normalized.get("vector_count", "0")
+        # vector_count: Redis는 모든 값을 str로 저장하므로 int 타입 필드는 별도 파싱
+        raw_count = normalized.get("vector_count", str(field_defaults.get("vector_count", 0)))
         try:
             vector_count = int(raw_count)
         except (ValueError, TypeError):
             logger.log(
                 _SCHEMA_LOG_LEVEL,
                 "[PERSONALIZED_INDEX][SCHEMA] from_redis_dict: 'vector_count'=%r is not "
-                "a valid integer; falling back to 0. "
+                "a valid integer; falling back to dataclass default. "
                 "(Adjust 'PERSONALIZED_INDEX_SCHEMA_LOG_LEVEL' env var to suppress during migration.)",
                 raw_count,
             )
-            vector_count = 0
+            vector_count = int(field_defaults.get("vector_count", 0))  # type: ignore[arg-type]
 
-        return cls(
-            **{name: normalized.get(name, "") for name in all_field_names if name != "vector_count"},
-            vector_count=vector_count,
-        )
+        # str 필드: normalized 값 우선, 없으면 dataclass 실제 기본값 사용 — "" 하드코딩 완전 제거
+        str_kwargs = {
+            name: normalized.get(name, field_defaults[name])
+            for name in field_defaults
+            if name != "vector_count"
+        }
+
+        return cls(**str_kwargs, vector_count=vector_count)
+
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -183,13 +183,16 @@ class IndexMetadata:
 
         처리 원칙:
           1. 모든 키·값을 str로 1회 정규화 — decode_responses 설정 무관 안전 동작.
-          2. 필드 목록은 dataclasses.fields(cls)에서 동적으로 파생 — 하드코딩 금지.
-             스키마 변경 시 데이터클래스 정의 한 곳만 수정하면 자동 반영 (SSOT).
-          3. 필드 누락 시 하드 크래시 대신 데이터클래스 기본값으로 폴백하고
-             _SCHEMA_LOG_LEVEL(환경변수 PERSONALIZED_INDEX_SCHEMA_LOG_LEVEL) 레벨로 로그.
-             → 마이그레이션 중 다량의 구(old) 레코드 처리 시 INFO로 낮춰 APM 노이즈 억제 가능.
-          4. vector_count 파싱 실패(비정수) 시 0으로 폴백하고 동일 레벨로 로그.
+          2. 필드 목록·기본값·타입을 dataclasses.fields(cls)와 get_type_hints(cls)에서
+             동적으로 파생 — 하드코딩 금지 (완전한 SSOT).
+          3. 기본값 없는 필수 필드(MISSING)가 Redis에도 없으면 즉시 ValueError — Fail-fast.
+             (현재 IndexMetadata는 모든 필드에 기본값이 있어 이 경로는 미래 대비 방어)
+          4. 필드 누락 시 dataclass 기본값으로 폴백, _SCHEMA_LOG_LEVEL 레벨로 로그.
+             → 마이그레이션 중 INFO로 낮춰 APM 노이즈 억제 가능.
+          5. per-type 디스패처로 str/int/float/bool 타입 각각 안전하게 변환.
+             미지원 타입은 WARNING 로그 후 raw str 사용.
         """
+        import typing
 
         def _to_str(v: bytes | str) -> str:
             return v.decode("utf-8") if isinstance(v, bytes) else str(v)
@@ -197,30 +200,29 @@ class IndexMetadata:
         # 1회 정규화: 이후 코드는 str key/value만 사용 — KeyError 교차 발생 원천 차단
         normalized: dict[str, str] = {_to_str(k): _to_str(v) for k, v in raw.items()}
 
-        # 필드 메타데이터를 데이터클래스 정의에서 동적 파생 — 이름·기본값 모두 SSOT
+        # 필드 메타데이터를 데이터클래스 정의에서 동적 파생 (완전한 SSOT)
         cls_fields = dataclasses.fields(cls)
+        type_hints: dict[str, type] = typing.get_type_hints(cls)
 
-        # 각 필드의 실제 기본값을 읽어 fallback 딕셔너리를 구성한다.
-        # - field.default         : 리터럴 기본값 (e.g. "", 0, False)
-        # - field.default_factory : 팩토리 함수 기반 기본값 (e.g. list, dict)
-        # - dataclasses.MISSING   : 기본값이 없는 필수 필드 → 이 클래스에서는 허용하지 않으므로 경고
         def _get_field_default(f: dataclasses.Field) -> object:
-            """dataclasses.Field에서 실제 사용 가능한 기본값을 반환한다."""
+            """
+            dataclasses.Field에서 실제 기본값을 반환한다.
+            MISSING(기본값 없음) → ValueError로 즉시 실패 (Fail-fast).
+            None을 조용히 반환하지 않아 구성 버그가 런타임에 은폐되지 않는다.
+            """
             if f.default is not dataclasses.MISSING:
                 return f.default
             if f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
                 return f.default_factory()  # type: ignore[misc]
-            # 기본값 없는 필드: 데이터 없이 인스턴스 생성 불가 → None 반환 후 호출자가 처리
-            logger.error(
-                "[PERSONALIZED_INDEX][SCHEMA] Field '%s' has no default value in IndexMetadata. "
-                "Redis data must always supply this field.",
-                f.name,
+            raise ValueError(
+                f"[PERSONALIZED_INDEX][SCHEMA] IndexMetadata field '{f.name}' has no "
+                f"default value and was not supplied by Redis. "
+                f"All IndexMetadata fields must have a dataclass default."
             )
-            return None
 
         field_defaults: dict[str, object] = {f.name: _get_field_default(f) for f in cls_fields}
 
-        # 누락 필드 감지: 하드 크래시 대신 _SCHEMA_LOG_LEVEL 레벨 로그 후 dataclass 기본값 폴백
+        # 누락 필드 감지: dataclass 기본값으로 폴백 + _SCHEMA_LOG_LEVEL 레벨 로그
         missing = [name for name in field_defaults if name not in normalized]
         if missing:
             logger.log(
@@ -231,28 +233,70 @@ class IndexMetadata:
                 missing,
             )
 
-        # vector_count: Redis는 모든 값을 str로 저장하므로 int 타입 필드는 별도 파싱
-        raw_count = normalized.get("vector_count", str(field_defaults.get("vector_count", 0)))
-        try:
-            vector_count = int(raw_count)
-        except (ValueError, TypeError):
-            logger.log(
-                _SCHEMA_LOG_LEVEL,
-                "[PERSONALIZED_INDEX][SCHEMA] from_redis_dict: 'vector_count'=%r is not "
-                "a valid integer; falling back to dataclass default. "
-                "(Adjust 'PERSONALIZED_INDEX_SCHEMA_LOG_LEVEL' env var to suppress during migration.)",
-                raw_count,
+        def _parse_value(field_name: str, raw_val: str, field_type: type, default: object) -> object:
+            """
+            Redis raw str 값을 필드의 실제 Python 타입으로 안전하게 변환한다.
+            지원 타입: str, int, float, bool
+            미지원 타입: WARNING 로그 후 raw str 반환 (서비스 장애 전파 방지)
+            """
+            origin = typing.get_origin(field_type)  # Optional, Union 등의 원본 타입
+            # Optional[X] → X 로 언래핑
+            if origin is typing.Union:
+                args = [a for a in typing.get_args(field_type) if a is not type(None)]
+                field_type = args[0] if args else str
+
+            if field_type is str:
+                return raw_val
+            if field_type is int:
+                try:
+                    return int(raw_val)
+                except (ValueError, TypeError):
+                    logger.log(
+                        _SCHEMA_LOG_LEVEL,
+                        "[PERSONALIZED_INDEX][SCHEMA] from_redis_dict: field '%s'=%r "
+                        "cannot be parsed as int; falling back to dataclass default. "
+                        "(Adjust 'PERSONALIZED_INDEX_SCHEMA_LOG_LEVEL' env var to suppress.)",
+                        field_name, raw_val,
+                    )
+                    return default
+            if field_type is float:
+                try:
+                    return float(raw_val)
+                except (ValueError, TypeError):
+                    logger.log(
+                        _SCHEMA_LOG_LEVEL,
+                        "[PERSONALIZED_INDEX][SCHEMA] from_redis_dict: field '%s'=%r "
+                        "cannot be parsed as float; falling back to dataclass default.",
+                        field_name, raw_val,
+                    )
+                    return default
+            if field_type is bool:
+                # Redis에 "True"/"False"/"1"/"0" 형태로 저장될 수 있음
+                return raw_val.lower() in ("true", "1", "yes")
+
+            # 미지원 타입: 안전하게 raw str 반환하고 운영자에게 알림
+            logger.warning(
+                "[PERSONALIZED_INDEX][SCHEMA] from_redis_dict: field '%s' has unsupported "
+                "type '%s' for automatic conversion; returning raw string. "
+                "Add a type handler to _parse_value() to suppress this warning.",
+                field_name, field_type,
             )
-            vector_count = int(field_defaults.get("vector_count", 0))  # type: ignore[arg-type]
+            return raw_val
 
-        # str 필드: normalized 값 우선, 없으면 dataclass 실제 기본값 사용 — "" 하드코딩 완전 제거
-        str_kwargs = {
-            name: normalized.get(name, field_defaults[name])
-            for name in field_defaults
-            if name != "vector_count"
-        }
+        # per-type 디스패처로 모든 필드를 타입에 맞게 안전하게 변환
+        kwargs: dict[str, object] = {}
+        for f in cls_fields:
+            field_type = type_hints.get(f.name, str)
+            default = field_defaults[f.name]
+            raw_val = normalized.get(f.name)
+            if raw_val is None:
+                # 필드가 Redis에 없는 경우: dataclass 기본값 사용 (이미 missing 로그 처리됨)
+                kwargs[f.name] = default
+            else:
+                kwargs[f.name] = _parse_value(f.name, raw_val, field_type, default)
 
-        return cls(**str_kwargs, vector_count=vector_count)
+        return cls(**kwargs)
+
 
 
 


### PR DESCRIPTION
- **[리뷰 반영: 기본값 하드코딩 "" 완전 제거]**
  - 기존: normalized.get(name, "")로 모든 str 필드의 폴백을 ""로 하드코딩
  - 변경: _get_field_default() 헬퍼로 각 필드의 실제 기본값 동적 추출
    - field.default → 리터럴 기본값 (str, int, bool 등)
    - field.default_factory() → 팩토리 기반 기본값 (list, dict 등)
    - dataclasses.MISSING → 기본값 없는 필드 (ERROR 로그 + None)
  - 효과: IndexMetadata에 bool/list/non-empty str 필드 추가 시 파싱 로직 수정 불필요

- **[완전한 SSOT 달성]**
  - PR#1162: 필드 이름을 dataclasses.fields(cls)에서 동적 파생 (이름 SSOT)
  - PR#1163 (이번): 기본값도 dataclasses.fields(cls)에서 동적 파생 (이름 + 기본값 SSOT)
  - 이제 IndexMetadata 데이터클래스 정의 한 곳 수정 → 파싱 동작 완전 자동 반영

- **[logic 검증]**
  - ast.parse 구문 검사 통과
  - 기본값 추출 로직 단위 검증: {'created_at': '', 'updated_at': '', 'vector_count': 0, 'index_path': ''}

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1163#pullrequestreview-4134669497)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Redis에서 인스턴스를 구성할 때 `IndexMetadata`의 필드 이름과 기본값을 dataclass 정의로부터 자동으로 가져오도록 하여, 하드코딩된 폴백 값을 제거하고 스키마 기본값 관리를 한 곳으로 중앙화했습니다.

버그 수정:
- 누락되었거나 잘못된 Redis 필드에 대해 하드코딩된 문자열/숫자 폴백 대신 dataclass에 정의된 기본값을 사용하도록 변경하여, 스키마 드리프트 문제를 줄였습니다.

개선 사항:
- `from_redis_dict`에서 dataclass 메타데이터로부터 필드별 기본값(팩토리 기반 기본값 포함)을 동적으로 추출하는 기능을 도입했습니다.
- 필수 필드에 기본값이 없거나 `vector_count` 파싱에 실패했을 때의 로깅을 개선하여, dataclass 기본값에 의존하는 부분을 더 명확히 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Derive field names and default values for IndexMetadata from its dataclass definition when constructing instances from Redis, removing hardcoded fallbacks and centralizing schema defaults.

Bug Fixes:
- Use dataclass-defined defaults for missing or invalid Redis fields instead of hardcoded string or numeric fallbacks, reducing schema drift issues.

Enhancements:
- Introduce dynamic extraction of per-field defaults (including factory-based defaults) from dataclass metadata for from_redis_dict.
- Improve logging when required fields lack defaults or when vector_count parsing fails, clarifying reliance on dataclass defaults.

</details>