### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/services/privacy_service.py
+++ b/backend/services/privacy_service.py
@@ -31,11 +31,13 @@ GDPR Right-to-Erasure — v9.0 Phase 2-4 (Privacy Pipeline ②)
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import os
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from backend.core.audit_logger import (
     AuditEventType,
@@ -147,6 +149,21 @@ class DeletionResult:
         """DB 레코드가 1건 이상 삭제되었는지 여부 (명시적 파생 필드)"""
         return self.db_rows_deleted > 0
 
+    def __getitem__(self, key: str) -> Any:
+        """기존 TypedDict 기반의 외부 호출부 하위 호환성을 위한 Mapping 인터페이스"""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """기존 TypedDict 호환성을 위한 get 메서드"""
+        return getattr(self, key, default)
+
+    def keys(self) -> list[str]:
+        """기존 TypedDict 호환성을 위한 keys 메서드"""
+        return [f.name for f in dataclasses.fields(self)] + ["db_deleted"]
+
     @classmethod
     def create(
         cls,
@@ -156,9 +173,10 @@ class DeletionResult:
         redis_meta_deleted: bool,
         compaction_recommended: bool,
         vacuum_needed: bool,
-        success: bool,
     ) -> DeletionResult:
         """파이프라인 상태를 캡슐화하여 일관된 인스턴스를 생성하는 팩토리 메서드."""
+        # success는 faiss_removed와 redis_meta_deleted의 조합으로 안전하게 자동 파생
+        success = faiss_removed and redis_meta_deleted
         return cls(
             masked_user_id=masked_uid,
             hashed_user_id=masked_uid,
@@ -366,7 +384,6 @@ async def delete_user_data(
             redis_meta_deleted=redis_meta_deleted,
             compaction_recommended=compaction_recommended,
             vacuum_needed=vacuum_needed,
-            success=False,
         )
 
     # ── 2. 누적 카운터 및 VACUUM 트리거 판단 ──────────────────────────────
@@ -471,5 +488,4 @@ async def delete_user_data(
         redis_meta_deleted=redis_meta_deleted,
         compaction_recommended=compaction_recommended,
         vacuum_needed=vacuum_needed,
-        success=overall_success,
     )

--- a/backend/services/privacy_service.py
+++ b/backend/services/privacy_service.py
@@ -150,15 +150,28 @@ class DeletionResult:
         return self.db_rows_deleted > 0
 
     def __getitem__(self, key: str) -> Any:
-        """기존 TypedDict 기반의 외부 호출부 하위 호환성을 위한 Mapping 인터페이스"""
-        try:
+        """기존 TypedDict 기반의 외부 호출부 하위 호환성을 위한 Mapping 인터페이스.
+
+        Mapping 인터페이스를 통해 노출되는 키는 `keys()`가 반환하는 키(데이터클래스 필드 + `db_deleted`)로 엄격히 제한합니다.
+        이를 통해 내부 메서드(예: .keys(), .get(), .create())가 노출되는 보안/설계 결함을 방지합니다.
+        """
+        if key == "db_deleted":
+            return self.db_deleted
+
+        if any(f.name == key for f in dataclasses.fields(self)):
             return getattr(self, key)
-        except AttributeError:
-            raise KeyError(key)
+
+        raise KeyError(key)
 
     def get(self, key: str, default: Any = None) -> Any:
-        """기존 TypedDict 호환성을 위한 get 메서드"""
-        return getattr(self, key, default)
+        """기존 TypedDict 호환성을 위한 get 메서드.
+
+        존재하지 않는 키이거나 Mapping 인터페이스에서 허용되지 않는 키인 경우 default를 반환합니다.
+        """
+        try:
+            return self[key]
+        except KeyError:
+            return default
 
     def keys(self) -> list[str]:
         """기존 TypedDict 호환성을 위한 keys 메서드"""


### PR DESCRIPTION
☘️ refactor [#12.2.13]: 12차 개선 - Dataclass 하위 호환성 확보 및 파생 필드 자동화 
☘️ refactor [#12.2.13]: 13차 개선 - Mapping 인터페이스 보안 강화 및 메서드 유출(Leakage) 차단

## Summary by Sourcery

기존의 TypedDict 사용 방식과의 하위 호환성을 유지하면서도, `DeletionResult`의 공개 인터페이스를 더 엄격하게 하고 파생 필드를 자동으로 처리하도록 개선합니다.

Enhancements:
- 내부 메서드가 노출되지 않도록, `DeletionResult`를 데이터클래스 필드와 파생 필드인 `db_deleted` 플래그로만 제한된 Mapping 유사 인터페이스(`__getitem__`, `get`, `keys`)로 노출합니다.
- 결과 생성 과정을 단순화하고 안정성을 높이기 위해, `DeletionResult.create` 내부에서 `success` 플래그를 명시적 인자로 받지 않고 `faiss_removed`와 `redis_meta_deleted` 값으로부터 파생하여 계산하도록 변경합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure DeletionResult remains backwards compatible with previous TypedDict usage while tightening its exposed interface and automating derived fields.

Enhancements:
- Expose DeletionResult as a restricted Mapping-like interface (__getitem__, get, keys) limited to dataclass fields plus the derived db_deleted flag to avoid leaking internal methods.
- Derive the success flag internally in DeletionResult.create from faiss_removed and redis_meta_deleted instead of requiring it as an explicit argument, simplifying and hardening result construction.

</details>