### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -764,21 +764,16 @@ def _compute_silhouette_safe(
 
 def _update_inertia_flatten_state(
     inertias: List[float],
-    current_inertia: float,
-    current_k: int,
     flatten_count: int,
 ) -> typing.Tuple[int, bool]:
     """
     [리뷰반영] 관성 평탄화 검사 로직을 순수 헬퍼 함수로 추출.
     """
-    if not inertias:
-        return flatten_count, False
+    if len(inertias) < _MIN_K_FOR_INERTIA_FLATTEN:
+        return 0, False
 
-    prev_inertia = inertias[-1]
-
-    # [리뷰반영] 조기 종료의 신뢰도를 보장하기 위해 데이터(배열 길이) 기반 가드 복원
-    # inertias는 아직 현재 관성이 추가되지 않은 과거 상태이므로 길이에 1을 더해 검사
-    if (len(inertias) + 1) < _MIN_K_FOR_INERTIA_FLATTEN or prev_inertia <= 0:
+    prev_inertia, current_inertia = inertias[-2], inertias[-1]
+    if prev_inertia <= 0:
         return 0, False
 
     improvement = (prev_inertia - current_inertia) / prev_inertia
@@ -788,15 +783,16 @@ def _update_inertia_flatten_state(
     else:
         flatten_count = 0
 
-    if flatten_count >= _MIN_FLATTEN_CONSECUTIVE_STEPS:
+    should_stop = flatten_count >= _MIN_FLATTEN_CONSECUTIVE_STEPS
+    if should_stop:
+        current_k = 2 + (len(inertias) - 1)
         logger.debug(
             "[TOPIC_CLUSTERING] Inertia flattened at k=%d over %d consecutive steps, short-circuiting.",
             current_k,
             flatten_count,
         )
-        return flatten_count, True
 
-    return flatten_count, False
+    return flatten_count, should_stop
 
 
 def _determine_optimal_k(embeddings: np.ndarray, max_k: int = _MAX_CLUSTERS_LIMIT) -> int:
@@ -821,32 +817,33 @@ def _determine_optimal_k(embeddings: np.ndarray, max_k: int = _MAX_CLUSTERS_LIMI
         labels = kmeans.fit_predict(embeddings)
         current_inertia = float(kmeans.inertia_)
         
-        # [리뷰반영] 헬퍼 함수를 통한 조기 종료 검사 (실루엣 연산 전 수행하여 O(N^2) 비용 절감)
-        inertia_flatten_count, should_stop = _update_inertia_flatten_state(
-            inertias, current_inertia, k, inertia_flatten_count
-        )
-        
-        # [리뷰반영] 조기 종료 시에도 메트릭에 추가하여 이전 로직과 엘보우/실루엣 배열 일관성 유지
         inertias.append(current_inertia)
         k_values.append(k)
 
+        # [리뷰반영] 헬퍼 함수를 통한 조기 종료 검사
+        inertia_flatten_count, should_stop = _update_inertia_flatten_state(
+            inertias, inertia_flatten_count
+        )
         if should_stop:
-            # 실루엣 연산을 생략하여 비용을 숏서킷(Short-circuit) 하되, 배열 길이를 맞추기 위해 버퍼값(-1.0) 추가
-            sil_scores.append(-1.0)
+            # 실루엣 연산을 생략하여 O(N^2) 비용 절감 (-1.0 버퍼값 없이 즉시 탈출)
             break
 
         # [리뷰반영] 실루엣 계산을 헬퍼 함수로 분리하여 복잡도 감소 (n_samples 파라미터 제거)
         sil_scores.append(_compute_silhouette_safe(embeddings, labels))
 
-    elbow_k = _find_elbow_point(inertias, k_values)
+    # [리뷰반영] 실제로 실루엣을 계산한 K 들만 잘라내어 배열 간 불일치(IndexError) 원천 차단
+    sil_k_values = k_values[: len(sil_scores)]
     best_sil_idx = int(np.argmax(sil_scores))
-    best_sil_k = k_values[best_sil_idx]
+    best_sil_k = sil_k_values[best_sil_idx]
 
-    # 1차 엘보우를 기본으로 하되, 실루엣 점수가 현저히 좋은 K가 있다면 그걸 채택
+    elbow_k = _find_elbow_point(inertias, k_values)
     elbow_idx = k_values.index(elbow_k)
 
-    # [리뷰반영] 0.1 하드코딩 제거 (환경 변수 상수 참조)
-    if (
+    # 1차 엘보우를 기본으로 하되, 실루엣 점수가 현저히 좋은 K가 있다면 그걸 채택
+    # [방어 로직] elbow_k가 조기 종료로 인해 sil_scores에 없는 K값일 경우를 대비한 안전망
+    if elbow_idx >= len(sil_scores):
+        optimal_k = elbow_k
+    elif (
         sil_scores[best_sil_idx] - sil_scores[elbow_idx]
         > _SILHOUETTE_IMPROVEMENT_THRESHOLD
     ):

--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -764,6 +764,7 @@ def _compute_silhouette_safe(
 
 def _update_inertia_flatten_state(
     inertias: List[float],
+    current_k: int,
     flatten_count: int,
 ) -> typing.Tuple[int, bool]:
     """
@@ -785,7 +786,6 @@ def _update_inertia_flatten_state(
 
     should_stop = flatten_count >= _MIN_FLATTEN_CONSECUTIVE_STEPS
     if should_stop:
-        current_k = 2 + (len(inertias) - 1)
         logger.debug(
             "[TOPIC_CLUSTERING] Inertia flattened at k=%d over %d consecutive steps, short-circuiting.",
             current_k,
@@ -820,9 +820,9 @@ def _determine_optimal_k(embeddings: np.ndarray, max_k: int = _MAX_CLUSTERS_LIMI
         inertias.append(current_inertia)
         k_values.append(k)
 
-        # [리뷰반영] 헬퍼 함수를 통한 조기 종료 검사
+        # [리뷰반영] 헬퍼 함수를 통한 조기 종료 검사 (current_k 명시적 전달)
         inertia_flatten_count, should_stop = _update_inertia_flatten_state(
-            inertias, inertia_flatten_count
+            inertias, k, inertia_flatten_count
         )
         if should_stop:
             # 실루엣 연산을 생략하여 O(N^2) 비용 절감 (-1.0 버퍼값 없이 즉시 탈출)
@@ -831,12 +831,17 @@ def _determine_optimal_k(embeddings: np.ndarray, max_k: int = _MAX_CLUSTERS_LIMI
         # [리뷰반영] 실루엣 계산을 헬퍼 함수로 분리하여 복잡도 감소 (n_samples 파라미터 제거)
         sil_scores.append(_compute_silhouette_safe(embeddings, labels))
 
+    elbow_k = _find_elbow_point(inertias, k_values)
+
+    # [방어 로직] 조기 종료가 너무 일찍 터져서 sil_scores가 아예 비어버린 극단적 엣지 케이스 방어
+    if not sil_scores:
+        return elbow_k
+
     # [리뷰반영] 실제로 실루엣을 계산한 K 들만 잘라내어 배열 간 불일치(IndexError) 원천 차단
     sil_k_values = k_values[: len(sil_scores)]
     best_sil_idx = int(np.argmax(sil_scores))
     best_sil_k = sil_k_values[best_sil_idx]
 
-    elbow_k = _find_elbow_point(inertias, k_values)
     elbow_idx = k_values.index(elbow_k)
 
     # 1차 엘보우를 기본으로 하되, 실루엣 점수가 현저히 좋은 K가 있다면 그걸 채택


### PR DESCRIPTION
☘️ refactor [#12.2.6]: 8차 개선 - 조기 종료 및 실루엣 평가 배열 동기화 로직 단순화 
☘️ refactor [#12.2.6]: 9차 개선 - 조기 종료 예외 방어 및 결합도(Coupling) 완화

## Summary by Sourcery

누적된 관성(inertia) 히스토리를 직접 활용하고, 관성과 실루엣(silhouette) 지표 간의 배열 정렬 안전장치를 강화하여, 최적 군집 개수를 선택하는 조기 종료(early-stopping) 로직을 단순화했습니다.

Bug Fixes:
- 조기 종료가 너무 이르게 혹은 예기치 않은 K 값에서 발생할 때 관성과 실루엣 점수 배열 간의 인덱스 불일치 및 잠재적인 IndexError가 발생하지 않도록 방지했습니다.
- 어떤 극단적인 조기 종료 상황에서는 실루엣 점수가 전혀 계산되지 않을 수 있는데, 이 경우에도 안전하게 엘보(elbow) 기반 K로 폴백(fallback)하도록 보호 장치를 추가했습니다.

Enhancements:
- 관성 평탄화 헬퍼를 저장된 관성 값만 사용하도록 개선하고, 전제 조건이 충족되지 않을 때는 카운터를 안전하게 리셋하도록 했습니다.
- 조기 종료 이후에는 불필요한 실루엣 계산을 수행하지 않도록 하여, 선택 로직의 견고함을 유지하면서도 O(N^2) 비용을 줄였습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the early-stopping logic for choosing the optimal number of clusters by relying directly on accumulated inertia history and tightening array-alignment safeguards between inertia and silhouette metrics.

Bug Fixes:
- Prevent index misalignment and potential IndexError between inertia and silhouette score arrays when early-stopping occurs too early or at unexpected Ks.
- Guard against extreme early-termination cases where no silhouette scores are computed by safely falling back to the elbow-based K.

Enhancements:
- Refine inertia flattening helper to use only stored inertia values, resetting counters safely when preconditions are not met.
- Avoid unnecessary silhouette computations after early-stopping, reducing O(N^2) cost while keeping selection logic robust.

</details>