### PR TITLE
☘️ refactor [#12.2.6]: 14차 개선 - 설정 검증 훅(Hook) 패턴 도입 및 도메인 에러 명시화

### DIFF
--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -292,24 +292,32 @@ _INERTIA_FLATTEN_THRESHOLD: float = 0.05
 _MIN_K_FOR_INERTIA_FLATTEN: int = 3
 _MIN_FLATTEN_CONSECUTIVE_STEPS: int = 2
 
-_is_config_validated: bool = False
 
-def validate_clustering_config() -> None:
-    """
-    [리뷰반영] 서비스 설정값 정합성 검증 훅.
-    서버 구동 직후 최초의 서비스 호출 시점에 단 1회만 실행되어 오설정을 검증한다.
-    Import-time 크래시를 방지하면서도 잘못된 빈 결과 반환(Silent Failure)을 예방한다.
-    """
-    global _is_config_validated
-    if _is_config_validated:
-        return
+class ClusteringConfigError(ValueError):
+    """클러스터링 알고리즘 설정값 오류 시 발생하는 도메인 특화 예외"""
+    pass
 
+
+def _assert_valid_clustering_config() -> None:
+    """
+    [리뷰반영] 클러스터링 관련 설정값을 검증하고, 잘못된 경우 로그를 남긴 후 커스텀 예외를 발생시킨다.
+    전역 상태(Shared Mutable State)를 제거하여 비동기 환경에서의 동시성 이슈를 차단하고 멱등성을 보장한다.
+    """
     if _MIN_K_FOR_INERTIA_FLATTEN < 2:
-        raise ValueError("[TOPIC_CLUSTERING] Misconfiguration: _MIN_K_FOR_INERTIA_FLATTEN must be >= 2.")
+        logger.critical(
+            "[TOPIC_CLUSTERING] Misconfiguration: _MIN_K_FOR_INERTIA_FLATTEN must be >= 2. "
+            "Current value: %s",
+            _MIN_K_FOR_INERTIA_FLATTEN,
+        )
+        raise ClusteringConfigError("[TOPIC_CLUSTERING] Misconfiguration: _MIN_K_FOR_INERTIA_FLATTEN must be >= 2.")
+    
     if _MIN_FLATTEN_CONSECUTIVE_STEPS < 1:
-        raise ValueError("[TOPIC_CLUSTERING] Misconfiguration: _MIN_FLATTEN_CONSECUTIVE_STEPS must be >= 1.")
-
-    _is_config_validated = True
+        logger.critical(
+            "[TOPIC_CLUSTERING] Misconfiguration: _MIN_FLATTEN_CONSECUTIVE_STEPS must be >= 1. "
+            "Current value: %s",
+            _MIN_FLATTEN_CONSECUTIVE_STEPS,
+        )
+        raise ClusteringConfigError("[TOPIC_CLUSTERING] Misconfiguration: _MIN_FLATTEN_CONSECUTIVE_STEPS must be >= 1.")
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -939,8 +947,8 @@ async def cluster_user_topics(hashed_user_id: str) -> List[Dict[str, Any]]:
     Returns:
         [{"label": "대표 쿼리", "weight": 0.5, "size": 10}, ...]
     """
-    # [리뷰반영] 런타임에 1회 검증 훅을 호출하여 Import-time 크래시를 방지하고 명시적 예외(ValueError)를 발생시킴
-    validate_clustering_config()
+    # [리뷰반영] 런타임에 설정값 정합성을 검증하고, 잘못된 경우 명시적 커스텀 예외를 발생시킴
+    _assert_valid_clustering_config()
 
     # 1) 히스토리 조회
     history = await get_search_history(hashed_user_id)

--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -292,6 +292,25 @@ _INERTIA_FLATTEN_THRESHOLD: float = 0.05
 _MIN_K_FOR_INERTIA_FLATTEN: int = 3
 _MIN_FLATTEN_CONSECUTIVE_STEPS: int = 2
 
+_is_config_validated: bool = False
+
+def validate_clustering_config() -> None:
+    """
+    [리뷰반영] 서비스 설정값 정합성 검증 훅.
+    서버 구동 직후 최초의 서비스 호출 시점에 단 1회만 실행되어 오설정을 검증한다.
+    Import-time 크래시를 방지하면서도 잘못된 빈 결과 반환(Silent Failure)을 예방한다.
+    """
+    global _is_config_validated
+    if _is_config_validated:
+        return
+
+    if _MIN_K_FOR_INERTIA_FLATTEN < 2:
+        raise ValueError("[TOPIC_CLUSTERING] Misconfiguration: _MIN_K_FOR_INERTIA_FLATTEN must be >= 2.")
+    if _MIN_FLATTEN_CONSECUTIVE_STEPS < 1:
+        raise ValueError("[TOPIC_CLUSTERING] Misconfiguration: _MIN_FLATTEN_CONSECUTIVE_STEPS must be >= 1.")
+
+    _is_config_validated = True
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Redis 키 빌더 (SSOT — 하드코딩 금지)
@@ -920,13 +939,8 @@ async def cluster_user_topics(hashed_user_id: str) -> List[Dict[str, Any]]:
     Returns:
         [{"label": "대표 쿼리", "weight": 0.5, "size": 10}, ...]
     """
-    # [리뷰반영] 동적 환경변수 오설정으로 인한 import-time 크래시를 방지하기 위해 서비스 호출 시점에 1회 검증
-    if _MIN_K_FOR_INERTIA_FLATTEN < 2:
-        logger.error("[TOPIC_CLUSTERING] Misconfiguration: _MIN_K_FOR_INERTIA_FLATTEN must be >= 2.")
-        return []
-    if _MIN_FLATTEN_CONSECUTIVE_STEPS < 1:
-        logger.error("[TOPIC_CLUSTERING] Misconfiguration: _MIN_FLATTEN_CONSECUTIVE_STEPS must be >= 1.")
-        return []
+    # [리뷰반영] 런타임에 1회 검증 훅을 호출하여 Import-time 크래시를 방지하고 명시적 예외(ValueError)를 발생시킴
+    validate_clustering_config()
 
     # 1) 히스토리 조회
     history = await get_search_history(hashed_user_id)


### PR DESCRIPTION
- **[조용한 실패(Silent Failure) 안티패턴 제거]**
  - 설정 오류 시 빈 리스트(`[]`)를 반환하던 임시 조치를 제거하고 명시적인 `ValueError` 예외 발생으로 변경
  - 상위 호출자(Caller)가 '정상적인 빈 결과(검색 기록 없음)'와 '시스템 환경 변수 오설정'을 명확히 구분하여 처리할 수 있도록 도메인 에러 시그니처 개선

- **[초기화 훅(Init Hook) 패턴을 통한 검증 로직 중앙화]**
  - 매번 비즈니스 로직(`cluster_user_topics`) 안에 섞여 있던 상호 의존적 상수(`_MIN_K_FOR_INERTIA_FLATTEN`, `_MIN_FLATTEN_CONSECUTIVE_STEPS`) 검증을 전용 훅 함수 `validate_clustering_config()`로 추출
  - 전역 상태 플래그(`_is_config_validated`)를 활용하여 서비스 생명주기 동안 최초 1회만 검증되도록 보장하여, 성능은 유지하면서 단일 책임 원칙(SRP)을 완벽히 준수

- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1223#pullrequestreview-4175508338)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

토픽 클러스터링 구성 검증을 전용 init 훅으로 중앙화하고, 잘못된 구성에 대해 조용히 대체(fallback)하던 방식 대신 명시적인 오류를 발생시키도록 변경합니다.

버그 수정:
- 잘못된 클러스터링 구성 시 빈 결과를 반환하던 대신 `ValueError`를 발생시켜, 토픽 클러스터링에서 조용히 실패하던 문제를 제거합니다.

개선 사항:
- 토픽 클러스터링을 위해, 최초 런타임 사용 시 의존 상수들을 검증하고 그 검증 결과를 캐시하는 1회성 구성 검증 훅을 도입합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize topic clustering configuration validation into a dedicated init hook and replace silent misconfiguration fallbacks with explicit errors.

Bug Fixes:
- Eliminate silent failures in topic clustering by raising a ValueError on invalid clustering configuration instead of returning an empty result set.

Enhancements:
- Introduce a one-time configuration validation hook for topic clustering that verifies dependent constants at first runtime use and caches the validation result.

</details>