### PR TITLE
☘️ refactor [#12.2.2]: 6차 개선 - `from_redis_dict` 엣지케이스 대응 및 Union 처리 강화

### DIFF
--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -24,6 +24,8 @@ import dataclasses
 import hashlib
 import logging
 import os
+import types
+import typing
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -192,8 +194,6 @@ class IndexMetadata:
           5. per-type 디스패처로 str/int/float/bool 타입 각각 안전하게 변환.
              미지원 타입은 WARNING 로그 후 raw str 사용.
         """
-        import typing
-
         def _to_str(v: bytes | str) -> str:
             return v.decode("utf-8") if isinstance(v, bytes) else str(v)
 
@@ -207,23 +207,18 @@ class IndexMetadata:
         def _get_field_default(f: dataclasses.Field) -> object:
             """
             dataclasses.Field에서 실제 기본값을 반환한다.
-            MISSING(기본값 없음) → ValueError로 즉시 실패 (Fail-fast).
-            None을 조용히 반환하지 않아 구성 버그가 런타임에 은폐되지 않는다.
+            기본값이 없으면 dataclasses.MISSING 을 반환한다.
             """
             if f.default is not dataclasses.MISSING:
                 return f.default
             if f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
                 return f.default_factory()  # type: ignore[misc]
-            raise ValueError(
-                f"[PERSONALIZED_INDEX][SCHEMA] IndexMetadata field '{f.name}' has no "
-                f"default value and was not supplied by Redis. "
-                f"All IndexMetadata fields must have a dataclass default."
-            )
+            return dataclasses.MISSING
 
         field_defaults: dict[str, object] = {f.name: _get_field_default(f) for f in cls_fields}
 
-        # 누락 필드 감지: dataclass 기본값으로 폴백 + _SCHEMA_LOG_LEVEL 레벨 로그
-        missing = [name for name in field_defaults if name not in normalized]
+        # 누락 필드 감지: dataclass 기본값으로 폴백 (MISSING이 아닌 경우) + _SCHEMA_LOG_LEVEL 레벨 로그
+        missing = [name for name in field_defaults if name not in normalized and field_defaults[name] is not dataclasses.MISSING]
         if missing:
             logger.log(
                 _SCHEMA_LOG_LEVEL,
@@ -239,10 +234,18 @@ class IndexMetadata:
             지원 타입: str, int, float, bool
             미지원 타입: WARNING 로그 후 raw str 반환 (서비스 장애 전파 방지)
             """
-            origin = typing.get_origin(field_type)  # Optional, Union 등의 원본 타입
-            # Optional[X] → X 로 언래핑
-            if origin is typing.Union:
+            origin = typing.get_origin(field_type)  # Optional, Union (typing / PEP 604) 등의 원본 타입
+            
+            # Union 처리 (typing.Union 또는 types.UnionType)
+            union_types = (typing.Union, getattr(types, "UnionType", ()))
+            if origin in union_types:
                 args = [a for a in typing.get_args(field_type) if a is not type(None)]
+                if len(args) > 1:
+                     raise TypeError(
+                         f"[PERSONALIZED_INDEX][SCHEMA] Field '{field_name}' uses a multi-type Union: {field_type}. "
+                         f"from_redis_dict does not support converting abstract multiple types. "
+                         f"Please use a single concrete type or Optional[T]."
+                     )
                 field_type = args[0] if args else str
 
             if field_type is str:
@@ -290,7 +293,14 @@ class IndexMetadata:
             default = field_defaults[f.name]
             raw_val = normalized.get(f.name)
             if raw_val is None:
-                # 필드가 Redis에 없는 경우: dataclass 기본값 사용 (이미 missing 로그 처리됨)
+                # 필드가 Redis에 없는 경우
+                if default is dataclasses.MISSING:
+                    # Redis에도 데이터가 없고, dataclass에도 기본값이 없는 경우에만 fail-fast
+                    raise ValueError(
+                        f"[PERSONALIZED_INDEX][SCHEMA] IndexMetadata field '{f.name}' has no "
+                        f"default value and was not supplied by Redis. Cannot instantiate."
+                    )
+                # dataclass 기본값 사용 (이미 missing 로그 처리됨)
                 kwargs[f.name] = default
             else:
                 kwargs[f.name] = _parse_value(f.name, raw_val, field_type, default)


### PR DESCRIPTION
- **[리뷰 반영: MISSING 필드 지연 예외 처리 적용]**
  - 기존: _get_field_default에서 MISSING 이면 무조건 ValueError 발생 (Redis에서 값을 주더라도 스키마에 기본값이 없으면 인스턴스화 불가)
  - 변경: _get_field_default는 dataclasses.MISSING 객체를 반환. 최종적으로 Redis에서도 해당 키 값이 없을 때만 ValueError 발생 (Fail-fast 시점 정상화)

- **[리뷰 반영: PEP 604 Union 지원 및 복합 Union 방어]**
  - 기존: origin is typing.Union만 검사 (int | None 같은 3.10+ 문법 미지원) 및 여러 타입이 선언된 다중 Union(Union[str, int])에서 단순 첫 번째 값 사용
  - 변경: types.UnionType을 감지 조건에 추가. args가 1개를 초과하는 복합 Union은 파싱 불가능하므로 명시적인 TypeError 발생 (안전성 강화)

- **[기타 코드 컨벤션 적용]**
  - `import typing` 은 메서드 내부가 아닌 모듈 상단에 선언하여 불필요한 런타임 오버헤드 방지 (.sys.modules 참조 비용 최소화)

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1165#pullrequestreview-4134690923)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pros

## Summary by Sourcery

누락된 필드와 union 타입 스키마 필드에 대해 `IndexMetadata.from_redis_dict` 동작을 다듬어, 역직렬화를 더 안전하고 예측 가능하게 합니다.

버그 수정:
- Redis에서 값을 제공하는 경우에도 불필요한 인스턴스화 오류가 발생하지 않도록, 누락된 `IndexMetadata` 필드에 대한 실패 시점을 Redis 데이터와 dataclass 기본값이 모두 없는 경우로 지연합니다.
- PEP 604의 `Optional` 문법을 지원하면서, 지원되지 않는 다중 타입 union에 대해서는 명확한 오류를 반환하도록 union 타입 필드 처리를 강화합니다.

개선 사항:
- 진정한 의미의 기본값 없음 필드를 `dataclasses.MISSING`으로 처리하고, 실제로 dataclass 기본값으로 되돌아가는 필드에 대해서만 로그를 남기도록 하여 `from_redis_dict` 스키마의 견고성을 향상합니다.
- 타이핑 관련 import를 메서드 본문에서 모듈 레벨로 이동시켜 모듈 import 구조를 단순화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine IndexMetadata.from_redis_dict behavior for missing fields and union-typed schema fields to make deserialization safer and more predictable.

Bug Fixes:
- Delay failure for missing IndexMetadata fields until both Redis data and dataclass defaults are absent, preventing unnecessary instantiation errors when Redis supplies values.
- Tighten handling of union-typed fields by supporting PEP 604 Optional syntax while rejecting unsupported multi-type unions with a clear error.

Enhancements:
- Improve from_redis_dict schema robustness by treating truly default-less fields as dataclasses.MISSING and logging only for fields that actually fall back to dataclass defaults.
- Simplify module import structure by moving typing-related imports out of the method body to the module level.

</details>