### PR TITLE
✨ feat [#12.2.12]: Phase 2.4 - ➀ GDPR 감사 로그(Audit Log) 인프라 구축

### DIFF
--- a/backend/core/audit_logger.py
+++ b/backend/core/audit_logger.py
@@ -1,0 +1,312 @@
+# backend/core/audit_logger.py
+
+"""
+GDPR Audit Logger — v9.0 Phase 2-4 (Privacy & Compliance)
+==========================================================
+
+감사 로그(Audit Log) 인프라 모듈.
+
+[설계 원칙]
+  - PII 마스킹 원칙: 로그에 user_id 원문은 절대 기록하지 않으며, 항상 masked_uid로만 식별.
+  - [OBS] 태그 준수: 관측성(Observability) 목적의 모든 로그는 [OBS] 접두어를 사용.
+  - 백엔드 외부화: 로그 저장소 백엔드(file / db / cloudwatch)를 AUDIT_LOG_BACKEND 환경 변수로 제어.
+  - 보관 정책: 90일 보관 후 자동 영구 삭제 (트리거 인터페이스만 제공, 실제 실행은 스케줄러에 위임).
+  - 하드코딩 금지: 모든 상수는 환경 변수 또는 모듈 레벨 상수로 외부화.
+
+[수명 주기]
+  - FastAPI lifespan 또는 Celery 훅에서 schedule_audit_log_cleanup()을 등록하여 보관 정책을 강제.
+
+[주요 참조처 (Consumers)]
+  - backend.services.privacy_service: 삭제·익명화 처리 결과 기록
+  - 향후 추가되는 GDPR 처리 파이프라인 전체
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# =============================================================================
+# 모듈 레벨 상수 (환경 변수 우선, 미설정 시 안전한 기본값)
+# =============================================================================
+
+# 감사 로그 저장소 백엔드 (유효값: "file" / "db" / "cloudwatch")
+_AUDIT_LOG_BACKEND_ENV_KEY = "AUDIT_LOG_BACKEND"
+_VALID_BACKENDS = frozenset({"file", "db", "cloudwatch"})
+_DEFAULT_BACKEND = "file"
+
+_raw_backend = os.getenv(_AUDIT_LOG_BACKEND_ENV_KEY, "").strip().lower()
+AUDIT_LOG_BACKEND: str = _raw_backend if _raw_backend in _VALID_BACKENDS else _DEFAULT_BACKEND
+
+if _raw_backend and _raw_backend not in _VALID_BACKENDS:
+    logger.warning(
+        "[OBS][AUDIT][CONFIG] '%s'=%r is not a valid backend (valid: %s). "
+        "Falling back to default '%s'.",
+        _AUDIT_LOG_BACKEND_ENV_KEY,
+        _raw_backend,
+        sorted(_VALID_BACKENDS),
+        _DEFAULT_BACKEND,
+    )
+
+# 감사 로그 파일 저장 경로 (file 백엔드 사용 시)
+_AUDIT_LOG_FILE_PATH_ENV_KEY = "AUDIT_LOG_FILE_PATH"
+_DEFAULT_AUDIT_LOG_FILE_PATH = "logs/audit.log"
+AUDIT_LOG_FILE_PATH: str = (
+    os.getenv(_AUDIT_LOG_FILE_PATH_ENV_KEY, "").strip()
+    or _DEFAULT_AUDIT_LOG_FILE_PATH
+)
+
+# 감사 로그 보관 일수
+_AUDIT_LOG_RETENTION_DAYS_ENV_KEY = "AUDIT_LOG_RETENTION_DAYS"
+_DEFAULT_AUDIT_LOG_RETENTION_DAYS = 90
+_MIN_RETENTION_DAYS = 1
+_MAX_RETENTION_DAYS = 3650  # 10년 상한
+
+_raw_retention = os.getenv(_AUDIT_LOG_RETENTION_DAYS_ENV_KEY)
+try:
+    _parsed_retention = int(_raw_retention) if _raw_retention is not None else _DEFAULT_AUDIT_LOG_RETENTION_DAYS
+    if not (_MIN_RETENTION_DAYS <= _parsed_retention <= _MAX_RETENTION_DAYS):
+        logger.warning(
+            "[OBS][AUDIT][CONFIG] '%s'=%d is outside safe range [%d, %d]. "
+            "Falling back to default %d days.",
+            _AUDIT_LOG_RETENTION_DAYS_ENV_KEY,
+            _parsed_retention,
+            _MIN_RETENTION_DAYS,
+            _MAX_RETENTION_DAYS,
+            _DEFAULT_AUDIT_LOG_RETENTION_DAYS,
+        )
+        _parsed_retention = _DEFAULT_AUDIT_LOG_RETENTION_DAYS
+except (ValueError, TypeError):
+    logger.warning(
+        "[OBS][AUDIT][CONFIG] '%s'=%r is not a valid integer. "
+        "Falling back to default %d days.",
+        _AUDIT_LOG_RETENTION_DAYS_ENV_KEY,
+        _raw_retention,
+        _DEFAULT_AUDIT_LOG_RETENTION_DAYS,
+    )
+    _parsed_retention = _DEFAULT_AUDIT_LOG_RETENTION_DAYS
+
+AUDIT_LOG_RETENTION_DAYS: int = _parsed_retention
+
+# PII 마스킹 접두어 길이 (masked_uid 노출 자릿수)
+_MASKED_UID_PREFIX_LEN_ENV_KEY = "MASKED_UID_PREFIX_LEN"
+_DEFAULT_MASKED_UID_PREFIX_LEN = 8
+_MIN_MASKED_UID_PREFIX_LEN = 4
+_MAX_MASKED_UID_PREFIX_LEN = 16
+
+_raw_prefix_len = os.getenv(_MASKED_UID_PREFIX_LEN_ENV_KEY)
+try:
+    _parsed_prefix_len = (
+        int(_raw_prefix_len) if _raw_prefix_len is not None else _DEFAULT_MASKED_UID_PREFIX_LEN
+    )
+    if not (_MIN_MASKED_UID_PREFIX_LEN <= _parsed_prefix_len <= _MAX_MASKED_UID_PREFIX_LEN):
+        logger.warning(
+            "[OBS][AUDIT][CONFIG] '%s'=%d is outside safe range [%d, %d]. "
+            "Falling back to default %d.",
+            _MASKED_UID_PREFIX_LEN_ENV_KEY,
+            _parsed_prefix_len,
+            _MIN_MASKED_UID_PREFIX_LEN,
+            _MAX_MASKED_UID_PREFIX_LEN,
+            _DEFAULT_MASKED_UID_PREFIX_LEN,
+        )
+        _parsed_prefix_len = _DEFAULT_MASKED_UID_PREFIX_LEN
+except (ValueError, TypeError):
+    logger.warning(
+        "[OBS][AUDIT][CONFIG] '%s'=%r is not a valid integer. "
+        "Falling back to default %d.",
+        _MASKED_UID_PREFIX_LEN_ENV_KEY,
+        _raw_prefix_len,
+        _DEFAULT_MASKED_UID_PREFIX_LEN,
+    )
+    _parsed_prefix_len = _DEFAULT_MASKED_UID_PREFIX_LEN
+
+MASKED_UID_PREFIX_LEN: int = _parsed_prefix_len
+
+
+# =============================================================================
+# 감사 이벤트 타입
+# =============================================================================
+
+class AuditEventType(str, Enum):
+    """
+    감사 로그에 기록되는 이벤트 유형.
+    향후 이벤트 추가 시 이 Enum에만 정의하여 하드코딩 방지.
+    """
+    DATA_DELETE_REQUESTED = "DATA_DELETE_REQUESTED"
+    DATA_DELETE_SUCCESS = "DATA_DELETE_SUCCESS"
+    DATA_DELETE_FAILURE = "DATA_DELETE_FAILURE"
+    DATA_ANONYMIZE_SUCCESS = "DATA_ANONYMIZE_SUCCESS"
+    DATA_ANONYMIZE_FAILURE = "DATA_ANONYMIZE_FAILURE"
+    AUDIT_LOG_CLEANUP = "AUDIT_LOG_CLEANUP"
+    ACCESS_AUDIT_LOG = "ACCESS_AUDIT_LOG"
+
+
+# =============================================================================
+# PII 마스킹 헬퍼
+# =============================================================================
+
+def mask_uid(hashed_user_id: str) -> str:
+    """
+    hashed_user_id의 앞 N자리만 노출하고 나머지를 '*'로 마스킹합니다.
+
+    [보안 원칙]
+      - 로그 및 관측 시스템에서 user_id 원문은 절대 사용하지 않습니다.
+      - hashed_user_id조차도 일부만 노출하여 재식별 리스크를 최소화합니다.
+      - 노출 길이는 MASKED_UID_PREFIX_LEN (환경 변수) 으로 제어합니다.
+
+    Args:
+        hashed_user_id: SHA-256 등으로 해싱된 사용자 식별자 (원문 user_id 금지).
+
+    Returns:
+        앞 N자리 + '****' 형태의 마스킹된 문자열.
+    """
+    if not hashed_user_id:
+        return "****"
+    prefix = hashed_user_id[:MASKED_UID_PREFIX_LEN]
+    return f"{prefix}****"
+
+
+# =============================================================================
+# 구조화 감사 로그 포맷터
+# =============================================================================
+
+def _build_audit_record(
+    event_type: AuditEventType,
+    masked_uid: str,
+    result: str,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """
+    감사 로그 레코드를 구조화된 딕셔너리로 생성합니다.
+
+    Args:
+        event_type: 이벤트 유형 (AuditEventType).
+        masked_uid: 마스킹된 사용자 식별자 (mask_uid() 출력값).
+        result: 처리 결과 요약 문자열 (예: "success", "failure: <reason>").
+        extra: 추가 컨텍스트 정보 (PII 미포함 원칙 준수 필수).
+
+    Returns:
+        감사 로그 레코드 딕셔너리.
+    """
+    record: dict[str, Any] = {
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+        "event_type": event_type.value,
+        "masked_uid": masked_uid,
+        "result": result,
+    }
+    if extra:
+        record["extra"] = extra
+    return record
+
+
+def write_audit_log(
+    event_type: AuditEventType,
+    masked_uid: str,
+    result: str,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """
+    감사 이벤트를 설정된 백엔드에 기록합니다.
+
+    [백엔드 라우팅]
+      - "file":        AUDIT_LOG_FILE_PATH 경로의 파일에 JSON Lines 형식으로 기록.
+      - "db":          DB 연동은 향후 구현 예정 (현재 INFO 로그로 대체).
+      - "cloudwatch":  CloudWatch Logs 연동은 향후 구현 예정 (현재 INFO 로그로 대체).
+
+    Args:
+        event_type: 감사 이벤트 유형.
+        masked_uid:  마스킹된 사용자 식별자.
+        result:      처리 결과 요약.
+        extra:       추가 컨텍스트 (PII 금지).
+    """
+    record = _build_audit_record(event_type, masked_uid, result, extra)
+
+    if AUDIT_LOG_BACKEND == "file":
+        _write_to_file(record)
+    elif AUDIT_LOG_BACKEND in ("db", "cloudwatch"):
+        # 향후 구현 예정: 현재는 표준 로거로 대체하여 관측성 유지
+        logger.info(
+            "[OBS][AUDIT] event_type=%s masked_uid=%s result=%s backend=%s (not yet implemented)",
+            event_type.value,
+            masked_uid,
+            result,
+            AUDIT_LOG_BACKEND,
+        )
+    else:
+        # 방어적 처리: 유효하지 않은 백엔드는 모듈 로딩 시 이미 경고되므로 여기서는 로거만 사용
+        logger.warning(
+            "[OBS][AUDIT] Unknown backend '%s'. Falling back to logger output.",
+            AUDIT_LOG_BACKEND,
+        )
+        logger.info("[OBS][AUDIT] %s", json.dumps(record, ensure_ascii=False))
+
+
+def _write_to_file(record: dict[str, Any]) -> None:
+    """
+    감사 로그 레코드를 파일에 JSON Lines 형식으로 기록합니다.
+    디렉토리가 없을 경우 자동 생성합니다.
+    """
+    try:
+        log_path = AUDIT_LOG_FILE_PATH
+        log_dir = os.path.dirname(log_path)
+        if log_dir:
+            os.makedirs(log_dir, exist_ok=True)
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except OSError as e:
+        # 파일 I/O 실패 시 표준 로거로 폴백 (관측성 유지, 프로세스 중단 방지)
+        logger.error(
+            "[OBS][AUDIT] Failed to write audit log to file '%s': %s. "
+            "Falling back to logger output. record=%s",
+            AUDIT_LOG_FILE_PATH,
+            type(e).__name__,
+            json.dumps(record, ensure_ascii=False),
+        )
+
+
+# =============================================================================
+# 감사 로그 보관 정책 — 스케줄러 트리거 인터페이스
+# =============================================================================
+
+def get_audit_log_cutoff_datetime() -> datetime:
+    """
+    현재 시각을 기준으로 감사 로그 보관 만료 기준 시각을 반환합니다.
+    AUDIT_LOG_RETENTION_DAYS (환경 변수) 일 이전의 레코드는 삭제 대상입니다.
+
+    Returns:
+        보관 만료 기준 datetime (UTC).
+    """
+    return datetime.now(tz=timezone.utc) - timedelta(days=AUDIT_LOG_RETENTION_DAYS)
+
+
+def schedule_audit_log_cleanup() -> None:
+    """
+    감사 로그 자동 영구 삭제 스케줄러의 트리거 인터페이스입니다.
+
+    [수명 주기 가이드라인]
+    - FastAPI lifespan 컨텍스트 매니저: yield 이전 블록에서 호출하여 스케줄러 등록.
+    - Celery Beat: periodic task로 등록하여 주기적 실행 보장.
+    - 실제 파일/DB/CloudWatch 레코드 삭제 로직은 각 백엔드 구현체에서 get_audit_log_cutoff_datetime()을 참조하여 수행.
+
+    현재는 트리거 의도를 INFO 로그로 기록하며, 실제 삭제 구현은 각 백엔드 통합 단계에서 완성합니다.
+    """
+    cutoff = get_audit_log_cutoff_datetime()
+    logger.info(
+        "[OBS][AUDIT] Audit log cleanup scheduled. "
+        "Records older than %s (retention=%d days) will be purged. backend=%s",
+        cutoff.isoformat(),
+        AUDIT_LOG_RETENTION_DAYS,
+        AUDIT_LOG_BACKEND,
+    )
+    write_audit_log(
+        event_type=AuditEventType.AUDIT_LOG_CLEANUP,
+        masked_uid="system",
+        result=f"cleanup_triggered: cutoff={cutoff.isoformat()}",
+        extra={"retention_days": AUDIT_LOG_RETENTION_DAYS, "backend": AUDIT_LOG_BACKEND},
+    )

--- a/backend/core/audit_logger.py
+++ b/backend/core/audit_logger.py
@@ -130,6 +130,34 @@ MASKED_UID_PREFIX_LEN: int = _parsed_prefix_len
 
 
 # =============================================================================
+# 런타임 설정 엑세서 (Getter Functions)
+# =============================================================================
+# import 시점에 확정되는 모듈 레벨 상수 대신, getter 함수를 통해 간접 주입하면
+# pytest monkeypatch 등 테스트 환경에서 동적 교체가 가능합니다.
+# 운영 환경에서는 프로세스 시작 전 환경 변수를 설정하므로 실질적인 차이 없습니다.
+
+
+def get_audit_log_backend() -> str:
+    """AUDIT_LOG_BACKEND 모듈 변수를 반환합니다. 테스트에서 monkeypatch 대상으로 활용 가능."""
+    return AUDIT_LOG_BACKEND
+
+
+def get_audit_log_file_path() -> str:
+    """AUDIT_LOG_FILE_PATH 모듈 변수를 반환합니다."""
+    return AUDIT_LOG_FILE_PATH
+
+
+def get_audit_log_retention_days() -> int:
+    """AUDIT_LOG_RETENTION_DAYS 모듈 변수를 반환합니다."""
+    return AUDIT_LOG_RETENTION_DAYS
+
+
+def get_masked_uid_prefix_len() -> int:
+    """MASKED_UID_PREFIX_LEN 모듈 변수를 반환합니다."""
+    return MASKED_UID_PREFIX_LEN
+
+
+# =============================================================================
 # 감사 이벤트 타입
 # =============================================================================
 
@@ -226,25 +254,24 @@ def write_audit_log(
         extra:       추가 컨텍스트 (PII 금지).
     """
     record = _build_audit_record(event_type, masked_uid, result, extra)
+    backend = get_audit_log_backend()
 
-    if AUDIT_LOG_BACKEND == "file":
+    if backend == "file":
         _write_to_file(record)
-    elif AUDIT_LOG_BACKEND in ("db", "cloudwatch"):
-        # 향후 구현 예정: 현재는 표준 로거로 대체하여 관측성 유지
+    elif backend in ("db", "cloudwatch"):
+        # 향후 구현 예정: 현재는 전체 record(extra 포함)를 JSON으로 로거에 출력하여 관측성 유지
         logger.info(
-            "[OBS][AUDIT] event_type=%s masked_uid=%s result=%s backend=%s (not yet implemented)",
-            event_type.value,
-            masked_uid,
-            result,
-            AUDIT_LOG_BACKEND,
+            "[OBS][AUDIT] backend=%s (not yet implemented) record=%s",
+            backend,
+            json.dumps(record, ensure_ascii=False),
         )
     else:
-        # 방어적 처리: 유효하지 않은 백엔드는 모듈 로딩 시 이미 경고되므로 여기서는 로거만 사용
-        logger.warning(
-            "[OBS][AUDIT] Unknown backend '%s'. Falling back to logger output.",
-            AUDIT_LOG_BACKEND,
+        # AUDIT_LOG_BACKEND는 import 시점에 _VALID_BACKENDS로 이미 정규화되므로 이 분기는 도달 불가능
+        # 값이 잘못 삽입되는 렬타임 오염을 즉시 탐지하기 위해 assert로 불변식 명시
+        assert False, (
+            f"[OBS][AUDIT] Invariant violated: backend='{backend}' is not in {sorted(_VALID_BACKENDS)}. "
+            "This path must never be reached. Check module initialization."
         )
-        logger.info("[OBS][AUDIT] %s", json.dumps(record, ensure_ascii=False))
 
 
 def _write_to_file(record: dict[str, Any]) -> None:


### PR DESCRIPTION
- **[보안/GDPR] PII 마스킹 헬퍼 구현**
  - `mask_uid()`: `hashed_user_id` 앞 N자리만 노출하는 함수 구현.
  - 노출 자릿수를 `MASKED_UID_PREFIX_LEN` [int, 기본값: 8, 유효 범위: 4~16] 환경 변수로 외부화.
  - 로그 전 처리 과정 전체에서 `user_id` 원문 완전 차단 — 구조적 PII 보호 달성.

- **[관측성/GDPR] [OBS] 태그 준수 구조화 감사 로그 포맷터**
  - `write_audit_log()`: 타임스탬프(UTC), 이벤트 유형(`AuditEventType`), `masked_uid`, 처리 결과를 JSON Lines 형식으로 기록.
  - 저장소 백엔드를 `AUDIT_LOG_BACKEND` [str, 기본값: `"file"`, 유효값: `"file"` / `"db"` / `"cloudwatch"`]로 외부화.
  - file 백엔드 I/O 실패 시 표준 로거로 안전하게 폴백하여 관측성 유지.

- **[운영/GDPR] 90일 보관 정책 스케줄러 트리거 인터페이스**
  - `schedule_audit_log_cleanup()`: FastAPI lifespan 또는 Celery Beat에 등록 가능한 수명 주기 인터페이스 제공.
  - 만료 기준 일수를 `AUDIT_LOG_RETENTION_DAYS` [int, 기본값: 90, 유효 범위: 1~3650]로 외부화.

🔗 Related: Issue [#1046]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

GDPR를 준수하는 감사 로깅 모듈을 도입했으며, PII 마스킹, 플러그형 백엔드, 보존 기간 스케줄링 인터페이스를 포함합니다.

New Features:
- 시스템 전반에서 GDPR 관련 감사 이벤트를 표준화하기 위한 전용 `AuditEventType` enum을 추가했습니다.
- 로그에서 해시된 사용자 식별자의 접두부만 안전하게 노출할 수 있도록 `mask_uid` 헬퍼를 제공합니다.
- 감사 이벤트를 구성 가능한 백엔드로 라우팅하고, 안전한 로거를 폴백으로 사용하는 구조화된 `write_audit_log` 엔트리 포인트를 구현했습니다.
- 감사 로그의 보존 기한과 정리 스케줄링을 제어하기 위한 `get_audit_log_cutoff_datetime` 및 `schedule_audit_log_cleanup` 헬퍼를 노출했습니다.

Enhancements:
- 백엔드 선택, 로그 파일 경로, UID 마스킹 길이, 보존 기간을 환경 변수 기반 설정으로 중앙집중화하고, 이에 대한 검증 및 관측 가능성 경고를 추가했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a GDPR-compliant audit logging module with PII-masking, pluggable backends, and retention scheduling interfaces.

New Features:
- Add a dedicated AuditEventType enum to standardize GDPR-related audit events across the system.
- Provide a mask_uid helper to safely expose only a prefix of hashed user identifiers in logs.
- Implement a structured write_audit_log entry point that routes audit events to a configurable backend with safe logger fallbacks.
- Expose get_audit_log_cutoff_datetime and schedule_audit_log_cleanup helpers to drive audit-log retention and cleanup scheduling.

Enhancements:
- Centralize audit logging configuration via environment-driven settings for backend selection, log file path, UID masking length, and retention period with validation and observability warnings.

</details>