### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/services/privacy_service.py
+++ b/backend/services/privacy_service.py
@@ -161,10 +161,12 @@ def _finalize_deletion_result(result: DeletionResult) -> DeletionResult:
     """결과 객체의 불변식(invariant)을 검증하고, 파생 필드를 계산하여 최종 반환합니다."""
     # db_deleted가 파이프라인 중간에 임의로 변경되지 않았는지(초기값 False인지) 검증
     # Python -O 옵션에 의해 무시될 수 있는 assert 대신 명시적 예외를 발생시킵니다.
-    if result.get("db_deleted") is not False:
+    # 키가 존재하지 않으면 KeyError를 그대로 발생시켜 구조 자체의 불변식 위반을 드러냅니다.
+    if result["db_deleted"] is not False:
         raise ValueError("db_deleted must not be modified directly. It is a derived field.")
     
     # 원본 객체를 직접 변조(mutate)하지 않고 얕은 복사본을 생성하여 반환 (Immutability)
+    # DeletionResult는 모든 필드가 원시 타입(primitive)이므로 얕은 복사로 충분히 불변성이 보장됩니다.
     final_result = result.copy()
     final_result["db_deleted"] = final_result["db_rows_deleted"] > 0
     return final_result

--- a/backend/services/privacy_service.py
+++ b/backend/services/privacy_service.py
@@ -160,11 +160,14 @@ def _init_deletion_result(masked_uid: str) -> DeletionResult:
 def _finalize_deletion_result(result: DeletionResult) -> DeletionResult:
     """결과 객체의 불변식(invariant)을 검증하고, 파생 필드를 계산하여 최종 반환합니다."""
     # db_deleted가 파이프라인 중간에 임의로 변경되지 않았는지(초기값 False인지) 검증
-    assert result["db_deleted"] is False, "db_deleted must not be modified directly. It is a derived field."
+    # Python -O 옵션에 의해 무시될 수 있는 assert 대신 명시적 예외를 발생시킵니다.
+    if result.get("db_deleted") is not False:
+        raise ValueError("db_deleted must not be modified directly. It is a derived field.")
     
-    # db_rows_deleted를 기반으로만 안전하게 파생
-    result["db_deleted"] = result["db_rows_deleted"] > 0
-    return result
+    # 원본 객체를 직접 변조(mutate)하지 않고 얕은 복사본을 생성하여 반환 (Immutability)
+    final_result = result.copy()
+    final_result["db_deleted"] = final_result["db_rows_deleted"] > 0
+    return final_result
 
 
 # =============================================================================


### PR DESCRIPTION
☘️ refactor [#12.2.13]: 8차 개선 - 런타임 불변식 검증 강화 및 Immutability 보장 
☘️ refactor [#12.2.13]: 9차 개선 - KeyError와 ValueError 분리 및 에러 시맨틱 정교화

## Summary by Sourcery

삭제 결과의 불변성을 강화하기 위해, 파생 필드에 대한 명시적인 런타임 검증과 불변성을 적용했습니다.

개선사항:
- 최적화된 실행에서 검증이 건너뛰어지는 일을 방지하기 위해, 삭제 결과에 대한 불변식 검사를 `assert` 대신 명시적인 `ValueError`로 대체했습니다.
- 원본을 변경하는 대신, 파생 필드인 `db_deleted`를 계산할 때 얕은 복사된 객체를 반환하여 삭제 결과를 불변 객체처럼 취급하도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen deletion result invariants by enforcing immutability and explicit runtime validation of derived fields.

Enhancements:
- Replace assertion-based invariant checking on the deletion result with explicit ValueError to ensure validation is not skipped in optimized runs.
- Treat the deletion result as immutable by returning a shallow-copied object when computing the derived db_deleted field, rather than mutating the original.

</details>