### PR TITLE
☘️ refactor [#12.2.13]: 6차 개선 - 예외 분기 내 중복 계산 제거 및 주석 구체화

### DIFF
--- a/backend/services/privacy_service.py
+++ b/backend/services/privacy_service.py
@@ -339,7 +339,6 @@ async def delete_user_data(
             masked_uid=masked,
             result=f"db_deletion_failed: {type(e).__name__}",
         )
-        result["db_deleted"] = result["db_rows_deleted"] > 0
         return result
 
     # ── 2. 누적 카운터 및 VACUUM 트리거 판단 ──────────────────────────────
@@ -444,8 +443,9 @@ async def delete_user_data(
         )
 
     # ── 최종 파생 필드 계산 및 반환 ──
-    # db_deleted는 개별 로직에서 변형되지 않고, 오직 최종 결과 반환 직전에
+    # db_deleted는 개별 로직에서 변형되지 않고, 오직 정상 종료 반환 직전에
     # db_rows_deleted로부터 파생되어 데이터 불일치(divergence)를 원천 차단합니다.
+    # (에러 조기 리턴 시에는 _init_deletion_result의 초기값 False가 안전하게 유지됩니다.)
     result["db_deleted"] = result["db_rows_deleted"] > 0
     
     return result

--- a/backend/services/privacy_service.py
+++ b/backend/services/privacy_service.py
@@ -157,6 +157,16 @@ def _init_deletion_result(masked_uid: str) -> DeletionResult:
     }
 
 
+def _finalize_deletion_result(result: DeletionResult) -> DeletionResult:
+    """결과 객체의 불변식(invariant)을 검증하고, 파생 필드를 계산하여 최종 반환합니다."""
+    # db_deleted가 파이프라인 중간에 임의로 변경되지 않았는지(초기값 False인지) 검증
+    assert result["db_deleted"] is False, "db_deleted must not be modified directly. It is a derived field."
+    
+    # db_rows_deleted를 기반으로만 안전하게 파생
+    result["db_deleted"] = result["db_rows_deleted"] > 0
+    return result
+
+
 # =============================================================================
 # 공개 API
 # =============================================================================
@@ -339,7 +349,7 @@ async def delete_user_data(
             masked_uid=masked,
             result=f"db_deletion_failed: {type(e).__name__}",
         )
-        return result
+        return _finalize_deletion_result(result)
 
     # ── 2. 누적 카운터 및 VACUUM 트리거 판단 ──────────────────────────────
     current_count = _increment_deletion_counter()
@@ -443,9 +453,5 @@ async def delete_user_data(
         )
 
     # ── 최종 파생 필드 계산 및 반환 ──
-    # db_deleted는 개별 로직에서 변형되지 않고, 오직 정상 종료 반환 직전에
-    # db_rows_deleted로부터 파생되어 데이터 불일치(divergence)를 원천 차단합니다.
-    # (에러 조기 리턴 시에는 _init_deletion_result의 초기값 False가 안전하게 유지됩니다.)
-    result["db_deleted"] = result["db_rows_deleted"] > 0
-    
-    return result
+    # 캡슐화된 헬퍼를 통해 중간 상태 변조를 검증하고 파생 필드를 계산합니다.
+    return _finalize_deletion_result(result)


### PR DESCRIPTION
- **[코드 최적화] 조기 리턴(Early Return) 경로의 중복 할당 제거**
  - DB 삭제 예외 발생 시, 이미 `_init_deletion_result` 헬퍼에 의해 `db_deleted`가 `False`로 안전하게 초기화되어 있으므로 불필요한 재계산 로직 제거.
  - "흐름 내에서 파생 필드를 변경하지 않고 반환 시점에만 계산한다"는 아키텍처 원칙(Single Source of Truth)을 예외 분기까지 엄격하게 적용하여 상태 관리를 단순화.

- **[문서화] 상태 관리 주석(Comment) 정교화**
  - 파생 필드 계산부 주석을 실제 구현 동작과 100% 일치하도록 업데이트. (정상 종료 시 파생 계산, 예외 조기 리턴 시 초기값 유지 명시)

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1290#pullrequestreview-4215931688)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

`db_rows_deleted`로부터 도출되는 단일 최종 `db_deleted` 파생값에 의존하도록 사용자 데이터 삭제 결과 처리를 단순화하고, 관련 문서를 명확히 했습니다.

개선 사항:
- 데이터베이스 삭제 에러 경로에서 중복된 `db_deleted` 재계산을 제거하고, 중앙화된 초기화 및 최종 파생 로직에만 의존하도록 변경했습니다.
- 정상 완료 및 조기 반환 에러 경로 모두에 대한 동작을 문서화하기 위해 `db_deleted` 상태 관리 관련 주석을 명확히 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify user data deletion result handling by relying on a single, final derivation of db_deleted from db_rows_deleted and clarifying the surrounding documentation.

Enhancements:
- Remove redundant db_deleted recalculation in the database deletion error path to rely on centralized initialization and final derivation logic.
- Clarify comments around db_deleted state management to document behavior for both normal completion and early-return error paths.

</details>