### PR TITLE
☘️ refactor [#12.2.8]: 2차 개선 - 정규화 허용치 분리 및 로그 레벨 최적화

### DIFF
--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -66,6 +66,10 @@ _COLD_START_GLOBAL_WEIGHT = 1.0
 # 합산 보정 수치 상수 (하드코딩 금지 — 이곳에서만 수정)
 # 합계가 이 값 미만이면 ZeroDivision 위험으로 간주하여 기본값으로 폴백
 _WEIGHT_SUM_ZERO_EPSILON: float = 1e-9
+# 합계가 1.0과 이 절댓값 이상 차이나면 재정규화를 수행한다.
+# rel_tol(_WEIGHT_SUM_ZERO_EPSILON)과 달리 abs_tol을 사용하여
+# "1.0 근처에서 얼마나 벗어났는가"를 예측 가능하게 판단한다.
+_WEIGHT_SUM_NORMALIZATION_TOLERANCE: float = 1e-6
 # 재정규화된 가중치를 반올림할 소수점 자리수 (6자리 ≈ 마이크로 단위 정밀도)
 _WEIGHT_NORMALIZATION_PRECISION: int = 6
 
@@ -175,7 +179,9 @@ def _load_index_weights() -> Tuple[float, float]:
         return _PERSONALIZED_WEIGHT_DEFAULT, _GLOBAL_WEIGHT_DEFAULT
 
     # 합계가 1.0이 아닌 경우 재정규화
-    if not math.isclose(total, 1.0, rel_tol=_WEIGHT_SUM_ZERO_EPSILON):
+    # abs_tol 사용: "1.0 근처에서 절대 오차로 판단"이 rel_tol보다 예측 가능
+    # (rel_tol=_WEIGHT_SUM_ZERO_EPSILON은 ZeroDivision 가드 전용 개념과 분리)
+    if not math.isclose(total, 1.0, abs_tol=_WEIGHT_SUM_NORMALIZATION_TOLERANCE):
         normalized_p = round(personalized / total, _WEIGHT_NORMALIZATION_PRECISION)
         normalized_g = round(global_w / total, _WEIGHT_NORMALIZATION_PRECISION)
         logger.warning(
@@ -254,7 +260,7 @@ async def get_index_weights(hashed_user_id: str) -> Tuple[float, float]:
         )
         return _COLD_START_PERSONALIZED_WEIGHT, _COLD_START_GLOBAL_WEIGHT
 
-    logger.info(
+    logger.debug(
         "[HYBRID_SEARCH][WEIGHT] 정상 사용자 가중치 적용 "
         "(masked_uid=%s, personalized=%.4f, global=%.4f)",
         masked_uid,

--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -178,10 +178,10 @@ def _load_index_weights() -> Tuple[float, float]:
         )
         return _PERSONALIZED_WEIGHT_DEFAULT, _GLOBAL_WEIGHT_DEFAULT
 
-    # 합계가 1.0이 아닌 경우 재정규화
-    # abs_tol 사용: "1.0 근처에서 절대 오차로 판단"이 rel_tol보다 예측 가능
+    # abs_tol 전용 판단: "1.0 근처에서 절대 오차만으로 판단"
+    # rel_tol=0.0 명시로 기본값(1e-9)의 암묵적 적용을 차단 → 주석과 코드 완전 일치
     # (rel_tol=_WEIGHT_SUM_ZERO_EPSILON은 ZeroDivision 가드 전용 개념과 분리)
-    if not math.isclose(total, 1.0, abs_tol=_WEIGHT_SUM_NORMALIZATION_TOLERANCE):
+    if not math.isclose(total, 1.0, rel_tol=0.0, abs_tol=_WEIGHT_SUM_NORMALIZATION_TOLERANCE):
         normalized_p = round(personalized / total, _WEIGHT_NORMALIZATION_PRECISION)
         normalized_g = round(global_w / total, _WEIGHT_NORMALIZATION_PRECISION)
         logger.warning(


### PR DESCRIPTION
- **[Fix 1] 재정규화 허용치 상수 분리 및 abs_tol 적용**
  - _WEIGHT_SUM_NORMALIZATION_TOLERANCE = 1e-6 신설
  - math.isclose(total, 1.0, rel_tol=...) → abs_tol=_WEIGHT_SUM_NORMALIZATION_TOLERANCE 로 교체
  - ZeroDivision 가드(_WEIGHT_SUM_ZERO_EPSILON, 1e-9)와 재정규화 판단(1e-6)의 의미를 상수·파라미터 모두 명확히 분리
  - abs_tol 사용으로 `1.0 근처에서 얼마나 벗어났는가`를 예측 가능하게 판단

- **[Fix 2] 정상 사용자 경로 로그 레벨 하향 (INFO → DEBUG)**
  - get_index_weights()의 정상 사용자 경로 logger.info → logger.debug
  - 매 검색 요청마다 발생하는 INFO 로그 노이즈 제거
  - Cold Start(이상 징후) 경로는 logger.info 유지하여 관측성 보존

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1250#pullrequestreview-4178480853)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

하이브리드 검색 가중치 정규화 허용 오차와 로깅 레벨을 조정합니다.

버그 수정:
- 0으로 나누는 것을 방지하는 epsilon과 가중치 합 정규화 허용 오차를 분리하고, 재정규화를 위해 1.0 주변의 절대 허용 오차를 사용하도록 변경했습니다.

개선 사항:
- 콜드 스타트 관측 가능성은 유지하면서 로그 노이즈를 줄이기 위해, 일반 사용자 경로에서 `get_index_weights`의 로그 레벨을 INFO에서 DEBUG로 낮추었습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust hybrid search weight normalization tolerance and logging levels.

Bug Fixes:
- Separate zero-division guard epsilon from weight sum normalization tolerance using an absolute tolerance around 1.0 for renormalization.

Enhancements:
- Lower normal user-path logging in get_index_weights from INFO to DEBUG to reduce log noise while preserving cold-start observability.

</details>