### PR TITLE
☘️ refactor [#12.2.6]: 12차 개선 - 런타임 최적화(Performance) 및 상태 일관성 복구

### DIFF
--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -292,11 +292,6 @@ _INERTIA_FLATTEN_THRESHOLD: float = 0.05
 _MIN_K_FOR_INERTIA_FLATTEN: int = 3
 _MIN_FLATTEN_CONSECUTIVE_STEPS: int = 2
 
-# [리뷰반영] 조기 종료 방어 로직의 상수는 모듈 스코프에서 한 번만 평가하여 루프 내 오버헤드(O(N)) 제거
-# Python 최적화 모드(-O)에서도 안전성을 100% 보장하기 위해 assert 대신 명시적 예외 발생
-if _MIN_K_FOR_INERTIA_FLATTEN < 2:
-    raise ValueError("Inertia flatten threshold must be at least 2 to prevent IndexError.")
-
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Redis 키 빌더 (SSOT — 하드코딩 금지)
@@ -925,6 +920,14 @@ async def cluster_user_topics(hashed_user_id: str) -> List[Dict[str, Any]]:
     Returns:
         [{"label": "대표 쿼리", "weight": 0.5, "size": 10}, ...]
     """
+    # [리뷰반영] 동적 환경변수 오설정으로 인한 import-time 크래시를 방지하기 위해 서비스 호출 시점에 1회 검증
+    if _MIN_K_FOR_INERTIA_FLATTEN < 2:
+        logger.error("[TOPIC_CLUSTERING] Misconfiguration: _MIN_K_FOR_INERTIA_FLATTEN must be >= 2.")
+        return []
+    if _MIN_FLATTEN_CONSECUTIVE_STEPS < 1:
+        logger.error("[TOPIC_CLUSTERING] Misconfiguration: _MIN_FLATTEN_CONSECUTIVE_STEPS must be >= 1.")
+        return []
+
     # 1) 히스토리 조회
     history = await get_search_history(hashed_user_id)
     if not history:

--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -292,6 +292,11 @@ _INERTIA_FLATTEN_THRESHOLD: float = 0.05
 _MIN_K_FOR_INERTIA_FLATTEN: int = 3
 _MIN_FLATTEN_CONSECUTIVE_STEPS: int = 2
 
+# [리뷰반영] 조기 종료 방어 로직의 상수는 모듈 스코프에서 한 번만 평가하여 루프 내 오버헤드(O(N)) 제거
+# Python 최적화 모드(-O)에서도 안전성을 100% 보장하기 위해 assert 대신 명시적 예외 발생
+if _MIN_K_FOR_INERTIA_FLATTEN < 2:
+    raise ValueError("Inertia flatten threshold must be at least 2 to prevent IndexError.")
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Redis 키 빌더 (SSOT — 하드코딩 금지)
@@ -801,10 +806,9 @@ def _maybe_update_inertia_flatten_state(
     [리뷰반영] 관성(inertia) 리스트 길이 확인 및 순수 헬퍼 호출을 감싸는 래퍼.
     메인 루프에서 분기 처리를 제거하여 선형성을 유지한다.
     """
-    assert _MIN_K_FOR_INERTIA_FLATTEN >= 2, "Inertia flatten threshold must be at least 2."
-    
     if len(inertias) < _MIN_K_FOR_INERTIA_FLATTEN:
-        return flatten_count, False
+        # [리뷰반영] 임계값 도달 전에는 평탄화 카운트를 0으로 리셋하여 기존 순수 로직과의 동작 일관성 보장
+        return 0, False
 
     prev_inertia, current_inertia = inertias[-2], inertias[-1]
     return _update_inertia_flatten_state(


### PR DESCRIPTION
- **[루프 오버헤드 제거 (Performance 최적화)]**
  - 기존에 핫 패스(Tight Loop) 내부 헬퍼 함수에서 반복적으로 실행되던 상수의 유효성 검사 로직을 모듈 스코프로 완전히 분리
  - 매 K값마다 평가되던 O(N)의 오버헤드를 모듈 임포트 시점 1회 평가로 줄여 알고리즘 성능 최적화
  - Python 최적화 모드(`-O`)에서는 `assert` 문이 무시되어 잠재적 버그를 유발할 수 있는 점을 방어하기 위해 명시적인 `if ... raise ValueError()` 구문으로 교체하여 운영 환경 100% 안전성 확보

- **[순수 헬퍼 함수의 동작 일관성(Consistency) 복구]**
  - 10차 개선에서 도입된 래퍼 헬퍼 `_maybe_update_inertia_flatten_state`가 기존 `flatten_count`를 그대로 리턴하던 동작(Silent return)을 발견 및 수정
  - 임계값(`_MIN_K_FOR_INERTIA_FLATTEN`) 미달 시 즉시 카운트를 `0`으로 리셋(`return 0, False`)하도록 복구하여, 기존의 '조건 불충족 시 연속 평탄화 상태 초기화'라는 비즈니스 로직의 의도를 완벽히 동기화

- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1221#pullrequestreview-4175495532)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

관성 플래트닝 임계값 처리 방식을 개선하여 루프 오버헤드를 제거하고 플래트닝 카운트 초기화 동작의 일관성을 복원합니다.

버그 수정:
- 최소 K 임계값을 만족하지 못할 때 관성 플래트닝 카운터를 0으로 리셋하여 기존 비즈니스 로직과 일치시키도록 했습니다.

개선 사항:
- 관성 플래트닝 임계값 검증을 모듈 범위로 이동하고 명시적으로 오류를 발생시키도록 하여, 반복마다 발생하는 오버헤드를 피하고 Python 최적화 모드에서도 안전성을 유지하도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine inertia flattening threshold handling to remove loop overhead and restore consistent flatten count reset behavior.

Bug Fixes:
- Reset the inertia flatten counter to zero when the minimum K threshold is not met to align with the original business logic.

Enhancements:
- Move the inertia flattening threshold validation to module scope with explicit error raising to avoid per-iteration overhead and maintain safety under Python optimized mode.

</details>