### PR TITLE
☘️ refactor [#12.2.3]: 2차 개선 - 동시성 제어를 위한 Redis 원자적 업데이트 및 컴팩션 로직 명확화

### DIFF
--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -721,7 +721,7 @@ def should_rebuild_index(metadata: IndexMetadata) -> bool:
         return True
 
     # 기준 2: 삭제된 데이터가 너무 많은 경우 (검색 품질 및 공간 효율성)
-    if total_count > _MIN_DATASET_SIZE_FOR_COMPACTION:
+    if total_count >= _MIN_DATASET_SIZE_FOR_COMPACTION:
         delete_ratio = metadata.deleted_count / total_count
         if delete_ratio >= _DELETE_RATIO_THRESHOLD:
             logger.info(
@@ -740,7 +740,11 @@ async def update_index_after_op(
     delete_delta: int,
 ) -> Optional[IndexMetadata]:
     """
-    벡터 추가/삭제 작업 후 메타데이터를 갱신하고, 컴팩션 필요 여부를 확인한다.
+    [원자적(Atomic) 연산 기능 업데이트]
+    벡터 추가/삭제 작업 후 메타데이터를 원자적으로 갱신하고, 컴팩션 필요 여부를 판단한다.
+
+    Redis Lua Script를 사용하여 동시성(Race Condition) 환경에서도 'Read-Modify-Write' 시 
+    데이터 갱신이 유실되지 않도록 보장한다. 갱신 후의 카운트는 항상 0 이상으로 유지된다.
 
     Args:
         hashed_user_id: 사용자 해시 ID
@@ -748,23 +752,50 @@ async def update_index_after_op(
         delete_delta: 무효(삭제 처리된) 벡터 수 변화량 (삭제 시 +)
 
     Returns:
-        갱신된 IndexMetadata, 또는 실패 시 None
+        갱신된 IndexMetadata, 또는 대상 메타키가 존재하지 않으면 None
     """
-    metadata = await load_index_metadata(hashed_user_id)
-    if not metadata:
+    await _ensure_redis_connected()
+
+    key = _build_meta_key(hashed_user_id)
+    now = _now_utc_iso()
+
+    # Lua 스크립트: 키 존재 여부 확인 -> 원자적 증감 -> 최신 HGETALL 반환
+    lua_script = """
+    if redis.call("EXISTS", KEYS[1]) == 0 then
+        return nil
+    end
+    local v = tonumber(redis.call("HGET", KEYS[1], "vector_count") or "0")
+    local d = tonumber(redis.call("HGET", KEYS[1], "deleted_count") or "0")
+    
+    v = math.max(0, v + tonumber(ARGV[1]))
+    d = math.max(0, d + tonumber(ARGV[2]))
+    
+    redis.call("HSET", KEYS[1], "vector_count", tostring(v), "deleted_count", tostring(d), "updated_at", ARGV[3])
+    redis.call("EXPIRE", KEYS[1], tonumber(ARGV[4]))
+    
+    return redis.call("HGETALL", KEYS[1])
+    """
+
+    raw_list = await redis_client.redis.eval(
+        lua_script,
+        1,  # Number of keys
+        key,
+        vector_delta,
+        delete_delta,
+        now,
+        _META_TTL_SECS,
+    )
+
+    if not raw_list:
         logger.error(
             "[PERSONALIZED_INDEX] Cannot update metrics: No metadata found for masked_uid=%s",
             hashed_user_id[:8],
         )
         return None
 
-    # 수치 갱신 (음수는 0으로 보정)
-    metadata.vector_count = max(0, metadata.vector_count + vector_delta)
-    metadata.deleted_count = max(0, metadata.deleted_count + delete_delta)
-    metadata.updated_at = _now_utc_iso()
-
-    # Redis 저장
-    await save_index_metadata(hashed_user_id, metadata)
+    # Lua HGETALL은 Flat List 형태([k1, v1, k2, v2, ...])를 반환하므로 dict로 변환
+    raw_dict: dict[bytes | str, bytes | str] = dict(zip(raw_list[0::2], raw_list[1::2]))
+    metadata = IndexMetadata.from_redis_dict(raw_dict)
 
     # 컴팩션 여부 확인 로그 추가 (비동기 워커 트리거의 진입점)
     if should_rebuild_index(metadata):

--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -204,6 +204,28 @@ _META_TTL_SECS: int = _load_meta_ttl()
 _COMPACTION_THRESHOLD: int = _load_compaction_threshold()
 _DELETE_RATIO_THRESHOLD: float = _load_delete_ratio()
 
+# 메타데이터 원자적 갱신을 위한 Lua 스크립트 (모듈 레벨 컴파일로 파싱 비용 절감)
+# - KEYS[1]: Redis Hash Key
+# - ARGV[1]: vector_delta (추가/삭제 수)
+# - ARGV[2]: delete_delta (무효화 수)
+# - ARGV[3]: updated_at (ISO 시간 문자열)
+# - ARGV[4]: _META_TTL_SECS
+_LUA_UPDATE_META_SCRIPT: str = """
+if redis.call("EXISTS", KEYS[1]) == 0 then
+    return nil
+end
+local v = tonumber(redis.call("HGET", KEYS[1], "vector_count") or "0")
+local d = tonumber(redis.call("HGET", KEYS[1], "deleted_count") or "0")
+
+v = math.max(0, v + tonumber(ARGV[1]))
+d = math.max(0, d + tonumber(ARGV[2]))
+
+redis.call("HSET", KEYS[1], "vector_count", tostring(v), "deleted_count", tostring(d), "updated_at", ARGV[3])
+redis.call("EXPIRE", KEYS[1], tonumber(ARGV[4]))
+
+return redis.call("HGETALL", KEYS[1])
+"""
+
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -759,34 +781,19 @@ async def update_index_after_op(
     key = _build_meta_key(hashed_user_id)
     now = _now_utc_iso()
 
-    # Lua 스크립트: 키 존재 여부 확인 -> 원자적 증감 -> 최신 HGETALL 반환
-    lua_script = """
-    if redis.call("EXISTS", KEYS[1]) == 0 then
-        return nil
-    end
-    local v = tonumber(redis.call("HGET", KEYS[1], "vector_count") or "0")
-    local d = tonumber(redis.call("HGET", KEYS[1], "deleted_count") or "0")
-    
-    v = math.max(0, v + tonumber(ARGV[1]))
-    d = math.max(0, d + tonumber(ARGV[2]))
-    
-    redis.call("HSET", KEYS[1], "vector_count", tostring(v), "deleted_count", tostring(d), "updated_at", ARGV[3])
-    redis.call("EXPIRE", KEYS[1], tonumber(ARGV[4]))
-    
-    return redis.call("HGETALL", KEYS[1])
-    """
-
+    # 모듈 레벨에서 호이스팅된 _LUA_UPDATE_META_SCRIPT 사용
     raw_list = await redis_client.redis.eval(
-        lua_script,
+        _LUA_UPDATE_META_SCRIPT,
         1,  # Number of keys
         key,
-        vector_delta,
-        delete_delta,
+        str(vector_delta),  # 안전한 통신을 위해 모든 ARGV 명시적 문자열 타입 캐스팅
+        str(delete_delta),
         now,
-        _META_TTL_SECS,
+        str(_META_TTL_SECS),
     )
 
-    if not raw_list:
+    # 빈 리스트 반환이 아닌, Lua 스크립트의 'return nil' (메타데이터 없음) 상황을 명시적으로 체크
+    if raw_list is None:
         logger.error(
             "[PERSONALIZED_INDEX] Cannot update metrics: No metadata found for masked_uid=%s",
             hashed_user_id[:8],


### PR DESCRIPTION
- **[리뷰 반영: Race Condition 방어]**
  - 기존: load → python 로컬 증감 연산 → save의 Read-Modify-Write 안티 패턴
  - 변경: 파이썬-레디스 간 통신을 Lua 스크립트를 통한 1-Depth 평가(Eval)로 교체하여 워커 간 Lost Update 문제를 원천 차단 (Atomic Transaction)

- **[리뷰 반영: 경계값 문서-코드 불일치 해소]**
  - 컴팩션 최소 데이터셋 비교 연산자를 `>` 에서 `>=` 로 수정하여 Policy 상의 '_MIN' 단어 의도(Inclusive limits)와 코드의 동작을 완벽히 동기화

- **[성능 및 안정성 최적화]**
  - Lua HGETALL 결과를 Python `zip()`을 활용해 O(N)으로 결합하여 파싱 오버헤드 최소화
  - Lua 내부 `math.max` 사용으로 Delete Delta 음의 편차 하방 경직(0 미만 방지) 보장

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1171#pullrequestreview-4136088837)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Redis에서 개인화된 인덱스 메타데이터 업데이트를 원자적으로 수행하고, 압축(compaction) 임계값을 문서화된 정책과 일치하도록 조정합니다.

New Features:
- 최신 메타데이터를 한 번의 라운드 트립으로 반환하는 Lua 스크립트를 통해 Redis에서 벡터 및 삭제 개수 메타데이터를 원자적으로 업데이트합니다.

Bug Fixes:
- Redis Lua 기반의 원자적 업데이트로 비원자적인 읽기-수정-쓰기 패턴을 대체하여 인덱스 메타데이터 업데이트에서 발생하던 경쟁 상태(race condition)를 수정합니다.
- `>=` 비교를 사용하여 압축 최소 데이터셋 크기 조건을 포함(inclusive) 정책과 일치하도록 조정합니다.

Enhancements:
- 동시 업데이트 중에도 인덱스 메타데이터 카운터가 0 아래로 내려가지 않도록 보장합니다.
- Redis `HGETALL` 응답의 flat 리스트를 바로 딕셔너리로 변환하여 `IndexMetadata` 재구성에 사용함으로써 파싱을 최적화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure personalized index metadata updates are atomic in Redis and align compaction thresholds with documented policy.

New Features:
- Perform atomic vector and deleted-count metadata updates in Redis via a Lua script that returns the latest metadata in a single round trip.

Bug Fixes:
- Fix a race condition in index metadata updates by replacing the non-atomic read-modify-write pattern with a Redis Lua-based atomic update.
- Align the compaction minimum dataset size condition with the inclusive policy by using a greater-than-or-equal comparison.

Enhancements:
- Guarantee index metadata counters never drop below zero during concurrent updates.
- Optimize Redis HGETALL parsing by converting the flat list response directly into a dictionary for IndexMetadata reconstruction.

</details>