### PR TITLE
☘️ refactor [#12.2.7]: 13차 개선 - RuntimeError 교체 및 callable 이중 가드로 런타임 계약 강화

### DIFF
--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -116,14 +116,16 @@ class ClusterCacheConfig:
         운영 환경에서 프로세스 재시작 없이 새 버전을 반영할 때 호출한다.
 
         이 메서드는 get_version에 @lru_cache가 적용되어 있음을 전제로 한다.
-        cache_clear 속성이 없을 경우 AssertionError를 발생시켜 조기 실패를 유도한다.
+        cache_clear가 존재하지 않거나 호출 불가능할 경우 RuntimeError로 조기 실패한다.
+        (functools._lru_cache_wrapper 같은 비공개 타입 직접 검사는 버전 호환성 문제로 사용하지 않는다.)
         """
-        if not hasattr(self.get_version, "cache_clear"):
-            raise AssertionError(
+        cache_clear_fn = getattr(self.get_version, "cache_clear", None)
+        if not callable(cache_clear_fn):
+            raise RuntimeError(
                 "get_version에 @lru_cache 데코레이터가 적용되어 있어야 합니다. "
                 "리팩터링 시 데코레이터를 제거하지 마십시오."
             )
-        self.get_version.cache_clear()
+        cache_clear_fn()
 
 # 모듈 레벨 싱글톤 인스턴스 (테스트 시 의존성 주입(DI)에 유리함)
 cluster_cache_config = ClusterCacheConfig()


### PR DESCRIPTION
- **[Robustness: 예외 타입 정확도]**
  - `AssertionError`를 `RuntimeError`로 교체하여 `런타임 계약 위반`이라는 시맨틱을 정확하게 표현 (-O 모드와 무관하게 항상 실행됨도 유지)

- **[Defensive Programming: callable 이중 가드]**
  - `hasattr` 단일 검사 대신 `getattr` + `callable()` 이중 검증으로 교체하여 `cache_clear` 속성이 실제로 호출 가능한 함수인지까지 보장
  - `functools._lru_cache_wrapper` 같은 비공개 내부 타입에 직접 의존하는 방식은 Python 버전 간 호환성을 해치므로 채택하지 않음

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1246#pullrequestreview-4176604003)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

토픽 클러스터링 서비스에서 캐시를 비우는 런타임 계약을 강화하기 위해, `cache_clear`가 호출 가능(callable)인지 검사하고, LRU 캐시 데코레이터가 누락된 경우 명확한 런타임 오류를 발생시키도록 합니다.

Enhancements:
- 예상했던 `@lru_cache`의 `cache_clear` 훅이 `get_version`에 존재하지 않을 때, 런타임 계약 위반을 더 잘 표현하기 위해 `AssertionError`를 `RuntimeError`로 교체합니다.
- 내부 `functools` 구현 세부사항에 의존하지 않도록, 호출 전에 `cache_clear` 속성에 대해 호출 가능 여부를 확인하는 가드를 추가하여 캐시 비우기 동작을 보호합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen runtime contract for cache clearing in topic clustering service by enforcing callable cache_clear and raising a clear runtime error when the LRU cache decorator is missing.

Enhancements:
- Replace AssertionError with RuntimeError when the expected @lru_cache cache_clear hook is not available on get_version to better represent runtime contract violations.
- Guard cache clearing with a callable check on the cache_clear attribute before invocation to avoid relying on internal functools implementation details.

</details>