### PR TITLE
☘️ refactor [#12.2.3]: 12차 개선 - 극단적 엣지 케이스 방어 및 명시적 인터페이스 문서화

### DIFF
--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -422,10 +422,18 @@ def _build_meta_key(hashed_user_id: str) -> str:
 def _extract_masked_uid_from_key(key: str) -> str:
     """
     Redis 메타데이터 키에서 유저 식별자(마스킹용 앞 8자리)를 역추출한다.
-    의도치 않은 타입(None 등)이 전달된 경우 명시적(Explicit) 에러를 발생시키기 위해
-    광범위한 예외 캐치를 수행하지 않습니다.
+    문자열이 아니거나 지정된 Prefix를 따르지 않는 등 의도치 않은 형식이 전달된 경우 
+    명시적(Explicit) ValueError를 발생시킨다.
     """
-    return key.rsplit(":", 1)[-1][:8]
+    expected_prefix = f"{_REDIS_META_PREFIX}:"
+    if not isinstance(key, str) or not key.startswith(expected_prefix):
+        raise ValueError(f"Invalid Redis key format for masked UID extraction: {key!r}")
+    
+    uid_part = key[len(expected_prefix):]
+    if not uid_part:
+        raise ValueError(f"Empty UID part in Redis key: {key!r}")
+        
+    return uid_part[:8]
 
 
 def _now_utc_iso() -> str:
@@ -774,8 +782,11 @@ class LuaScriptCache:
         self._compiled: Optional["redis.commands.core.AsyncScript"] = None
 
     def get_or_register(self, client: "redis_async.Redis") -> "redis.commands.core.AsyncScript":
-        # Coroutine 경쟁이 일어나더라도 register_script 의 부하가 미비하므로
-        # 락 없이 단순화하여 인지 부담(Cognitive Load)을 줄임
+        """
+        스크립트 객체를 등록/조회하는 동기(Sync) 인터페이스입니다.
+        (경쟁 상태의 부하가 미비하므로 비동기 Lock 없이 단순 메모리 검사만 수행)
+        반환된 `AsyncScript` 인스턴스 획득 시에는 await를 사용하지 마세요. (실행 시에만 사용)
+        """
         if self._compiled is None:
             self._compiled = client.register_script(self.script_body)
         return self._compiled

--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -29,6 +29,9 @@ import typing
 import redis.asyncio as redis_async
 import redis.exceptions
 from dataclasses import dataclass
+
+# [타입 힌팅 Alias] 동기 함수가 반환하는 스크립트 객체임을 명시하여 await 오용 방지
+CompiledRedisScriptHandle = "redis.commands.core.AsyncScript"
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -427,11 +430,12 @@ def _extract_masked_uid_from_key(key: str) -> str:
     """
     expected_prefix = f"{_REDIS_META_PREFIX}:"
     if not isinstance(key, str) or not key.startswith(expected_prefix):
-        raise ValueError(f"Invalid Redis key format for masked UID extraction: {key!r}")
+        # [리뷰반영] 보안성을 위해 오류 메시지에 원본 키 전체 노출 방지(Masking)
+        raise ValueError("Invalid Redis key format for masked UID extraction (raw key masked for security)")
     
     uid_part = key[len(expected_prefix):]
     if not uid_part:
-        raise ValueError(f"Empty UID part in Redis key: {key!r}")
+        raise ValueError("Empty UID part in Redis key (raw key masked for security)")
         
     return uid_part[:8]
 
@@ -779,13 +783,13 @@ class LuaScriptCache:
     """Lua 스크립트의 EVALSHA 캐시를 캡슐화하고, 연결 유실 시 자율 복구하는 헬퍼 클래스"""
     def __init__(self, script_body: str):
         self.script_body = script_body
-        self._compiled: Optional["redis.commands.core.AsyncScript"] = None
+        self._compiled: Optional[CompiledRedisScriptHandle] = None
 
-    def get_or_register(self, client: "redis_async.Redis") -> "redis.commands.core.AsyncScript":
+    def get_compiled_script_handle(self, client: "redis_async.Redis") -> CompiledRedisScriptHandle:
         """
-        스크립트 객체를 등록/조회하는 동기(Sync) 인터페이스입니다.
+        스크립트 객체의 '참조(Handle)'를 반환하는 동기(Sync) 인터페이스입니다.
         (경쟁 상태의 부하가 미비하므로 비동기 Lock 없이 단순 메모리 검사만 수행)
-        반환된 `AsyncScript` 인스턴스 획득 시에는 await를 사용하지 마세요. (실행 시에만 사용)
+        반환된 인스턴스 획득 시에는 await를 사용하지 마세요. (실행 시에만 체이닝 사용)
         """
         if self._compiled is None:
             self._compiled = client.register_script(self.script_body)
@@ -807,14 +811,15 @@ async def _execute_update_meta_script(
 ) -> Optional[list[typing.Any]]:
     # 전역 인스턴스에 강제 종속되지 않도록 대체 캐시(DI) 허용
     updater = meta_updater or _meta_updater
-    compiled_script = updater.get_or_register(client)
+    compiled_script_handle = updater.get_compiled_script_handle(client)
 
     # [리뷰반영] 예외 삼키기(Swallowing) 안티패턴을 제거하고 단일 헬퍼 사용
     # key가 문자열이 아닌 경우 명시적(Explicit) 에러가 발생하여 상위 버그를 조기 발견할 수 있음
     masked_uid = _extract_masked_uid_from_key(key)
 
     try:
-        return await compiled_script(
+        # 반환받은 '핸들(Handle)'을 비로소 await 하여 스크립트 실행
+        return await compiled_script_handle(
             keys=[key],
             args=[str(vector_delta), str(delete_delta), str(now), str(_META_TTL_SECS)],
         )


### PR DESCRIPTION
- **[Explicit Failure (사일런트 버그 차단)]**
  - `_extract_masked_uid_from_key` 헬퍼 로직을 고도화하여, 제공된 파라미터가 단순 문자열이 아니거나 `_REDIS_META_PREFIX` 규칙을 준수하지 않을 경우 즉시 `ValueError`를 발생(Raise)
  - 파이썬 기본 슬라이싱의 유연함으로 인해, 오염된 키 값이 마스킹된 UID처럼 둔갑되어 시스템을 조용히 망가뜨리는(Silent Failure) 현상을 원천 방어

- **[Sync/Async 인터페이스 오용 방지 방어벽]**
  - `LuaScriptCache.get_or_register`에 구체적인 Docstring 추가
  - 해당 함수가 동기(Sync) 인터페이스임과 AsyncScript 객체 자체의 반환값에 `await`를 남발하지 않도록 명확한 사용 규약(Contract)을 명시하여 타 개발자의 휴먼 에러 방지

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1181#pullrequestreview-4136204271)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Redis 메타데이터 키 처리의 안정성을 강화하고 Lua 스크립트 캐시 사용 계약을 명확히 합니다.

버그 수정:
- `_extract_masked_uid_from_key`에서 Redis 메타데이터 키를 검증하고, 잘못되었거나 손상된 키에 대해 명시적인 오류를 발생시켜 조용한 실패를 방지합니다.

개선 사항:
- 마스킹된 사용자 ID를 추출할 때 Redis 메타데이터 키에 더 엄격한 형식을 적용하여, 필수 접두사와 비어 있지 않은 UID 세그먼트를 요구하도록 합니다.
- `LuaScriptCache.get_or_register`의 동기식 사용 계약을 문서화하여, 반환된 `AsyncScript`는 조회 시점이 아니라 실행 시점에만 `await` 되어야 함을 명확히 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden Redis metadata key handling and clarify Lua script cache usage contracts.

Bug Fixes:
- Validate Redis metadata keys in `_extract_masked_uid_from_key` and raise explicit errors for invalid or malformed keys to avoid silent failures.

Enhancements:
- Enforce a stricter format for Redis metadata keys when extracting masked user IDs, including required prefixes and non-empty UID segments.
- Document the synchronous usage contract of `LuaScriptCache.get_or_register`, clarifying that the returned `AsyncScript` should only be awaited on execution, not retrieval.

</details>