### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -7,6 +7,9 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import PydanticOutputParser
 from pydantic import BaseModel, Field
 
+from backend.services.hybrid_search_service import HybridSearchService
+from backend.services.topic_clustering_service import cluster_user_topics
+
 # Try importing specific exceptions for better error handling
 try:
     from langchain_core.exceptions import OutputParserException
@@ -56,13 +59,49 @@ def analyze_node(state: AgentState) -> Dict[str, Any]:
     return {"extracted_keywords": keywords}
 
 
+def _build_query_from_keywords(keywords: list[str]) -> str:
+    return " ".join(keywords)
+
+
+def _inject_topics_into_query(query: str, clusters: list[dict[str, Any]]) -> str:
+    topic_labels = [c["label"] for c in clusters if "label" in c]
+    if not topic_labels:
+        return query
+    topics_str = ", ".join(topic_labels)
+    return f"[{topics_str}] {query}"
+
+
+def _format_rrf_results(rrf_result) -> str:
+    results = rrf_result.results
+    if not results:
+        return "No relevant documents found."
+    docs = []
+    for res in results:
+        item = res.get("item", {})
+        content = item.get("content", str(item))
+        docs.append(f"- {content}")
+    return "Retrieved Context:\n" + "\n".join(docs)
+
+
+async def _run_hybrid_search(hashed_user_id: str, query: str) -> str:
+    clusters = await cluster_user_topics(hashed_user_id)
+    query_with_topics = _inject_topics_into_query(query, clusters or [])
+
+    hybrid_service = HybridSearchService()
+    router_result = await hybrid_service.route_weighted_search(
+        hashed_user_id=hashed_user_id,
+        query=query_with_topics,
+    )
+    rrf_result = hybrid_service.merge_with_rrf(router_result)
+    return _format_rrf_results(rrf_result)
+
+
 async def retrieve_node(state: AgentState) -> Dict[str, Any]:
     """
     맥락 검색 노드: 키워드 기반 유사 문서 검색 (RAG)
     """
     keywords = state.get("extracted_keywords", [])
-    query = " ".join(keywords)
-
+    query = _build_query_from_keywords(keywords)
     hashed_user_id = state.get("hashed_user_id")
 
     if not hashed_user_id:
@@ -71,41 +110,12 @@ async def retrieve_node(state: AgentState) -> Dict[str, Any]:
         return {"retrieved_context": context}
 
     try:
