### PR TITLE
☘️ refactor [#12.2.7]: 4차 개선 - 캐시 무효화 헬퍼 함수 재사용 및 캐시 버전 관리 외부화

### DIFF
--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -70,7 +70,17 @@ _MSG_PAIR_COUNT_PREFIX: str = "cls:msg_pair_count"
 _RAG_SEARCH_COUNT_PREFIX: str = "cls:rag_search_count"
 _QUERY_HISTORY_PREFIX: str = "cls:query_history"  # 사용자 검색어 히스토리 (List)
 _CLUSTER_CACHE_PREFIX: str = "cls:result"         # 클러스터링 결과 캐시 (JSON String)
-_CLUSTER_CACHE_VERSION: str = "v1"                # 데이터 스키마 버전 (버전 업 시 구버전 캐시 자동 무효화)
+
+# 데이터 스키마 버전 (버전 업 시 구버전 캐시 자동 무효화, 환경 변수로 외부화)
+_CLUSTER_CACHE_VERSION_ENV_KEY = "CLUSTER_CACHE_VERSION"
+_CLUSTER_CACHE_VERSION_DEFAULT = "v1"
+
+def _load_cluster_cache_version() -> str:
+    """CLUSTER_CACHE_VERSION 환경 변수를 로드한다."""
+    val = os.environ.get(_CLUSTER_CACHE_VERSION_ENV_KEY, "").strip()
+    return val if val else _CLUSTER_CACHE_VERSION_DEFAULT
+
+_CLUSTER_CACHE_VERSION: str = _load_cluster_cache_version()
 
 # 콜드 스타트 판별 임계값 (환경 변수로 외부화)
 # COLD_START_THRESHOLD: 누적 활동 수가 이 값 미만이면 콜드 스타트로 간주
@@ -1048,14 +1058,8 @@ async def _get_cached_cluster_result(hashed_user_id: str) -> Optional[List[Dict[
             mask_pii_id(hashed_user_id),
             exc,
         )
-        try:
-            await redis_client.redis.delete(cache_key)
-        except RedisError as del_exc:
-            logger.warning(
-                "[TOPIC_CLUSTERING] 손상된 캐시 삭제 실패 (masked_uid=%s). exc=%r",
-                mask_pii_id(hashed_user_id),
-                del_exc,
-            )
+        # [리뷰반영] 파손된 캐시 삭제 로직을 _invalidate_cluster_cache 헬퍼 호출로 대체 (DRY 및 연결 보장)
+        await _invalidate_cluster_cache(hashed_user_id)
         return None
     except RedisError as exc:
         logger.warning(


### PR DESCRIPTION
- **[DRY & Clean Code]**
  - `_get_cached_cluster_result` 내에서 JSON 디코딩 실패 시 손상된 캐시를 삭제하는 로직을 중복 작성하는 대신, 이미 만들어둔 `_invalidate_cluster_cache` 헬퍼 함수 호출로 대체
  - 이를 통해 삭제 전 `_ensure_redis_connected()` 연결 보장 로직을 자연스럽게 재사용하고, 중복 코드(Boilerplate)를 제거하여 유지보수성을 극대화

- **[Configuration Externalization (하드코딩 제거)]**
  - 캐시 키 스키마를 관리하는 상수가 하드코딩되어 있던 문제를 개선하여, `CLUSTER_CACHE_VERSION` 환경 변수에서 동적으로 로드하도록 변경 (기본값 "v1")
  - 향후 소스코드 수정 없이도 인프라(Config) 단에서 안전하게 캐시 버전업을 수행할 수 있도록 확장성(Scalability) 및 운영 편의성 확보

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1235#pullrequestreview-4176545271)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

토픽 클러스터링 캐시 버전 설정을 외부로 분리하고, 캐시된 데이터가 손상되었을 때 캐시 무효화를 위해 헬퍼를 재사용하도록 합니다.

New Features:
- `CLUSTER_CACHE_VERSION` 환경 변수를 통해 토픽 클러스터링 캐시 버전을 로드하며, 기본값을 제공합니다.

Enhancements:
- 토픽 클러스터링에서 손상된 캐시 삭제 로직을 리팩터링하여, 기존의 `_invalidate_cluster_cache` 헬퍼를 재사용함으로써 DRY 원칙을 지키고 커넥션 처리를 개선했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Externalize the topic clustering cache version configuration and reuse a helper for cache invalidation when cached data is corrupted.

New Features:
- Load the topic clustering cache version from the CLUSTER_CACHE_VERSION environment variable with a default value.

Enhancements:
- Refactor corrupted cache deletion in topic clustering to reuse the existing _invalidate_cluster_cache helper for better DRYness and connection handling.

</details>