### PR TITLE
☘️ refactor [#12.2.6]: 10차 개선 - 배열 의존성 격리 및 명시적 실루엣 인덱스 매핑 도입

### DIFF
--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -763,17 +763,14 @@ def _compute_silhouette_safe(
 
 
 def _update_inertia_flatten_state(
-    inertias: List[float],
+    prev_inertia: float,
+    current_inertia: float,
     current_k: int,
     flatten_count: int,
 ) -> typing.Tuple[int, bool]:
     """
     [리뷰반영] 관성 평탄화 검사 로직을 순수 헬퍼 함수로 추출.
     """
-    if len(inertias) < _MIN_K_FOR_INERTIA_FLATTEN:
-        return 0, False
-
-    prev_inertia, current_inertia = inertias[-2], inertias[-1]
     if prev_inertia <= 0:
         return 0, False
 
@@ -810,6 +807,7 @@ def _determine_optimal_k(embeddings: np.ndarray, max_k: int = _MAX_CLUSTERS_LIMI
     inertias: List[float] = []
     sil_scores: List[float] = []
     k_values: List[int] = []
+    sil_k_values: List[int] = []  # 실제로 실루엣이 계산된 K만 담는 전용 리스트
     inertia_flatten_count = 0
 
     for k in range(2, limit_k + 1):
@@ -820,40 +818,44 @@ def _determine_optimal_k(embeddings: np.ndarray, max_k: int = _MAX_CLUSTERS_LIMI
         inertias.append(current_inertia)
         k_values.append(k)
 
-        # [리뷰반영] 헬퍼 함수를 통한 조기 종료 검사 (current_k 명시적 전달)
-        inertia_flatten_count, should_stop = _update_inertia_flatten_state(
-            inertias, k, inertia_flatten_count
-        )
+        # [리뷰반영] 헬퍼 함수의 배열 의존성을 제거하고, 조기 종료 여부를 바깥에서 검증
+        if len(inertias) >= _MIN_K_FOR_INERTIA_FLATTEN:
+            # _MIN_K_FOR_INERTIA_FLATTEN은 최소 2 이상임을 보장해야 함
+            prev_inertia, cur_inertia = inertias[-2], inertias[-1]
+            inertia_flatten_count, should_stop = _update_inertia_flatten_state(
+                prev_inertia, cur_inertia, k, inertia_flatten_count
+            )
+        else:
+            should_stop = False
+
         if should_stop:
-            # 실루엣 연산을 생략하여 O(N^2) 비용 절감 (-1.0 버퍼값 없이 즉시 탈출)
+            # 실루엣 연산을 생략하여 O(N^2) 비용 절감
             break
 
-        # [리뷰반영] 실루엣 계산을 헬퍼 함수로 분리하여 복잡도 감소 (n_samples 파라미터 제거)
+        # [리뷰반영] 실루엣 점수가 존재하는 K만 별도 관리하여 슬라이싱/마법 인덱싱 완전 제거
         sil_scores.append(_compute_silhouette_safe(embeddings, labels))
+        sil_k_values.append(k)
 
     elbow_k = _find_elbow_point(inertias, k_values)
 
-    # [방어 로직] 조기 종료가 너무 일찍 터져서 sil_scores가 아예 비어버린 극단적 엣지 케이스 방어
+    # 조기 종료가 너무 일찍 터져서 sil_scores가 아예 비어버린 극단적 엣지 케이스 방어
     if not sil_scores:
         return elbow_k
 
-    # [리뷰반영] 실제로 실루엣을 계산한 K 들만 잘라내어 배열 간 불일치(IndexError) 원천 차단
-    sil_k_values = k_values[: len(sil_scores)]
     best_sil_idx = int(np.argmax(sil_scores))
     best_sil_k = sil_k_values[best_sil_idx]
 
-    elbow_idx = k_values.index(elbow_k)
-
     # 1차 엘보우를 기본으로 하되, 실루엣 점수가 현저히 좋은 K가 있다면 그걸 채택
-    # [방어 로직] elbow_k가 조기 종료로 인해 sil_scores에 없는 K값일 경우를 대비한 안전망
-    if elbow_idx >= len(sil_scores):
-        optimal_k = elbow_k
-    elif (
-        sil_scores[best_sil_idx] - sil_scores[elbow_idx]
-        > _SILHOUETTE_IMPROVEMENT_THRESHOLD
-    ):
-        optimal_k = best_sil_k
+    if elbow_k in sil_k_values:
+        elbow_sil_idx = sil_k_values.index(elbow_k)
+        elbow_sil = sil_scores[elbow_sil_idx]
+
+        if (sil_scores[best_sil_idx] - elbow_sil) > _SILHOUETTE_IMPROVEMENT_THRESHOLD:
+            optimal_k = best_sil_k
+        else:
+            optimal_k = elbow_k
     else:
+        # elbow_k가 조기 종료로 인해 실루엣 계산에서 제외된 경우
         optimal_k = elbow_k
 
     logger.info(

--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -792,6 +792,29 @@ def _update_inertia_flatten_state(
     return flatten_count, should_stop
 
 
+def _maybe_update_inertia_flatten_state(
+    inertias: List[float],
+    current_k: int,
+    flatten_count: int,
+) -> typing.Tuple[int, bool]:
+    """
+    [리뷰반영] 관성(inertia) 리스트 길이 확인 및 순수 헬퍼 호출을 감싸는 래퍼.
+    메인 루프에서 분기 처리를 제거하여 선형성을 유지한다.
+    """
+    assert _MIN_K_FOR_INERTIA_FLATTEN >= 2, "Inertia flatten threshold must be at least 2."
+    
+    if len(inertias) < _MIN_K_FOR_INERTIA_FLATTEN:
+        return flatten_count, False
+
+    prev_inertia, current_inertia = inertias[-2], inertias[-1]
+    return _update_inertia_flatten_state(
+        prev_inertia,
+        current_inertia,
+        current_k,
+        flatten_count,
+    )
+
+
 def _determine_optimal_k(embeddings: np.ndarray, max_k: int = _MAX_CLUSTERS_LIMIT) -> int:
     """
     엘보우 메서드(1차)와 실루엣 계수(2차)를 활용하여 최적의 K(클러스터 수)를 결정한다.
@@ -805,9 +828,8 @@ def _determine_optimal_k(embeddings: np.ndarray, max_k: int = _MAX_CLUSTERS_LIMI
         return 1
 
     inertias: List[float] = []
-    sil_scores: List[float] = []
     k_values: List[int] = []
-    sil_k_values: List[int] = []  # 실제로 실루엣이 계산된 K만 담는 전용 리스트
+    sil_by_k: Dict[int, float] = {}  # [리뷰반영] K를 키로 실루엣을 매핑하여 O(n) 탐색 제거
     inertia_flatten_count = 0
 
     for k in range(2, limit_k + 1):
@@ -818,44 +840,32 @@ def _determine_optimal_k(embeddings: np.ndarray, max_k: int = _MAX_CLUSTERS_LIMI
         inertias.append(current_inertia)
         k_values.append(k)
 
-        # [리뷰반영] 헬퍼 함수의 배열 의존성을 제거하고, 조기 종료 여부를 바깥에서 검증
-        if len(inertias) >= _MIN_K_FOR_INERTIA_FLATTEN:
-            # _MIN_K_FOR_INERTIA_FLATTEN은 최소 2 이상임을 보장해야 함
-            prev_inertia, cur_inertia = inertias[-2], inertias[-1]
-            inertia_flatten_count, should_stop = _update_inertia_flatten_state(
-                prev_inertia, cur_inertia, k, inertia_flatten_count
-            )
-        else:
-            should_stop = False
-
+        # [리뷰반영] 래퍼 헬퍼를 통해 루프 내 분기를 제거하고 선형성을 극대화
+        inertia_flatten_count, should_stop = _maybe_update_inertia_flatten_state(
+            inertias, k, inertia_flatten_count
+        )
         if should_stop:
             # 실루엣 연산을 생략하여 O(N^2) 비용 절감
             break
 
-        # [리뷰반영] 실루엣 점수가 존재하는 K만 별도 관리하여 슬라이싱/마법 인덱싱 완전 제거
-        sil_scores.append(_compute_silhouette_safe(embeddings, labels))
-        sil_k_values.append(k)
+        sil_by_k[k] = _compute_silhouette_safe(embeddings, labels)
 
     elbow_k = _find_elbow_point(inertias, k_values)
 
-    # 조기 종료가 너무 일찍 터져서 sil_scores가 아예 비어버린 극단적 엣지 케이스 방어
-    if not sil_scores:
+    # 조기 종료가 너무 일찍 터져서 sil_by_k가 아예 비어버린 극단적 엣지 케이스 방어
+    if not sil_by_k:
         return elbow_k
 
-    best_sil_idx = int(np.argmax(sil_scores))
-    best_sil_k = sil_k_values[best_sil_idx]
+    best_sil_k, best_sil = max(sil_by_k.items(), key=lambda kv: kv[1])
+    elbow_sil = sil_by_k.get(elbow_k)
 
     # 1차 엘보우를 기본으로 하되, 실루엣 점수가 현저히 좋은 K가 있다면 그걸 채택
-    if elbow_k in sil_k_values:
-        elbow_sil_idx = sil_k_values.index(elbow_k)
-        elbow_sil = sil_scores[elbow_sil_idx]
-
-        if (sil_scores[best_sil_idx] - elbow_sil) > _SILHOUETTE_IMPROVEMENT_THRESHOLD:
-            optimal_k = best_sil_k
-        else:
-            optimal_k = elbow_k
-    else:
+    if elbow_sil is None:
         # elbow_k가 조기 종료로 인해 실루엣 계산에서 제외된 경우
+        optimal_k = elbow_k
+    elif (best_sil - elbow_sil) > _SILHOUETTE_IMPROVEMENT_THRESHOLD:
+        optimal_k = best_sil_k
+    else:
         optimal_k = elbow_k
 
     logger.info(


### PR DESCRIPTION
- **[배열 의존성(Coupling) 원천 차단]**
  - `_update_inertia_flatten_state` 헬퍼 함수가 `inertias` 전체 배열을 받던 구조를 스칼라 값(`prev_inertia`, `current_inertia`)만 받도록 변경
  - 길이에 대한 검증(Guard) 로직을 루프 내부로 끌어올려, 외부 환경 설정값 (`_MIN_K_FOR_INERTIA_FLATTEN`) 변경 시 헬퍼 내부에서 발생할 수 있는 잠재적 `IndexError`를 완벽히 격리

- **[마법(Magic) 슬라이싱 제거 및 명시적 데이터 정렬]**
  - 조기 종료 여부에 따라 배열 길이가 달라지면서 발생하던 `k_values[:len(sil_scores)]` 식의 암묵적 슬라이싱 제거
  - 오직 실루엣 점수가 계산된 시점에만 기록되는 전용 배열 `sil_k_values`를 도입하여 `sil_scores`와 1:1 완벽 매핑
  - 이후 로직에서 `in` 연산자(`if elbow_k in sil_k_values:`)를 활용함으로써, 인덱스 바운드 체크 같은 방어 코드를 없애고 훨씬 직관적이고 견고한 구조 달성

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1219#pullrequestreview-4175331439)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Sourcery에 의한 요약

관성(inertia) 평탄화(flatten) 감지 로직을 공유 배열과 분리하고, 실루엣 점수 인덱싱을 명시적이고 더 안전하게 만들어 최적 클러스터 개수 선택을 개선합니다.

개선 사항:
- 관성 평탄화 헬퍼가 스칼라 관성 값만 받도록 수정하고, 조기 중단(early-stop) 여부는 외부의 길이 검사에 의존하도록 업데이트합니다.
- 실루엣 계산에 사용된 K 값을 전용 리스트로 추적하여 실루엣 점수와 1:1 매핑을 유지하고, 암묵적인 슬라이싱 및 인덱스 범위 보호 로직을 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine optimal cluster count selection by decoupling inertia flatten detection from shared arrays and making silhouette score indexing explicit and safer.

Enhancements:
- Update inertia flatten helper to accept only scalar inertia values and rely on external length checks for early-stop decisions.
- Track K values used for silhouette computation in a dedicated list to maintain a 1:1 mapping with silhouette scores and remove implicit slicing and index-bound guards.

</details>