### PR TITLE
☘️ refactor [#12.2.5]: 2차 개선 - `Fire-and-Forget` 전환 및 방어 로직 3종 강화

### DIFF
--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -8,6 +8,7 @@
 2. PARACategory Enum 및 DTO(HybridSearchResult) 도입으로 타입 안전성 강화
 """
 
+import asyncio
 import logging
 import re
 from dataclasses import dataclass
@@ -246,21 +247,27 @@ class HybridSearchService:
         if k < 1:
             raise ValueError(f"k must be greater than or equal to 1, got {k}")
 
-        # 0. 히스토리 로깅 (Best-effort)
+        # 0. 히스토리 로깅 (Best-effort, Fire-and-Forget)
         # PII 정책: user_id는 반드시 해싱(mask_pii_id)하여 전달한다.
-        # [리뷰반영] try/except로 격리하여 Redis 지연·오류가 검색 응답에 전파되지 않도록 보장한다.
+        # [리뷰반영] asyncio.create_task로 완전한 비동기 분리:
+        #   - await가 아니므로 Redis 지연이 검색 응답 시간에 전혀 영향을 주지 않음.
+        #   - Task 내부에서 예외를 처리하여 'Task exception was never retrieved' 경고를 방지.
         if user_info and "id" in user_info:
             user_id_raw = str(user_info["id"])
             hashed_user_id = mask_pii_id(user_id_raw, truncate_len=0)  # 전체 해시 확보
-            try:
-                await topic_clustering_service.log_search_query(hashed_user_id, query)
-            except Exception:  # noqa: BLE001
-                # 히스토리 로깅 실패는 검색 응답에 영향을 주지 않는다 (best-effort).
-                # 쿼리 원문은 PII 노출 위험이 있으므로 로그에 포함하지 않는다.
-                logger.warning(
-                    "[HYBRID_SEARCH] 검색 히스토리 로깅 실패 (검색 응답에는 영향 없음).",
-                    exc_info=True,
-                )
+
+            async def _log_history_task() -> None:
+                try:
+                    await topic_clustering_service.log_search_query(hashed_user_id, query)
+                except Exception:  # noqa: BLE001
+                    # 히스토리 로깅 실패는 검색 응답에 영향을 주지 않는다 (best-effort).
+                    # 쿼리 원문은 PII 노출 위험이 있으므로 로그에 포함하지 않는다.
+                    logger.warning(
+                        "[HYBRID_SEARCH] 검색 히스토리 로깅 실패 (검색 응답에는 영향 없음).",
+                        exc_info=True,
+                    )
+
+            asyncio.create_task(_log_history_task())
 
         # 1. PARA 카테고리 검증 및 필터 병합
         effective_filter = self._build_metadata_filter(category, metadata_filter)

--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -470,14 +470,14 @@ async def log_search_query(hashed_user_id: str, query: str) -> None:
     if not clean_query:
         return
 
-    await _ensure_redis_connected()
-    
+    # [리뷰반영] _ensure_redis_connected 중복 호출 제거:
+    # increment_rag_search_count 내부에서 이미 호출하므로 여기서는 불필요하다.
     # 2. 카운터 증가 (기존 로직 재사용)
     await increment_rag_search_count(hashed_user_id)
 
     # 3. 히스토리 리스트 추가
     history_key = _build_query_history_key(hashed_user_id)
-    
+
     try:
         # LPUSH(최신 쿼리가 맨 앞) + LTRIM(최대 길이 유지) 수행
         await redis_client.redis.lpush(history_key, clean_query)
@@ -499,8 +499,12 @@ async def vectorize_queries(queries: List[str]) -> List[List[float]]:
     run_in_threadpool로 래핑하여 asyncio 이벤트루프를 즉시 반환하고
     별도 스레드에서 임베딩 API 호출을 처리한다.
 
+    반환 정책 (보수적):
+    - 임베딩 수가 요청한 쿼리 수와 다르면 [] 반환 (쿼리-벡터 인덱스 불일치 방지)
+    - 부분 결과는 silent bug로 이어질 수 있으므로 전부 버린다.
+
     Returns:
-        임베딩 벡터 리스트 (성공 시 len(queries)와 동일한 길이)
+        임베딩 벡터 리스트 (성공 시 len(queries)와 동일한 길이, 실패 시 [])
     """
     if not queries:
         return []
@@ -509,7 +513,19 @@ async def vectorize_queries(queries: List[str]) -> List[List[float]]:
         generator = _get_embedding_generator()
         # [리뷰반영] 동기 메서드를 run_in_threadpool로 래핑 → 이벤트루프 비차단 보장
         result = await run_in_threadpool(generator.generate_embeddings, queries)
-        return result.get("embeddings", [])
+        embeddings = result.get("embeddings") or []
+
+        # [리뷰반영] 길이 검증: 부분 실패로 인한 쿼리-벡터 인덱스 불일치 방지
+        if len(embeddings) != len(queries):
+            logger.warning(
+                "[TOPIC_CLUSTERING] 벡터화 결과 길이 불일치 "
+                "(queries=%d, embeddings=%d). 부분 결과는 무시합니다.",
+                len(queries),
+                len(embeddings),
+            )
+            return []
+
+        return embeddings
     except Exception as exc:  # noqa: BLE001
         logger.error(
             "[TOPIC_CLUSTERING] 검색 히스토리 벡터화 실패 (count=%d). exc=%r",
@@ -522,18 +538,22 @@ async def vectorize_queries(queries: List[str]) -> List[List[float]]:
 async def get_search_history(hashed_user_id: str) -> List[str]:
     """
     사용자의 최근 검색어 히스토리를 반환한다. (최신순)
-    
+    Redis 연결 실패를 포함하여 모든 예외를 내부에서 처리하며,
+    오류 발생 시 빈 리스트를 반환한다 (best-effort).
+
     Returns:
         검색어 리스트 (비어있을 수 있음)
     """
-    await _ensure_redis_connected()
     history_key = _build_query_history_key(hashed_user_id)
-    
+
     try:
+        # [리뷰반영] _ensure_redis_connected를 try 블록 안으로 이동:
+        # 연결 오류 발생 시에도 docstring대로 빈 리스트를 반환한다.
+        await _ensure_redis_connected()
         raw_list = await redis_client.redis.lrange(history_key, 0, -1)
         if not raw_list:
             return []
-        
+
         # Redis 응답은 bytes일 수 있으므로 디코딩
         return [q.decode("utf-8") if isinstance(q, bytes) else str(q) for q in raw_list]
     except (RedisError, UnicodeDecodeError) as exc:

--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -500,6 +500,7 @@ async def vectorize_queries(queries: List[str]) -> List[List[float]]:
     별도 스레드에서 임베딩 API 호출을 처리한다.
 
     반환 정책 (보수적):
+    - generate_embeddings가 dict가 아니거나 None을 반환하면 [] 반환
     - 임베딩 수가 요청한 쿼리 수와 다르면 [] 반환 (쿼리-벡터 인덱스 불일치 방지)
     - 부분 결과는 silent bug로 이어질 수 있으므로 전부 버린다.
 
@@ -513,6 +514,17 @@ async def vectorize_queries(queries: List[str]) -> List[List[float]]:
         generator = _get_embedding_generator()
         # [리뷰반영] 동기 메서드를 run_in_threadpool로 래핑 → 이벤트루프 비차단 보장
         result = await run_in_threadpool(generator.generate_embeddings, queries)
+
+        # [리뷰반영] result 타입 검증:
+        # generate_embeddings가 예외 대신 None이나 비-dict를 반환할 경우 AttributeError를 예방한다.
+        if not isinstance(result, dict):
+            logger.warning(
+                "[TOPIC_CLUSTERING] generate_embeddings 반환값이 dict가 아닙니다 "
+                "(type=%s). 빈 리스트를 반환합니다.",
+                type(result).__name__,
+            )
+            return []
+
         embeddings = result.get("embeddings") or []
 
         # [리뷰반영] 길이 검증: 부분 실패로 인한 쿼리-벡터 인덱스 불일치 방지
@@ -541,6 +553,10 @@ async def get_search_history(hashed_user_id: str) -> List[str]:
     Redis 연결 실패를 포함하여 모든 예외를 내부에서 처리하며,
     오류 발생 시 빈 리스트를 반환한다 (best-effort).
 
+    [리뷰반영] except 범위를 Exception으로 확장하여 docstring과 동작을 일치시킨다.
+    RedisError · UnicodeDecodeError 외에도 OSError 등 예상치 못한 예외가 말 수 있으므로,
+    모두 빈 리스트로 폐백 처리한다.
+
     Returns:
         검색어 리스트 (비어있을 수 있음)
     """
@@ -556,7 +572,8 @@ async def get_search_history(hashed_user_id: str) -> List[str]:
 
         # Redis 응답은 bytes일 수 있으므로 디코딩
         return [q.decode("utf-8") if isinstance(q, bytes) else str(q) for q in raw_list]
-    except (RedisError, UnicodeDecodeError) as exc:
+    except Exception as exc:  # noqa: BLE001
+        # RedisError · UnicodeDecodeError 외의 예상치 못한 예외도 조용히 폐백한다.
         logger.warning(
             "[TOPIC_CLUSTERING] 검색 히스토리 조회 실패 (masked_uid=%s). exc=%r",
             mask_pii_id(hashed_user_id),


### PR DESCRIPTION
- **[Fix A]** `hybrid_search_service`: `asyncio.create_task`로 히스토리 로깅 완전 분리
  - `await` → `create_task` 전환으로 Redis 지연이 검색 응답에 영향 Zero
  - Task 내부 try/except로 `Task exception was never retrieved` 경고 방지
  - 쿼리 원문 로그 미포함 (PII 보호 정책 유지)

- **[Fix B]** `topic_clustering_service`: `get_search_history try` 범위 확장
  - `_ensure_redis_connected`를 `try` 블록 안으로 이동
  - 연결 실패 시에도 `docstring`대로 빈 리스트 반환 (일관성 확보)

- **[Fix C]** `topic_clustering_service`: `log_search_query` 중복 ping 제거
  - `increment_rag_search_count` 내부에서 이미 호출하므로 명시적 호출 제거
  - Redis 왕복 1회 절약

- **[Fix D]** `topic_clustering_service`: `vectorize_queries` 길이 검증 추가
  - 임베딩 수 != 쿼리 수일 때 WARNING 로그 후 [] 반환 (보수적 정책)
  - 부분 실패로 인한 쿼리-벡터 인덱스 불일치(silent bug) 사전 차단

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1199#pullrequestreview-4149364048)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

하이브리드 검색 응답에서 검색 기록 로깅을 분리하고, Redis 기반 토픽 클러스터링 로직을 강화하여 더 안전한 best-effort 동작을 보장합니다.

Bug Fixes:
- 문서화된 대로 Redis 연결 실패 시 `get_search_history`가 빈 리스트를 반환하도록 보장합니다.
- 부분적인 임베딩 결과를 거부하여, 쿼리와 임베딩 인덱스 간의 불일치를 조용히 넘어가는 문제를 방지합니다.

Enhancements:
- `hybrid_search_service`의 검색 기록 로깅을 fire-and-forget 방식의 백그라운드 작업으로 전환하여, Redis 지연 및 오류가 검색 지연 시간에 영향을 주지 않도록 합니다.
- 검색 쿼리를 로깅할 때 불필요한 왕복 호출을 줄이기 위해, 중복된 Redis 연결 체크를 제거합니다.
- `vectorize_queries`에 보수적인 길이 검증과 로깅을 추가하고, 개수가 일치하지 않는 경우 임베딩을 반환하지 않도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Decouple search history logging from hybrid search responses and harden Redis-based topic clustering logic for safer, best-effort behavior.

Bug Fixes:
- Ensure get_search_history returns an empty list on Redis connection failures as documented.
- Prevent silent query–embedding index mismatches by rejecting partial embedding results.

Enhancements:
- Convert search history logging in hybrid_search_service to a fire-and-forget background task so Redis latency and errors do not impact search latency.
- Remove redundant Redis connection checks when logging search queries to avoid unnecessary round trips.
- Add conservative length validation and logging to vectorize_queries, returning no embeddings when counts do not match.

</details>