### PR TITLE
☘️ refactor [#12.2.3]: 6차 개선 - 클린 코드 모듈화 및 Redis 예외 장애 모드 분리

### DIFF
--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -764,7 +764,7 @@ async def _execute_update_meta_script(
     vector_delta: int,
     delete_delta: int,
     now: str,
-) -> Optional[typing.Any]:
+) -> Optional[list[typing.Any]]:
     global _compiled_lua_script
 
     if _compiled_lua_script is None:
@@ -773,7 +773,7 @@ async def _execute_update_meta_script(
     try:
         return await _compiled_lua_script(
             keys=[key],
-            args=[str(vector_delta), str(delete_delta), now, str(_META_TTL_SECS)],
+            args=[str(vector_delta), str(delete_delta), str(now), str(_META_TTL_SECS)],
         )
     except (redis.exceptions.NoScriptError, redis.exceptions.ConnectionError) as e:
         # [리뷰반영] Transient 에러나 스크립트 리셋 상황(NOSCRIPT 등)에서만 캐시 무효화 수행
@@ -784,7 +784,7 @@ async def _execute_update_meta_script(
             key,
             e,
         )
-        raise e
+        raise
     except redis.exceptions.RedisError as e:
         # [리뷰반영] 일반적인 Redis 장애는 캐시 무효화 없이 로깅 후 상위 전파하여, "메타 부재(None)" 상황과 진짜 DB 장애를 명확히 구분
         logger.error(
@@ -792,7 +792,7 @@ async def _execute_update_meta_script(
             key,
             e,
         )
-        raise e
+        raise
 
 
 def _hgetall_list_to_dict(

--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -759,6 +759,58 @@ def should_rebuild_index(metadata: IndexMetadata) -> bool:
 
 _compiled_lua_script = None
 
+async def _execute_update_meta_script(
+    key: str,
+    vector_delta: int,
+    delete_delta: int,
+    now: str,
+) -> Optional[typing.Any]:
+    global _compiled_lua_script
+
+    if _compiled_lua_script is None:
+        _compiled_lua_script = redis_client.redis.register_script(_LUA_UPDATE_META_SCRIPT)
+
+    try:
+        return await _compiled_lua_script(
+            keys=[key],
+            args=[str(vector_delta), str(delete_delta), now, str(_META_TTL_SECS)],
+        )
+    except (redis.exceptions.NoScriptError, redis.exceptions.ConnectionError) as e:
+        # [리뷰반영] Transient 에러나 스크립트 리셋 상황(NOSCRIPT 등)에서만 캐시 무효화 수행
+        _compiled_lua_script = None
+        logger.error(
+            "[PERSONALIZED_INDEX] Failed to execute atomic Lua script for key=%s "
+            "(Script Cache invalidated): %s",
+            key,
+            e,
+        )
+        raise e
+    except redis.exceptions.RedisError as e:
+        # [리뷰반영] 일반적인 Redis 장애는 캐시 무효화 없이 로깅 후 상위 전파하여, "메타 부재(None)" 상황과 진짜 DB 장애를 명확히 구분
+        logger.error(
+            "[PERSONALIZED_INDEX] Redis error executing script for key=%s: %s",
+            key,
+            e,
+        )
+        raise e
+
+
+def _hgetall_list_to_dict(
+    masked_uid: str,
+    raw_list: typing.Any,
+) -> Optional[dict[bytes | str, bytes | str]]:
+    if not isinstance(raw_list, list) or len(raw_list) % 2 != 0:
+        actual = len(raw_list) if isinstance(raw_list, list) else type(raw_list).__name__
+        logger.error(
+            "[PERSONALIZED_INDEX] Corrupted Redis metadata response for masked_uid=%s. "
+            "Expected an even-length list from HGETALL, got length/type=%s.",
+            masked_uid[:8],
+            actual,
+        )
+        return None
+    return dict(zip(raw_list[0::2], raw_list[1::2]))
+
+
 async def update_index_after_op(
     hashed_user_id: str,
     vector_delta: int,
@@ -779,41 +831,19 @@ async def update_index_after_op(
     Returns:
         갱신된 IndexMetadata, 또는 대상 메타키가 존재하지 않으면 None
     """
-    global _compiled_lua_script
     await _ensure_redis_connected()
-
-    # 스크립트 로드 최소화 (EVALSHA 사용 캐싱 기법)
-    if _compiled_lua_script is None:
-        _compiled_lua_script = redis_client.redis.register_script(_LUA_UPDATE_META_SCRIPT)
 
     key = _build_meta_key(hashed_user_id)
     now = _now_utc_iso()
 
-    try:
-        # 모듈 레벨에서 호이스팅 및 EVALSHA로 등록된 스크립트 호출
-        raw_list = await _compiled_lua_script(
-            keys=[key],
-            args=[
-                str(vector_delta),  # 안전한 통신을 위해 모든 ARGV 명시적 문자열 타입 캐스팅
-                str(delete_delta),
-                now,
-                str(_META_TTL_SECS),
-            ]
-        )
-    except redis.exceptions.RedisError as e:
-        # [리뷰반영] 광범위한 Exception 캐치 제거 -> 명시적 RedisError 캐치
-        # Redis 연결이 끊기거나 SCRIPT FLUSH로 인해 NOSCRIPT가 발생했을 때 캐시를 무효화하여
-        # 다음 호출 시 새로운 커넥션 컨텍스트로 register_script가 다시 일어나도록 설정
-        _compiled_lua_script = None
-        
-        logger.error(
-            "[PERSONALIZED_INDEX] Failed to execute atomic Lua script for masked_uid=%s (Script Cache invalidated): %s",
-            hashed_user_id[:8],
-            e,
-        )
-        return None
-
-    # 빈 리스트 반환이 아닌, Lua 스크립트의 'return nil' (메타데이터 없음) 상황을 명시적으로 체크
+    # 분리된 Helper를 통해 스크립트 실행 (에러 시 raise되어 제어권 위임됨)
+    raw_list = await _execute_update_meta_script(
+        key=key,
+        vector_delta=vector_delta,
+        delete_delta=delete_delta,
+        now=now,
+    )
+    
     if raw_list is None:
         logger.error(
             "[PERSONALIZED_INDEX] Cannot update metrics: No metadata found for masked_uid=%s",
@@ -821,23 +851,13 @@ async def update_index_after_op(
         )
         return None
 
-    # [리뷰반영] 방어적 프로그래밍(Defensive Validation): Redis 응답 구조 손상 여부 검증
-    # HGETALL 호출 결과는 반드시 짝수 길이를 가진 리스트(키-값 쌍)여야 함
-    if not isinstance(raw_list, list) or len(raw_list) % 2 != 0:
-        actual_len = len(raw_list) if isinstance(raw_list, list) else type(raw_list).__name__
-        logger.error(
-            "[PERSONALIZED_INDEX] Corrupted Redis metadata response for masked_uid=%s. "
-            "Expected an even-length list from HGETALL, got length/type=%s.",
-            hashed_user_id[:8],
-            actual_len,
-        )
+    # 분리된 Helper를 통해 안전하게 파싱
+    raw_dict = _hgetall_list_to_dict(hashed_user_id, raw_list)
+    if raw_dict is None:
         return None
 
-    # Lua HGETALL은 Flat List 형태([k1, v1, k2, v2, ...])를 반환하므로 dict로 변환
-    raw_dict: dict[bytes | str, bytes | str] = dict(zip(raw_list[0::2], raw_list[1::2]))
     metadata = IndexMetadata.from_redis_dict(raw_dict)
 
-    # 컴팩션 여부 확인 로그 추가 (비동기 워커 트리거의 진입점)
     if should_rebuild_index(metadata):
         logger.warning(
             "[PERSONALIZED_INDEX][ASYNC] Index for %s needs REBUILD. "


### PR DESCRIPTION
- **[메인 비즈니스 로직 복잡도 개선]**
  - 글로벌 상태 변수(`_compiled_lua_script`) 조작과 Lua 스크립트 캐싱 관리를 `_execute_update_meta_script` 헬퍼 함수로 완전 캡슐화
  - HGETALL 방어적 유효성 검사 로직을 `_hgetall_list_to_dict` 헬퍼 함수로 분리하여 메인 함수의 가독성을 선형적(Linear)으로 최적화

- **[ 에러 원인 격리와 전파(Propagate)]**
  - RedisError 캐치를 단일 체인에서 두 가지로 분리
  - `NoScriptError` / `ConnectionError` 시에만 스크립트 캐시를 무효화
  - 그 외의 장애는 '메타데이터 부재(None)'로 오판하지 않도록 캐시 유지 후 상위로 예외 상황을 명시적으로 `raise` 하여 호출자가 올바른 릴레이 조치를 취할 수 있도록 아키텍처 레벨 방어망 구축

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1175#pullrequestreview-4136133304)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개인화된 인덱스 메타데이터 업데이트 로직을 리팩터링하여 Redis Lua 스크립트 실행과 `HGETALL` 파싱을 헬퍼 함수 뒤로 캡슐화하고, 에러 처리와 실패 모드의 분리를 더욱 엄격하게 했습니다.

버그 수정:
- Redis 스크립트 캐시는 `NoScriptError` 또는 연결 실패가 발생했을 때만 무효화하고, 그 외의 Redis 에러는 로깅 후 재발생시켜, 장애를 메타데이터 누락으로 잘못 분류하는 것을 방지합니다.

개선 사항:
- 인덱스 메타데이터 업데이트를 위해 캐시된 Lua 스크립트의 등록, 실행, 그리고 Redis 에러 전파를 관리하는 헬퍼를 분리했습니다.
- 메타데이터 파싱을 위해 `HGETALL` 리스트 응답을 방어적으로 검증하고 딕셔너리로 변환하는 헬퍼를 분리했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor personalized index metadata updates to encapsulate Redis Lua script execution and HGETALL parsing behind helpers while tightening error handling and separation of failure modes.

Bug Fixes:
- Ensure Redis script cache is only invalidated on NoScriptError or connection failures while other Redis errors are logged and re-raised to avoid misclassifying outages as missing metadata.

Enhancements:
- Extract helper to manage cached Lua script registration, execution, and Redis error propagation for index metadata updates.
- Extract helper to defensively validate and convert HGETALL list responses into dictionaries for metadata parsing.

</details>