### PR TITLE
☘️ refactor [#12.2.13]: 4차 개선 - API 계약 명확화 및 방어적 로깅 고도화

### DIFF
--- a/backend/services/privacy_service.py
+++ b/backend/services/privacy_service.py
@@ -244,10 +244,11 @@ def _remove_faiss_index_file(index_path: Path) -> bool:
         return True
     except OSError as e:
         logger.exception(
-            "[OBS][PRIVACY] Failed to remove FAISS index file at path=%s, error=%s. "
+            "[OBS][PRIVACY] Failed to remove FAISS index file at path=%s, error_type=%s, error_msg=%s. "
             "Manual cleanup may be required.",
             index_path,
             type(e).__name__,
+            str(e),
         )
         return False
 
@@ -314,7 +315,6 @@ async def delete_user_data(
     try:
         rows_deleted: int = await db_delete_fn(hashed_user_id)
         result["db_rows_deleted"] = rows_deleted
-        result["db_deleted"] = rows_deleted > 0
         if rows_deleted == 0:
             logger.info(
                 "[OBS][PRIVACY] DB records already deleted (idempotent): rows=%d, masked_uid=%s",
@@ -339,6 +339,7 @@ async def delete_user_data(
             masked_uid=masked,
             result=f"db_deletion_failed: {type(e).__name__}",
         )
+        result["db_deleted"] = result["db_rows_deleted"] > 0
         return result
 
     # ── 2. 누적 카운터 및 VACUUM 트리거 판단 ──────────────────────────────
@@ -442,4 +443,9 @@ async def delete_user_data(
             redis_meta_deleted,
         )
 
+    # ── 최종 파생 필드 계산 및 반환 ──
+    # db_deleted는 개별 로직에서 변형되지 않고, 오직 최종 결과 반환 직전에
+    # db_rows_deleted로부터 파생되어 데이터 불일치(divergence)를 원천 차단합니다.
+    result["db_deleted"] = result["db_rows_deleted"] > 0
+    
     return result

--- a/backend/services/privacy_service.py
+++ b/backend/services/privacy_service.py
@@ -134,11 +134,27 @@ class DeletionResult(TypedDict):
     masked_user_id: str        # 마스킹된 UID (masked_uid, 원문 PII 미사용)
     hashed_user_id: str        # [DEPRECATED] 이전 API 호환성을 위해 유지 (masked_user_id와 동일)
     db_rows_deleted: int       # DB 레코드 실제 삭제 행 수
+    db_deleted: bool           # DB 레코드가 1건 이상 삭제되었는지 여부 (계약 명확화)
     faiss_file_removed: bool   # FAISS 인덱스 파일 물리 삭제 성공 여부
     redis_meta_deleted: bool   # Redis 메타데이터 삭제 성공 여부
     compaction_recommended: bool  # FAISS Compaction 권장 여부
     vacuum_triggered: bool     # VACUUM 즉시 실행 권장 여부
     success: bool              # FAISS 파일 + Redis 메타 삭제 전체 성공 여부 (DB 0행은 멱등 성공으로 허용)
+
+
+def _init_deletion_result(masked_uid: str) -> DeletionResult:
+    """초기 결과 객체를 생성하여 masked_user_id와 hashed_user_id가 항상 동일함을 보장합니다."""
+    return {
+        "masked_user_id": masked_uid,
+        "hashed_user_id": masked_uid,
+        "db_rows_deleted": 0,
+        "db_deleted": False,
+        "faiss_file_removed": False,
+        "redis_meta_deleted": False,
+        "compaction_recommended": False,
+        "vacuum_triggered": False,
+        "success": False,
+    }
 
 
 # =============================================================================
@@ -228,9 +244,10 @@ def _remove_faiss_index_file(index_path: Path) -> bool:
         return True
     except OSError as e:
         logger.exception(
-            "[OBS][PRIVACY] Failed to remove FAISS index file at path=%s. "
+            "[OBS][PRIVACY] Failed to remove FAISS index file at path=%s, error=%s. "
             "Manual cleanup may be required.",
             index_path,
+            type(e).__name__,
         )
         return False
 
@@ -285,16 +302,7 @@ async def delete_user_data(
         raise ValueError("delete_user_data: 'storage_base_path' must not be empty.")
 
     masked = mask_uid(hashed_user_id)
-    result: DeletionResult = {
-        "masked_user_id": masked,
-        "hashed_user_id": masked,
-        "db_rows_deleted": 0,
-        "faiss_file_removed": False,
-        "redis_meta_deleted": False,
-        "compaction_recommended": False,
-        "vacuum_triggered": False,
-        "success": False,
-    }
+    result: DeletionResult = _init_deletion_result(masked)
 
     # ── 1. DB 레코드 물리적 삭제 ──────────────────────────────────────────
     write_audit_log(
@@ -306,6 +314,7 @@ async def delete_user_data(
     try:
         rows_deleted: int = await db_delete_fn(hashed_user_id)
         result["db_rows_deleted"] = rows_deleted
+        result["db_deleted"] = rows_deleted > 0
         if rows_deleted == 0:
             logger.info(
                 "[OBS][PRIVACY] DB records already deleted (idempotent): rows=%d, masked_uid=%s",


### PR DESCRIPTION
- **[API/계약] 명시적 `db_deleted` 플래그 추가**
  - 전체 삭제 파이프라인의 멱등적 성공(`success=True`)과 별개로, 실제 DB 레코드가 1건 이상 삭제되었는지를 호출자가 직관적으로 알 수 있도록 `db_deleted: bool` 필드를 `DeletionResult`에 명시적 노출.

- **[안정성] `DeletionResult` 초기화 헬퍼 도입 (휴먼 에러 차단)**
  - `masked_user_id`와 하위 호환성용 `hashed_user_id` 필드가 미래의 수정 과정에서 파편화(divergence)되지 않도록, `_init_deletion_result()` 헬퍼 함수를 통해 무조건 동일한 값으로 생성되도록 생성 시점 구조화.

- **[관측성] 예외 로깅 첫 줄에 Exception Type 명시**
  - `logger.exception()` 사용 시 스택 트레이스를 파싱하지 않는 경량 알림 시스템(대시보드)에서도 실패 원인을 즉시 식별할 수 있도록, 로그 메시지 본문에 `type(e).__name__`을 포함시켜 로깅 가시성 극대화.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1287#pullrequestreview-4215909199)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

삭제 API 계약을 명확히 하고, 사용자 데이터 삭제와 관련된 로깅 및 결과 초기화를 강화합니다.

New Features:
- 실제로 어떤 데이터베이스 행이 삭제되었는지를 나타내기 위해 `DeletionResult`에 새로운 `db_deleted` 플래그를 추가합니다.

Enhancements:
- `DeletionResult`를 초기화할 때 `masked_user_id`와 `hashed_user_id` 필드가 일관되게 정렬되도록 해 주는 헬퍼를 도입합니다.
- 더 나은 관측 가능성을 위해, FAISS 인덱스 삭제 실패 로그에 예외 타입을 포함하여 로그 정보를 강화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the deletion API contract and harden logging and result initialization around user data deletion.

New Features:
- Expose a new db_deleted flag in DeletionResult to indicate whether any database rows were actually removed.

Enhancements:
- Introduce a helper to consistently initialize DeletionResult with aligned masked_user_id and hashed_user_id fields.
- Enrich FAISS index deletion failure logs by including the exception type for better observability.

</details>