### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -282,9 +282,13 @@ def _load_sil_sample_size() -> int:
 
 # 모듈 로드 시 1회 계산
 _SILHOUETTE_SAMPLE_SIZE: int = _load_sil_sample_size()
-
 # ML 재현성(Idempotency) 보장을 위한 전역 시드 상수
 _ML_RANDOM_STATE: int = 42
+
+# 클러스터링 알고리즘 하이퍼파라미터 (SSOT)
+_MIN_SAMPLES_FOR_CLUSTERING: int = 3
+_MAX_CLUSTERS_LIMIT: int = 10
+_INERTIA_FLATTEN_THRESHOLD: float = 0.05
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -730,12 +734,12 @@ def _create_kmeans(n_clusters: int) -> KMeans:
     return KMeans(n_clusters=n_clusters, random_state=_ML_RANDOM_STATE, n_init="auto")
 
 
-def _determine_optimal_k(embeddings: np.ndarray, max_k: int = 5) -> int:
+def _determine_optimal_k(embeddings: np.ndarray, max_k: int = _MAX_CLUSTERS_LIMIT) -> int:
     """
     엘보우 메서드(1차)와 실루엣 계수(2차)를 활용하여 최적의 K(클러스터 수)를 결정한다.
     """
     n_samples = embeddings.shape[0]
-    if n_samples <= 3:
+    if n_samples < _MIN_SAMPLES_FOR_CLUSTERING:
         return 1 if n_samples > 0 else 0
 
     limit_k = min(n_samples - 1, max_k)
@@ -744,12 +748,15 @@ def _determine_optimal_k(embeddings: np.ndarray, max_k: int = 5) -> int:
 
     inertias = []
     sil_scores = []
-    k_range = list(range(2, limit_k + 1))
+    actual_k_range = []
 
-    for k in k_range:
+    for k in range(2, limit_k + 1):
         kmeans = _create_kmeans(k)
         labels = kmeans.fit_predict(embeddings)
-        inertias.append(float(kmeans.inertia_))
+        current_inertia = float(kmeans.inertia_)
+        
+        inertias.append(current_inertia)
+        actual_k_range.append(k)
 
         # [리뷰반영] 모든 샘플이 동일한 클러스터로 할당되는 붕괴 현상 방어
         # silhouette_score는 고유 라벨이 2개 이상일 때만 동작하므로,
@@ -769,13 +776,23 @@ def _determine_optimal_k(embeddings: np.ndarray, max_k: int = 5) -> int:
             )
         else:
             sil_scores.append(-1.0)
+            
+        # [리뷰반영] 관성(Inertia) 평탄화 시 Short-circuit
+        # 비용이 큰 실루엣 연산을 줄이기 위해, Inertia 감소율이 5% 미만이면 탐색을 조기 종료한다.
+        if len(inertias) >= 2:
+            prev_inertia = inertias[-2]
+            if prev_inertia > 0:
+                improvement = (prev_inertia - current_inertia) / prev_inertia
+                if improvement < _INERTIA_FLATTEN_THRESHOLD:
+                    logger.debug("[TOPIC_CLUSTERING] Inertia flattened at k=%d, short-circuiting.", k)
+                    break
 
-    elbow_k = _find_elbow_point(inertias, k_range)
+    elbow_k = _find_elbow_point(inertias, actual_k_range)
     best_sil_idx = int(np.argmax(sil_scores))
-    best_sil_k = k_range[best_sil_idx]
+    best_sil_k = actual_k_range[best_sil_idx]
 
     # 1차 엘보우를 기본으로 하되, 실루엣 점수가 현저히 좋은 K가 있다면 그걸 채택
