### PR TITLE
☘️ refactor [#12.2.2]: 7차 개선 - PEP 604 Union 처리 중 발생할 수 있는 들여쓰기 오류 수정

### DIFF
--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -241,11 +241,11 @@ class IndexMetadata:
             if origin in union_types:
                 args = [a for a in typing.get_args(field_type) if a is not type(None)]
                 if len(args) > 1:
-                     raise TypeError(
-                         f"[PERSONALIZED_INDEX][SCHEMA] Field '{field_name}' uses a multi-type Union: {field_type}. "
-                         f"from_redis_dict does not support converting abstract multiple types. "
-                         f"Please use a single concrete type or Optional[T]."
-                     )
+                    raise TypeError(
+                        f"[PERSONALIZED_INDEX][SCHEMA] Field '{field_name}' uses a multi-type Union: {field_type}. "
+                        f"from_redis_dict does not support converting abstract multiple types. "
+                        f"Please use a single concrete type or Optional[T]."
+                    )
                 field_type = args[0] if args else str
 
             if field_type is str:


### PR DESCRIPTION
- **[리뷰 반영: IndentationError 대비 띄어쓰기 교정]**
  - 원인: 다중 Union 파싱 불가 시 나타나는 `raise TypeError` 줄에 추가된 불필요한 스페이스 문자(1칸)로 인한 구문 오류 위험
  - 조치: 해당 줄과 파생 메시지의 들여쓰기(Indentation)를 상위 `if` 블록에 맞춰 올바르게 제거 및 정렬

- **[리뷰 반영: 글로벌 Import 위치 확인]**
  - `import typing` 및 `import types` 구문이 메서드 내부가 아닌 모듈 최상단 전역 스코프에 정상적으로 배치됨을 확인

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1167#pullrequestreview-4134714318)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pros

## Summary by Sourcery

버그 수정:
- 다중 타입 `Union` 필드를 처리하는 과정에서, 정렬이 맞지 않는 `raise TypeError` 구문으로 인해 발생할 수 있는 `IndentationError` 문제를 수정했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix potential IndentationError caused by misaligned raise TypeError statement when handling multi-type Union fields.

</details>