### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -63,14 +63,28 @@ _GLOBAL_WEIGHT_MAX = 1.0
 _COLD_START_PERSONALIZED_WEIGHT = 0.0
 _COLD_START_GLOBAL_WEIGHT = 1.0
 
-# 합산 보정 수치 상수 (하드코딩 금지 — 이곳에서만 수정)
-# 합계가 이 값 미만이면 ZeroDivision 위험으로 간주하여 기본값으로 폴백
+# ── [그룹 A] ZeroDivision 가드 ──────────────────────────────────────────────
+# 두 가중치 합이 이 값 미만이면 나눗셈 자체가 불가능(ZeroDivision 위험)하므로
+# 정규화 대신 기본값으로 즉시 폴백한다.
+# 역할: "합이 사실상 0인가?" 판단 (정규화 허용치와 개념 분리)
 _WEIGHT_SUM_ZERO_EPSILON: float = 1e-9
-# 합계가 1.0과 이 절댓값 이상 차이나면 재정규화를 수행한다.
-# rel_tol(_WEIGHT_SUM_ZERO_EPSILON)과 달리 abs_tol을 사용하여
-# "1.0 근처에서 얼마나 벗어났는가"를 예측 가능하게 판단한다.
+
+# ── [그룹 B] 재정규화 허용치 & 반올림 정밀도 ────────────────────────────────
+# 두 상수는 함께 설계된 쌍이다.
+#
+# _WEIGHT_SUM_NORMALIZATION_TOLERANCE = 1e-6
+#   합계가 1.0과 이 절댓값(abs_tol) 이상 차이나면 재정규화를 수행한다.
+#   역할: "합이 1.0에서 유의미하게 벗어났는가?" 판단
+#
+# _WEIGHT_NORMALIZATION_PRECISION = 6
+#   재정규화 후 round(..., 6) 을 적용한다.
+#
+# [수학적 일관성 근거]
+#   round(..., 6) 의 최대 반올림 오차는 값 1개당 5e-7 이다.
+#   두 값을 각각 반올림하면 합산 최대 오차 = 2 × 5e-7 = 1e-6 = TOLERANCE.
+#   따라서 정규화 직후 합이 다시 허용치를 벗어날 수 없어 oscillation 위험이 없다.
+#   또한 _load_index_weights()는 재귀 없이 1회만 실행되므로 구조적으로 진동 불가.
 _WEIGHT_SUM_NORMALIZATION_TOLERANCE: float = 1e-6
-# 재정규화된 가중치를 반올림할 소수점 자리수 (6자리 ≈ 마이크로 단위 정밀도)
 _WEIGHT_NORMALIZATION_PRECISION: int = 6
 
 

--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -16,6 +16,13 @@
 설계 원칙 (개인정보 보호 우선):
   - user_id는 절대 로그에 평문으로 기록하지 않는다.
   - 로그에 user_id를 출력해야 하는 경우 반드시 mask_pii_id() 헬퍼를 사용한다.
+
+[설계 노트: 가중치 재정규화 허용치와 정밀도]
+  _WEIGHT_SUM_NORMALIZATION_TOLERANCE와 _WEIGHT_NORMALIZATION_PRECISION은
+  항상 수학적 일관성을 유지해야 한다.
+  (근거) round(..., p) 2개의 합산 시 최대 오차는 10**(-p) 이며, 
+  재정규화 직후 다시 허용치를 벗어나 무한 진동(oscillation)하는 것을 방지하려면
+  TOLERANCE >= 10**(-PRECISION) 이어야 한다.
 """
 
 import asyncio
@@ -70,22 +77,18 @@ _COLD_START_GLOBAL_WEIGHT = 1.0
 _WEIGHT_SUM_ZERO_EPSILON: float = 1e-9
 
 # ── [그룹 B] 재정규화 허용치 & 반올림 정밀도 ────────────────────────────────
-# 두 상수는 함께 설계된 쌍이다.
-#
-# _WEIGHT_SUM_NORMALIZATION_TOLERANCE = 1e-6
-#   합계가 1.0과 이 절댓값(abs_tol) 이상 차이나면 재정규화를 수행한다.
-#   역할: "합이 1.0에서 유의미하게 벗어났는가?" 판단
-#
-# _WEIGHT_NORMALIZATION_PRECISION = 6
-#   재정규화 후 round(..., 6) 을 적용한다.
-#
-# [수학적 일관성 근거]
-#   round(..., 6) 의 최대 반올림 오차는 값 1개당 5e-7 이다.
-#   두 값을 각각 반올림하면 합산 최대 오차 = 2 × 5e-7 = 1e-6 = TOLERANCE.
-#   따라서 정규화 직후 합이 다시 허용치를 벗어날 수 없어 oscillation 위험이 없다.
-#   또한 _load_index_weights()는 재귀 없이 1회만 실행되므로 구조적으로 진동 불가.
+# 두 상수는 쌍으로 작동하며, 정밀도(PRECISION)에 따른 최대 오차가 허용치(TOLERANCE)를 
+# 넘지 않도록 런타임에 강제된다 (모듈 레벨 주석의 [설계 노트] 참조).
 _WEIGHT_SUM_NORMALIZATION_TOLERANCE: float = 1e-6
 _WEIGHT_NORMALIZATION_PRECISION: int = 6
+
+_MAX_WEIGHT_SUM_ROUNDING_ERROR = 10 ** (-_WEIGHT_NORMALIZATION_PRECISION)
+if _MAX_WEIGHT_SUM_ROUNDING_ERROR > _WEIGHT_SUM_NORMALIZATION_TOLERANCE:
+    raise RuntimeError(
+        f"Invariant violated: _WEIGHT_SUM_NORMALIZATION_TOLERANCE({_WEIGHT_SUM_NORMALIZATION_TOLERANCE}) "
+        f"must be >= max rounding error({_MAX_WEIGHT_SUM_ROUNDING_ERROR}) "
+        f"implied by _WEIGHT_NORMALIZATION_PRECISION({_WEIGHT_NORMALIZATION_PRECISION})."
+    )
 
 
 def _parse_bounded_weight(env_key: str, default: float, min_val: float, max_val: float) -> float:


### PR DESCRIPTION
☘️ refactor [#12.2.8]: 4차 개선 - 가중치 임계값 그룹핑 및 수학적 일관성 근거 문서화 
☘️ refactor [#12.2.8]: 5차 개선 - 가중치 정규화 설계 노트 분리 및 런타임 불변성 강제

## Summary by Sourcery

하이브리드 검색 가중치 정규화 임계값과 불변 조건을 명확히 하고 강화했습니다.

Enhancements:
- 역할을 더 명확히 하기 위해, 가중치 관련 상수를 0 나누기 방지용 가드와 정규화 허용오차로 구분하여 그룹화했습니다.
- 설정된 정밀도에서 암시되는 최대 반올림 오차보다 정규화 허용오차가 항상 크거나 같도록 하는 런타임 불변 조건을 강제했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify and harden the hybrid search weight normalization thresholds and invariants.

Enhancements:
- Group weight-related constants into zero-division guards vs normalization tolerances for clearer responsibilities.
- Enforce a runtime invariant ensuring normalization tolerance is at least as large as the maximum rounding error implied by the configured precision.

</details>