### PR TITLE
☘️ refactor [#12.2.12]: 2차 개선 - 런타임 상수 참조 게터로 전면 교체 및 불변식 강화

### DIFF
--- a/backend/core/audit_logger.py
+++ b/backend/core/audit_logger.py
@@ -282,8 +282,8 @@ def _write_to_file(record: dict[str, Any]) -> None:
     감사 로그 레코드를 파일에 JSON Lines 형식으로 기록합니다.
     디렉토리가 없을 경우 자동 생성합니다.
     """
+    log_path = get_audit_log_file_path()
     try:
-        log_path = get_audit_log_file_path()
         log_dir = os.path.dirname(log_path)
         if log_dir:
             os.makedirs(log_dir, exist_ok=True)
@@ -291,10 +291,11 @@ def _write_to_file(record: dict[str, Any]) -> None:
             f.write(json.dumps(record, ensure_ascii=False) + "\n")
     except OSError as e:
         # 파일 I/O 실패 시 표준 로거로 폴백 (관측성 유지, 프로세스 중단 방지)
+        # log_path는 try 진입 전에 한 번만 계산하여 try/except 양쪽에서 일관되게 참조
         logger.error(
             "[OBS][AUDIT] Failed to write audit log to file '%s': %s. "
             "Falling back to logger output. record=%s",
-            get_audit_log_file_path(),
+            log_path,
             type(e).__name__,
             json.dumps(record, ensure_ascii=False),
         )

--- a/backend/core/audit_logger.py
+++ b/backend/core/audit_logger.py
@@ -196,7 +196,7 @@ def mask_uid(hashed_user_id: str) -> str:
     """
     if not hashed_user_id:
         return "****"
-    prefix = hashed_user_id[:MASKED_UID_PREFIX_LEN]
+    prefix = hashed_user_id[:get_masked_uid_prefix_len()]
     return f"{prefix}****"
 
 
@@ -267,11 +267,14 @@ def write_audit_log(
         )
     else:
         # AUDIT_LOG_BACKEND는 import 시점에 _VALID_BACKENDS로 이미 정규화되므로 이 분기는 도달 불가능
-        # 값이 잘못 삽입되는 렬타임 오염을 즉시 탐지하기 위해 assert로 불변식 명시
-        assert False, (
+        # 값이 잘못 삽입되는 런타임 오염을 즉시 탐지하기 위해 예외를 발생시켜 불변식을 보장합니다.
+        # 주의: assert는 -O 플래그로 제거되므로, 프로덕션에서도 동작해야 하는 불변식에는 사용 금지
+        message = (
             f"[OBS][AUDIT] Invariant violated: backend='{backend}' is not in {sorted(_VALID_BACKENDS)}. "
             "This path must never be reached. Check module initialization."
         )
+        logger.error(message)
+        raise RuntimeError(message)
 
 
 def _write_to_file(record: dict[str, Any]) -> None:
@@ -280,7 +283,7 @@ def _write_to_file(record: dict[str, Any]) -> None:
     디렉토리가 없을 경우 자동 생성합니다.
     """
     try:
-        log_path = AUDIT_LOG_FILE_PATH
+        log_path = get_audit_log_file_path()
         log_dir = os.path.dirname(log_path)
         if log_dir:
             os.makedirs(log_dir, exist_ok=True)
@@ -291,7 +294,7 @@ def _write_to_file(record: dict[str, Any]) -> None:
         logger.error(
             "[OBS][AUDIT] Failed to write audit log to file '%s': %s. "
             "Falling back to logger output. record=%s",
-            AUDIT_LOG_FILE_PATH,
+            get_audit_log_file_path(),
             type(e).__name__,
             json.dumps(record, ensure_ascii=False),
         )
@@ -309,7 +312,7 @@ def get_audit_log_cutoff_datetime() -> datetime:
     Returns:
         보관 만료 기준 datetime (UTC).
     """
-    return datetime.now(tz=timezone.utc) - timedelta(days=AUDIT_LOG_RETENTION_DAYS)
+    return datetime.now(tz=timezone.utc) - timedelta(days=get_audit_log_retention_days())
 
 
 def schedule_audit_log_cleanup() -> None:
@@ -328,12 +331,12 @@ def schedule_audit_log_cleanup() -> None:
         "[OBS][AUDIT] Audit log cleanup scheduled. "
         "Records older than %s (retention=%d days) will be purged. backend=%s",
         cutoff.isoformat(),
-        AUDIT_LOG_RETENTION_DAYS,
-        AUDIT_LOG_BACKEND,
+        get_audit_log_retention_days(),
+        get_audit_log_backend(),
     )
     write_audit_log(
         event_type=AuditEventType.AUDIT_LOG_CLEANUP,
         masked_uid="system",
         result=f"cleanup_triggered: cutoff={cutoff.isoformat()}",
-        extra={"retention_days": AUDIT_LOG_RETENTION_DAYS, "backend": AUDIT_LOG_BACKEND},
+        extra={"retention_days": get_audit_log_retention_days(), "backend": get_audit_log_backend()},
     )


### PR DESCRIPTION
- **[테스트 유연성/일관성] 런타임 함수 내 상수 직접 참조 게터로 전면 교체**
  - `mask_uid()`, `_write_to_file()`, `get_audit_log_cutoff_datetime()`, `schedule_audit_log_cleanup()` 내부에 남아있던 모듈 레벨 상수(`MASKED_UID_PREFIX_LEN`, `AUDIT_LOG_FILE_PATH`, `AUDIT_LOG_RETENTION_DAYS`, `AUDIT_LOG_BACKEND`) 직접 참조를 게터 호출로 전면 교체.
  - 이제 `pytest monkeypatch`로 게터의 반환값을 교체하면 런타임 경로 전체에 즉시 반영되어 실제적인 테스트 유연성 확보.

- **[안정성] `assert False` → `RuntimeError` 교체 (프로덕션 불변식 강화)**
  - `assert`는 Python `-O` 최적화 플래그로 실행 시 제거되어 불변식이 무력화될 위험이 있음.
  - `logger.error(message)` + `raise RuntimeError(message)` 패턴으로 교체하여 플래그와 무관하게 불변식을 항상 강제.

- **[가독성] 오타 수정** ("렬타임" → "런타임")

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1280#pullrequestreview-4214458580)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

감사(audit) 로깅의 런타임 동작이 설정용 getter 함수를 기반으로 동작하도록 리팩터링하고, 잘못된 백엔드 감지를 위한 불변 조건( invariant )을 강화합니다.

버그 수정:
- 조건부 `assert`를 로깅이 동반된 `RuntimeError`로 교체하여, 프로덕션 환경에서 감사 백엔드에 대한 불변 조건이 항상 보장되도록 합니다.

개선 사항:
- 런타임 설정 가능성과 테스트 용이성을 높이기 위해 감사 관련 모듈 수준 상수에 대한 직접 참조를 getter 호출로 대체합니다.
- 잘못된 감사 백엔드를 감지했을 때의 로깅과 에러 처리 방식을 개선하고, 예외를 발생시키기 전에 명시적으로 에러를 로깅하도록 합니다.
- 감사 로거 주석에 있는 오타를 수정하여 런타임 동작에 대한 한국어 표현을 더 명확하게 다듬습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor audit logging runtime behavior to rely on configuration getter functions and strengthen invariants for invalid backend detection.

Bug Fixes:
- Ensure audit backend invariant is always enforced in production by replacing a conditional assert with a logged RuntimeError.

Enhancements:
- Replace direct references to audit-related module-level constants with getter calls to improve runtime configurability and testability.
- Improve logging and error handling when an invalid audit backend is encountered, including explicit error logging before raising.
- Fix a typo in an audit logger comment for clearer Korean wording around runtime behavior.

</details>