### PR TITLE
☘️ refactor [#12.2.6]: 18차 개선 - 예외의 범용성 확대 및 로깅 중복 완전 제거

### DIFF
--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -295,15 +295,17 @@ _MIN_FLATTEN_CONSECUTIVE_STEPS: int = 2
 
 class ClusteringConfigError(ValueError):
     """클러스터링 알고리즘 설정값 오류 시 발생하는 도메인 특화 예외"""
-    def __init__(self, message: str, param: str, value: Any):
+    def __init__(self, message: str, param: Optional[str] = None, value: Optional[Any] = None):
         super().__init__(message)
         self.param = param
         self.value = value
 
     def __str__(self) -> str:
-        # [리뷰반영] 예외를 문자열로 출력할 때 속성값들이 명확히 보이도록 오버라이드
+        # [리뷰반영] 파라미터가 없는 범용 에러인 경우를 우아하게 처리
         base_msg = super().__str__()
-        return f"{base_msg} (param={self.param}, value={self.value})"
+        if self.param is not None:
+            return f"{base_msg} (param={self.param}, value={self.value})"
+        return base_msg
 
 
 def _assert_valid_clustering_config(
@@ -316,22 +318,22 @@ def _assert_valid_clustering_config(
     전역 상태에 직접 의존하지 않아 테스트 용이성(Testability)이 높다.
     """
     if min_k_flatten < 2:
-        msg = "[TOPIC_CLUSTERING] Misconfiguration: _MIN_K_FOR_INERTIA_FLATTEN must be >= 2."
-        logger.critical("%s Current value: %s", msg, min_k_flatten)
-        raise ClusteringConfigError(
-            msg,
+        err = ClusteringConfigError(
+            "[TOPIC_CLUSTERING] Misconfiguration: _MIN_K_FOR_INERTIA_FLATTEN must be >= 2.",
             param="_MIN_K_FOR_INERTIA_FLATTEN",
             value=min_k_flatten,
         )
+        logger.critical(str(err))
+        raise err
     
     if min_consecutive_steps < 1:
-        msg = "[TOPIC_CLUSTERING] Misconfiguration: _MIN_FLATTEN_CONSECUTIVE_STEPS must be >= 1."
-        logger.critical("%s Current value: %s", msg, min_consecutive_steps)
-        raise ClusteringConfigError(
-            msg,
+        err = ClusteringConfigError(
+            "[TOPIC_CLUSTERING] Misconfiguration: _MIN_FLATTEN_CONSECUTIVE_STEPS must be >= 1.",
             param="_MIN_FLATTEN_CONSECUTIVE_STEPS",
             value=min_consecutive_steps,
         )
+        logger.critical(str(err))
+        raise err
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -301,11 +301,23 @@ class ClusteringConfigError(ValueError):
         self.value = value
 
     def __str__(self) -> str:
-        # [리뷰반영] 파라미터가 없는 범용 에러인 경우를 우아하게 처리
+        # [리뷰반영] 파라미터/값 유무에 따라 부분적인 정보 유실 없이 유연하게 에러 메시지 구성
         base_msg = super().__str__()
-        if self.param is not None:
-            return f"{base_msg} (param={self.param}, value={self.value})"
-        return base_msg
+        
+        # (1) param, value 둘 다 없는 범용 에러
+        if self.param is None and self.value is None:
+            return base_msg
+
+        # (2) value만 있는 경우
+        if self.param is None:
+            return f"{base_msg} (value={self.value})"
+
+        # (3) param만 있는 경우
+        if self.value is None:
+            return f"{base_msg} (param={self.param})"
+
+        # (4) param과 value가 모두 있는 경우
+        return f"{base_msg} (param={self.param}, value={self.value})"
 
 
 def _assert_valid_clustering_config(


### PR DESCRIPTION
- **[커스텀 예외의 범용성 확대 (Optional Arguments)]**
  - `ClusteringConfigError`의 `param`과 `value` 속성을 선택적 인자(Optional)로 변경하여, 구체적인 파라미터가 없는 일반적인 설정 오류 상황에서도 해당 예외를 재사용할 수 있도록 유연성 제공
  - `__str__` 매직 메서드에 파라미터가 `None`인 경우를 우아하게 처리(Graceful degradation)하는 방어 로직 추가

- **[극한의 중복 제거 (DRY의 완성)]**
  - 예외 객체 자체(`__str__`)가 이미 `param`과 `value`를 예쁘게 포맷팅해주므로, 기존에 `logger.critical`에서 `Current value: %s` 형태로 중복 포맷팅하던 로직을 완전 제거
  - 먼저 예외 인스턴스(`err`)를 생성하고, 이를 그대로 로깅한 뒤 `raise`하는 패턴을 적용하여 메시지와 포맷팅의 중복을 1바이트도 남기지 않고 제거 (단일 진실 공급원)

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1227#pullrequestreview-4175529311)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

클러스터링 구성 오류 처리 방식을 완화하고, 잘못된 구성(misconfiguration) 검사 시 치명적 로그를 단순화합니다.

버그 수정:
- 클러스터링 구성 오류에 특정 파라미터 컨텍스트가 없을 때 발생하는 오해의 소지가 있거나 어색한 오류 메시지를 방지합니다.

개선사항:
- 보다 일반적인 구성 오류 시나리오를 지원하기 위해 `ClusteringConfigError` 파라미터를 선택적(optional)으로 만듭니다.
- 로거 호출에서 포매팅을 중복하지 않고 예외 인스턴스를 직접 로그에 남겨, 클러스터링 구성 오류 메시지 포매팅을 중앙집중화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax clustering configuration error handling and simplify critical logging for misconfiguration checks.

Bug Fixes:
- Prevent misleading or awkward error messages when clustering configuration errors lack specific parameter context.

Enhancements:
- Make ClusteringConfigError parameters optional to support more generic configuration error scenarios.
- Centralize formatting of clustering configuration error messages by logging the exception instance directly instead of duplicating formatting in logger calls.

</details>