### PR TITLE
☘️ refactor [#12.2.8]: 4차 개선 - 가중치 임계값 그룹핑 및 수학적 일관성 근거 문서화

### DIFF
--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -63,14 +63,28 @@ _GLOBAL_WEIGHT_MAX = 1.0
 _COLD_START_PERSONALIZED_WEIGHT = 0.0
 _COLD_START_GLOBAL_WEIGHT = 1.0
 
-# 합산 보정 수치 상수 (하드코딩 금지 — 이곳에서만 수정)
-# 합계가 이 값 미만이면 ZeroDivision 위험으로 간주하여 기본값으로 폴백
+# ── [그룹 A] ZeroDivision 가드 ──────────────────────────────────────────────
+# 두 가중치 합이 이 값 미만이면 나눗셈 자체가 불가능(ZeroDivision 위험)하므로
+# 정규화 대신 기본값으로 즉시 폴백한다.
+# 역할: "합이 사실상 0인가?" 판단 (정규화 허용치와 개념 분리)
 _WEIGHT_SUM_ZERO_EPSILON: float = 1e-9
-# 합계가 1.0과 이 절댓값 이상 차이나면 재정규화를 수행한다.
-# rel_tol(_WEIGHT_SUM_ZERO_EPSILON)과 달리 abs_tol을 사용하여
-# "1.0 근처에서 얼마나 벗어났는가"를 예측 가능하게 판단한다.
+
+# ── [그룹 B] 재정규화 허용치 & 반올림 정밀도 ────────────────────────────────
+# 두 상수는 함께 설계된 쌍이다.
+#
+# _WEIGHT_SUM_NORMALIZATION_TOLERANCE = 1e-6
+#   합계가 1.0과 이 절댓값(abs_tol) 이상 차이나면 재정규화를 수행한다.
+#   역할: "합이 1.0에서 유의미하게 벗어났는가?" 판단
+#
+# _WEIGHT_NORMALIZATION_PRECISION = 6
+#   재정규화 후 round(..., 6) 을 적용한다.
+#
+# [수학적 일관성 근거]
+#   round(..., 6) 의 최대 반올림 오차는 값 1개당 5e-7 이다.
+#   두 값을 각각 반올림하면 합산 최대 오차 = 2 × 5e-7 = 1e-6 = TOLERANCE.
+#   따라서 정규화 직후 합이 다시 허용치를 벗어날 수 없어 oscillation 위험이 없다.
+#   또한 _load_index_weights()는 재귀 없이 1회만 실행되므로 구조적으로 진동 불가.
 _WEIGHT_SUM_NORMALIZATION_TOLERANCE: float = 1e-6
-# 재정규화된 가중치를 반올림할 소수점 자리수 (6자리 ≈ 마이크로 단위 정밀도)
 _WEIGHT_NORMALIZATION_PRECISION: int = 6
 
 

--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -16,6 +16,13 @@
 설계 원칙 (개인정보 보호 우선):
   - user_id는 절대 로그에 평문으로 기록하지 않는다.
   - 로그에 user_id를 출력해야 하는 경우 반드시 mask_pii_id() 헬퍼를 사용한다.
+
+[설계 노트: 가중치 재정규화 허용치와 정밀도]
+  _WEIGHT_SUM_NORMALIZATION_TOLERANCE와 _WEIGHT_NORMALIZATION_PRECISION은
+  항상 수학적 일관성을 유지해야 한다.
+  (근거) round(..., p) 2개의 합산 시 최대 오차는 10**(-p) 이며, 
+  재정규화 직후 다시 허용치를 벗어나 무한 진동(oscillation)하는 것을 방지하려면
+  TOLERANCE >= 10**(-PRECISION) 이어야 한다.
 """
 
 import asyncio
@@ -70,22 +77,18 @@ _COLD_START_GLOBAL_WEIGHT = 1.0
 _WEIGHT_SUM_ZERO_EPSILON: float = 1e-9
 
 # ── [그룹 B] 재정규화 허용치 & 반올림 정밀도 ────────────────────────────────
-# 두 상수는 함께 설계된 쌍이다.
-#
-# _WEIGHT_SUM_NORMALIZATION_TOLERANCE = 1e-6
-#   합계가 1.0과 이 절댓값(abs_tol) 이상 차이나면 재정규화를 수행한다.
-#   역할: "합이 1.0에서 유의미하게 벗어났는가?" 판단
-#
-# _WEIGHT_NORMALIZATION_PRECISION = 6
-#   재정규화 후 round(..., 6) 을 적용한다.
-#
-# [수학적 일관성 근거]
-#   round(..., 6) 의 최대 반올림 오차는 값 1개당 5e-7 이다.
-#   두 값을 각각 반올림하면 합산 최대 오차 = 2 × 5e-7 = 1e-6 = TOLERANCE.
-#   따라서 정규화 직후 합이 다시 허용치를 벗어날 수 없어 oscillation 위험이 없다.
-#   또한 _load_index_weights()는 재귀 없이 1회만 실행되므로 구조적으로 진동 불가.
+# 두 상수는 쌍으로 작동하며, 정밀도(PRECISION)에 따른 최대 오차가 허용치(TOLERANCE)를 
+# 넘지 않도록 런타임에 강제된다 (모듈 레벨 주석의 [설계 노트] 참조).
 _WEIGHT_SUM_NORMALIZATION_TOLERANCE: float = 1e-6
 _WEIGHT_NORMALIZATION_PRECISION: int = 6
+
+_MAX_WEIGHT_SUM_ROUNDING_ERROR = 10 ** (-_WEIGHT_NORMALIZATION_PRECISION)
+if _MAX_WEIGHT_SUM_ROUNDING_ERROR > _WEIGHT_SUM_NORMALIZATION_TOLERANCE:
+    raise RuntimeError(
+        f"Invariant violated: _WEIGHT_SUM_NORMALIZATION_TOLERANCE({_WEIGHT_SUM_NORMALIZATION_TOLERANCE}) "
+        f"must be >= max rounding error({_MAX_WEIGHT_SUM_ROUNDING_ERROR}) "
+        f"implied by _WEIGHT_NORMALIZATION_PRECISION({_WEIGHT_NORMALIZATION_PRECISION})."
+    )
 
 
 def _parse_bounded_weight(env_key: str, default: float, min_val: float, max_val: float) -> float:


### PR DESCRIPTION
- **[Fix 1] 허용치와 정밀도 간의 수학적 안전성 증명 문서화**
  - `_WEIGHT_SUM_NORMALIZATION_TOLERANCE(1e-6)`와 `_WEIGHT_NORMALIZATION_PRECISION(6)`의 관계 설명 추가
  - round(..., 6) 2회 수행 시 최대 반올림 오차(1e-6)가 허용치와 일치하여 정규화 직후 다시 허용치를 벗어나는 진동(oscillation) 리스크가 없음을 명시
  - `_load_index_weights()`의 단일 실행 특성을 명기하여 구조적 안전성 보장

- **[Fix 2] 상수 역할별 시맨틱 그룹핑 (Semantic Grouping)**
  - [그룹 A] ZeroDivision 가드: 나눗셈 불능 방지용 (_WEIGHT_SUM_ZERO_EPSILON)
  - [그룹 B] 재정규화 허용치 & 반올림 정밀도: 의미적 오차 판단용
  - 상수가 혼재되어 있던 구조를 역할과 의도에 맞게 재배치하여 미래 유지보수성 극대화

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1252#pullrequestreview-4178814055)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

하이브리드 검색 가중치 정규화 상수를 문서화하고 의미적으로 그룹화하여, 수학적으로 일관된 동작과 더 안전한 0으로 나누기 처리(division by zero handling)를 보장합니다.

Enhancements:
- 0으로 나누기 방지용 가드와 정규화 임계값 및 정밀도(precision)를 명확히 구분할 수 있도록, 가중치 관련 상수들을 의미적 역할별로 그룹화합니다.

Documentation:
- 정규화 허용오차(tolerance)와 정밀도 간의 수학적 관계, 그리고 그것이 재정규화 이후의 진동(oscillation)을 어떻게 방지하는지에 대해 설명하는 인라인(in-code) 문서를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document and semantically group hybrid search weight normalization constants to ensure mathematically consistent behavior and safer zero-division handling.

Enhancements:
- Group weight-related constants by semantic role to clarify zero-division guards versus normalization thresholds and precision.

Documentation:
- Add in-code documentation explaining the mathematical relationship between normalization tolerance and precision, and why it prevents oscillation after re-normalization.

</details>