### PR TITLE
✨ feat [#12.2.9]: Phase 2.3 - ➁ 개인화 컨텍스트 혼합 검색 라우터 구현 (Router Layer)

### DIFF
--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -297,9 +297,6 @@ _PERSONALIZED_SEARCH_TIMEOUT_ENV_KEY = "PERSONALIZED_INDEX_SEARCH_TIMEOUT"
 _PERSONALIZED_SEARCH_TIMEOUT_DEFAULT = 2.0
 _PERSONALIZED_SEARCH_TIMEOUT_MIN = 0.1
 
-# 라우터 Graceful Degradation 시 사용할 빈 결과 (불변 참조, 매 요청 재할당 방지)
-_EMPTY_SEARCH_RESULTS: List[Dict[str, Any]] = []
-
 
 def _load_personalized_search_timeout() -> float:
     """
@@ -768,7 +765,7 @@ class HybridSearchService:
                 filter_expansion_factor=filter_expansion_factor,
             )
             return IndexSearchResults(
-                personalized_results=list(_EMPTY_SEARCH_RESULTS),
+                personalized_results=[],
                 global_results=global_results.results,
                 personalized_weight=personalized_weight,
                 global_weight=global_weight,
@@ -815,7 +812,7 @@ class HybridSearchService:
                     masked_uid,
                     _PERSONALIZED_SEARCH_TIMEOUT,
                 )
-                return list(_EMPTY_SEARCH_RESULTS)
+                return []
             except Exception:  # noqa: BLE001
                 logger.warning(
                     "[HYBRID_SEARCH][ROUTER] 개인화 인덱스 조회 실패 (masked_uid=%s) "
@@ -823,19 +820,38 @@ class HybridSearchService:
                     masked_uid,
                     exc_info=True,
                 )
-                return list(_EMPTY_SEARCH_RESULTS)
+                return []
 
         async def _search_global() -> List[Dict[str, Any]]:
-            """전역 인덱스 조회 코루틴."""
-            result = await run_in_threadpool(
-                self._execute_search,
-                query=query,
-                k=k,
-                alpha=alpha,
-                metadata_filter=metadata_filter,
-                filter_expansion_factor=filter_expansion_factor,
-            )
-            return result.results
+            """
+            전역 인덱스 조회 코루틴.
+
+            정책: 전역 인덱스는 필수 질의 소스다.
+              - 성공: 결과 목록 반환
+              - 실패: ERROR 로그 후 예외를 상위로 전파하여 요청 전체를 실패시킨다.
+              - (개인화 인덱스와의 차이) 개인화 인덱스는 부가적(Optional)이라
+                실패 시 빈 결과로 Graceful Degradation하지만,
+                전역 인덱스는 폴백이 없으므로 예외를 전파한다.
+            """
+            try:
+                result = await run_in_threadpool(
+                    self._execute_search,
+                    query=query,
+                    k=k,
+                    alpha=alpha,
+                    metadata_filter=metadata_filter,
+                    filter_expansion_factor=filter_expansion_factor,
+                )
+                return result.results
+            except Exception:  # noqa: BLE001
+                logger.error(
+                    "[HYBRID_SEARCH][ROUTER] 전역 인덱스 조회 실패 (masked_uid=%s) "
+                    "→ 요청 전체를 실패시킵니다. "
+                    "(전역 인덱스 실패는 Graceful Degradation 대상이 아닙니다.)",
+                    masked_uid,
+                    exc_info=True,
+                )
+                raise
 
         personalized_results, global_results = await asyncio.gather(
             _search_personalized(),

--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -287,6 +287,93 @@ async def get_index_weights(hashed_user_id: str) -> Tuple[float, float]:
     return _PERSONALIZED_INDEX_WEIGHT, _GLOBAL_INDEX_WEIGHT
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# [Step 2-3 / Phase 2.3] 2단계: 혼합 검색 라우터 (Router Layer)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# 개인화 인덱스 조회 타임아웃 환경 변수 (하드코딩 금지)
+# PERSONALIZED_INDEX_SEARCH_TIMEOUT [float, 기본값: 2.0초, 최소: 0.1초]
+_PERSONALIZED_SEARCH_TIMEOUT_ENV_KEY = "PERSONALIZED_INDEX_SEARCH_TIMEOUT"
+_PERSONALIZED_SEARCH_TIMEOUT_DEFAULT = 2.0
+_PERSONALIZED_SEARCH_TIMEOUT_MIN = 0.1
+
+# 라우터 Graceful Degradation 시 사용할 빈 결과 (불변 참조, 매 요청 재할당 방지)
+_EMPTY_SEARCH_RESULTS: List[Dict[str, Any]] = []
+
+
+def _load_personalized_search_timeout() -> float:
+    """
+    PERSONALIZED_INDEX_SEARCH_TIMEOUT 환경 변수를 안전하게 파싱한다.
+
+    동작 우선순위:
+      1) 미설정(None)  → 조용히 기본값 반환
+      2) 빈값/공백    → WARNING + 기본값
+      3) 파싱 실패    → WARNING + 기본값
+      4) 최솟값 미만  → Clamp + WARNING
+    """
+    raw = os.environ.get(_PERSONALIZED_SEARCH_TIMEOUT_ENV_KEY)
+    if raw is None:
+        return _PERSONALIZED_SEARCH_TIMEOUT_DEFAULT
+
+    stripped = raw.strip()
+    if not stripped:
+        logger.warning(
+            "[HYBRID_SEARCH][ROUTER] %s 가 설정됐으나 빈값/공백입니다. 기본값 %.1f초로 폴백합니다.",
+            _PERSONALIZED_SEARCH_TIMEOUT_ENV_KEY,
+            _PERSONALIZED_SEARCH_TIMEOUT_DEFAULT,
+        )
+        return _PERSONALIZED_SEARCH_TIMEOUT_DEFAULT
+
+    try:
+        value = float(stripped)
+    except (ValueError, TypeError):
+        logger.warning(
+            "[HYBRID_SEARCH][ROUTER] %s 파싱 실패 (값=%r). 기본값 %.1f초로 폴백합니다.",
+            _PERSONALIZED_SEARCH_TIMEOUT_ENV_KEY,
+            stripped,
+            _PERSONALIZED_SEARCH_TIMEOUT_DEFAULT,
+        )
+        return _PERSONALIZED_SEARCH_TIMEOUT_DEFAULT
+
+    if value < _PERSONALIZED_SEARCH_TIMEOUT_MIN:
+        logger.warning(
+            "[HYBRID_SEARCH][ROUTER] %s=%.3f 가 최솟값(%.1f) 미만입니다. %.1f초로 보정합니다.",
+            _PERSONALIZED_SEARCH_TIMEOUT_ENV_KEY,
+            value,
+            _PERSONALIZED_SEARCH_TIMEOUT_MIN,
+            _PERSONALIZED_SEARCH_TIMEOUT_MIN,
+        )
+        return _PERSONALIZED_SEARCH_TIMEOUT_MIN
+
+    return value
+
+
+# 모듈 로드 시 1회 파싱 (변경 시 재시작 필요)
+_PERSONALIZED_SEARCH_TIMEOUT: float = _load_personalized_search_timeout()
+
+
+@dataclass
+class IndexSearchResults:
+    """
+    2단계 라우터의 병렬 조회 결과 DTO.
+
+    두 인덱스의 결과를 함께 전달하여 3단계 RRF 병합의 타입 계약을 명확히 한다.
+
+    Fields:
+        personalized_results : 개인화 인덱스 조회 결과 (Cold Start 시 빈 리스트)
+        global_results       : 전역 인덱스 조회 결과
+        personalized_weight  : 실제 적용된 개인화 가중치 (1단계 SSOT에서 결정)
+        global_weight        : 실제 적용된 전역 가중치 (1단계 SSOT에서 결정)
+        is_cold_start        : Cold Start 경로 사용 여부 (3단계 RRF 로직 분기용)
+    """
+
+    personalized_results: List[Dict[str, Any]]
+    global_results: List[Dict[str, Any]]
+    personalized_weight: float
+    global_weight: float
+    is_cold_start: bool
+
+
 async def _log_search_history_bg(hashed_user_id: str, query: str) -> None:
     """
     검색 히스토리 로깅 백그라운드 태스크 (Fire-and-Forget 전용).