-        from backend.services.hybrid_search_service import HybridSearchService
-        from backend.services.topic_clustering_service import cluster_user_topics
-
-        # 1. 클러스터 토픽 주입 (개인화 서브-인덱스 우선 참조 유도)
-        clusters = await cluster_user_topics(hashed_user_id)
-        if clusters:
-            topic_labels = [c["label"] for c in clusters if "label" in c]
-            if topic_labels:
-                topics_str = ", ".join(topic_labels)
-                query = f"[{topics_str}] {query}"
-
-        # 2. 혼합 검색 라우터 호출
-        hybrid_service = HybridSearchService()
-        router_result = await hybrid_service.route_weighted_search(
-            hashed_user_id=hashed_user_id,
-            query=query
+        context = await _run_hybrid_search(hashed_user_id, query)
+    except Exception:
+        logger.error(
+            "[HYBRID_SEARCH] 라우터 호출 실패. 전역 인덱스 검색으로 Graceful Degradation 처리합니다.",
+            exc_info=True,
         )
-        
-        # 3. RRF 병합
-        rrf_result = hybrid_service.merge_with_rrf(router_result)
-        
-        # 4. 컨텍스트 포맷팅
-        results = rrf_result.results
-        if not results:
-            context = "No relevant documents found."
-        else:
-            docs = []
-            for res in results:
-                item = res.get("item", {})
-                content = item.get("content", str(item))
-                docs.append(f"- {content}")
-            context = "Retrieved Context:\n" + "\n".join(docs)
-
-    except Exception as e:
-        logger.error("[HYBRID_SEARCH] 라우터 호출 실패. 전역 인덱스 검색으로 Graceful Degradation 처리합니다.", exc_info=True)
         context = search_similar_docs(keywords)
 
     return {"retrieved_context": context}

--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -56,16 +56,58 @@ def analyze_node(state: AgentState) -> Dict[str, Any]:
     return {"extracted_keywords": keywords}
 
 
-def retrieve_node(state: AgentState) -> Dict[str, Any]:
+async def retrieve_node(state: AgentState) -> Dict[str, Any]:
     """
     맥락 검색 노드: 키워드 기반 유사 문서 검색 (RAG)
     """
-    # NotRequired 필드 안전한 접근
     keywords = state.get("extracted_keywords", [])
+    query = " ".join(keywords)
 
-    # 헬퍼 함수 호출 (Stub -> Mock)
-    context = search_similar_docs(keywords)
-    # State 업데이트: retrieved_context
+    hashed_user_id = state.get("hashed_user_id")
+
+    if not hashed_user_id:
+        logger.info("[HYBRID_SEARCH] hashed_user_id 누락. 전역 검색으로 폴백합니다.")
+        context = search_similar_docs(keywords)
+        return {"retrieved_context": context}
+
+    try:
+        from backend.services.hybrid_search_service import HybridSearchService
+        from backend.services.topic_clustering_service import cluster_user_topics
+
+        # 1. 클러스터 토픽 주입 (개인화 서브-인덱스 우선 참조 유도)
+        clusters = await cluster_user_topics(hashed_user_id)
+        if clusters:
+            topic_labels = [c["label"] for c in clusters if "label" in c]
+            if topic_labels:
+                topics_str = ", ".join(topic_labels)
+                query = f"[{topics_str}] {query}"
+
+        # 2. 혼합 검색 라우터 호출
+        hybrid_service = HybridSearchService()
+        router_result = await hybrid_service.route_weighted_search(
+            hashed_user_id=hashed_user_id,
+            query=query
+        )
+        
+        # 3. RRF 병합
+        rrf_result = hybrid_service.merge_with_rrf(router_result)
+        
+        # 4. 컨텍스트 포맷팅
+        results = rrf_result.results
+        if not results:
+            context = "No relevant documents found."
+        else:
+            docs = []
+            for res in results:
+                item = res.get("item", {})
+                content = item.get("content", str(item))
+                docs.append(f"- {content}")
+            context = "Retrieved Context:\n" + "\n".join(docs)
+
+    except Exception as e:
+        logger.error("[HYBRID_SEARCH] 라우터 호출 실패. 전역 인덱스 검색으로 Graceful Degradation 처리합니다.", exc_info=True)
+        context = search_similar_docs(keywords)
+
     return {"retrieved_context": context}
 
 

--- a/backend/agent/state.py
+++ b/backend/agent/state.py
@@ -26,6 +26,8 @@ class AgentState(TypedDict):
     # 입력 (필수)
     file_content: str
     file_name: str
+    user_id: NotRequired[str]
+    hashed_user_id: NotRequired[str]
 
     # 내부 처리 (선택적)
     extracted_keywords: NotRequired[List[str]]


### PR DESCRIPTION
✨ feat [#12.2.11]: Phase 2.3 - ➃ LangGraph retrieve_node 혼합 검색 파이프라인 통합 
☘️ refactor [#12.2.11]: 1차 개선 - retrieve_node 복잡도 완화 및 모듈 레벨 import

## Summary by Sourcery

사용자 식별자를 포함하도록 에이전트 상태를 확장하면서, 에이전트 검색 노드에 하이브리드 토픽 인지 검색 파이프라인을 통합합니다.

새로운 기능:
- 사용자 토픽 클러스터로 쿼리를 보강하고, 검색된 컨텍스트를 반환하기 전에 RRF를 사용해 결과를 병합하는 하이브리드 검색 파이프라인을 추가했습니다.

개선 사항:
- 쿼리 구성, 토픽 라벨 주입, 결과 포맷팅, 사용자 데이터가 없거나 검색에 실패했을 때도 우아하게 성능이 저하되는(hybrid search with graceful degradation) 하이브리드 검색 실행을 위한 더 작은 헬퍼 함수들로 검색 노드를 리팩터링했습니다.
- 개인화된 검색을 지원하기 위해 `AgentState` 스키마를 선택적 필드인 `user_id`와 `hashed_user_id`로 확장했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate a hybrid topic-aware search pipeline into the agent retrieval node while expanding the agent state to carry user identifiers.

New Features:
- Add a hybrid search pipeline that augments queries with user topic clusters and merges results using RRF before returning retrieved context.

Enhancements:
- Refactor the retrieval node into smaller helper functions for building queries, injecting topic labels, formatting results, and executing hybrid search with graceful degradation when user data is unavailable or search fails.
- Extend the AgentState schema with optional user_id and hashed_user_id fields to support personalized retrieval.

</details>