### PR TITLE
☘️ refactor [#12.2.10]: 6차 개선 - 오타 수정 및 인라인 주석 간결화

### DIFF
--- a/backend/services/hybrid_search_service.py
+++ b/backend/services/hybrid_search_service.py
@@ -1061,7 +1061,7 @@ class HybridSearchService:
         # top_k 타입 검증: 직접 호출 시 비정수 타입이 전달될 경우 비교 연산에서 TypeError 발생.
         #
         # [bool 명시 거부]
-        # Python에서 bool은 int의 서브클래스이므로 numbers.Integral 코주를
+        # Python에서 bool은 int의 서브클래스이므로 numbers.Integral 코드를
         # 통과한다. top_k=True(=1)나 top_k=False(=0)은 거의 확실히 프로그래밍
         # 오류이므로 명시적으로 거부한다.
         if isinstance(top_k, bool):
@@ -1130,11 +1130,7 @@ class HybridSearchService:
               오히려 운영 중 버그 시그널을 놓칠 수 있다.
             """
             if weight == 0.0:
-                # [float 정확 비교 사용 이유]
-                # IndexSearchResults 생성 레이어가 Cold Start를
-                # math.isclose로 판단한 후 상수 0.0을 리터럴로 DTO에 저장하므로
-                # 여기서의 정확 비교는 계약 준수 시 안전하다.
-                # 설계 불변식: weight==0.0이면 results도 비어 있어야 한다.
+                # Cold Start 정상 경로. 설계 불변식: weight==0.0이면 results도 비어 있어야 한다.
                 if results:
                     logger.warning(
                         "[HYBRID_SEARCH][RRF] weight=0.0인데 results가 비어 있지 않습니다 "


### PR DESCRIPTION
- **[오타 수정]** numbers.Integral 설명 주석
  - '코주를' → '코드를' 수정 (5차 작업 중 오타)

- **[주석 간결화]** if weight == 0.0 인라인 주석
  - float 정확 비교 근거 설명 4줄 → 1줄로 압축
  - 상세 설계 근거는 _accumulate docstring([float 비교 설계 근거])에 이미 존재하므로 인라인 중복 제거 → 함수 본문 가독성 향상

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1264#pullrequestreview-4203369836)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

하이브리드 검색 서비스의 주석에서 오타를 수정하고, RRF 누적 경로에서 부동소수점 비교에 대한 인라인 설명을 단순화했습니다.

개선 사항:
- 하이브리드 검색 서비스의 `numbers.Integral` 관련 주석에 있는 오타를 수정했습니다.
- 기존 docstring과의 중복을 줄이기 위해 `weight == 0.0` 콜드 스타트 분기 인라인 주석을 간결하고 명확하게 정리했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine hybrid search service comments by correcting a typo and simplifying an inline explanation for float comparison in the RRF accumulation path.

Enhancements:
- Fix a typo in the numbers.Integral-related comment in the hybrid search service.
- Condense and clarify the inline comment for the weight == 0.0 cold-start branch to reduce redundancy with existing docstrings.

</details>