-    elbow_idx = k_range.index(elbow_k)
+    elbow_idx = actual_k_range.index(elbow_k)
 
     # [리뷰반영] 0.1 하드코딩 제거 (환경 변수 상수 참조)
     if (
@@ -854,13 +871,13 @@ async def cluster_user_topics(hashed_user_id: str) -> List[Dict[str, Any]]:
         embeddings = np.array(embeddings_list)
         n_samples = embeddings.shape[0]
 
-        if n_samples < 3:
-            # [리뷰반영] 쿼리가 1~2개로 매우 적은 경우 클러스터링 알고리즘의 실익이 없으므로,
+        if n_samples < _MIN_SAMPLES_FOR_CLUSTERING:
+            # [리뷰반영] 쿼리가 매우 적은 경우 클러스터링 알고리즘의 실익이 없으므로,
             # 첫 번째 쿼리(가장 최근 검색어)를 해당 사용자의 대표(canonical) 토픽으로 간주한다.
             return [{"label": history[0], "weight": 1.0, "size": n_samples}]
 
-        # 최대 클러스터 개수는 샘플 수에 비례하되 최대 10개로 제한
-        optimal_k = _determine_optimal_k(embeddings, max_k=min(10, n_samples - 1))
+        # 최대 클러스터 개수는 샘플 수에 비례하되 전역 상한으로 제한
+        optimal_k = _determine_optimal_k(embeddings, max_k=min(_MAX_CLUSTERS_LIMIT, n_samples - 1))
 
         # [리뷰반영] 공통 팩토리 헬퍼를 사용하여 KMeans 초기화 (매직넘버 제거)
         kmeans = _create_kmeans(optimal_k)

--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -289,6 +289,8 @@ _ML_RANDOM_STATE: int = 42
 _MIN_SAMPLES_FOR_CLUSTERING: int = 3
 _MAX_CLUSTERS_LIMIT: int = 10
 _INERTIA_FLATTEN_THRESHOLD: float = 0.05
+_MIN_K_FOR_INERTIA_FLATTEN: int = 3
+_MIN_FLATTEN_CONSECUTIVE_STEPS: int = 2
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -749,6 +751,7 @@ def _determine_optimal_k(embeddings: np.ndarray, max_k: int = _MAX_CLUSTERS_LIMI
     inertias = []
     sil_scores = []
     actual_k_range = []
+    inertia_flatten_count = 0
 
     for k in range(2, limit_k + 1):
         kmeans = _create_kmeans(k)
@@ -777,14 +780,25 @@ def _determine_optimal_k(embeddings: np.ndarray, max_k: int = _MAX_CLUSTERS_LIMI
         else:
             sil_scores.append(-1.0)
             
-        # [리뷰반영] 관성(Inertia) 평탄화 시 Short-circuit
-        # 비용이 큰 실루엣 연산을 줄이기 위해, Inertia 감소율이 5% 미만이면 탐색을 조기 종료한다.
-        if len(inertias) >= 2:
+        # [리뷰반영] 관성(Inertia) 평탄화 시 조기 종료 (Early Stopping)
+        # 비용이 큰 실루엣 연산을 줄이기 위해, Inertia 감소율이 5% 미만인 상태가
+        # 일정 k 이상에서 연속적으로 관찰되면 탐색을 조기 종료한다.
+        if len(inertias) >= _MIN_K_FOR_INERTIA_FLATTEN:
             prev_inertia = inertias[-2]
             if prev_inertia > 0:
                 improvement = (prev_inertia - current_inertia) / prev_inertia
+
                 if improvement < _INERTIA_FLATTEN_THRESHOLD:
-                    logger.debug("[TOPIC_CLUSTERING] Inertia flattened at k=%d, short-circuiting.", k)
+                    inertia_flatten_count += 1
+                else:
+                    inertia_flatten_count = 0
+
+                if inertia_flatten_count >= _MIN_FLATTEN_CONSECUTIVE_STEPS:
+                    logger.debug(
+                        "[TOPIC_CLUSTERING] Inertia flattened at k=%d over %d consecutive steps, short-circuiting.",
+                        k,
+                        inertia_flatten_count,
+                    )
                     break
 
     elbow_k = _find_elbow_point(inertias, actual_k_range)


### PR DESCRIPTION
☘️ refactor [#12.2.6]: 4차 개선 - 클러스터링 상수 추출 및 Short-circuit 알고리즘 도입 
☘️ refactor [#12.2.6]: 5차 개선 - 관성(Inertia) 기반 조기 종료(Early Stopping) 로직 견고화

## Summary by Sourcery

토픽 클러스터링을 개선하여 하이퍼파라미터를 중앙집중화하고, 최적 클러스터 수를 결정하기 위한 관성(inertia) 기반 조기 종료 휴리스틱을 도입합니다.

개선 사항:
- 클러스터링 관련 상수들을 모듈 수준 설정으로 분리하여 재사용성과 단일 진실 공급원(single source of truth)을 확보합니다.
- 매우 작은 쿼리 집합의 경우 클러스터링을 우회하고 가장 최근 쿼리를 기준 토픽으로 사용하도록 최소 샘플 처리 기준을 더욱 엄격하게 조정합니다.
- 관성 향상이 연속된 단계에서 평탄해질 때 탐색을 조기에 종료하여 실루엣(silhouette) 계산을 줄이도록 K 선택을 최적화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine topic clustering to centralize hyperparameters and introduce an inertia-based early-stopping heuristic for determining the optimal number of clusters.

Enhancements:
- Extract clustering-related constants into module-level configuration for reuse and single source of truth.
- Tighten minimum sample handling so very small query sets bypass clustering and use the most recent query as the canonical topic.
- Optimize K selection by short-circuiting the search when inertia improvements flatten over consecutive steps to reduce silhouette computations.

</details>