### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -1057,6 +1057,14 @@ class HybridSearchService:
             )
             rrf_k = _RRF_K_MIN
 
+        # top_k 타입 검증: 직접 호출 시 None 또는 비정수 타입이 전달될 경우 비교 연산에서 TypeError 발생.
+        # isinstance 사전 검증으로 명확한 오류 메시지를 보장한다.
+        if not isinstance(top_k, int):
+            raise TypeError(
+                f"[HYBRID_SEARCH][RRF] top_k는 int 타입이어야 합니다. "
+                f"수신된 타입: {type(top_k).__name__!r}, 값: {top_k!r}"
+            )
+
         # top_k: 음수 시 Python 리스트 슬라이싱이 끝에서 역방향으로 동작하여
         #        "상위 N개" 의미와 완전히 달라진다. max(0, top_k)로 안전하게 보정한다.
         # top_k 상한: env 로더(_load_int_env)와 동일한 _RRF_TOP_K_MAX 기준을 직접
@@ -1086,20 +1094,42 @@ class HybridSearchService:
         ) -> None:
             """단일 인덱스 결과 목록의 RRF 스코어를 score_table에 누산한다.
 
-            weight <= 0.0 인 경우:
+            weight 분기:
+              - weight > 0.0: 정상 경로. RRF 스코어를 누산한다.
               - weight == 0.0: Cold Start 등 정상적인 빈 기여 경로.
-                이 경우 전체 results가 비어 있으므로(route_weighted_search 설계)
-                루프 자체가 실행되지 않아 자연스럽게 스킵된다.
+                설계상 results도 비어 있어야 하며, 비어 있지 않으면
+                불변식 위반으로 WARNING을 발생시킨다.
               - weight < 0.0: 가중치 계산 버그 등 비정상 경로.
-                기여값이 음수가 되어 의도치 않은 역순위를 유발하므로 즉시 스킵한다.
+                음수 기여값이 score_table에 누산되면 의도치 않은 역순위를
+                유발하므로 WARNING 발생 후 즉시 스킵한다.
             """
-            if weight <= 0.0:
-                logger.debug(
-                    "[HYBRID_SEARCH][RRF] weight=%.6f <= 0 인 인덱스를 스킵합니다. "
-                    "(weight==0.0: Cold Start 정상 경로, weight<0: 비정상 경로)",
+            if weight == 0.0:
+                # 설계 불변식: weight==0.0이면 results도 비어 있어야 한다.
+                # (route_weighted_search는 Cold Start 시 personalized_results=[]를 보장)
+                # 비어 있지 않으면 불변식 위반 — WARNING으로 표면시킨다.
+                if results:
+                    logger.warning(
+                        "[HYBRID_SEARCH][RRF] weight=0.0인데 results가 비어 있지 않습니다 "
+                        "(len=%d). 설계 불변식 위반 — 스킵합니다.",
+                        len(results),
+                    )
+                else:
+                    logger.debug(
+                        "[HYBRID_SEARCH][RRF] weight=0.0 (Cold Start 정상 경로) — 스킵합니다.",
+                    )
+                return
+
+            if weight < 0.0:
+                # 비정상 경로: 가중치 계산 버그 가능성. WARNING으로 표면하여 운영 중 탐지를 보장한다.
+                logger.warning(
+                    "[HYBRID_SEARCH][RRF] weight=%.6f 가 음수입니다. "
+                    "음수 기여값은 역순위를 유발하며 이는 가중치 계산 버그일 가능성이 높습니다. "
+                    "인덱스를 스킵합니다.",
                     weight,
                 )
                 return
+
+            # weight > 0.0: 정상 경로
             for rank, item in enumerate(results, start=1):  # rank는 1-indexed
                 doc_id = _extract_doc_id(item)
                 contribution = weight / (rrf_k + rank)

--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -1059,6 +1059,8 @@ class HybridSearchService:
 
         # top_k: 음수 시 Python 리스트 슬라이싱이 끝에서 역방향으로 동작하여
         #        "상위 N개" 의미와 완전히 달라진다. max(0, top_k)로 안전하게 보정한다.
+        # top_k 상한: env 로더(_load_int_env)와 동일한 _RRF_TOP_K_MAX 기준을 직접
+        #             호출 경로에도 적용하여, 예상치 못하게 큰 결과 집합을 방지한다.
         effective_top_k = top_k
         if top_k < 0:
             logger.warning(
@@ -1067,6 +1069,12 @@ class HybridSearchService:
                 top_k,
             )
             effective_top_k = 0
+        elif top_k > _RRF_TOP_K_MAX:
+            logger.warning(
+                "[HYBRID_SEARCH][RRF] top_k=%d 가 상한값(%d) 초과입니다. %d으로 보정합니다.",
+                top_k, _RRF_TOP_K_MAX, _RRF_TOP_K_MAX,
+            )
+            effective_top_k = _RRF_TOP_K_MAX
 
         # ── 스코어 누산 테이블 ──────────────────────────────────────────────
         # {doc_id: {"score": float, "item": Dict}} 구조
@@ -1076,7 +1084,22 @@ class HybridSearchService:
             results: List[Dict[str, Any]],
             weight: float,
         ) -> None:
-            """단일 인덱스 결과 목록의 RRF 스코어를 score_table에 누산한다."""
+            """단일 인덱스 결과 목록의 RRF 스코어를 score_table에 누산한다.
+
+            weight <= 0.0 인 경우:
+              - weight == 0.0: Cold Start 등 정상적인 빈 기여 경로.
+                이 경우 전체 results가 비어 있으므로(route_weighted_search 설계)
+                루프 자체가 실행되지 않아 자연스럽게 스킵된다.
+              - weight < 0.0: 가중치 계산 버그 등 비정상 경로.
+                기여값이 음수가 되어 의도치 않은 역순위를 유발하므로 즉시 스킵한다.
+            """
+            if weight <= 0.0:
+                logger.debug(
+                    "[HYBRID_SEARCH][RRF] weight=%.6f <= 0 인 인덱스를 스킵합니다. "
+                    "(weight==0.0: Cold Start 정상 경로, weight<0: 비정상 경로)",
+                    weight,
+                )
+                return
             for rank, item in enumerate(results, start=1):  # rank는 1-indexed
                 doc_id = _extract_doc_id(item)
                 contribution = weight / (rrf_k + rank)


### PR DESCRIPTION
☘️ refactor [#12.2.10]: 2차 개선 - top_k 상한 Clamp 및 weight 비정상값 방어 추가 
☘️ refactor [#12.2.10]: 3차 개선 - weight 분기 명시화 및 top_k 타입 검증 강화

## Summary by Sourcery

잘못된 `top_k` 및 가중치 값으로 인해 잘못된 랭킹 결과나 런타임 오류가 발생하는 것을 방지하기 위해, RRF 하이브리드 검색 파라미터에 대한 방어적 처리를 강화했습니다.

버그 수정:
- 과도하게 큰 `top_k` 값을 설정된 최대값으로 클램핑(clamp)하고, 음수 값을 정규화하여 예기치 않은 슬라이싱 동작을 방지합니다.
- `top_k`에 대해 명시적인 타입 체크를 추가하여, 비교 과정에서 일반적인 `TypeError`가 발생하는 대신 명확한 에러와 함께 조기에 실패(fail fast)하도록 합니다.
- RRF 누적 과정에서 0 또는 음수 가중치를 방지하기 위해, 잘못된 기여분은 건너뛰고 로깅을 통해 불변 조건(invariants)과 이상(anomalies)을 드러나게 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen defensive handling of RRF hybrid search parameters to prevent invalid top_k and weight values from causing incorrect rankings or runtime errors.

Bug Fixes:
- Clamp excessively large top_k values to a configured maximum and normalize negative values to prevent unexpected slicing behavior.
- Add explicit type checking for top_k to fail fast with a clear error instead of raising a generic TypeError during comparisons.
- Guard against zero or negative weights in RRF accumulation, skipping invalid contributions and surfacing invariants and anomalies via logging.

</details>