@@ -619,7 +706,159 @@ class HybridSearchService:
 
         return HybridSearchResult(results=raw_results, applied_filter=metadata_filter)
 
-    def save_indices(self):
+    # ------------------------------------------------------------------
+    # [Step 2-3 / Phase 2.3] 2단계: 혼합 검색 라우터 (Router Layer)
+    # ------------------------------------------------------------------
+
+    async def route_weighted_search(
+        self,
+        hashed_user_id: str,
+        query: str,
+        k: int = 5,
+        alpha: float = 0.5,
+        metadata_filter: Optional[Dict[str, Any]] = None,
+        filter_expansion_factor: int = 2,
+    ) -> IndexSearchResults:
+        """
+        1단계 가중치 결정 함수(get_index_weights)를 SSOT로 참조하여
+        개인화 인덱스와 전역 인덱스를 병렬로 조회하는 혼합 검색 라우터.
+
+        설계 원칙:
+          - PII 보호: hashed_user_id를 mask_pii_id()로 마스킹한 masked_uid만 로그에 사용
+          - Cold Start 단락(Short-circuit): personalized_weight == 0.0이면 전역 단독 실행
+          - 병렬 조회: 정상 사용자는 asyncio.gather로 두 인덱스를 동시에 조회하여 지연 최소화
+          - Graceful Degradation: 개인화 인덱스 조회 실패(타임아웃·예외) 시 빈 결과로 폴백,
+            전역 인덱스 결과만으로 계속 진행 (서비스 연속성 우선)
+
+        Args:
+            hashed_user_id       : SHA-256 해시된 사용자 식별자 (평문 user_id 금지)
+            query                : 검색 쿼리 문자열
+            k                    : 각 인덱스에서 조회할 최대 결과 수
+            alpha                : 하이브리드 검색 FAISS/BM25 혼합 비율 (0.0~1.0)
+            metadata_filter      : 메타데이터 필터 (선택)
+            filter_expansion_factor: 필터 확장 계수 (선택)
+
+        Returns:
+            IndexSearchResults — 두 인덱스 결과, 적용된 가중치, Cold Start 여부를 담은 DTO.
+            3단계 RRF 병합 로직의 직접 입력으로 사용된다.
+        """
+        masked_uid = mask_pii_id(hashed_user_id)
+
+        # ── 1단계 SSOT에서 가중치 확정 ────────────────────────────────────────
+        personalized_weight, global_weight = await get_index_weights(hashed_user_id)
+
+        # ── Cold Start 단락(Short-circuit) 경로 ───────────────────────────────
+        # personalized_weight == _COLD_START_PERSONALIZED_WEIGHT(0.0) 이면
+        # 개인화 인덱스 조회를 아예 건너뛰어 불필요한 I/O를 차단한다.
+        if math.isclose(personalized_weight, _COLD_START_PERSONALIZED_WEIGHT,
+                        rel_tol=0.0, abs_tol=_WEIGHT_SUM_ZERO_EPSILON):
+            logger.info(
+                "[HYBRID_SEARCH][ROUTER] Cold Start 단락 경로 → 전역 인덱스 단독 조회 "
+                "(masked_uid=%s, personalized=%.1f, global=%.1f)",
+                masked_uid,
+                personalized_weight,
+                global_weight,
+            )
+            global_results = await run_in_threadpool(
+                self._execute_search,
+                query=query,
+                k=k,
+                alpha=alpha,
+                metadata_filter=metadata_filter,
+                filter_expansion_factor=filter_expansion_factor,
+            )
+            return IndexSearchResults(
+                personalized_results=list(_EMPTY_SEARCH_RESULTS),
+                global_results=global_results.results,
+                personalized_weight=personalized_weight,
+                global_weight=global_weight,
+                is_cold_start=True,
+            )
+
+        # ── 정상 사용자: 병렬 조회 경로 ───────────────────────────────────────
+        # 개인화 인덱스와 전역 인덱스를 asyncio.gather로 동시 실행한다.
+        # 개인화 인덱스 조회에만 타임아웃을 적용하여 느린 서브-인덱스가
+        # 전체 응답을 블로킹하지 않도록 방어한다.
+        logger.debug(
+            "[HYBRID_SEARCH][ROUTER] 병렬 조회 시작 "
+            "(masked_uid=%s, personalized=%.4f, global=%.4f, timeout=%.1fs)",
+            masked_uid,
+            personalized_weight,
+            global_weight,
+            _PERSONALIZED_SEARCH_TIMEOUT,
+        )
+
+        async def _search_personalized() -> List[Dict[str, Any]]:
+            """
+            개인화 인덱스 조회 코루틴 (타임아웃 + Graceful Degradation 내장).
+
+            현재는 동일한 HybridSearcher를 사용하며, 향후 사용자별 FAISS 서브-인덱스가
+            실제로 분리되면 이 내부 함수에서 personalized_index_service 조회로 교체한다.
+            """
+            try:
+                result = await asyncio.wait_for(
+                    run_in_threadpool(
+                        self._execute_search,
+                        query=query,
+                        k=k,
+                        alpha=alpha,
+                        metadata_filter=metadata_filter,
+                        filter_expansion_factor=filter_expansion_factor,
+                    ),
+                    timeout=_PERSONALIZED_SEARCH_TIMEOUT,
+                )
+                return result.results
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[HYBRID_SEARCH][ROUTER] 개인화 인덱스 조회 타임아웃 "
+                    "(masked_uid=%s, timeout=%.1fs) → 빈 결과로 폴백.",
+                    masked_uid,
+                    _PERSONALIZED_SEARCH_TIMEOUT,
+                )
+                return list(_EMPTY_SEARCH_RESULTS)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "[HYBRID_SEARCH][ROUTER] 개인화 인덱스 조회 실패 (masked_uid=%s) "
+                    "→ 빈 결과로 폴백. 전역 인덱스 결과만으로 계속 진행합니다.",
+                    masked_uid,
+                    exc_info=True,
+                )
+                return list(_EMPTY_SEARCH_RESULTS)
+
+        async def _search_global() -> List[Dict[str, Any]]:
+            """전역 인덱스 조회 코루틴."""
+            result = await run_in_threadpool(
+                self._execute_search,
+                query=query,
+                k=k,
+                alpha=alpha,
+                metadata_filter=metadata_filter,
+                filter_expansion_factor=filter_expansion_factor,
+            )
+            return result.results
+
+        personalized_results, global_results = await asyncio.gather(
+            _search_personalized(),
+            _search_global(),
+        )
+
+        logger.debug(
+            "[HYBRID_SEARCH][ROUTER] 병렬 조회 완료 "
+            "(masked_uid=%s, personalized_hits=%d, global_hits=%d)",
+            masked_uid,
+            len(personalized_results),
+            len(global_results),
+        )
+
+        return IndexSearchResults(
+            personalized_results=personalized_results,
+            global_results=global_results,
+            personalized_weight=personalized_weight,
+            global_weight=global_weight,
+            is_cold_start=False,
+        )
+
+
         """FAISS와 BM25 인덱스를 디스크에 저장"""
         from backend.config import PathConfig
 


