### PR TITLE
☘️ refactor [#12.2.4]: 7차 개선 - 용어 수정 및 isinstance 가드 문서화

### DIFF
--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -80,13 +80,13 @@ def _parse_bounded_env_number(
     특성상 int 로더는 `parser=int`, float 로더는 `parser=float`를 전달한다.
 
     동작 우선순위:
-      1) 미설정(None)     → 조용히 기본값 반환
-      2) 빈값/공백      → 운영자 오설정 의심 → WARNING + 기본값
-      3) 파싱 실패      → WARNING + 기본값
-      4) 비유한 값 (float 전용) → NaN / ±inf 유효하지 않은 값 → WARNING + 기본값
-         (math.isfinite()로 NaN와 ±inf를 통합 차단)
-      5) 범위 이탈      → Clamp + WARNING
-      6) 정상           → 파싱된 값 반환
+      1) 미설정(None)      → 조용히 기본값 반환
+      2) 빈값/공백       → 운영자 오설정 의심 → WARNING + 기본값
+      3) 파싱 실패       → WARNING + 기본값
+      4) 비정상 부동소수점 (float 전용) → NaN·±inf 유효하지 않은 값 → WARNING + 기본값
+         (math.isfinite()로 NaN과 ±inf를 통합 차단, int는 TypeVar 제약으로 해당 없음)
+      5) 범위 이탈       → Clamp + WARNING
+      6) 정상            → 파싱된 값 반환
     """
     raw = os.environ.get(env_key)
 
@@ -117,13 +117,16 @@ def _parse_bounded_env_number(
         )
         return default
 
-    # 4) 비유한 값 체크 (float 전용): NaN과 ±inf는 명시적으로 무효 처리
-    #    - NaN: 모든 비교에서 False → Clamp 바이패스
-    #    - ±inf: 실제 운영 수치칠 수 없으므로 안전한 기본값으로 폴백
-    #    int('NaN')은 ValueError로 위에서 이미 catch되어 float에만 해당
+    # 4) 비정상 부동소수점 체크 (float 전용)
+    #    NaN과 ±inf는 운영 수치로 사용할 수 없는 바시 측 코드 오설정 활녀 의심
+    #    - NaN:  모든 비교에서 False → Clamp 바이패스 위험
+    #    - ±inf: 실제 운영 수치치 유효하지 않음
+    #    isinstance(value, float) 제약: _NumT = TypeVar("_NumT", int, float)로
+    #    이 헬퍼는 int 또는 float 전용으로 지정되어 있으며, int는 해당 없음
+    #    (Decimal 등 다른 숫자 타입은 TypeVar 확장 시 별도 검토 필요)
     if isinstance(value, float) and not math.isfinite(value):
         logger.warning(
-            "[TOPIC_CLUSTERING] %s 값이 비유한(NaN 또는 ±inf)입니다 (운영자 오설정 의심). "
+            "[TOPIC_CLUSTERING] %s 값이 비정상 부동소수점(NaN 또는 ±inf)입니다 (운영자 오설정 의심). "
             "기본값 %r로 폴백합니다.",
             env_key,
             default,

--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -84,7 +84,7 @@ def _parse_bounded_env_number(
       2) 빈값/공백       → 운영자 오설정 의심 → WARNING + 기본값
       3) 파싱 실패       → WARNING + 기본값
       4) 비정상 부동소수점 (float 전용) → NaN·±inf 유효하지 않은 값 → WARNING + 기본값
-         (math.isfinite()로 NaN과 ±inf를 통합 차단, int는 TypeVar 제약으로 해당 없음)
+         (이 헬퍼는 현재 int/float만 지원하며, int는 NaN/inf 자체가 불가하므로 해당 없음)
       5) 범위 이탈       → Clamp + WARNING
       6) 정상            → 파싱된 값 반환
     """
@@ -118,12 +118,11 @@ def _parse_bounded_env_number(
         return default
 
     # 4) 비정상 부동소수점 체크 (float 전용)
-    #    NaN과 ±inf는 운영 수치로 사용할 수 없는 바시 측 코드 오설정 활녀 의심
+    #    NaN과 ±inf는 운영 수치로 사용할 수 없는 값으로, 서비스 측 오설정이 의심됨
     #    - NaN:  모든 비교에서 False → Clamp 바이패스 위험
-    #    - ±inf: 실제 운영 수치치 유효하지 않음
-    #    isinstance(value, float) 제약: _NumT = TypeVar("_NumT", int, float)로
-    #    이 헬퍼는 int 또는 float 전용으로 지정되어 있으며, int는 해당 없음
-    #    (Decimal 등 다른 숫자 타입은 TypeVar 확장 시 별도 검토 필요)
+    #    - ±inf: 실제 운영 수치로 유효하지 않음
+    #    이 헬퍼는 현재 int/float만을 지원하며, 다른 수치 타입을 추가하려면
+    #    이 체크 블록도 함께 검토해야 한다 (int는 NaN/inf 불가하므로 해당 없음)
     if isinstance(value, float) and not math.isfinite(value):
         logger.warning(
             "[TOPIC_CLUSTERING] %s 값이 비정상 부동소수점(NaN 또는 ±inf)입니다 (운영자 오설정 의심). "


### PR DESCRIPTION
- **[용어 수정 (가독성/명확성)]**
  - `비유한` → `비정상 부동소수점(NaN·±inf)` 으로 교체
  - Docstring, 인라인 주석, WARNING 로그 메시지 일괄 반영

- **[isinstance 가드 의도 문서화]**
  - _NumT = TypeVar('_NumT', int, float) 제약으로 int/float 전용임을 명시
  - Decimal 등 타입 확장 시 TypeVar 수정 및 별도 검토 필요함을 주석으로 안내

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1195#pullrequestreview-4141945790)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

토픽 클러스터링 서비스에서 환경 번호 파싱과 관련된 용어를 명확히 하고, 타입 제약 사항에 대한 문서를 보완했습니다.

개선 사항:
- 주석과 경고 로그 전반에서 잘못된 부동소수점 값에 대한 표현을 더 명확하게 하기 위해, 해당 참조를 모두 '비정상 부동소수점(NaN·±inf)'로 변경했습니다.
- 제한된 환경 번호 파서가 부동소수점에만 적용된다는 점과, TypeVar를 기반으로 한 int/float 제약 조건을 문서화하고, 이를 다른 수치 타입으로 확장하는 방법에 대한 안내를 추가했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify terminology and document type constraints for environment number parsing in the topic clustering service.

Enhancements:
- Rename references to invalid float values to '비정상 부동소수점(NaN·±inf)' across comments and warning logs for better clarity.
- Document the float-only applicability and TypeVar-based int/float constraint of the bounded environment number parser, including guidance for extending to other numeric types.

</details>