### PR TITLE
☘️ refactor [#12.2.3]: 16차 개선 - ValueError 메타데이터 형식 완전 통일

### DIFF
--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -422,32 +422,31 @@ def _build_meta_key(hashed_user_id: str) -> str:
     return f"{_REDIS_META_PREFIX}:{hashed_user_id}"
 
 
-def _extract_masked_uid_from_key(key: str) -> str:
+def _format_key_meta(key: typing.Any) -> str:
+    """에러 메시지용 키 메타 정보를 PII 안전한 형식으로 포맷한다."""
+    key_type = type(key).__name__
+    key_len = len(key) if isinstance(key, str) else "N/A"
+    return f"type={key_type}, len={key_len}"
+
+
+def _extract_masked_uid_from_key(key: typing.Any) -> str:
     """
     Redis 메타데이터 키에서 유저 식별자(마스킹용 앞 8자리)를 역추출한다.
-    문자열이 아니거나 지정된 Prefix를 따르지 않는 등 의도치 않은 형식이 전달된 경우 
+    문자열이 아니거나 지정된 Prefix를 따르지 않는 등 의도치 않은 형식이 전달된 경우
     명시적(Explicit) ValueError를 발생시킨다.
+    파라미터 타입이 Any인 이유: 비문자열 입력을 의도적으로 감지·ValueError로 처리함.
     """
     expected_prefix = f"{_REDIS_META_PREFIX}:"
-    # [리뷰반영] 두 실패 경로 모두 동일한 메타데이터 형식(type, len)을 사용하여
-    # 로그 상관 분석 및 디버깅 일관성을 보장 (str() 변환 없이 타입 체크 기반 방어)
     if not isinstance(key, str) or not key.startswith(expected_prefix):
-        key_type = type(key).__name__
-        key_len = len(key) if isinstance(key, str) else "N/A"
         raise ValueError(
             f"Invalid Redis key format for masked UID extraction "
-            f"(type={key_type}, len={key_len})"
+            f"({_format_key_meta(key)})"
         )
 
     uid_part = key[len(expected_prefix):]
     if not uid_part:
-        # 이 분기는 isinstance(key, str) 통과 후이므로 len(key)가 안전함
-        # len(str(key)) 대신 len(key)를 사용하여 불필요한 str() 호출 방지
-        key_type = type(key).__name__
-        key_len = len(key)
         raise ValueError(
-            f"Empty UID part in Redis key (prefix matched — "
-            f"type={key_type}, len={key_len})"
+            f"Empty UID part in Redis key (prefix matched — {_format_key_meta(key)})"
         )
 
     return uid_part[:8]

--- a/backend/services/personalized_index_service.py
+++ b/backend/services/personalized_index_service.py
@@ -429,9 +429,9 @@ def _extract_masked_uid_from_key(key: str) -> str:
     명시적(Explicit) ValueError를 발생시킨다.
     """
     expected_prefix = f"{_REDIS_META_PREFIX}:"
+    # [리뷰반영] 두 실패 경로 모두 동일한 메타데이터 형식(type, len)을 사용하여
+    # 로그 상관 분석 및 디버깅 일관성을 보장 (str() 변환 없이 타입 체크 기반 방어)
     if not isinstance(key, str) or not key.startswith(expected_prefix):
-        # [리뷰반영] 보안성을 위해 전체 키를 노출하지 않으면서도, 디버깅을 위한
-        # 짧은 프리뷰(또는 타입) 단서를 제공하여 실패 원인 추적을 용이하게 함
         key_type = type(key).__name__
         key_len = len(key) if isinstance(key, str) else "N/A"
         raise ValueError(
@@ -441,11 +441,15 @@ def _extract_masked_uid_from_key(key: str) -> str:
 
     uid_part = key[len(expected_prefix):]
     if not uid_part:
-        # [리뷰반영] 향후 리팩터링 안전성을 위해 len(str(key)) 방어적 처리 사용
+        # 이 분기는 isinstance(key, str) 통과 후이므로 len(key)가 안전함
+        # len(str(key)) 대신 len(key)를 사용하여 불필요한 str() 호출 방지
+        key_type = type(key).__name__
+        key_len = len(key)
         raise ValueError(
-            f"Empty UID part in Redis key (prefix matched, total length: {len(str(key))})"
+            f"Empty UID part in Redis key (prefix matched — "
+            f"type={key_type}, len={key_len})"
         )
-        
+
     return uid_part[:8]
 
 


### PR DESCRIPTION
- 두 실패 경로(포맷 불일치/Empty UID)의 에러 메시지를 동일한 '(type=, len=)' 형식으로 표준화하여 로그 상관 분석 일관성 달성
- len(str(key)) 불필요한 str() 변환 제거, str 타입 확인 후 len(key) 직접 사용으로 방어 논리 명확화

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1185#pullrequestreview-4136235559)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Redis 키 파싱 실패에 대한 `ValueError` 메타데이터를 표준화하고, 문자열 키에 대한 방어적 길이 처리 로직을 단순화했습니다.

버그 수정:
- 잘못되었거나 비어 있는 Redis UID 키에 대한 에러 메시지를 `(type=..., len=...)` 형식으로 일관되게 맞춰, 디버깅 및 로그 상관관계를 개선했습니다.

개선 사항:
- `len(key)`를 사용하기 전에 명시적인 문자열 타입 체크에 의존함으로써, 키 길이를 계산할 때 불필요한 문자열 변환을 제거했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize ValueError metadata for Redis key parsing failures and simplify defensive length handling for string keys.

Bug Fixes:
- Align error messages for invalid or empty Redis UID keys to a consistent '(type=..., len=...)' format to improve debuggability and log correlation.

Enhancements:
- Remove unnecessary string conversions when computing key length by relying on explicit string type checks before using len(key).

</details>