### PR DESCRIPTION
- **[IndexSearchResults DTO 신설]**
  - 두 인덱스의 결과, 적용 가중치, Cold Start 여부를 캡슐화
  - 3단계 RRF 병합 로직의 타입 계약을 명확히 선언

- **[환경 변수 외부화]**
  - PERSONALIZED_INDEX_SEARCH_TIMEOUT [float, 기본값: 2.0초, 최소: 0.1초]
  - 방어 로직: 빈값/파싱실패/최솟값 미만 각각 WARNING + 폴백

- **[route_weighted_search() 메서드 구현]**
  - 1단계 get_index_weights()를 SSOT로 호출하여 가중치 확정
  - Cold Start 단락(Short-circuit): personalized_weight ≈ 0.0이면 개인화 인덱스 I/O를 완전히 건너뛰고 전역 단독 실행
  - 정상 사용자: asyncio.gather로 두 인덱스 병렬 조회하여 지연 최소화
  - Graceful Degradation: 개인화 인덱스 타임아웃·예외 시 빈 결과 폴백, 전역 인덱스 결과만으로 서비스 연속성 보장
  - 모든 로그: masked_uid 전용 사용 (평문 user_id 노출 원천 차단)

🔗 Related: Issue [#1046]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개인화 및 글로벌 하이브리드 검색을 조합하여 오케스트레이션하는 라우터 레이어를 도입합니다. 이 레이어는 설정 가능한 타임아웃, 콜드 스타트 처리, 그리고 다운스트림 결과 머지를 위한 타입이 지정된 DTO를 제공합니다.

새로운 기능:
- 개인화/글로벌 인덱스 결과, 가중치, 콜드 스타트 상태를 머지 단계로 전달하기 위한 `IndexSearchResults` DTO를 추가했습니다.
- 하이브리드 검색 서비스에 `route_weighted_search` API를 구현하여, 개인화 인덱스와 글로벌 인덱스 간에 쿼리를 라우팅하고 병렬 실행 및 점진적 성능 저하(graceful degradation)를 지원합니다.

개선 사항:
- 개인화 인덱스 검색 타임아웃을 검증된 환경 변수로 외부화하고, 안전한 기본값과 잘못된 설정에 대한 로깅을 추가했습니다.
- 라우터 로깅에서 마스킹된 사용자 식별자를 사용하여 원시 사용자 ID가 노출되지 않도록 보장합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a router layer that orchestrates personalized and global hybrid searches with configurable timeouts, cold-start handling, and a typed DTO for downstream result merging.

New Features:
- Add an IndexSearchResults DTO to carry personalized/global index results, weights, and cold-start state to the merge stage.
- Implement a route_weighted_search API on the hybrid search service that routes queries across personalized and global indices with parallel execution and graceful degradation.

Enhancements:
- Externalize the personalized index search timeout into a validated environment variable with safe defaults and logging for invalid configurations.
- Ensure router logging uses masked user identifiers to avoid exposing raw user IDs.

</details>