### PR TITLE
☘️ fix [#12.2.5]: 8차 개선 - 백그라운드 태스크 타임아웃 환경변수화 및 예외 분리

### DIFF
--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -41,6 +41,7 @@ from backend.services.chat_history_service import (  # type: ignore[import]
 )
 from backend.services.redis_pubsub import redis_client  # type: ignore[import]
 from backend.utils import mask_pii_id  # type: ignore[import]
+from backend.utils.common import safe_parse_env_int  # type: ignore[import]
 
 logger = logging.getLogger(__name__)
 
@@ -919,10 +920,10 @@ async def run_negative_feedback_eval_pipeline(
 
 # [Step 2-3] 관리자 보고서용 Redis SCAN 상한 (요청당 최대 반복 횟수)
 # 환경변수 EVAL_REPORT_MAX_SCAN_ITERATIONS 로 조정 가능
-_EVAL_REPORT_MAX_SCAN_ITERATIONS = max(1, int(os.getenv("EVAL_REPORT_MAX_SCAN_ITERATIONS", "100")))
+_EVAL_REPORT_MAX_SCAN_ITERATIONS = max(1, safe_parse_env_int("EVAL_REPORT_MAX_SCAN_ITERATIONS", 100))
 
 # [Step 2-3] Redis SCAN 1회당 조회할 키 개수 (기본 500, 최소 1 이상 보장)
-_EVAL_REPORT_SCAN_BATCH_SIZE = max(1, int(os.getenv("EVAL_REPORT_SCAN_BATCH_SIZE", "500")))
+_EVAL_REPORT_SCAN_BATCH_SIZE = max(1, safe_parse_env_int("EVAL_REPORT_SCAN_BATCH_SIZE", 500))
 
 # [Step 2-3] 조사 제거 및 TF 계산을 위한 경량화된 한국어 불용어
 _KOREAN_STOPWORDS = {

--- a/backend/services/finetune_service.py
+++ b/backend/services/finetune_service.py
@@ -23,6 +23,7 @@ from openai import OpenAI, APIError, APIConnectionError
 from backend.config import ModelConfig  # type: ignore[import]
 from backend.services.redis_pubsub import redis_client  # type: ignore[import]
 from backend.utils import mask_pii_id  # type: ignore[import]
+from backend.utils.common import safe_parse_env_int
 from backend.utils.observability import ObsEvent, ObsMetaTag  # type: ignore[import]
 
 logger = logging.getLogger(__name__)
@@ -51,20 +52,14 @@ _FINETUNE_DATA_DIR: Path = Path(
     )
 )
 
-# Job 상태 폴링 간격(초) — 환경 변수로 오버라이드 가능
-_FINETUNE_POLL_INTERVAL_SECS: int = int(
-    os.getenv("FINETUNE_POLL_INTERVAL_SECS", "30")
-)
+# Job 상태 폴링 간격(초) — 환경 변수로 오버라이드 가능 (기본 30초, 최소 5초)
+_FINETUNE_POLL_INTERVAL_SECS: int = safe_parse_env_int("FINETUNE_POLL_INTERVAL_SECS", 30, min_val=5)
 
-# Job 완료 대기 최대 시간(초) — 기본 2시간 (환경 변수로 오버라이드 가능)
-_FINETUNE_POLL_TIMEOUT_SECS: int = int(
-    os.getenv("FINETUNE_POLL_TIMEOUT_SECS", str(2 * 60 * 60))
-)
+# Job 완료 대기 최대 시간(초) — 기본 2시간, 최소 600초 (환경 변수로 오버라이드 가능)
+_FINETUNE_POLL_TIMEOUT_SECS: int = safe_parse_env_int("FINETUNE_POLL_TIMEOUT_SECS", 2 * 60 * 60, min_val=600)
 
-# Redis에 Job 상태를 보관하는 TTL (기본 7일)
-_FINETUNE_REDIS_TTL_SECS: int = int(
-    os.getenv("FINETUNE_REDIS_TTL_SECS", str(7 * 24 * 60 * 60))
-)
+# Redis에 Job 상태를 보관하는 TTL (기본 7일, 최소 1일)
+_FINETUNE_REDIS_TTL_SECS: int = safe_parse_env_int("FINETUNE_REDIS_TTL_SECS", 7 * 24 * 60 * 60, min_val=86400)
 
 # 파인튜닝 Job 생성 시 사용할 기반 모델 (환경 변수로 오버라이드 가능)
 _FINETUNE_BASE_MODEL: str = os.getenv("FINETUNE_BASE_MODEL", "gpt-4o-mini-2024-07-18")

--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -22,13 +22,14 @@ from backend.hybrid_search import HybridSearcher, Retriever
 from backend.api.models import PARACategory
 from backend.services.search_cache_service import search_cache_service
 from backend.services import topic_clustering_service  # type: ignore[import]
-from backend.utils.common import mask_pii_id            # type: ignore[import]
+from backend.utils.common import mask_pii_id, safe_parse_env_float  # type: ignore[import]
 from fastapi.concurrency import run_in_threadpool
 
 logger = logging.getLogger(__name__)
 
 # [리뷰반영] 하드코딩 제거: 로깅 타임아웃을 환경 변수에서 가져오도록 설정 (기본값 3.0초)
-_LOG_SEARCH_HISTORY_TIMEOUT = float(os.getenv("SEARCH_HISTORY_LOG_TIMEOUT", "3.0"))
+# [리뷰반영] import 시점 크래시 방지: safe_parse_env_float 헬퍼를 사용하여 비정상 값 방어 및 0.1초 이상 강제
+_LOG_SEARCH_HISTORY_TIMEOUT = safe_parse_env_float("SEARCH_HISTORY_LOG_TIMEOUT", 3.0, min_val=0.1)
 
 
 async def _log_search_history_bg(hashed_user_id: str, query: str) -> None:

--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -10,6 +10,7 @@
 
 import asyncio
 import logging
+import os
 import re
 from dataclasses import dataclass
 from functools import lru_cache
@@ -26,6 +27,9 @@ from fastapi.concurrency import run_in_threadpool
 
 logger = logging.getLogger(__name__)
 
+# [리뷰반영] 하드코딩 제거: 로깅 타임아웃을 환경 변수에서 가져오도록 설정 (기본값 3.0초)
+_LOG_SEARCH_HISTORY_TIMEOUT = float(os.getenv("SEARCH_HISTORY_LOG_TIMEOUT", "3.0"))
+
 
 async def _log_search_history_bg(hashed_user_id: str, query: str) -> None:
     """
@@ -41,17 +45,25 @@ async def _log_search_history_bg(hashed_user_id: str, query: str) -> None:
     """
     try:
         # [리뷰반영] 백그라운드 태스크 무한 대기 방지:
-        # Redis 연결 지연이나 블로킹으로 인해 백그라운드 태스크가 쌓이는 것을 막기 위해 명시적 타임아웃 적용
+        # Redis 연결 지연이나 블로킹으로 인해 백그라운드 태스크가 쌓이는 것을 막기 위해 환경 변수로 설정 가능한 타임아웃 적용
         await asyncio.wait_for(
             topic_clustering_service.log_search_query(hashed_user_id, query),
-            timeout=3.0,
+            timeout=_LOG_SEARCH_HISTORY_TIMEOUT,
+        )
+    except asyncio.TimeoutError:
+        # [리뷰반영] TimeoutError 분리:
+        # 일시적인 지연(latency) 문제와 기능적 오류를 분리하여 장애 원인 분석의 정확도 향상
+        logger.warning(
+            "[HYBRID_SEARCH] 검색 히스토리 로깅 시간 초과 (timeout=%.1fs, hashed_user_id=%s).",
+            _LOG_SEARCH_HISTORY_TIMEOUT,
+            hashed_user_id,
         )
     except Exception:  # noqa: BLE001
         # 히스토리 로깅 실패는 검색 응답에 영향을 주지 않는다 (best-effort).
         # 쿼리 원문은 PII 노출 위험이 있으므로 로그에 포함하지 않는다.
         # [리뷰반영] PII 정책: 비-PII 식별자인 hashed_user_id를 로그에 포함하여 장애 연관성 추적 강화
         logger.warning(
-            "[HYBRID_SEARCH] 검색 히스토리 로깅 실패 (검색 응답에는 영향 없음, hashed_user_id=%s).",
+            "[HYBRID_SEARCH] 검색 히스토리 로깅 실패 (기능적 오류, 검색 응답에는 영향 없음, hashed_user_id=%s).",
             hashed_user_id,
             exc_info=True,
         )

--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -7,23 +7,89 @@ FlowNote MVP - 유틸리티 함수
 """
 
 import os
+import logging
 import tiktoken  # type: ignore[import]
 from pathlib import Path
 from typing import Optional, Dict, Any, List, Union
 from datetime import datetime
 import hashlib
 
+logger = logging.getLogger(__name__)
+
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━
-# 💙 새로 추가하는 함수들
+# 새로 추가하는 함수들
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 INVALID_PII_SENTINEL = "<INVALID_PII>"
 
+
+def safe_parse_env_int(
+    env_var_name: str, default: int, min_val: Optional[int] = None
+) -> int:
+    """환경 변수를 int로 안전하게 파싱합니다. 실패 시 로그를 남기고 기본값을 반환합니다."""
+    val = os.getenv(env_var_name)
+    if val is None:
+        return default
+    try:
+        parsed = int(val)
+        if min_val is not None and parsed < min_val:
+            logger.warning(
+                "[%s] 환경 변수 '%s'의 값(%s)은 최소 %s 이상이어야 합니다. 기본값 %s을(를) 사용합니다.",
+                __name__,
+                env_var_name,
+                val,
+                min_val,
+                default,
+            )
+            return default
+        return parsed
+    except ValueError:
+        logger.warning(
+            "[%s] 환경 변수 '%s'의 값(%s)을 int로 파싱할 수 없습니다. 기본값 %s을(를) 사용합니다.",
+            __name__,
+            env_var_name,
+            val,
+            default,
+        )
+        return default
+
+
+def safe_parse_env_float(
+    env_var_name: str, default: float, min_val: Optional[float] = None
+) -> float:
+    """환경 변수를 float으로 안전하게 파싱합니다. 실패 시 로그를 남기고 기본값을 반환합니다."""
+    val = os.getenv(env_var_name)
+    if val is None:
+        return default
+    try:
+        parsed = float(val)
+        if min_val is not None and parsed < min_val:
+            logger.warning(
+                "[%s] 환경 변수 '%s'의 값(%s)은 최소 %s 이상이어야 합니다. 기본값 %s을(를) 사용합니다.",
+                __name__,
+                env_var_name,
+                val,
+                min_val,
+                default,
+            )
+            return default
+        return parsed
+    except ValueError:
+        logger.warning(
+            "[%s] 환경 변수 '%s'의 값(%s)을 float으로 파싱할 수 없습니다. 기본값 %s을(를) 사용합니다.",
+            __name__,
+            env_var_name,
+            val,
+            default,
+        )
+        return default
+
+
 def mask_pii_id(value: Optional[str], truncate_len: int = 12) -> str:
     """
-    민감 문자열(user_id, session_id 등)을 SHA-256 해시화하여 
+    민감 문자열(user_id, session_id 등)을 SHA-256 해시화하여
     로그에 안전하게 기록하기 위한 중앙 유틸리티.
-    
+
     Args:
         value: 마스킹할 원본 문자열
         truncate_len: 반환할 해시 문자열의 최대 길이
@@ -33,11 +99,11 @@ def mask_pii_id(value: Optional[str], truncate_len: int = 12) -> str:
     """
     if not value or not isinstance(value, str):
         return INVALID_PII_SENTINEL
-    
+
     # [Security Validation] 음수 방어(Safe Wrapper)
     safe_len = max(0, truncate_len)
-    
-    hashed = str(hashlib.sha256(value.encode('utf-8')).hexdigest())
+
+    hashed = str(hashlib.sha256(value.encode("utf-8")).hexdigest())
     if safe_len > 0:
         return hashed[:safe_len]  # type: ignore[index]
     return hashed


### PR DESCRIPTION
- **[Fix 1]** 타임아웃 예외(asyncio.TimeoutError) 분리 로깅
  - 일시적인 네트워크/Redis 지연(Latency) 문제와 실제 기능적 오류(Exception)를 분리하여 로깅함으로써, 추후 에러 원인 분석의 정확도 및 가시성 대폭 향상

- **[Fix 2]** 타임아웃 하드코딩 제거 (설정 주입)
  - `_log_search_history_bg` 내부의 3.0초 하드코딩을 제거하고 `SEARCH_HISTORY_LOG_TIMEOUT` 환경 변수를 통해 배포 환경에 맞게 튜닝 가능하도록 유연성 확보

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1205#pullrequestreview-4155287104)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

백그라운드 검색 기록 로깅 타임아웃을 설정 가능하도록 만들고, 타임아웃과 기능적 실패를 구분해 오류 로그의 명확성을 개선합니다.

버그 수정:
- 하이브리드 검색 백그라운드 작업에서 검색 기록을 로깅할 때, 진단 향상을 위해 asyncio 타임아웃 처리를 다른 예외 처리와 분리합니다.

개선 사항:
- 백그라운드 검색 기록 로깅에 사용되던 하드코딩된 3초 타임아웃을, 환경 변수로 설정 가능한 타임아웃 값으로 대체합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make background search history logging timeout configurable and improve error logging clarity for timeouts versus functional failures.

Bug Fixes:
- Separate asyncio timeout handling from other exceptions when logging search history in the hybrid search background task to improve diagnostics.

Enhancements:
- Replace hardcoded 3-second timeout for background search history logging with an environment-configurable timeout value.

</details>