### PR TITLE
☘️ refactor [#12.2.11]: 6차 개선 - 빈 결과값 공용 상수 전면 중앙집중화 및 Lifespan 헬퍼 시그니처 개선

### DIFF
--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -3,7 +3,7 @@ import logging
 from functools import lru_cache
 from contextlib import asynccontextmanager
 from backend.agent.state import AgentState
-from backend.agent.utils import get_llm, extract_keywords, search_similar_docs, resolve_active_model
+from backend.agent.utils import get_llm, extract_keywords, search_similar_docs, resolve_active_model, EMPTY_RETRIEVED_CONTEXT
 
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import PydanticOutputParser
@@ -32,10 +32,6 @@ logger = logging.getLogger(__name__)
 # Used in conditional edges (should_retry) logic
 CONFIDENCE_THRESHOLD = 0.7
 MAX_RETRY_COUNT = 3
-
-# 하이브리드 검색에서 빈 결과를 명확히 표현하는 공용 상수 (매직 스트링 제거)
-EMPTY_RETRIEVED_CONTEXT: str = ""
-
 
 # =================================================================
 # Pydantic Models for Output Parsing
@@ -78,7 +74,7 @@ def cleanup_hybrid_search_service() -> None:
 
 
 @asynccontextmanager
-async def managed_hybrid_search_async(app: Any = None) -> AsyncGenerator[None, None]:
+async def managed_hybrid_search_async(*args: Any, **kwargs: Any) -> AsyncGenerator[None, None]:
     """
     FastAPI lifespan 등 장기 실행 애플리케이션에 주입하여 하이브리드 검색 싱글톤의 수명 주기를 
     코드 레벨에서 안전하게 보장하는 비동기 컨텍스트 매니저 헬퍼입니다.

--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -74,7 +74,7 @@ def cleanup_hybrid_search_service() -> None:
 
 
 @asynccontextmanager
-async def managed_hybrid_search_async(*args: Any, **kwargs: Any) -> AsyncGenerator[None, None]:
+async def managed_hybrid_search_async(app: Any | None = None, **_kwargs: Any) -> AsyncGenerator[None, None]:
     """
     FastAPI lifespan 등 장기 실행 애플리케이션에 주입하여 하이브리드 검색 싱글톤의 수명 주기를 
     코드 레벨에서 안전하게 보장하는 비동기 컨텍스트 매니저 헬퍼입니다.

--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -19,6 +19,9 @@ load_dotenv()
 # 이 상수를 수정하면 resolve_active_model() 폴백, get_llm() 기본값이 모두 함께 바뀝니다.
 DEFAULT_MODEL_NAME: str = os.getenv("GPT4O_MODEL", "gpt-4o")
 
+# 하이브리드 검색에서 빈 결과를 명확히 표현하는 공용 상수 (매직 스트링 제거)
+EMPTY_RETRIEVED_CONTEXT: str = ""
+
 # Hot-swap 활성 모델을 저장하는 Redis 키 (finetune_service._FINETUNE_ACTIVE_MODEL_KEY와 동일한 환경 변수 참조)
 # finetune_service의 상수가 모듈-프라이빗(_)이므로 직접 임포트 대신 동일한 환경 변수를 공유 진실 공급원으로 사용합니다.
 # strip() 후 or 패턴으로 빈 문자열("") 및 공백 전용("   ") 환경 변수 값도 올바르게 기본값으로 대체합니다.
@@ -182,7 +185,7 @@ def search_similar_docs(keywords: List[str]) -> str:
     현재는 실제 Vector Store가 없으므로 검색된 척하는 더미 데이터를 반환합니다.
     """
     if not keywords:
-        return ""
+        return EMPTY_RETRIEVED_CONTEXT
 
     # Mock Response: 키워드가 포함된 가상의 문서를 반환하여 RAG 흐름 테스트
     docs = [

--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -20,6 +20,10 @@ load_dotenv()
 DEFAULT_MODEL_NAME: str = os.getenv("GPT4O_MODEL", "gpt-4o")
 
 # 하이브리드 검색에서 빈 결과를 명확히 표현하는 공용 상수 (매직 스트링 제거)
+# [주요 참조처 (Consumers)]
+# 1. backend.agent.nodes.retrieve_node: 빈 키워드에 대한 단락 평가(Short-circuit) 시 즉시 반환
+# 2. backend.agent.utils.search_similar_docs: 빈 키워드 폴백 로직 내 반환
+# ※ 향후 "검색 결과 없음"의 표현 형식이 바뀔 경우, 파편화 방지를 위해 반드시 이 상수만을 수정해야 합니다.
 EMPTY_RETRIEVED_CONTEXT: str = ""
 
 # Hot-swap 활성 모델을 저장하는 Redis 키 (finetune_service._FINETUNE_ACTIVE_MODEL_KEY와 동일한 환경 변수 참조)


### PR DESCRIPTION
- **[구조/무결성] 매직 스트링 전면 중앙집중화 (Single Source of Truth)**
  - `EMPTY_RETRIEVED_CONTEXT` 상수를 `utils.py` 레벨로 끌어내려 순환 참조를 방지.
  - `retrieve_node`의 단락 평가 분기뿐만 아니라, 폴백 함수인 `search_similar_docs` 내부에서도 동일한 상수를 반환하도록 수정하여 시스템 전체의 컨텍스트 파편화 및 타입 불일치 위험 완벽 제거.
- **[안정성] Lifespan 헬퍼 시그니처 범용성 확보**
  - `managed_hybrid_search_async` 컨텍스트 매니저의 인자를 `*args: Any, **kwargs: Any`로 변경.
  - 미사용 인자로 인한 잠재적 혼란(Linter 경고 등)을 없애고, FastAPI 등 외부 프레임워크가 주입하는 임의의 인자에 대해 가장 탄탄하게(Robust) 대응하는 방어적 시그니처 확립.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1272#pullrequestreview-4209871528)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

하이브리드 검색에서 사용되는 빈 결과 상수를 중앙에서 관리하고, 더 넓은 범위의 프레임워크와 호환되도록 lifespan 헬퍼 컨텍스트 매니저의 시그니처를 완화했습니다.

Enhancements:
- `EMPTY_RETRIEVED_CONTEXT` 상수를 공용 utils 모듈로 이동하고, 하이브리드 검색용 표준 빈 결과로 사용하도록 변경했습니다.
- 외부 프레임워크와의 통합을 더욱 견고하게 만들기 위해, `managed_hybrid_search_async` lifespan 헬퍼가 임의의 위치 인자와 키워드 인자를 받을 수 있도록 시그니처를 업데이트했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize the empty hybrid search result constant and relax the lifespan helper context manager signature for broader framework compatibility.

Enhancements:
- Move the EMPTY_RETRIEVED_CONTEXT constant to the shared utils module and use it as the standard empty result for hybrid search.
- Update the managed_hybrid_search_async lifespan helper to accept arbitrary positional and keyword arguments for more robust integration with external frameworks.

</details>