### PR TITLE
☘️ refactor [#12.2.11]: 10차 개선 - LifespanApp 프로토콜 도입으로 정적 타입 좁히기 완결

### DIFF
--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -84,14 +84,15 @@ class LifespanApp(Protocol):
 
 
 @asynccontextmanager
-async def managed_hybrid_search_async(app: LifespanApp | None = None, **_kwargs: Any) -> AsyncGenerator[None, None]:
+async def managed_hybrid_search_async(_app: LifespanApp | None = None, **_kwargs: Any) -> AsyncGenerator[None, None]:
     """
     FastAPI lifespan 등 장기 실행 애플리케이션에 주입하여 하이브리드 검색 싱글톤의 수명 주기를 
     코드 레벨에서 안전하게 보장하는 비동기 컨텍스트 매니저 헬퍼입니다.
     
     [매개변수 설계 안내]
-    - `app: LifespanApp | None`: IDE 자동완성 및 정적 타입 힌팅을 제공하기 위한 주 매개변수 명시.
-      (Any 대신 빈 Protocol을 사용하여 프레임워크 종속성 없이 타입 안정성 확보)
+    - `_app: LifespanApp | None`: IDE 자동완성 및 정적 타입 힌팅을 제공하기 위한 주 매개변수 명시.
+      (사용하지 않는 인자임을 명확히 하기 위해 `_` 접두사를 사용하였으며, Any 대신 빈 Protocol을 
+       사용하여 프레임워크 종속성 없이 타입 안정성 확보)
     - `**_kwargs: Any`: FastAPI lifespan 등 외부 프레임워크가 임의로 주입할 수 있는 
       추가 인자를 에러 없이 수용(Tolerant)하기 위한 안전장치입니다. (제거하지 마세요)
     

--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -1,4 +1,4 @@
-from typing import Literal, Dict, Any, List, Optional, AsyncGenerator
+from typing import Literal, Dict, Any, List, Optional, AsyncGenerator, Protocol
 import logging
 from functools import lru_cache
 from contextlib import asynccontextmanager
@@ -74,14 +74,24 @@ def cleanup_hybrid_search_service() -> None:
     _get_hybrid_search_service.cache_clear()
 
 
+class LifespanApp(Protocol):
+    """
+    FastAPI 등 수명 주기 매니저를 호출하는 애플리케이션 프레임워크의 최소 요구 인터페이스입니다.
+    현재 `managed_hybrid_search_async` 내부에서는 애플리케이션의 특정 속성을 참조하지 않으므로 
+    비어있는 상태(빈 프로토콜)로 정의되어 결합도를 최소화합니다.
+    """
+    pass
+
+
 @asynccontextmanager
-async def managed_hybrid_search_async(app: Any | None = None, **_kwargs: Any) -> AsyncGenerator[None, None]:
+async def managed_hybrid_search_async(app: LifespanApp | None = None, **_kwargs: Any) -> AsyncGenerator[None, None]:
     """
     FastAPI lifespan 등 장기 실행 애플리케이션에 주입하여 하이브리드 검색 싱글톤의 수명 주기를 
     코드 레벨에서 안전하게 보장하는 비동기 컨텍스트 매니저 헬퍼입니다.
     
     [매개변수 설계 안내]
-    - `app: Any | None`: IDE 자동완성 및 정적 타입 힌팅을 제공하기 위한 주 매개변수 명시.
+    - `app: LifespanApp | None`: IDE 자동완성 및 정적 타입 힌팅을 제공하기 위한 주 매개변수 명시.
+      (Any 대신 빈 Protocol을 사용하여 프레임워크 종속성 없이 타입 안정성 확보)
     - `**_kwargs: Any`: FastAPI lifespan 등 외부 프레임워크가 임의로 주입할 수 있는 
       추가 인자를 에러 없이 수용(Tolerant)하기 위한 안전장치입니다. (제거하지 마세요)
     


### PR DESCRIPTION
- **[타입안정성/DX] `Any` 의존성 탈피 및 Protocol 도입**
  - `managed_hybrid_search_async` 컨텍스트 매니저의 `app` 파라미터 타입을 `Any`에서 커스텀 `LifespanApp(Protocol)`로 좁힘(Narrowing).
  - 타입 체커(Type Checker)를 무력화하는 `Any`의 부작용을 제거하고, 특정 프레임워크에 종속되지 않는 덕 타이핑(Duck Typing) 기반의 안전한 인터페이스 계약(Contract) 확립.

- **[무결성] 매직 스트링 전면 중앙집중화 재검증 (Double-check)**
  - 코드베이스 전체를 재검토하여 `search_similar_docs` 및 파이프라인 내에 하드코딩된 섀도우 상수(Shadow constant)가 없음을 최종 확인 및 검증 완료.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1276#pullrequestreview-4214378189)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

프레임워크에 구애받지 않는 LifespanApp 프로토콜을 도입하고, 정적 타입 안전성을 향상시키기 위해 `managed_hybrid_search_async` 앱 파라미터 타입을 `Any`에서 더 좁은 타입으로 변경합니다.

향상 사항:
- 특정 구현에 결합되지 않으면서도 lifespan 기능을 가진 애플리케이션 프레임워크를 표현하기 위한 최소한의 `LifespanApp` 프로토콜을 정의합니다.
- `managed_hybrid_search_async`가 `Any` 대신 `LifespanApp`을 받도록 수정하고, 더 엄격하면서도 프레임워크에 독립적인 타입 정의를 반영하도록 문서를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a framework-agnostic LifespanApp protocol and narrow the managed_hybrid_search_async app parameter type away from Any to improve static type safety.

Enhancements:
- Define a minimal LifespanApp Protocol to represent lifespan-capable application frameworks without coupling to a specific implementation.
- Update managed_hybrid_search_async to accept LifespanApp instead of Any and adjust documentation to reflect the stricter, framework-agnostic typing.

</details>