### PR TITLE
☘️ refactor [#12.2.11]: 4차 개선 - 빈 키워드 단락 평가 완결 및 싱글톤 수명 주기 문서화

### DIFF
--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -1,6 +1,7 @@
-from typing import Literal, Dict, Any, List, Optional
+from typing import Literal, Dict, Any, List, Optional, AsyncGenerator
 import logging
 from functools import lru_cache
+from contextlib import asynccontextmanager
 from backend.agent.state import AgentState
 from backend.agent.utils import get_llm, extract_keywords, search_similar_docs, resolve_active_model
 
@@ -31,6 +32,9 @@ logger = logging.getLogger(__name__)
 # Used in conditional edges (should_retry) logic
 CONFIDENCE_THRESHOLD = 0.7
 MAX_RETRY_COUNT = 3
+
+# 하이브리드 검색에서 빈 결과를 명확히 표현하는 공용 상수 (매직 스트링 제거)
+EMPTY_RETRIEVED_CONTEXT: str = ""
 
 
 # =================================================================
@@ -69,14 +73,30 @@ def _get_hybrid_search_service() -> HybridSearchService:
 def cleanup_hybrid_search_service() -> None:
     """
     싱글톤 HybridSearchService 인스턴스를 초기화(캐시 해제)합니다.
-    
-    [수명 주기 관리 가드레일 (Lifecycle Guardrails)]
-    장기 실행되는 프로세스에서 커넥션 누수를 방지하려면 반드시 애플리케이션 종료 훅에 이 함수를 등록해야 합니다:
-    - FastAPI 환경: 메인 애플리케이션의 `lifespan` 컨텍스트 매니저 (yield 이후 블록)
-    - 백그라운드 워커: Celery `worker_process_shutdown` 또는 `atexit` 훅
-    - 테스트 환경: pytest의 `teardown` 픽스처
     """
     _get_hybrid_search_service.cache_clear()
+
+
+@asynccontextmanager
+async def managed_hybrid_search_async(app: Any = None) -> AsyncGenerator[None, None]:
+    """
+    FastAPI lifespan 등 장기 실행 애플리케이션에 주입하여 하이브리드 검색 싱글톤의 수명 주기를 
+    코드 레벨에서 안전하게 보장하는 비동기 컨텍스트 매니저 헬퍼입니다.
+    
+    사용 예시:
+    ```python
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        async with managed_hybrid_search_async():
+            # 시스템 기동
+            yield
+        # 시스템 종료 시 자동으로 cleanup_hybrid_search_service 호출
+    ```
+    """
+    try:
+        yield
+    finally:
+        cleanup_hybrid_search_service()
 
 
 def _build_query_from_keywords(keywords: list[str]) -> str:
@@ -169,7 +189,7 @@ async def retrieve_node(state: AgentState) -> Dict[str, Any]:
     # 불필요한 함수 호출(search_similar_docs)을 방지하고 중립적인 빈 문자열을 즉시 반환(단락 평가)
     if not keywords:
         logger.debug("[HYBRID_SEARCH] 키워드가 없어 빈 검색 결과를 반환합니다.")
-        return {"retrieved_context": ""}
+        return {"retrieved_context": EMPTY_RETRIEVED_CONTEXT}
         
     query = _build_query_from_keywords(keywords)
     hashed_user_id = state.get("hashed_user_id")

--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -69,8 +69,12 @@ def _get_hybrid_search_service() -> HybridSearchService:
 def cleanup_hybrid_search_service() -> None:
     """
     싱글톤 HybridSearchService 인스턴스를 초기화(캐시 해제)합니다.
-    장시간 실행되는 애플리케이션 또는 테스트 환경에서 커넥션 등 리소스 누수를 방지하고 
-    명시적인 수명 주기 관리(Teardown)를 가능하게 합니다.
+    
+    [수명 주기 관리 가드레일 (Lifecycle Guardrails)]
+    장기 실행되는 프로세스에서 커넥션 누수를 방지하려면 반드시 애플리케이션 종료 훅에 이 함수를 등록해야 합니다:
+    - FastAPI 환경: 메인 애플리케이션의 `lifespan` 컨텍스트 매니저 (yield 이후 블록)
+    - 백그라운드 워커: Celery `worker_process_shutdown` 또는 `atexit` 훅
+    - 테스트 환경: pytest의 `teardown` 픽스처
     """
     _get_hybrid_search_service.cache_clear()
 
@@ -162,9 +166,10 @@ async def retrieve_node(state: AgentState) -> Dict[str, Any]:
     """
     keywords = state.get("extracted_keywords", [])
     
+    # 불필요한 함수 호출(search_similar_docs)을 방지하고 중립적인 빈 문자열을 즉시 반환(단락 평가)
     if not keywords:
         logger.debug("[HYBRID_SEARCH] 키워드가 없어 빈 검색 결과를 반환합니다.")
-        return {"retrieved_context": search_similar_docs(keywords)}
+        return {"retrieved_context": ""}
         
     query = _build_query_from_keywords(keywords)
     hashed_user_id = state.get("hashed_user_id")


### PR DESCRIPTION
- **[성능/논리] 완벽한 단락 평가(Short-circuit) 구현**
  - 추출된 키워드가 없을 때, 무의미한 폴백 함수(`search_similar_docs`) 호출을 방지하고 즉시 빈 컨텍스트(`""`)를 반환하도록 로직을 최적화.
  - 로그 메시지("빈 검색 결과를 반환합니다")와 실제 동작 간의 100% 논리적 정합성 확보.
- **[안정성/문서화] 싱글톤 리소스 해제(Teardown) 가드레일 확립**
  - 장기 실행 프로세스에서의 메모리/커넥션 누수를 방지하기 위해, `cleanup_hybrid_search_service()` 헬퍼의 사용처를 명문화.
  - FastAPI `lifespan`, Celery `worker_process_shutdown`, pytest `teardown` 등 구체적인 시스템 종료 훅(Hook)을 Docstring에 가이드라인으로 명시하여 휴먼 에러 원천 차단.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1270#pullrequestreview-4209849229)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

키워드가 비어 있는 경우의 하이브리드 검색 동작을 정교하게 다듬고, 공유 검색 서비스 싱글톤의 라이프사이클 문서를 보강합니다.

버그 수정:
- 키워드가 비어 있는 검색에서는 하이브리드 검색 폴백을 호출하지 않고, 빈 컨텍스트를 반환하여 즉시 종료되도록 합니다.

개선 사항:
- 장시간 실행되는 리소스 누수를 방지하기 위해, 하이브리드 검색 싱글톤 정리(helper)를 반드시 등록해야 하는 구체적인 애플리케이션 종료 훅(shutdown hook)을 문서화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine hybrid search behavior for empty keyword scenarios and strengthen lifecycle documentation for the shared search service singleton.

Bug Fixes:
- Ensure empty keyword searches short-circuit by returning an empty context instead of invoking the hybrid search fallback.

Enhancements:
- Document concrete application shutdown hooks where the hybrid search singleton cleanup helper must be registered to prevent long-running resource leaks.

</details>