### PR TITLE
☘️ refactor [#12.2.13]: 12차 개선 - Dataclass 하위 호환성 확보 및 파생 필드 자동화

### DIFF
--- a/backend/services/privacy_service.py
+++ b/backend/services/privacy_service.py
@@ -31,11 +31,13 @@ GDPR Right-to-Erasure — v9.0 Phase 2-4 (Privacy Pipeline ②)
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import os
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from backend.core.audit_logger import (
     AuditEventType,
@@ -147,6 +149,21 @@ class DeletionResult:
         """DB 레코드가 1건 이상 삭제되었는지 여부 (명시적 파생 필드)"""
         return self.db_rows_deleted > 0
 
+    def __getitem__(self, key: str) -> Any:
+        """기존 TypedDict 기반의 외부 호출부 하위 호환성을 위한 Mapping 인터페이스"""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """기존 TypedDict 호환성을 위한 get 메서드"""
+        return getattr(self, key, default)
+
+    def keys(self) -> list[str]:
+        """기존 TypedDict 호환성을 위한 keys 메서드"""
+        return [f.name for f in dataclasses.fields(self)] + ["db_deleted"]
+
     @classmethod
     def create(
         cls,
@@ -156,9 +173,10 @@ class DeletionResult:
         redis_meta_deleted: bool,
         compaction_recommended: bool,
         vacuum_needed: bool,
-        success: bool,
     ) -> DeletionResult:
         """파이프라인 상태를 캡슐화하여 일관된 인스턴스를 생성하는 팩토리 메서드."""
+        # success는 faiss_removed와 redis_meta_deleted의 조합으로 안전하게 자동 파생
+        success = faiss_removed and redis_meta_deleted
         return cls(
             masked_user_id=masked_uid,
             hashed_user_id=masked_uid,
@@ -366,7 +384,6 @@ async def delete_user_data(
             redis_meta_deleted=redis_meta_deleted,
             compaction_recommended=compaction_recommended,
             vacuum_needed=vacuum_needed,
-            success=False,
         )
 
     # ── 2. 누적 카운터 및 VACUUM 트리거 판단 ──────────────────────────────
@@ -471,5 +488,4 @@ async def delete_user_data(
         redis_meta_deleted=redis_meta_deleted,
         compaction_recommended=compaction_recommended,
         vacuum_needed=vacuum_needed,
-        success=overall_success,
     )

--- a/backend/services/privacy_service.py
+++ b/backend/services/privacy_service.py
@@ -150,15 +150,28 @@ class DeletionResult:
         return self.db_rows_deleted > 0
 
     def __getitem__(self, key: str) -> Any:
-        """기존 TypedDict 기반의 외부 호출부 하위 호환성을 위한 Mapping 인터페이스"""
-        try:
+        """기존 TypedDict 기반의 외부 호출부 하위 호환성을 위한 Mapping 인터페이스.
+
+        Mapping 인터페이스를 통해 노출되는 키는 `keys()`가 반환하는 키(데이터클래스 필드 + `db_deleted`)로 엄격히 제한합니다.
+        이를 통해 내부 메서드(예: .keys(), .get(), .create())가 노출되는 보안/설계 결함을 방지합니다.
+        """
+        if key == "db_deleted":
+            return self.db_deleted
+
+        if any(f.name == key for f in dataclasses.fields(self)):
             return getattr(self, key)
-        except AttributeError:
-            raise KeyError(key)
+
+        raise KeyError(key)
 
     def get(self, key: str, default: Any = None) -> Any:
-        """기존 TypedDict 호환성을 위한 get 메서드"""
-        return getattr(self, key, default)
+        """기존 TypedDict 호환성을 위한 get 메서드.
+
+        존재하지 않는 키이거나 Mapping 인터페이스에서 허용되지 않는 키인 경우 default를 반환합니다.
+        """
+        try:
+            return self[key]
+        except KeyError:
+            return default
 
     def keys(self) -> list[str]:
         """기존 TypedDict 호환성을 위한 keys 메서드"""


### PR DESCRIPTION
- **[호환성/인터페이스] `TypedDict` 외부 접근 패턴 하위 호환성 완벽 보장**
  - `DeletionResult`를 `dataclass`로 마이그레이션함에 따라 기존 딕셔너리 접근 방식(`result["field"]`)이 깨지는 문제를 방지하기 위해 `__getitem__`, `get()`, `keys()` 매직 메서드 구현.
  - 기존 API Consumer 코드의 수정 없이 무장애(Zero-breaking) 도입 보장.

- **[아키텍처/캡슐화] 팩토리 내부 파생 필드(`success`) 도출 고도화**
  - 팩토리 메서드(`create()`) 호출 시 외부에서 `success` 상태를 강제 주입하지 않고, 내부에서 `faiss_removed`와 `redis_meta_deleted` 상태를 조합하여 안전하게 자동 도출(Derived)되도록 개선.
  - 상태 불일치(State Divergence) 버그 발생 가능성을 원천 차단.

🔗 Related: Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1296#pullrequestreview-4216234933)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

`DeletionResult`가 내부적으로 삭제 플래그에 기반해 성공 상태를 계산하면서도, 이전 `TypedDict` 사용 방식과의 하위 호환성을 유지하도록 합니다.

개선사항:
- 기존의 딕셔너리 스타일 접근 패턴을 유지하기 위해 `DeletionResult`에 `Mapping` 유사 인터페이스(`__getitem__`, `get`, `keys`)를 노출합니다.
- 호출자가 직접 값을 넘기지 않고도, `faiss` 및 Redis 삭제 결과로부터 `DeletionResult` 팩토리 내부에서 `success` 필드를 도출하도록 하여, 호출 지점별로 상태가 불일치하는 문제를 방지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure DeletionResult remains backward compatible with previous TypedDict usage while deriving its success status internally from underlying deletion flags.

Enhancements:
- Expose a Mapping-like interface (__getitem__, get, keys) on DeletionResult to preserve existing dictionary-style access patterns.
- Derive the success field inside the DeletionResult factory from faiss and Redis deletion results instead of requiring it from callers, preventing inconsistent state across call sites.

</details>