### PR TITLE
☘️ refactor [#12.2.3]: 10차 개선 - 오버엔지니어링(Lock) 제거 및 인지 부담 최소화

### DIFF
--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -419,6 +419,15 @@ def _build_meta_key(hashed_user_id: str) -> str:
     return f"{_REDIS_META_PREFIX}:{hashed_user_id}"
 
 
+def _extract_masked_uid_from_key(key: str) -> str:
+    """
+    Redis 메타데이터 키에서 유저 식별자(마스킹용 앞 8자리)를 역추출한다.
+    의도치 않은 타입(None 등)이 전달된 경우 명시적(Explicit) 에러를 발생시키기 위해
+    광범위한 예외 캐치를 수행하지 않습니다.
+    """
+    return key.rsplit(":", 1)[-1][:8]
+
+
 def _now_utc_iso() -> str:
     """현재 UTC 시각을 ISO 8601 문자열로 반환한다."""
     return datetime.now(timezone.utc).isoformat()
@@ -789,11 +798,9 @@ async def _execute_update_meta_script(
     updater = meta_updater or _meta_updater
     compiled_script = updater.get_or_register(client)
 
-    # 파라미터 개수를 줄이고 내부에서 masked uid 추출 (캡슐화)
-    try:
-        masked_uid = key.rsplit(":", 1)[-1][:8]
-    except Exception:
-        masked_uid = "unknown"
+    # [리뷰반영] 예외 삼키기(Swallowing) 안티패턴을 제거하고 단일 헬퍼 사용
+    # key가 문자열이 아닌 경우 명시적(Explicit) 에러가 발생하여 상위 버그를 조기 발견할 수 있음
+    masked_uid = _extract_masked_uid_from_key(key)
 
     try:
         return await compiled_script(

--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -21,7 +21,6 @@ Path 전략:
 from __future__ import annotations
 
 import dataclasses
-import asyncio
 import hashlib
 import logging
 import os
@@ -764,15 +763,12 @@ class LuaScriptCache:
     def __init__(self, script_body: str):
         self.script_body = script_body
         self._compiled: Optional["redis.commands.core.AsyncScript"] = None
-        self._lock = asyncio.Lock()
 
-    async def get_or_register(self, client: "redis_async.Redis") -> "redis.commands.core.AsyncScript":
-        # 다수 코루틴 간 경쟁 상황(Race Condition)으로 인한 스크립트 중복 등록을
-        # 방지하기 위해 비동기 락과 Double-Checked Locking 적용
+    def get_or_register(self, client: "redis_async.Redis") -> "redis.commands.core.AsyncScript":
+        # Coroutine 경쟁이 일어나더라도 register_script 의 부하가 미비하므로
+        # 락 없이 단순화하여 인지 부담(Cognitive Load)을 줄임
         if self._compiled is None:
-            async with self._lock:
-                if self._compiled is None:
-                    self._compiled = client.register_script(self.script_body)
+            self._compiled = client.register_script(self.script_body)
         return self._compiled
 
     def invalidate(self) -> None:
@@ -783,7 +779,6 @@ _meta_updater = LuaScriptCache(_LUA_UPDATE_META_SCRIPT)
 
 async def _execute_update_meta_script(
     client: "redis_async.Redis",
-    masked_uid: str,
     key: str,
     vector_delta: int,
     delete_delta: int,
@@ -792,7 +787,13 @@ async def _execute_update_meta_script(
 ) -> Optional[list[typing.Any]]:
     # 전역 인스턴스에 강제 종속되지 않도록 대체 캐시(DI) 허용
     updater = meta_updater or _meta_updater
-    compiled_script = await updater.get_or_register(client)
+    compiled_script = updater.get_or_register(client)
+
+    # 파라미터 개수를 줄이고 내부에서 masked uid 추출 (캡슐화)
+    try:
+        masked_uid = key.rsplit(":", 1)[-1][:8]
+    except Exception:
+        masked_uid = "unknown"
 
     try:
         return await compiled_script(
@@ -863,7 +864,6 @@ async def update_index_after_op(
     # 분리된 Helper를 통해 스크립트 실행 (에러 시 raise되어 제어권 위임됨)
     raw_list = await _execute_update_meta_script(
         client=redis_client.redis,
-        masked_uid=hashed_user_id[:8],
         key=key,
         vector_delta=vector_delta,
         delete_delta=delete_delta,


### PR DESCRIPTION
- **[불필요한 동시성 제어 제거 (단순화)]**
  - Redis `register_script`의 멱등성(Idempotency) 및 경량 구조를 십분 활용하여, `LuaScriptCache` 내의 무거운 `asyncio.Lock`과 Double-Checked Locking 구조를 제거
  - `get_or_register`를 단순 동기 함수로 되돌려 코드 가독성 및 팀원들의 인지 부담(Cognitive Load)을 극적으로 해소

- **[파라미터 간소화 및 자체 유도 캡슐화]**
  - 로깅 목적의 `masked_uid`를 파라미터로 주입받는 대신, 헬퍼 함수 내부에서 `key`를 기반으로(`rsplit`) 자체 추출하도록 수정
  - 메인 비즈니스 계층(`update_index_after_op`) 호출부의 인터페이스 노출을 최소화하고 캡슐화(Encapsulation) 원칙 강화

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1179#pullrequestreview-4136188283)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Redis Lua 스크립트 캐싱을 단순화하고 인덱스 업데이트 작업에 대한 호출자 측 복잡성을 줄입니다.

개선 사항:
- Redis `LuaScriptCache`에서 불필요한 asyncio 락 및 이중 체크 락킹을 제거하고, 스크립트 등록을 단순한 동기 호출로 변경합니다.
- 캡슐화를 개선하고 매개변수를 줄이기 위해, 공개 인터페이스인 `update_index_after_op`를 통해 전달하던 마스킹된 사용자 식별자를 Redis 키로부터 헬퍼 내부에서 유도하도록 변경합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify Redis Lua script caching and reduce caller-facing complexity for index update operations.

Enhancements:
- Remove unnecessary asyncio locking and double-checked locking from Redis LuaScriptCache and make script registration a simple synchronous call.
- Derive masked user identifiers from Redis keys within the helper instead of passing them through the public update_index_after_op interface to improve encapsulation and reduce parameters.

</details>