### PR TITLE
☘️ refactor [#12.2.3]: 4차 완료 - Lua 스크립트 EVALSHA 최적화 및 방어적 유효성 검사

### DIFF
--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -26,6 +26,7 @@ import logging
 import os
 import types
 import typing
+import redis.exceptions
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -799,9 +800,14 @@ async def update_index_after_op(
                 str(_META_TTL_SECS),
             ]
         )
-    except Exception as e:
+    except redis.exceptions.RedisError as e:
+        # [리뷰반영] 광범위한 Exception 캐치 제거 -> 명시적 RedisError 캐치
+        # Redis 연결이 끊기거나 SCRIPT FLUSH로 인해 NOSCRIPT가 발생했을 때 캐시를 무효화하여
+        # 다음 호출 시 새로운 커넥션 컨텍스트로 register_script가 다시 일어나도록 설정
+        _compiled_lua_script = None
+        
         logger.error(
-            "[PERSONALIZED_INDEX] Failed to execute atomic Lua script for masked_uid=%s: %s",
+            "[PERSONALIZED_INDEX] Failed to execute atomic Lua script for masked_uid=%s (Script Cache invalidated): %s",
             hashed_user_id[:8],
             e,
         )

--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -756,6 +756,8 @@ def should_rebuild_index(metadata: IndexMetadata) -> bool:
     return False
 
 
+_compiled_lua_script = None
+
 async def update_index_after_op(
     hashed_user_id: str,
     vector_delta: int,
@@ -776,27 +778,52 @@ async def update_index_after_op(
     Returns:
         갱신된 IndexMetadata, 또는 대상 메타키가 존재하지 않으면 None
     """
+    global _compiled_lua_script
     await _ensure_redis_connected()
+
+    # 스크립트 로드 최소화 (EVALSHA 사용 캐싱 기법)
+    if _compiled_lua_script is None:
+        _compiled_lua_script = redis_client.redis.register_script(_LUA_UPDATE_META_SCRIPT)
 
     key = _build_meta_key(hashed_user_id)
     now = _now_utc_iso()
 
-    # 모듈 레벨에서 호이스팅된 _LUA_UPDATE_META_SCRIPT 사용
-    raw_list = await redis_client.redis.eval(
-        _LUA_UPDATE_META_SCRIPT,
-        1,  # Number of keys
-        key,
-        str(vector_delta),  # 안전한 통신을 위해 모든 ARGV 명시적 문자열 타입 캐스팅
-        str(delete_delta),
-        now,
-        str(_META_TTL_SECS),
-    )
+    try:
+        # 모듈 레벨에서 호이스팅 및 EVALSHA로 등록된 스크립트 호출
+        raw_list = await _compiled_lua_script(
+            keys=[key],
+            args=[
+                str(vector_delta),  # 안전한 통신을 위해 모든 ARGV 명시적 문자열 타입 캐스팅
+                str(delete_delta),
+                now,
+                str(_META_TTL_SECS),
+            ]
+        )
+    except Exception as e:
+        logger.error(
+            "[PERSONALIZED_INDEX] Failed to execute atomic Lua script for masked_uid=%s: %s",
+            hashed_user_id[:8],
+            e,
+        )
+        return None
 
     # 빈 리스트 반환이 아닌, Lua 스크립트의 'return nil' (메타데이터 없음) 상황을 명시적으로 체크
     if raw_list is None:
         logger.error(
             "[PERSONALIZED_INDEX] Cannot update metrics: No metadata found for masked_uid=%s",
             hashed_user_id[:8],
+        )
+        return None
+
+    # [리뷰반영] 방어적 프로그래밍(Defensive Validation): Redis 응답 구조 손상 여부 검증
+    # HGETALL 호출 결과는 반드시 짝수 길이를 가진 리스트(키-값 쌍)여야 함
+    if not isinstance(raw_list, list) or len(raw_list) % 2 != 0:
+        actual_len = len(raw_list) if isinstance(raw_list, list) else type(raw_list).__name__
+        logger.error(
+            "[PERSONALIZED_INDEX] Corrupted Redis metadata response for masked_uid=%s. "
+            "Expected an even-length list from HGETALL, got length/type=%s.",
+            hashed_user_id[:8],
+            actual_len,
         )
         return None
 


### PR DESCRIPTION
- **[고동시성 오버헤드 제거 (EVALSHA)]**
  - 기존 `EVAL` 직접 호출로 인한 반복 컴파일 및 네트워크 페이로드 오버헤드 감소를 위해, `redis.register_script()`를 도입하여 `EVALSHA` 기반 스크립트 캐싱(Lazy Initialization) 적용

- **[방어적 프로그래밍 (Defensive Validation)]**
  - Redis HGETALL 응답 결과가 리스트 형식이 아니거나 홀수 길이(키-값 불일치 또는 데이터 손상)일 경우, `zip()` 수행 전 조기 차단(Early Return) 및 Data Corruption 에러 로깅 수행
  - 예상치 못한 Redis 타입 응답 시의 하드 크래시 방어

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1173#pullrequestreview-4136112972)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개인화 인덱스 업데이트를 위한 Redis Lua 스크립트 실행을 최적화하고, Redis 응답에 대한 방어적 검증을 추가합니다.

개선 사항:
- `redis.register_script`를 통해 `EVALSHA`를 사용해 Lua 업데이트 스크립트를 캐시하여 반복적인 컴파일과 네트워크 오버헤드를 줄입니다.
- 지연 초기화와 원자적 스크립트 실행에 대한 오류 처리를 포함한 모듈 레벨의 컴파일된 스크립트 핸들을 도입합니다.
- 딕셔너리로 변환하기 전에 Redis `HGETALL` 스타일 응답에 대한 방어적 검증을 추가하고, 예상치 못한 타입 또는 홀수 길이 리스트인 경우 로그를 남기고 처리를 중단합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize Redis Lua script execution for personalized index updates and add defensive validation for Redis responses.

Enhancements:
- Cache the Lua update script using EVALSHA via redis.register_script to reduce repeated compilation and network overhead.
- Introduce a module-level compiled script handle with lazy initialization and error handling around atomic script execution.
- Add defensive validation of Redis HGETALL-style responses before converting to a dict, logging and aborting on unexpected types or odd-length lists.

</details>