### PR TITLE
☘️ refactor [#12.2.11]: 8차 개선 - 공유 상수 모듈 분리 및 Lifespan 설계 의도 문서화

### DIFF
--- a/backend/agent/constants.py
+++ b/backend/agent/constants.py
@@ -4,9 +4,11 @@
 차단하고, 단일 진실 공급원(Single Source of Truth)을 유지하기 위해 사용됩니다.
 """
 
+from typing import Final
+
 # 하이브리드 검색에서 빈 결과를 명확히 표현하는 공용 상수 (매직 스트링 제거)
 # [주요 참조처 (Consumers)]
 # 1. backend.agent.nodes.retrieve_node: 빈 키워드에 대한 단락 평가(Short-circuit) 시 즉시 반환
 # 2. backend.agent.utils.search_similar_docs: 빈 키워드 폴백 로직 내 반환
 # ※ 향후 "검색 결과 없음"의 표현 형식이 바뀔 경우, 파편화 방지를 위해 반드시 이 상수만을 수정해야 합니다.
-EMPTY_RETRIEVED_CONTEXT: str = ""
+EMPTY_RETRIEVED_CONTEXT: Final[str] = ""

--- a/backend/agent/constants.py
+++ b/backend/agent/constants.py
@@ -1,0 +1,12 @@
+"""
+에이전트 파이프라인(Agent Pipeline) 전역에서 공유되는 공통 상수를 정의합니다.
+유틸리티(utils)나 노드(nodes) 모듈 간의 순환 참조(Circular Import)를 구조적으로 
+차단하고, 단일 진실 공급원(Single Source of Truth)을 유지하기 위해 사용됩니다.
+"""
+
+# 하이브리드 검색에서 빈 결과를 명확히 표현하는 공용 상수 (매직 스트링 제거)
+# [주요 참조처 (Consumers)]
+# 1. backend.agent.nodes.retrieve_node: 빈 키워드에 대한 단락 평가(Short-circuit) 시 즉시 반환
+# 2. backend.agent.utils.search_similar_docs: 빈 키워드 폴백 로직 내 반환
+# ※ 향후 "검색 결과 없음"의 표현 형식이 바뀔 경우, 파편화 방지를 위해 반드시 이 상수만을 수정해야 합니다.
+EMPTY_RETRIEVED_CONTEXT: str = ""

--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -3,7 +3,8 @@ import logging
 from functools import lru_cache
 from contextlib import asynccontextmanager
 from backend.agent.state import AgentState
-from backend.agent.utils import get_llm, extract_keywords, search_similar_docs, resolve_active_model, EMPTY_RETRIEVED_CONTEXT
+from backend.agent.utils import get_llm, extract_keywords, search_similar_docs, resolve_active_model
+from backend.agent.constants import EMPTY_RETRIEVED_CONTEXT
 
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import PydanticOutputParser
@@ -78,6 +79,12 @@ async def managed_hybrid_search_async(app: Any | None = None, **_kwargs: Any) ->
     """
     FastAPI lifespan 등 장기 실행 애플리케이션에 주입하여 하이브리드 검색 싱글톤의 수명 주기를 
     코드 레벨에서 안전하게 보장하는 비동기 컨텍스트 매니저 헬퍼입니다.
+    
+    [매개변수 설계 안내]
+    - `app: Any | None`: IDE 자동완성 및 정적 타입 힌팅을 제공하기 위한 주 매개변수 명시.
+    - `**_kwargs: Any`: FastAPI lifespan 등 외부 프레임워크가 임의로 주입할 수 있는 
+      추가 인자를 에러 없이 수용(Tolerant)하기 위한 안전장치입니다. (제거하지 마세요)
+    
     
     사용 예시:
     ```python

--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -85,7 +85,6 @@ async def managed_hybrid_search_async(app: Any | None = None, **_kwargs: Any) ->
     - `**_kwargs: Any`: FastAPI lifespan 등 외부 프레임워크가 임의로 주입할 수 있는 
       추가 인자를 에러 없이 수용(Tolerant)하기 위한 안전장치입니다. (제거하지 마세요)
     
-    
     사용 예시:
     ```python
     @asynccontextmanager

--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 
 from dotenv import load_dotenv
 
+from backend.agent.constants import EMPTY_RETRIEVED_CONTEXT
 from backend.services.finetune_service import get_active_finetune_model
 
 # 로컬 환경 변수 로드 (.env 파일이 없으면 무시됨)
@@ -18,13 +19,6 @@ load_dotenv()
 # (참고: ModelConfig.GPT4O_MODEL 과 동일한 패턴을 따릅니다.)
 # 이 상수를 수정하면 resolve_active_model() 폴백, get_llm() 기본값이 모두 함께 바뀝니다.
 DEFAULT_MODEL_NAME: str = os.getenv("GPT4O_MODEL", "gpt-4o")
-
-# 하이브리드 검색에서 빈 결과를 명확히 표현하는 공용 상수 (매직 스트링 제거)
-# [주요 참조처 (Consumers)]
-# 1. backend.agent.nodes.retrieve_node: 빈 키워드에 대한 단락 평가(Short-circuit) 시 즉시 반환
-# 2. backend.agent.utils.search_similar_docs: 빈 키워드 폴백 로직 내 반환
-# ※ 향후 "검색 결과 없음"의 표현 형식이 바뀔 경우, 파편화 방지를 위해 반드시 이 상수만을 수정해야 합니다.
-EMPTY_RETRIEVED_CONTEXT: str = ""
 
 # Hot-swap 활성 모델을 저장하는 Redis 키 (finetune_service._FINETUNE_ACTIVE_MODEL_KEY와 동일한 환경 변수 참조)
 # finetune_service의 상수가 모듈-프라이빗(_)이므로 직접 임포트 대신 동일한 환경 변수를 공유 진실 공급원으로 사용합니다.


### PR DESCRIPTION
- **[아키텍처/의존성] 공유 상수 전용 모듈(`constants.py`) 신설**
  - `utils.py`에 있던 `EMPTY_RETRIEVED_CONTEXT` 상수를 순수 상수 전용 모듈인 `constants.py`로 격리/이전.
  - 모듈 간의 잠재적인 순환 참조(Circular Import) 위험을 원천 차단하고, 프로젝트 전역의 단일 진실 공급원(Single Source of Truth) 역할 강화.

- **[유지보수/문서화] 방어적 매개변수 설계 의도 명문화**
  - `managed_hybrid_search_async` 컨텍스트 매니저의 `**_kwargs`가 외부 프레임워크(FastAPI 등)의 주입을 수용(Tolerant)하기 위한 의도적 장치임을 도크스트링에 명시.
  - 미래의 유지보수 작업자가 해당 코드를 불필요한 코드로 오인하여 삭제(Regression)하는 휴먼 에러 방어.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1274#pullrequestreview-4209899437)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

공유 에이전트 상수를 전용 모듈로 분리하고, 하이브리드 검색 lifespan 헬퍼의 방어적인 파라미터 설계를 문서화합니다.

향상 사항:
- 순환 import를 방지하고 설정을 중앙집중화하기 위해, 에이전트 전반에서 공유되는 값을 위한 전용 constants 모듈을 도입합니다.
- 관대한 kwargs 처리가 실수로 제거되는 일을 방지하기 위해, `managed_hybrid_search_async` 컨텍스트 매니저 매개변수의 목적을 문서에서 명확히 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract shared agent constants into a dedicated module and document the defensive parameter design of the hybrid search lifespan helper.

Enhancements:
- Introduce a dedicated constants module for agent-wide shared values to avoid circular imports and centralize configuration.
- Clarify the purpose of the managed_hybrid_search_async context manager parameters in its documentation to prevent accidental removal of tolerant kwargs handling.

</details>