### PR TITLE
☘️ refactor [#12.2.4]: 5차 개선 - NaN float 파싱 방어 처리 추가

### DIFF
--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -80,13 +80,13 @@ def _parse_bounded_env_number(
     특성상 int 로더는 `parser=int`, float 로더는 `parser=float`를 전달한다.
 
     동작 우선순위:
-      1) 미설정(None)    → 조용히 기본값 반환
-      2) 빈값/공백     → 운영자 오설정 의심 → WARNING + 기본값
-      3) 파싱 실패     → WARNING + 기본값
-      4) NaN (float전용) → 유효하지 않은 값 → WARNING + 기본값
-         (NaN은 모든 비교에서 False를 반환하므로 Clamp을 바이패스함)
-      5) 범위 이탈     → Clamp + WARNING
-      6) 정상          → 파싱된 값 반환
+      1) 미설정(None)     → 조용히 기본값 반환
+      2) 빈값/공백      → 운영자 오설정 의심 → WARNING + 기본값
+      3) 파싱 실패      → WARNING + 기본값
+      4) 비유한 값 (float 전용) → NaN / ±inf 유효하지 않은 값 → WARNING + 기본값
+         (math.isfinite()로 NaN와 ±inf를 통합 차단)
+      5) 범위 이탈      → Clamp + WARNING
+      6) 정상           → 파싱된 값 반환
     """
     raw = os.environ.get(env_key)
 
@@ -117,17 +117,20 @@ def _parse_bounded_env_number(
         )
         return default
 
-    # 4) NaN 체크 (float 전용): NaN은 모든 비교에서 False를 반환해 Clamp을 바이패스함
-    #    int('NaN')은 ValueError로 위에서 이미 catch되므로 float에만 해당
-    if isinstance(value, float) and math.isnan(value):
+    # 4) 비유한 값 체크 (float 전용): NaN과 ±inf는 명시적으로 무효 처리
+    #    - NaN: 모든 비교에서 False → Clamp 바이패스
+    #    - ±inf: 실제 운영 수치칠 수 없으므로 안전한 기본값으로 폴백
+    #    int('NaN')은 ValueError로 위에서 이미 catch되어 float에만 해당
+    if isinstance(value, float) and not math.isfinite(value):
         logger.warning(
-            "[TOPIC_CLUSTERING] %s 값이 NaN입니다 (유효하지 않은 값). 기본값 %r로 폴백합니다.",
+            "[TOPIC_CLUSTERING] %s 값이 비유한(NaN 또는 ±inf)입니다 (운영자 오설정 의심). "
+            "기본값 %r로 폴백합니다.",
             env_key,
             default,
         )
         return default
 
-    # 4) 범위 Clamp
+    # 5) 범위 Clamp
     if value < min_val:
         logger.warning(
             "[TOPIC_CLUSTERING] %s=%r 가 최솟값(%r) 미만입니다. %r로 보정합니다.",

--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -22,6 +22,7 @@ Redis 스키마:
 from __future__ import annotations
 
 import logging
+import math
 import os
 import typing
 from typing import Callable, Optional, TypeVar
@@ -79,11 +80,13 @@ def _parse_bounded_env_number(
     특성상 int 로더는 `parser=int`, float 로더는 `parser=float`를 전달한다.
 
     동작 우선순위:
-      1) 미설정(None)   → 조용히 기본값 반환
-      2) 빈값/공백    → 운영자 오설정 의심 → WARNING + 기본값
-      3) 파싱 실패    → WARNING + 기본값
-      4) 범위 이탈    → Clamp + WARNING
-      5) 정상         → 파싱된 값 반환
+      1) 미설정(None)    → 조용히 기본값 반환
+      2) 빈값/공백     → 운영자 오설정 의심 → WARNING + 기본값
+      3) 파싱 실패     → WARNING + 기본값
+      4) NaN (float전용) → 유효하지 않은 값 → WARNING + 기본값
+         (NaN은 모든 비교에서 False를 반환하므로 Clamp을 바이패스함)
+      5) 범위 이탈     → Clamp + WARNING
+      6) 정상          → 파싱된 값 반환
     """
     raw = os.environ.get(env_key)
 
@@ -110,6 +113,16 @@ def _parse_bounded_env_number(
             "[TOPIC_CLUSTERING] %s 파싱 실패 (값=%r). 기본값 %r로 폴백합니다.",
             env_key,
             raw_stripped,
+            default,
+        )
+        return default
+
+    # 4) NaN 체크 (float 전용): NaN은 모든 비교에서 False를 반환해 Clamp을 바이패스함
+    #    int('NaN')은 ValueError로 위에서 이미 catch되므로 float에만 해당
+    if isinstance(value, float) and math.isnan(value):
+        logger.warning(
+            "[TOPIC_CLUSTERING] %s 값이 NaN입니다 (유효하지 않은 값). 기본값 %r로 폴백합니다.",
+            env_key,
             default,
         )
         return default


### PR DESCRIPTION
- **[float NaN 엣지케이스 방어]**
  - `import math` 추가
  - `_parse_bounded_env_number()`에 `math.isnan()` 체크 삽입 (단계 4)
  - float('NaN')은 모든 비교 연산에서 False를 반환하여 기존 Clamp 로직을 완전히 바이패스하는 실제 버그였음
  - NaN 감지 시 WARNING 로그 + 기본값 폴백 (파싱 실패와 동일 처리)
  - int('NaN')은 ValueError로 이미 처리되므로 float 전용 체크

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1193#pullrequestreview-4141866883)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

토픽 클러스터링을 위한 환경 변수 기반 숫자 구성 파싱에서 NaN 값을 처리하고, 범위 검사 우회를 허용하지 않고 안전한 기본값으로 되돌아가도록 합니다.

버그 수정:
- 환경 변수에 있는 부동소수 NaN 값이 범위 클램핑 로직을 우회하여 유효한 설정값으로 처리될 수 있던 버그를 수정합니다.

개선 사항:
- NaN 처리를 잘못된 값 사례로 명시적으로 포함하도록 환경 숫자 파싱의 우선순위 및 동작에 대한 문서를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle NaN values in environment-based numeric configuration parsing for topic clustering and ensure they fall back to safe defaults instead of bypassing range checks.

Bug Fixes:
- Fix a bug where float NaN values in environment variables could bypass range clamping logic and be treated as valid configuration.

Enhancements:
- Document the updated precedence and behavior of environment number parsing to explicitly cover NaN handling as an invalid value case.

</details>