### PR TITLE
☘️ refactor [#12.2.11]: 2차 개선 - PII 보호 강화, 싱글톤 패턴 적용 및 예외 제어망 세분화

### DIFF
--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -66,6 +66,15 @@ def _get_hybrid_search_service() -> HybridSearchService:
     return HybridSearchService()
 
 
+def cleanup_hybrid_search_service() -> None:
+    """
+    싱글톤 HybridSearchService 인스턴스를 초기화(캐시 해제)합니다.
+    장시간 실행되는 애플리케이션 또는 테스트 환경에서 커넥션 등 리소스 누수를 방지하고 
+    명시적인 수명 주기 관리(Teardown)를 가능하게 합니다.
+    """
+    _get_hybrid_search_service.cache_clear()
+
+
 def _build_query_from_keywords(keywords: list[str]) -> str:
     return " ".join(keywords)
 
@@ -86,7 +95,10 @@ def _format_rrf_results(rrf_result) -> str:
     """
     RRF 결과를 LLM 입력에 적합한 간결한 컨텍스트 문자열로 포맷팅합니다.
     """
-    results = getattr(rrf_result, "results", None) or []
+    # 제너레이터/이터러블 1회 소진 및 len() 호출 시 TypeError 방지를 위해 명시적으로 리스트화합니다.
+    raw_results = getattr(rrf_result, "results", None) or []
+    results = list(raw_results)
+    
     if not results:
         return "No relevant documents found."
 
@@ -119,10 +131,15 @@ def _format_rrf_results(rrf_result) -> str:
 
     result_str = "Retrieved Context:\n" + "\n".join(formatted_docs)
 
-    if len(results) > len(formatted_docs):
-        notice = "\n- [Additional retrieved documents omitted for brevity]"
+    omitted_count = len(results) - len(formatted_docs)
+    if omitted_count > 0:
+        notice = f"\n- [{omitted_count} additional retrieved documents omitted for brevity]"
         if len(result_str) + len(notice) <= _MAX_TOTAL_CHARS:
             result_str += notice
+        else:
+            # 예산이 부족해도 관측성 확보를 위해 최소한의 알림 추가
+            short_notice = f"\n- [...{omitted_count} more]"
+            result_str += short_notice
 
     return result_str
 

--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -1,5 +1,6 @@
 from typing import Literal, Dict, Any, List, Optional
 import logging
+from functools import lru_cache
 from backend.agent.state import AgentState
 from backend.agent.utils import get_llm, extract_keywords, search_similar_docs, resolve_active_model
 
@@ -59,6 +60,12 @@ def analyze_node(state: AgentState) -> Dict[str, Any]:
     return {"extracted_keywords": keywords}
 
 
+@lru_cache(maxsize=1)
+def _get_hybrid_search_service() -> HybridSearchService:
+    """HybridSearchService의 싱글톤 인스턴스를 반환합니다."""
+    return HybridSearchService()
+
+
 def _build_query_from_keywords(keywords: list[str]) -> str:
     return " ".join(keywords)
 
@@ -71,23 +78,59 @@ def _inject_topics_into_query(query: str, clusters: list[dict[str, Any]]) -> str
     return f"[{topics_str}] {query}"
 
 
+_MAX_ITEMS = 5
+_MAX_CHARS_PER_ITEM = 500
+_MAX_TOTAL_CHARS = 4000
+
 def _format_rrf_results(rrf_result) -> str:
-    results = rrf_result.results
+    """
+    RRF 결과를 LLM 입력에 적합한 간결한 컨텍스트 문자열로 포맷팅합니다.
+    """
+    results = getattr(rrf_result, "results", None) or []
     if not results:
         return "No relevant documents found."
-    docs = []
-    for res in results:
-        item = res.get("item", {})
-        content = item.get("content", str(item))
-        docs.append(f"- {content}")
-    return "Retrieved Context:\n" + "\n".join(docs)
+
+    formatted_docs: list[str] = []
+    total_len = len("Retrieved Context:\n")
+
+    for idx, res in enumerate(results):
+        if idx >= _MAX_ITEMS:
+            break
+
+        item = res.get("item", {}) if isinstance(res, dict) else getattr(res, "item", {})
+        if not isinstance(item, dict):
+            content = str(item)
+        else:
+            content = item.get("content") or str(item)
+
+        if len(content) > _MAX_CHARS_PER_ITEM:
+            content = content[: _MAX_CHARS_PER_ITEM - 3] + "..."
+
+        line = f"- {content}"
+        
+        if total_len + len(line) + 1 > _MAX_TOTAL_CHARS:
+            break
+
+        formatted_docs.append(line)
+        total_len += len(line) + 1
+
+    if not formatted_docs:
+        return "No relevant documents found."
+
+    result_str = "Retrieved Context:\n" + "\n".join(formatted_docs)
+
+    if len(results) > len(formatted_docs):
+        notice = "\n- [Additional retrieved documents omitted for brevity]"
+        if len(result_str) + len(notice) <= _MAX_TOTAL_CHARS:
+            result_str += notice
+
+    return result_str
 
 
-async def _run_hybrid_search(hashed_user_id: str, query: str) -> str:
-    clusters = await cluster_user_topics(hashed_user_id)
-    query_with_topics = _inject_topics_into_query(query, clusters or [])
+async def _run_hybrid_search(hashed_user_id: str, query: str, clusters: list[dict[str, Any]]) -> str:
+    query_with_topics = _inject_topics_into_query(query, clusters)
 
-    hybrid_service = HybridSearchService()
+    hybrid_service = _get_hybrid_search_service()
     router_result = await hybrid_service.route_weighted_search(
         hashed_user_id=hashed_user_id,
         query=query_with_topics,
@@ -101,6 +144,11 @@ async def retrieve_node(state: AgentState) -> Dict[str, Any]:
     맥락 검색 노드: 키워드 기반 유사 문서 검색 (RAG)
     """
     keywords = state.get("extracted_keywords", [])
+    
+    if not keywords:
+        logger.debug("[HYBRID_SEARCH] 키워드가 없어 빈 검색 결과를 반환합니다.")
+        return {"retrieved_context": search_similar_docs(keywords)}
+        
     query = _build_query_from_keywords(keywords)
     hashed_user_id = state.get("hashed_user_id")
 
@@ -109,8 +157,21 @@ async def retrieve_node(state: AgentState) -> Dict[str, Any]:
         context = search_similar_docs(keywords)
         return {"retrieved_context": context}
 
+    # 1. 클러스터링 시도
+    clusters = []
     try:
-        context = await _run_hybrid_search(hashed_user_id, query)
+        clusters_res = await cluster_user_topics(hashed_user_id)
+        if clusters_res:
+            clusters = clusters_res
+    except Exception:
+        logger.warning(
+            "[HYBRID_SEARCH] 토픽 클러스터링 실패. 개인화 컨텍스트 없이 하이브리드 검색을 계속합니다.",
+            exc_info=True,
+        )
+
+    # 2. 하이브리드 검색 시도
+    try:
+        context = await _run_hybrid_search(hashed_user_id, query, clusters)
     except Exception:
         logger.error(
             "[HYBRID_SEARCH] 라우터 호출 실패. 전역 인덱스 검색으로 Graceful Degradation 처리합니다.",

--- a/backend/agent/state.py
+++ b/backend/agent/state.py
@@ -26,7 +26,6 @@ class AgentState(TypedDict):
     # 입력 (필수)
     file_content: str
     file_name: str
-    user_id: NotRequired[str]
     hashed_user_id: NotRequired[str]
 
     # 내부 처리 (선택적)


### PR DESCRIPTION
- **[성능] HybridSearchService 싱글톤 패턴 도입**
  - 매 노드 호출 시마다 발생하는 서비스 생성 오버헤드를 막기 위해 `@lru_cache(maxsize=1)` 기반의 `_get_hybrid_search_service()` 팩토리 적용.
- **[안정성/성능] 빈 키워드 단락 평가 및 LLM 토큰 초과 방어**
  - 추출된 키워드가 없을 경우 곧바로 폴백 로직을 반환(Short-circuit)하여 불필요한 하이브리드 라우터 I/O 낭비 방지.
  - LLM Context Window 폭발을 막기 위해 검색 결과 포맷팅 시 최대 반환 개수, 항목당 글자 수, 전체 글자 수 제한(_MAX_TOTAL_CHARS 등 모듈 상수로 관리, 하드코딩 완전 배제).
- **[보안/PII] 원본 user_id 상태(State) 제거**
  - 보안 리뷰 지적에 따라 `AgentState`에서 PII에 해당하는 원본 `user_id`를 완전히 제거.
  - 해시 처리된 `hashed_user_id`만 남겨 다운스트림에서의 실수에 의한 개인정보 유출을 원천 차단.
- **[구조/관측성] 예외 제어망 분리 및 좁히기**
  - 광범위했던 `try/except`를 분리하여, `cluster_user_topics`(토픽 추출)가 실패하더라도 `_run_hybrid_search`(라우터 검색)는 정상적으로 시도되도록 예외/폴백 스코프를 타이트하게 세분화.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1268#pullrequestreview-4209818444)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

하이브리드 검색 retrieval 노드를 개선하여 성능, 안정성, 견고성을 높이고, 사용자 식별자의 상태 처리(state handling)를 더 엄격하게 다듬었습니다.

버그 수정:
- 비어 있는 검색 결과에 대비하고, LLM 컨텍스트 윈도우를 초과할 수 있는 과도하게 긴 하이브리드 검색 컨텍스트를 방지했습니다.

개선 사항:
- `HybridSearchService`에 대해 캐시된 싱글톤 팩토리를 도입하여 호출마다 인스턴스를 생성하는 오버헤드를 제거했습니다.
- 하이브리드 검색 결과에 대해 항목 수와 문자 길이에 제한을 두는 포매팅을 추가하여 LLM 컨텍스트를 간결하게 유지했습니다.
- 키워드가 추출되지 않은 경우 하이브리드 검색을 단락(short-circuit)하여 불필요한 라우팅과 I/O를 피했습니다.
- 예외 처리를 더 좁고 분리된 방식으로 변경하여, 토픽 클러스터링 실패가 더 이상 하이브리드 검색 실행을 막지 않도록 했습니다.

기타 작업:
- PII 노출을 줄이기 위해 `AgentState`에서 원본 `user_id`를 제거하고 `hashed_user_id`만 유지하도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the hybrid search retrieval node for better performance, safety, and robustness while tightening state handling of user identifiers.

Bug Fixes:
- Guard against empty retrieval results and overly long hybrid search contexts that could overflow the LLM context window.

Enhancements:
- Introduce a cached singleton factory for HybridSearchService to eliminate per-call instantiation overhead.
- Add bounded formatting of hybrid search results with limits on item count and character length to keep LLM context concise.
- Short-circuit hybrid search when no keywords are extracted, avoiding unnecessary routing and I/O.
- Narrow and separate exception handling so topic clustering failures no longer prevent hybrid search from running.

Chores:
- Remove raw user_id from AgentState, retaining only hashed_user_id to reduce PII exposure.

</details>