### PR TITLE
☘️ refactor [#12.2.3]: 8차 개선 - 의존성 주입 및 보안 로깅 캡슐화 완수

### DIFF
--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -757,39 +757,53 @@ def should_rebuild_index(metadata: IndexMetadata) -> bool:
     return False
 
 
-_compiled_lua_script = None
+class LuaScriptCache:
+    """Lua 스크립트의 EVALSHA 캐시를 캡슐화하고, 연결 유실 시 자율 복구하는 헬퍼 클래스"""
+    def __init__(self, script_body: str):
+        self.script_body = script_body
+        self._compiled = None
+
+    def get_or_register(self, client: typing.Any) -> typing.Any:
+        if self._compiled is None:
+            self._compiled = client.register_script(self.script_body)
+        return self._compiled
+
+    def invalidate(self) -> None:
+        self._compiled = None
+
+# 모듈 레벨 캡슐화 객체 (단일 진실 공급원)
+_meta_updater = LuaScriptCache(_LUA_UPDATE_META_SCRIPT)
 
 async def _execute_update_meta_script(
+    client: typing.Any,
+    masked_uid: str,
     key: str,
     vector_delta: int,
     delete_delta: int,
     now: str,
 ) -> Optional[list[typing.Any]]:
-    global _compiled_lua_script
-
-    if _compiled_lua_script is None:
-        _compiled_lua_script = redis_client.redis.register_script(_LUA_UPDATE_META_SCRIPT)
+    compiled_script = _meta_updater.get_or_register(client)
 
     try:
-        return await _compiled_lua_script(
+        return await compiled_script(
             keys=[key],
             args=[str(vector_delta), str(delete_delta), str(now), str(_META_TTL_SECS)],
         )
     except (redis.exceptions.NoScriptError, redis.exceptions.ConnectionError) as e:
         # [리뷰반영] Transient 에러나 스크립트 리셋 상황(NOSCRIPT 등)에서만 캐시 무효화 수행
-        _compiled_lua_script = None
+        _meta_updater.invalidate()
         logger.error(
-            "[PERSONALIZED_INDEX] Failed to execute atomic Lua script for key=%s "
+            "[PERSONALIZED_INDEX] Failed to execute atomic Lua script for masked_uid=%s "
             "(Script Cache invalidated): %s",
-            key,
+            masked_uid,
             e,
         )
         raise
     except redis.exceptions.RedisError as e:
         # [리뷰반영] 일반적인 Redis 장애는 캐시 무효화 없이 로깅 후 상위 전파하여, "메타 부재(None)" 상황과 진짜 DB 장애를 명확히 구분
         logger.error(
-            "[PERSONALIZED_INDEX] Redis error executing script for key=%s: %s",
-            key,
+            "[PERSONALIZED_INDEX] Redis error executing script for masked_uid=%s: %s",
+            masked_uid,
             e,
         )
         raise
@@ -838,6 +852,8 @@ async def update_index_after_op(
 
     # 분리된 Helper를 통해 스크립트 실행 (에러 시 raise되어 제어권 위임됨)
     raw_list = await _execute_update_meta_script(
+        client=redis_client.redis,
+        masked_uid=hashed_user_id[:8],
         key=key,
         vector_delta=vector_delta,
         delete_delta=delete_delta,

--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -21,11 +21,13 @@ Path 전략:
 from __future__ import annotations
 
 import dataclasses
+import asyncio
 import hashlib
 import logging
 import os
 import types
 import typing
+import redis.asyncio as redis_async
 import redis.exceptions
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -761,11 +763,16 @@ class LuaScriptCache:
     """Lua 스크립트의 EVALSHA 캐시를 캡슐화하고, 연결 유실 시 자율 복구하는 헬퍼 클래스"""
     def __init__(self, script_body: str):
         self.script_body = script_body
-        self._compiled = None
+        self._compiled: Optional["redis.commands.core.AsyncScript"] = None
+        self._lock = asyncio.Lock()
 
-    def get_or_register(self, client: typing.Any) -> typing.Any:
+    async def get_or_register(self, client: "redis_async.Redis") -> "redis.commands.core.AsyncScript":
+        # 다수 코루틴 간 경쟁 상황(Race Condition)으로 인한 스크립트 중복 등록을
+        # 방지하기 위해 비동기 락과 Double-Checked Locking 적용
         if self._compiled is None:
-            self._compiled = client.register_script(self.script_body)
+            async with self._lock:
+                if self._compiled is None:
+                    self._compiled = client.register_script(self.script_body)
         return self._compiled
 
     def invalidate(self) -> None:
@@ -775,14 +782,17 @@ class LuaScriptCache:
 _meta_updater = LuaScriptCache(_LUA_UPDATE_META_SCRIPT)
 
 async def _execute_update_meta_script(
-    client: typing.Any,
+    client: "redis_async.Redis",
     masked_uid: str,
     key: str,
     vector_delta: int,
     delete_delta: int,
     now: str,
+    meta_updater: Optional[LuaScriptCache] = None,
 ) -> Optional[list[typing.Any]]:
-    compiled_script = _meta_updater.get_or_register(client)
+    # 전역 인스턴스에 강제 종속되지 않도록 대체 캐시(DI) 허용
+    updater = meta_updater or _meta_updater
+    compiled_script = await updater.get_or_register(client)
 
     try:
         return await compiled_script(
@@ -791,7 +801,7 @@ async def _execute_update_meta_script(
         )
     except (redis.exceptions.NoScriptError, redis.exceptions.ConnectionError) as e:
         # [리뷰반영] Transient 에러나 스크립트 리셋 상황(NOSCRIPT 등)에서만 캐시 무효화 수행
-        _meta_updater.invalidate()
+        updater.invalidate()
         logger.error(
             "[PERSONALIZED_INDEX] Failed to execute atomic Lua script for masked_uid=%s "
             "(Script Cache invalidated): %s",


### PR DESCRIPTION
- **[정보 보안 관점의 Key 로깅 제한]**
  - 원자적 업데이트 헬퍼(`_execute_update_meta_script`)에서 에러 발생 시 내부의 RAW `key`가 로그에 남지 않도록 제거
  - 상위에서 마스킹 형태로 파싱된 `masked_uid`(`hashed_user_id[:8]`)를 직접 주입받아 로그 출력함으로써 잠재적 정보 유출 차단 및 로깅 컨텍스트 통일

- **[글로벌 변수 상태 관리 및 의존성 주입(DI)]**
  - 파이썬 모듈 레벨의 변경 가능한 글로벌 변수(`global _compiled_... `)를 전면 폐기하고, 스크립트 상태와 캐시 무효화를 캡슐화한 전용 헬퍼 객체 `LuaScriptCache` 클래스 도입 적용
  - 하드코딩된 모듈 레벨 `redis_client` 참조를 끊고, `update_index_after_op` 비즈니스 로직으로부터 커넥션(client) 인터페이스를 명시적으로 주입(Inject)받아 테스트 용이성(Testability)과 독립성 극대화 달성

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1177#pullrequestreview-4136160332)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개인화된 인덱스 메타데이터 업데이트 로직을 리팩터링하여 Lua 스크립트 캐싱을 캡슐화하고, 의존성 주입 방식의 Redis 클라이언트를 지원하면서도 원시 사용자 키가 로그에 기록되지 않도록 합니다.

버그 수정:
- 민감한 원시 Redis 키가 에러 로그에 기록되지 않도록, 대신 마스킹된 사용자 식별자를 로그에 남기도록 합니다.

개선 사항:
- Lua EVALSHA 스크립트 등록 및 캐시 무효화를 캡슐화하기 위한 `LuaScriptCache` 헬퍼를 도입합니다.
- 메타데이터 업데이트 헬퍼에 Redis 클라이언트를 주입하여 모듈 레벨 전역 변수와의 결합을 줄이고, 테스트 용이성을 향상시킵니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor personalized index metadata update to encapsulate Lua script caching and avoid logging raw user keys while supporting dependency-injected Redis clients.

Bug Fixes:
- Prevent sensitive raw Redis keys from being written to error logs by logging masked user identifiers instead.

Enhancements:
- Introduce a LuaScriptCache helper to encapsulate Lua EVALSHA script registration and cache invalidation.
- Inject the Redis client into the metadata update helper to decouple it from module-level globals and improve testability.

</details>