### PR TITLE
☘️ fix [#12.2.5]: 9차 개선 - 환경변수 안전 파싱 헬퍼 도입 및 Import-time 크래시 일괄 방지

### DIFF
--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -920,10 +920,10 @@ async def run_negative_feedback_eval_pipeline(
 
 # [Step 2-3] 관리자 보고서용 Redis SCAN 상한 (요청당 최대 반복 횟수)
 # 환경변수 EVAL_REPORT_MAX_SCAN_ITERATIONS 로 조정 가능
-_EVAL_REPORT_MAX_SCAN_ITERATIONS = max(1, safe_parse_env_int("EVAL_REPORT_MAX_SCAN_ITERATIONS", 100))
+_EVAL_REPORT_MAX_SCAN_ITERATIONS = safe_parse_env_int("EVAL_REPORT_MAX_SCAN_ITERATIONS", 100, min_val=1)
 
 # [Step 2-3] Redis SCAN 1회당 조회할 키 개수 (기본 500, 최소 1 이상 보장)
-_EVAL_REPORT_SCAN_BATCH_SIZE = max(1, safe_parse_env_int("EVAL_REPORT_SCAN_BATCH_SIZE", 500))
+_EVAL_REPORT_SCAN_BATCH_SIZE = safe_parse_env_int("EVAL_REPORT_SCAN_BATCH_SIZE", 500, min_val=1)
 
 # [Step 2-3] 조사 제거 및 TF 계산을 위한 경량화된 한국어 불용어
 _KOREAN_STOPWORDS = {

--- a/backend/services/eval_service.py
+++ b/backend/services/eval_service.py
@@ -41,6 +41,7 @@ from backend.services.chat_history_service import (  # type: ignore[import]
 )
 from backend.services.redis_pubsub import redis_client  # type: ignore[import]
 from backend.utils import mask_pii_id  # type: ignore[import]
+from backend.utils.common import safe_parse_env_int  # type: ignore[import]
 
 logger = logging.getLogger(__name__)
 
@@ -919,10 +920,10 @@ async def run_negative_feedback_eval_pipeline(
 
 # [Step 2-3] 관리자 보고서용 Redis SCAN 상한 (요청당 최대 반복 횟수)
 # 환경변수 EVAL_REPORT_MAX_SCAN_ITERATIONS 로 조정 가능
-_EVAL_REPORT_MAX_SCAN_ITERATIONS = max(1, int(os.getenv("EVAL_REPORT_MAX_SCAN_ITERATIONS", "100")))
+_EVAL_REPORT_MAX_SCAN_ITERATIONS = max(1, safe_parse_env_int("EVAL_REPORT_MAX_SCAN_ITERATIONS", 100))
 
 # [Step 2-3] Redis SCAN 1회당 조회할 키 개수 (기본 500, 최소 1 이상 보장)
-_EVAL_REPORT_SCAN_BATCH_SIZE = max(1, int(os.getenv("EVAL_REPORT_SCAN_BATCH_SIZE", "500")))
+_EVAL_REPORT_SCAN_BATCH_SIZE = max(1, safe_parse_env_int("EVAL_REPORT_SCAN_BATCH_SIZE", 500))
 
 # [Step 2-3] 조사 제거 및 TF 계산을 위한 경량화된 한국어 불용어
 _KOREAN_STOPWORDS = {

--- a/backend/services/finetune_service.py
+++ b/backend/services/finetune_service.py
@@ -23,6 +23,7 @@ from openai import OpenAI, APIError, APIConnectionError
 from backend.config import ModelConfig  # type: ignore[import]
 from backend.services.redis_pubsub import redis_client  # type: ignore[import]
 from backend.utils import mask_pii_id  # type: ignore[import]
+from backend.utils.common import safe_parse_env_int
 from backend.utils.observability import ObsEvent, ObsMetaTag  # type: ignore[import]
 
 logger = logging.getLogger(__name__)
@@ -51,20 +52,14 @@ _FINETUNE_DATA_DIR: Path = Path(
     )
 )
 
-# Job 상태 폴링 간격(초) — 환경 변수로 오버라이드 가능
-_FINETUNE_POLL_INTERVAL_SECS: int = int(
-    os.getenv("FINETUNE_POLL_INTERVAL_SECS", "30")
-)
+# Job 상태 폴링 간격(초) — 환경 변수로 오버라이드 가능 (기본 30초, 최소 5초)
+_FINETUNE_POLL_INTERVAL_SECS: int = safe_parse_env_int("FINETUNE_POLL_INTERVAL_SECS", 30, min_val=5)
 
-# Job 완료 대기 최대 시간(초) — 기본 2시간 (환경 변수로 오버라이드 가능)
-_FINETUNE_POLL_TIMEOUT_SECS: int = int(
-    os.getenv("FINETUNE_POLL_TIMEOUT_SECS", str(2 * 60 * 60))
-)
+# Job 완료 대기 최대 시간(초) — 기본 2시간, 최소 600초 (환경 변수로 오버라이드 가능)
+_FINETUNE_POLL_TIMEOUT_SECS: int = safe_parse_env_int("FINETUNE_POLL_TIMEOUT_SECS", 2 * 60 * 60, min_val=600)
 
-# Redis에 Job 상태를 보관하는 TTL (기본 7일)
-_FINETUNE_REDIS_TTL_SECS: int = int(
-    os.getenv("FINETUNE_REDIS_TTL_SECS", str(7 * 24 * 60 * 60))
-)
+# Redis에 Job 상태를 보관하는 TTL (기본 7일, 최소 1일)
+_FINETUNE_REDIS_TTL_SECS: int = safe_parse_env_int("FINETUNE_REDIS_TTL_SECS", 7 * 24 * 60 * 60, min_val=86400)
 
 # 파인튜닝 Job 생성 시 사용할 기반 모델 (환경 변수로 오버라이드 가능)
 _FINETUNE_BASE_MODEL: str = os.getenv("FINETUNE_BASE_MODEL", "gpt-4o-mini-2024-07-18")

--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -22,13 +22,14 @@ from backend.hybrid_search import HybridSearcher, Retriever
 from backend.api.models import PARACategory
 from backend.services.search_cache_service import search_cache_service
 from backend.services import topic_clustering_service  # type: ignore[import]
-from backend.utils.common import mask_pii_id            # type: ignore[import]
+from backend.utils.common import mask_pii_id, safe_parse_env_float  # type: ignore[import]
 from fastapi.concurrency import run_in_threadpool
 
 logger = logging.getLogger(__name__)
 
 # [리뷰반영] 하드코딩 제거: 로깅 타임아웃을 환경 변수에서 가져오도록 설정 (기본값 3.0초)
-_LOG_SEARCH_HISTORY_TIMEOUT = float(os.getenv("SEARCH_HISTORY_LOG_TIMEOUT", "3.0"))
+# [리뷰반영] import 시점 크래시 방지: safe_parse_env_float 헬퍼를 사용하여 비정상 값 방어 및 0.1초 이상 강제
+_LOG_SEARCH_HISTORY_TIMEOUT = safe_parse_env_float("SEARCH_HISTORY_LOG_TIMEOUT", 3.0, min_val=0.1)
 
 
 async def _log_search_history_bg(hashed_user_id: str, query: str) -> None:

--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -7,23 +7,89 @@ FlowNote MVP - 유틸리티 함수
 """
 
 import os
+import logging
 import tiktoken  # type: ignore[import]
 from pathlib import Path
 from typing import Optional, Dict, Any, List, Union
 from datetime import datetime
 import hashlib
 
+logger = logging.getLogger(__name__)
+
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━
-# 💙 새로 추가하는 함수들
+# 새로 추가하는 함수들
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 INVALID_PII_SENTINEL = "<INVALID_PII>"
 
+
+def safe_parse_env_int(
+    env_var_name: str, default: int, min_val: Optional[int] = None
+) -> int:
+    """환경 변수를 int로 안전하게 파싱합니다. 실패 시 로그를 남기고 기본값을 반환합니다."""
+    val = os.getenv(env_var_name)
+    if val is None:
+        return default
+    try:
+        parsed = int(val)
+        if min_val is not None and parsed < min_val:
+            logger.warning(
+                "[%s] 환경 변수 '%s'의 값(%s)은 최소 %s 이상이어야 합니다. 기본값 %s을(를) 사용합니다.",
+                __name__,
+                env_var_name,
+                val,
+                min_val,
+                default,
+            )
+            return default
+        return parsed
+    except ValueError:
+        logger.warning(
+            "[%s] 환경 변수 '%s'의 값(%s)을 int로 파싱할 수 없습니다. 기본값 %s을(를) 사용합니다.",
+            __name__,
+            env_var_name,
+            val,
+            default,
+        )
+        return default
+
+
+def safe_parse_env_float(
+    env_var_name: str, default: float, min_val: Optional[float] = None
+) -> float:
+    """환경 변수를 float으로 안전하게 파싱합니다. 실패 시 로그를 남기고 기본값을 반환합니다."""
+    val = os.getenv(env_var_name)
+    if val is None:
+        return default
+    try:
+        parsed = float(val)
+        if min_val is not None and parsed < min_val:
+            logger.warning(
+                "[%s] 환경 변수 '%s'의 값(%s)은 최소 %s 이상이어야 합니다. 기본값 %s을(를) 사용합니다.",
+                __name__,
+                env_var_name,
+                val,
+                min_val,
+                default,
+            )
+            return default
+        return parsed
+    except ValueError:
+        logger.warning(
+            "[%s] 환경 변수 '%s'의 값(%s)을 float으로 파싱할 수 없습니다. 기본값 %s을(를) 사용합니다.",
+            __name__,
+            env_var_name,
+            val,
+            default,
+        )
+        return default
+
+
 def mask_pii_id(value: Optional[str], truncate_len: int = 12) -> str:
     """
-    민감 문자열(user_id, session_id 등)을 SHA-256 해시화하여 
+    민감 문자열(user_id, session_id 등)을 SHA-256 해시화하여
     로그에 안전하게 기록하기 위한 중앙 유틸리티.
-    
+
     Args:
         value: 마스킹할 원본 문자열
         truncate_len: 반환할 해시 문자열의 최대 길이
@@ -33,11 +99,11 @@ def mask_pii_id(value: Optional[str], truncate_len: int = 12) -> str:
     """
     if not value or not isinstance(value, str):
         return INVALID_PII_SENTINEL
-    
+
     # [Security Validation] 음수 방어(Safe Wrapper)
     safe_len = max(0, truncate_len)
-    
-    hashed = str(hashlib.sha256(value.encode('utf-8')).hexdigest())
+
+    hashed = str(hashlib.sha256(value.encode("utf-8")).hexdigest())
     if safe_len > 0:
         return hashed[:safe_len]  # type: ignore[index]
     return hashed

--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -34,8 +34,7 @@ def safe_parse_env_int(
         parsed = int(val)
         if min_val is not None and parsed < min_val:
             logger.warning(
-                "[%s] 환경 변수 '%s'의 값(%s)은 최소 %s 이상이어야 합니다. 기본값 %s을(를) 사용합니다.",
-                __name__,
+                "환경 변수 '%s'의 값(%s)은 최소 %s 이상이어야 합니다. 기본값 %s을(를) 사용합니다.",
                 env_var_name,
                 val,
                 min_val,
@@ -45,8 +44,7 @@ def safe_parse_env_int(
         return parsed
     except ValueError:
         logger.warning(
-            "[%s] 환경 변수 '%s'의 값(%s)을 int로 파싱할 수 없습니다. 기본값 %s을(를) 사용합니다.",
-            __name__,
+            "환경 변수 '%s'의 값(%s)을 int로 파싱할 수 없습니다. 기본값 %s을(를) 사용합니다.",
             env_var_name,
             val,
             default,
@@ -65,8 +63,7 @@ def safe_parse_env_float(
         parsed = float(val)
         if min_val is not None and parsed < min_val:
             logger.warning(
-                "[%s] 환경 변수 '%s'의 값(%s)은 최소 %s 이상이어야 합니다. 기본값 %s을(를) 사용합니다.",
-                __name__,
+                "환경 변수 '%s'의 값(%s)은 최소 %s 이상이어야 합니다. 기본값 %s을(를) 사용합니다.",
                 env_var_name,
                 val,
                 min_val,
@@ -76,8 +73,7 @@ def safe_parse_env_float(
         return parsed
     except ValueError:
         logger.warning(
-            "[%s] 환경 변수 '%s'의 값(%s)을 float으로 파싱할 수 없습니다. 기본값 %s을(를) 사용합니다.",
-            __name__,
+            "환경 변수 '%s'의 값(%s)을 float으로 파싱할 수 없습니다. 기본값 %s을(를) 사용합니다.",
             env_var_name,
             val,
             default,


### PR DESCRIPTION
- [Fix 1] 환경변수 파싱용 공통 헬퍼 추가 (Global Validation Policy)
  - backend/utils/common.py에 safe_parse_env_int, safe_parse_env_float 신설
  - 잘못된 값(문자열 등) 주입 시 ValueError를 던져 앱 전체가 죽는(Import-time Crash) 대신, 기본값으로 우아하게 Fallback하고 Warning 로그만 남기도록 개선
  - min_val 바운더리 체크 기능 내장

- [Fix 2] 하이브리드 검색, 평가, 파인튜닝 서비스 일괄 적용
  - hybrid_search_service.py (SEARCH_HISTORY_LOG_TIMEOUT)
  - eval_service.py (EVAL_REPORT_MAX_SCAN_ITERATIONS 등)
  - finetune_service.py (FINETUNE_POLL_INTERVAL_SECS 등)
  - 모두 모듈 레벨에서 int() / float() 직접 호출하던 것을 제거하고 헬퍼로 교체

🔗 Related: Issue [#1046], [#1045]

🔗 PR Review: https://github.com/jjaayy2222/flownote-mvp/pull/1206

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

잘못된 설정으로 인해 발생하는 임포트 시점 크래시를 방지하기 위해, 숫자 환경 변수를 안전하게 파싱하는 헬퍼를 도입하고 이를 각 서비스에 적용합니다.

버그 수정:
- 잘못된 정수 또는 실수 환경 변수 값으로 인해 발생하는 임포트 시점 크래시를, 로깅과 함께 안전한 기본값으로 대체하여 방지합니다.

개선 사항:
- 최소값(옵션)과 잘못된 값에 대한 경고 로그를 지원하는, `int` 및 `float` 환경 변수를 안전하게 파싱하는 공용 헬퍼를 추가합니다.
- 새로운 안전 파싱 헬퍼를 파인튜닝, 평가, 하이브리드 검색 서비스에 적용하여, 타임아웃, TTL, 반복 횟수 제한에 대해 합리적인 최소값을 강제합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce safe helpers for parsing numeric environment variables and apply them across services to prevent import-time crashes from invalid configuration.

Bug Fixes:
- Prevent import-time crashes caused by invalid integer or float environment variable values by falling back to safe defaults with logging.

Enhancements:
- Add shared helpers for safely parsing int and float environment variables with optional minimum bounds and warning logs on invalid values.
- Apply the new safe parsing helpers to fine-tuning, evaluation, and hybrid search services to enforce sane minimums for timeouts, TTLs, and iteration limits.

</details>