### PR TITLE
✨ feat [#12.2.11]: Phase 2.3 - ➃ LangGraph retrieve_node 혼합 검색 파이프라인 통합

### DIFF
--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -7,6 +7,9 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import PydanticOutputParser
 from pydantic import BaseModel, Field
 
+from backend.services.hybrid_search_service import HybridSearchService
+from backend.services.topic_clustering_service import cluster_user_topics
+
 # Try importing specific exceptions for better error handling
 try:
     from langchain_core.exceptions import OutputParserException
@@ -56,13 +59,49 @@ def analyze_node(state: AgentState) -> Dict[str, Any]:
     return {"extracted_keywords": keywords}
 
 
+def _build_query_from_keywords(keywords: list[str]) -> str:
+    return " ".join(keywords)
+
+
+def _inject_topics_into_query(query: str, clusters: list[dict[str, Any]]) -> str:
+    topic_labels = [c["label"] for c in clusters if "label" in c]
+    if not topic_labels:
+        return query
+    topics_str = ", ".join(topic_labels)
+    return f"[{topics_str}] {query}"
+
+
+def _format_rrf_results(rrf_result) -> str:
+    results = rrf_result.results
+    if not results:
+        return "No relevant documents found."
+    docs = []
+    for res in results:
+        item = res.get("item", {})
+        content = item.get("content", str(item))
+        docs.append(f"- {content}")
+    return "Retrieved Context:\n" + "\n".join(docs)
+
+
+async def _run_hybrid_search(hashed_user_id: str, query: str) -> str:
+    clusters = await cluster_user_topics(hashed_user_id)
+    query_with_topics = _inject_topics_into_query(query, clusters or [])
+
+    hybrid_service = HybridSearchService()
+    router_result = await hybrid_service.route_weighted_search(
+        hashed_user_id=hashed_user_id,
+        query=query_with_topics,
+    )
+    rrf_result = hybrid_service.merge_with_rrf(router_result)
+    return _format_rrf_results(rrf_result)
+
+
 async def retrieve_node(state: AgentState) -> Dict[str, Any]:
     """
     맥락 검색 노드: 키워드 기반 유사 문서 검색 (RAG)
     """
     keywords = state.get("extracted_keywords", [])
-    query = " ".join(keywords)
-
+    query = _build_query_from_keywords(keywords)
     hashed_user_id = state.get("hashed_user_id")
 
     if not hashed_user_id:
@@ -71,41 +110,12 @@ async def retrieve_node(state: AgentState) -> Dict[str, Any]:
         return {"retrieved_context": context}
 
     try:
-        from backend.services.hybrid_search_service import HybridSearchService
-        from backend.services.topic_clustering_service import cluster_user_topics
-
-        # 1. 클러스터 토픽 주입 (개인화 서브-인덱스 우선 참조 유도)
-        clusters = await cluster_user_topics(hashed_user_id)
-        if clusters:
-            topic_labels = [c["label"] for c in clusters if "label" in c]
-            if topic_labels:
-                topics_str = ", ".join(topic_labels)
-                query = f"[{topics_str}] {query}"
-
-        # 2. 혼합 검색 라우터 호출
-        hybrid_service = HybridSearchService()
-        router_result = await hybrid_service.route_weighted_search(
-            hashed_user_id=hashed_user_id,
-            query=query
+        context = await _run_hybrid_search(hashed_user_id, query)
+    except Exception:
+        logger.error(
+            "[HYBRID_SEARCH] 라우터 호출 실패. 전역 인덱스 검색으로 Graceful Degradation 처리합니다.",
+            exc_info=True,
         )
-        
-        # 3. RRF 병합
-        rrf_result = hybrid_service.merge_with_rrf(router_result)
-        
-        # 4. 컨텍스트 포맷팅
-        results = rrf_result.results
-        if not results:
-            context = "No relevant documents found."
-        else:
-            docs = []
-            for res in results:
-                item = res.get("item", {})
-                content = item.get("content", str(item))
-                docs.append(f"- {content}")
-            context = "Retrieved Context:\n" + "\n".join(docs)
-
-    except Exception as e:
-        logger.error("[HYBRID_SEARCH] 라우터 호출 실패. 전역 인덱스 검색으로 Graceful Degradation 처리합니다.", exc_info=True)
         context = search_similar_docs(keywords)
 
     return {"retrieved_context": context}

--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -56,16 +56,58 @@ def analyze_node(state: AgentState) -> Dict[str, Any]:
     return {"extracted_keywords": keywords}
 
 
-def retrieve_node(state: AgentState) -> Dict[str, Any]:
+async def retrieve_node(state: AgentState) -> Dict[str, Any]:
     """
     맥락 검색 노드: 키워드 기반 유사 문서 검색 (RAG)
     """
-    # NotRequired 필드 안전한 접근
     keywords = state.get("extracted_keywords", [])
+    query = " ".join(keywords)
 
-    # 헬퍼 함수 호출 (Stub -> Mock)
-    context = search_similar_docs(keywords)
-    # State 업데이트: retrieved_context
+    hashed_user_id = state.get("hashed_user_id")
+
+    if not hashed_user_id:
+        logger.info("[HYBRID_SEARCH] hashed_user_id 누락. 전역 검색으로 폴백합니다.")
+        context = search_similar_docs(keywords)
+        return {"retrieved_context": context}
+
+    try:
+        from backend.services.hybrid_search_service import HybridSearchService
+        from backend.services.topic_clustering_service import cluster_user_topics
+
+        # 1. 클러스터 토픽 주입 (개인화 서브-인덱스 우선 참조 유도)
+        clusters = await cluster_user_topics(hashed_user_id)
+        if clusters:
+            topic_labels = [c["label"] for c in clusters if "label" in c]
+            if topic_labels:
+                topics_str = ", ".join(topic_labels)
+                query = f"[{topics_str}] {query}"
+
+        # 2. 혼합 검색 라우터 호출
+        hybrid_service = HybridSearchService()
+        router_result = await hybrid_service.route_weighted_search(
+            hashed_user_id=hashed_user_id,
+            query=query
+        )
+        
+        # 3. RRF 병합
+        rrf_result = hybrid_service.merge_with_rrf(router_result)
+        
+        # 4. 컨텍스트 포맷팅
+        results = rrf_result.results
+        if not results:
+            context = "No relevant documents found."
+        else:
+            docs = []
+            for res in results:
+                item = res.get("item", {})
+                content = item.get("content", str(item))
+                docs.append(f"- {content}")
+            context = "Retrieved Context:\n" + "\n".join(docs)
+
+    except Exception as e:
+        logger.error("[HYBRID_SEARCH] 라우터 호출 실패. 전역 인덱스 검색으로 Graceful Degradation 처리합니다.", exc_info=True)
+        context = search_similar_docs(keywords)
+
     return {"retrieved_context": context}
 
 

--- a/backend/agent/state.py
+++ b/backend/agent/state.py
@@ -26,6 +26,8 @@ class AgentState(TypedDict):
     # 입력 (필수)
     file_content: str
     file_name: str
+    user_id: NotRequired[str]
+    hashed_user_id: NotRequired[str]
 
     # 내부 처리 (선택적)
     extracted_keywords: NotRequired[List[str]]


### PR DESCRIPTION
- **[통합] 혼합 검색 라우터 연동**
  - `backend/agent/nodes.py`의 `retrieve_node`를 비동기화하고, `HybridSearchService` 기반의 RRF 병합 검색 파이프라인으로 전면 교체.
  - `AgentState`(`backend/agent/state.py`)에 `hashed_user_id` 속성을 추가하여 개인화 검색에 필요한 사용자 컨텍스트 획득 기반 마련.

- **[개인화] 관심 토픽 클러스터 기반 쿼리 주입**
  - `topic_clustering_service.cluster_user_topics()`를 호출하여 사용자의 관심사(클러스터 라벨) 추출.
  - 검색어 앞에 토픽을 선행 주입(`[Topic1, Topic2] Original Query`)하여 개인화 서브-인덱스에서 관련 토픽이 우선 참조될 수 있도록 문맥 유도.

- **[안정성] Graceful Degradation 및 에러 핸들링 방어**
  - 라우터 호출 실패(네트워크 오류 등) 또는 `hashed_user_id` 누락 시 서비스 중단 없이 기존 `search_similar_docs`를 이용한 전역 인덱스 검색으로 안전하게 폴백(Fallback) 처리.
  - 예외 발생 시 ERROR 로그에 PII를 마스킹한 채 에러 정보만 남겨 관측성 확보.

🔗 Related: Issue [#1046]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

에이전트 검색 노드에 비동기 하이브리드 검색 파이프라인을 통합하고, 장애 시 기존 글로벌 검색으로 우아하게 폴백하도록 합니다.

New Features:
- 라우터 기반 RRF 머지 파이프라인을 사용하여 retrieve 노드에 사용자 범위의 하이브리드 검색을 추가했습니다.
- 사용자 관심 라벨을 검색 쿼리에 주입하여 토픽 클러스터 기반 개인화를 지원합니다.
- 개인화된 검색을 활성화하기 위해 AgentState에 선택적 필드인 `user_id` 및 `hashed_user_id`를 추가했습니다.

Enhancements:
- 하이브리드 검색 실패 시 우아한 성능 저하(graceful degradation) 및 로깅을 구현하고, 기존 글로벌 similar-docs 검색 파이프라인으로 폴백하도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate an asynchronous hybrid search pipeline into the agent retrieval node with graceful fallback to the legacy global search.

New Features:
- Add user-scoped hybrid search in the retrieve node using a router-driven RRF merge pipeline.
- Support topic-cluster-based personalization by injecting user interest labels into the search query.
- Extend AgentState with optional user_id and hashed_user_id fields to enable personalized retrieval.

Enhancements:
- Implement graceful degradation and logging for hybrid search failures, falling back to the existing global similar-docs search pipeline.

</details>