### PR TITLE
☘️ refactor [#12.2.12]: 4차 개선 - 커스텀 예외 도입 및 cleanup 함수 게터 중복 호출 제거

### DIFF
--- a/backend/core/audit_logger.py
+++ b/backend/core/audit_logger.py
@@ -32,6 +32,22 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# 이 모듈의 공개 API를 명시적으로 선언합니다.
+# 외부 모듈(예: privacy_service)에서 AuditConfigError를 안정적으로 import하고
+# `except AuditConfigError`로 포착할 수 있도록 공개 계약을 보장합니다.
+__all__ = [
+    "AuditConfigError",
+    "AuditEventType",
+    "mask_uid",
+    "write_audit_log",
+    "schedule_audit_log_cleanup",
+    "get_audit_log_cutoff_datetime",
+    "get_audit_log_backend",
+    "get_audit_log_file_path",
+    "get_audit_log_retention_days",
+    "get_masked_uid_prefix_len",
+]
+
 # =============================================================================
 # 모듈 레벨 상수 (환경 변수 우선, 미설정 시 안전한 기본값)
 # =============================================================================

--- a/backend/core/audit_logger.py
+++ b/backend/core/audit_logger.py
@@ -130,6 +130,21 @@ MASKED_UID_PREFIX_LEN: int = _parsed_prefix_len
 
 
 # =============================================================================
+# 커스텀 예외 (Custom Exceptions)
+# =============================================================================
+
+class AuditConfigError(RuntimeError):
+    """
+    감사 로그 모듈의 설정 불변식(Invariant) 위반 시 발생하는 커스텀 예외입니다.
+
+    일반 RuntimeError가 아닌 이 예외를 사용하면:
+    - 상위 에러 핸들러가 `except AuditConfigError`로 정확히 포착 가능
+    - APM/SIEM 시스템에서 감사 모듈 고유 설정 오류로 분류 및 알림 가능
+    - 코드를 보는 동료나 행위자가 어떤 시스템에서 발생한 문제인지 즉시 파악 가능
+    """
+
+
+# =============================================================================
 # 런타임 설정 엑세서 (Getter Functions)
 # =============================================================================
 # import 시점에 확정되는 모듈 레벨 상수 대신, getter 함수를 통해 간접 주입하면
@@ -274,7 +289,7 @@ def write_audit_log(
             "This path must never be reached. Check module initialization."
         )
         logger.error(message)
-        raise RuntimeError(message)
+        raise AuditConfigError(message)
 
 
 def _write_to_file(record: dict[str, Any]) -> None:
@@ -328,16 +343,18 @@ def schedule_audit_log_cleanup() -> None:
     현재는 트리거 의도를 INFO 로그로 기록하며, 실제 삭제 구현은 각 백엔드 통합 단계에서 완성합니다.
     """
     cutoff = get_audit_log_cutoff_datetime()
+    retention_days = get_audit_log_retention_days()
+    backend = get_audit_log_backend()
     logger.info(
         "[OBS][AUDIT] Audit log cleanup scheduled. "
         "Records older than %s (retention=%d days) will be purged. backend=%s",
         cutoff.isoformat(),
-        get_audit_log_retention_days(),
-        get_audit_log_backend(),
+        retention_days,
+        backend,
     )
     write_audit_log(
         event_type=AuditEventType.AUDIT_LOG_CLEANUP,
         masked_uid="system",
         result=f"cleanup_triggered: cutoff={cutoff.isoformat()}",
-        extra={"retention_days": get_audit_log_retention_days(), "backend": get_audit_log_backend()},
+        extra={"retention_days": retention_days, "backend": backend},
     )


### PR DESCRIPTION
- **[관측성/에러 처리] AuditConfigError 커스텀 예외 신설**
  - 불변식 위반 시 발생하는 `RuntimeError`를 `AuditConfigError(RuntimeError)` 커스텀 예외로 교체.
  - 상위 에러 핸들러가 `except AuditConfigError`로 감사 모듈 고유 설정 오류를 정밀하게 포착·분류 가능.
  - `RuntimeError` 상속 구조 유지로 기존 핸들러와의 하위 호환성 보장.

- **[성능/일관성] `schedule_audit_log_cleanup` 게터 중복 호출 제거**
  - `get_audit_log_retention_days()`, `get_audit_log_backend()`를 로컬 변수(`retention_days`, `backend`)에 한 번씩만 저장 후 재사용.
  - `logger.info` 메시지와 `extra` 페이로드가 항상 동일한 값을 참조하여 타이밍 기반 불일치 가능성 원천 차단.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1282#pullrequestreview-4214597099)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

전용 감사 로깅 구성 오류 타입을 도입하고 감사 로그 정리 스케줄링을 간소화합니다.

New Features:
- 감사 로깅 구성 불변 조건 위반을 위해 `AuditConfigError` 커스텀 예외를 추가합니다.

Enhancements:
- 도달 불가능한 구성 상태에서 일반 `RuntimeError` 대신 새로운 `AuditConfigError`를 발생시키도록 감사 로그 기록 로직을 업데이트합니다.
- 감사 로그 정리 스케줄링에서 가져온 보존 기간(retention)과 백엔드 값을 재사용하여, 로깅과 감사 이벤트 메타데이터에 활용함으로써 중복 getter 호출을 방지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated audit logging configuration error type and streamline audit log cleanup scheduling.

New Features:
- Add an AuditConfigError custom exception for audit logging configuration invariant violations.

Enhancements:
- Update audit log writing to raise the new AuditConfigError instead of a generic RuntimeError on unreachable configuration states.
- Avoid duplicate getter calls in audit log cleanup scheduling by reusing retrieved retention and backend values for logging and audit event metadata.

</details>