### PR TITLE
☘️ refactor [#12.2.13]: 8차 개선 - 런타임 불변식 검증 강화 및 Immutability 보장

### DIFF
--- a/backend/services/privacy_service.py
+++ b/backend/services/privacy_service.py
@@ -161,10 +161,12 @@ def _finalize_deletion_result(result: DeletionResult) -> DeletionResult:
     """결과 객체의 불변식(invariant)을 검증하고, 파생 필드를 계산하여 최종 반환합니다."""
     # db_deleted가 파이프라인 중간에 임의로 변경되지 않았는지(초기값 False인지) 검증
     # Python -O 옵션에 의해 무시될 수 있는 assert 대신 명시적 예외를 발생시킵니다.
-    if result.get("db_deleted") is not False:
+    # 키가 존재하지 않으면 KeyError를 그대로 발생시켜 구조 자체의 불변식 위반을 드러냅니다.
+    if result["db_deleted"] is not False:
         raise ValueError("db_deleted must not be modified directly. It is a derived field.")
     
     # 원본 객체를 직접 변조(mutate)하지 않고 얕은 복사본을 생성하여 반환 (Immutability)
+    # DeletionResult는 모든 필드가 원시 타입(primitive)이므로 얕은 복사로 충분히 불변성이 보장됩니다.
     final_result = result.copy()
     final_result["db_deleted"] = final_result["db_rows_deleted"] > 0
     return final_result

--- a/backend/services/privacy_service.py
+++ b/backend/services/privacy_service.py
@@ -160,11 +160,14 @@ def _init_deletion_result(masked_uid: str) -> DeletionResult:
 def _finalize_deletion_result(result: DeletionResult) -> DeletionResult:
     """결과 객체의 불변식(invariant)을 검증하고, 파생 필드를 계산하여 최종 반환합니다."""
     # db_deleted가 파이프라인 중간에 임의로 변경되지 않았는지(초기값 False인지) 검증
-    assert result["db_deleted"] is False, "db_deleted must not be modified directly. It is a derived field."
+    # Python -O 옵션에 의해 무시될 수 있는 assert 대신 명시적 예외를 발생시킵니다.
+    if result.get("db_deleted") is not False:
+        raise ValueError("db_deleted must not be modified directly. It is a derived field.")
     
-    # db_rows_deleted를 기반으로만 안전하게 파생
-    result["db_deleted"] = result["db_rows_deleted"] > 0
-    return result
+    # 원본 객체를 직접 변조(mutate)하지 않고 얕은 복사본을 생성하여 반환 (Immutability)
+    final_result = result.copy()
+    final_result["db_deleted"] = final_result["db_rows_deleted"] > 0
+    return final_result
 
 
 # =============================================================================


### PR DESCRIPTION
- **[안정성/방어적 프로그래밍] `assert`를 명시적 `ValueError`로 교체**
  - 운영 환경의 최적화 실행(`python -O`) 시 `assert` 구문이 생략(Stripped)되는 파이썬의 특성으로 인해 불변식 검증이 무력화되는 취약점 해결.
  - 도메인 룰(`db_deleted`의 직접 수정 금지) 위반 시 무조건적으로 실행되는 명시적 `if` 가드 및 `ValueError`로 교체하여 프로덕션 런타임의 안전성 100% 보장.

- **[설계/순수성] `_finalize_deletion_result`의 내부 변조(Mutation) 제거**
  - 함수 내에서 인자로 전달받은 `result` 딕셔너리를 In-place로 직접 수정하여 발생할 수 있는 사이드 이펙트 차단.
  - 얕은 복사(`result.copy()`)본을 생성한 뒤 파생 필드를 계산하여 반환하는 방식으로 변경하여 함수형 프로그래밍의 불변성(Immutability) 원칙 준수.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1292#pullrequestreview-4215946674)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

프라이버시 삭제 결과에 대한 런타임 불변성 검사를 강화하고, 결과 객체를 제자리(in-place)에서 변경하지 않도록 합니다.

버그 수정:
- 프로덕션 환경에서도 항상 검증이 수행되도록, `db_deleted`에 대한 `assert` 기반 불변성 검사를 명시적인 `ValueError` 발생으로 대체합니다.

개선 사항:
- 불변성을 더 잘 지키기 위해, 원본 객체를 변경하는 대신 파생된 `db_deleted` 필드를 가진 얕은 복사(shallow copy)된 삭제 결과를 반환합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen runtime invariant checks for privacy deletion results and avoid mutating result objects in-place.

Bug Fixes:
- Replace assert-based invariant check for db_deleted with an explicit ValueError to ensure validation is always enforced in production.

Enhancements:
- Return a shallow-copied deletion result with derived db_deleted field instead of mutating the original object to better respect immutability.

</details>