### PR TITLE
☘️ refactor [#12.2.13]: 16차 개선 - Mapping 프로토콜 상속 및 lru_cache를 통한 서브클래스 안전성 확보

### DIFF
--- a/backend/services/privacy_service.py
+++ b/backend/services/privacy_service.py
@@ -32,9 +32,10 @@ GDPR Right-to-Erasure — v9.0 Phase 2-4 (Privacy Pipeline ②)
 from __future__ import annotations
 
 import dataclasses
+import functools
 import logging
 import os
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -129,7 +130,7 @@ def get_vacuum_batch_threshold() -> int:
 # =============================================================================
 
 @dataclass(frozen=True)
-class DeletionResult:
+class DeletionResult(Mapping[str, Any]):
     """
     delete_user_data() 반환값의 타입 계약.
     frozen=True를 통해 불변성(Immutability)을 보장하며, 
@@ -149,46 +150,35 @@ class DeletionResult:
         """DB 레코드가 1건 이상 삭제되었는지 여부 (명시적 파생 필드)"""
         return self.db_rows_deleted > 0
 
-    def keys(self) -> tuple[str, ...]:
-        """기존 TypedDict 호환성을 위한 keys 메서드 (지연 캐싱 적용).
+    @classmethod
+    @functools.lru_cache(maxsize=None)
+    def _allowed_keys(cls) -> tuple[str, ...]:
+        return tuple(f.name for f in dataclasses.fields(cls)) + ("db_deleted",)
 
-        클래스 레벨 캐시를 사용하여 리플렉션 오버헤드를 1회로 제한하며,
-        __dict__에 의존하지 않아 향후 slots=True 변경 시에도 안전합니다.
-        """
-        cache_key = "_allowed_keys_cache"
-        if not hasattr(self.__class__, cache_key):
-            allowed = tuple(f.name for f in dataclasses.fields(self)) + ("db_deleted",)
-            setattr(self.__class__, cache_key, allowed)
-        return getattr(self.__class__, cache_key)
+    @classmethod
+    @functools.lru_cache(maxsize=None)
+    def _allowed_key_set(cls) -> frozenset[str]:
+        return frozenset(cls._allowed_keys())
+
+    # --- Mapping Protocol Implementation ---
 
     def __getitem__(self, key: str) -> Any:
-        """기존 TypedDict 기반의 외부 호출부 하위 호환성을 위한 Mapping 인터페이스.
-
-        keys()에 선언된 필드만 허용하여 동적 속성 및 메서드 유출을 완벽히 차단합니다.
-        """
-        if key not in self.keys():
+        """기존 TypedDict 기반의 외부 호출부 하위 호환성을 위한 Mapping 인터페이스."""
+        if key not in self.__class__._allowed_key_set():
             raise KeyError(key)
         return getattr(self, key)
 
-    def get(self, key: str, default: Any = None) -> Any:
-        """기존 TypedDict 호환성을 위한 get 메서드."""
-        try:
-            return self[key]
-        except KeyError:
-            return default
+    def __iter__(self) -> Iterator[str]:
+        """dict() 형변환 및 Mapping 타입 반복문 지원을 위한 인터페이스."""
+        return iter(self.__class__._allowed_keys())
 
-    def __iter__(self):
-        """dict() 형변환 및 Mapping 타입 반복문 지원을 위한 인터페이스.
-        단일 진실 공급원인 keys()로 위임하여 중복을 제거합니다.
-        """
-        return iter(self.keys())
+    def __len__(self) -> int:
+        """Mapping 프로토콜 완성을 위한 데이터 길이 반환."""
+        return len(self.__class__._allowed_keys())
 
-    def items(self):
-        """dict() 형변환 및 Mapping 타입 반복문 지원을 위한 인터페이스.
-        단일 진실 공급원인 keys()와 __getitem__()으로 위임합니다.
-        """
-        for key in self.keys():
-            yield key, self[key]
+    def keys(self) -> tuple[str, ...]:  # type: ignore[override]
+        """기존 TypedDict 호환성을 위한 엄격한 튜플 반환형의 keys 메서드."""
+        return self.__class__._allowed_keys()
 
     @classmethod
     def create(

--- a/backend/services/privacy_service.py
+++ b/backend/services/privacy_service.py
@@ -151,9 +151,15 @@ class DeletionResult(Mapping[str, Any]):
         return self.db_rows_deleted > 0
 
     @classmethod
+    def _extra_allowed_keys(cls) -> tuple[str, ...]:
+        """서브클래스에서 노출할 추가 파생 필드(property)를 정의하는 확장 훅."""
+        return ("db_deleted",)
+
+    @classmethod
     @functools.lru_cache(maxsize=None)
     def _allowed_keys(cls) -> tuple[str, ...]:
-        return tuple(f.name for f in dataclasses.fields(cls)) + ("db_deleted",)
+        """데이터클래스 필드와 추가 허용 필드(훅)를 결합하여 캐싱합니다."""
+        return tuple(f.name for f in dataclasses.fields(cls)) + cls._extra_allowed_keys()
 
     @classmethod
     @functools.lru_cache(maxsize=None)
@@ -175,10 +181,6 @@ class DeletionResult(Mapping[str, Any]):
     def __len__(self) -> int:
         """Mapping 프로토콜 완성을 위한 데이터 길이 반환."""
         return len(self.__class__._allowed_keys())
-
-    def keys(self) -> tuple[str, ...]:  # type: ignore[override]
-        """기존 TypedDict 호환성을 위한 엄격한 튜플 반환형의 keys 메서드."""
-        return self.__class__._allowed_keys()
 
     @classmethod
     def create(


### PR DESCRIPTION
- **[버그 방어/아키텍처] `@functools.lru_cache` 기반의 클래스별 지연 캐싱 도입**
  - 기존 수동 클래스 캐싱(`hasattr/setattr`) 방식이 서브클래스 상속 시 부모의 캐시를 오염/공유하게 되는 치명적 버그(Class Attribute Inheritance Bug)를 방지하기 위해 `@lru_cache`가 적용된 `@classmethod` 팩토리 도입.
  - 이를 통해 `slots=True`와의 호환성을 유지하면서도, 각 서브클래스가 자신만의 독립적인 필드 캐시를 O(1) 성능으로 생성하도록 최적화.

- **[구조/단순화] `collections.abc.Mapping` 상속을 통한 보일러플레이트 제거**
  - 딕셔너리 호환성을 위해 수동으로 구현했던 `get`, `items` 등의 메서드를 모두 제거하고, `Mapping[str, Any]`를 상속받아 파이썬 내장 프로토콜에 동작을 완벽히 위임.
  - `__len__`, `__iter__` 및 정확한 `Iterator` 타입 힌트를 구현하여 제네릭 유틸리티 함수와의 100% 통합성 및 정적 분석(IDE) 안전성 확보.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1300#pullrequestreview-4216267690)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

`DeletionResult` 반환 타입을 `Mapping`과 호환되는 불변 결과 객체로 개선하여, 서브클래스별로 더 안전한 키 캐싱과 완전한 `Mapping` 프로토콜 지원을 제공하도록 합니다.

개선 사항:
- 클래스 메서드를 기반으로 한 `lru_cache` 지원 키 캐시를 도입하여, 공유 클래스 속성 상태를 피하고 서브클래스에 안전한 필드 검색을 보장합니다.
- `DeletionResult`가 `collections.abc.Mapping`을 상속받도록 하고, `__getitem__`, `__iter__`, `__len__` 및 엄격한 `keys()` 오버라이드를 구현하여, 커스텀 dict 유사 헬퍼 대신 표준 `Mapping` 프로토콜에 의존하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the DeletionResult return type to be a Mapping-compatible immutable result object with safer subclass-specific key caching and full Mapping protocol support.

Enhancements:
- Adopt classmethod-based lru_cache-backed key caches to avoid shared class-attribute state and ensure subclass-safe field discovery.
- Have DeletionResult inherit from collections.abc.Mapping and implement __getitem__, __iter__, __len__, and a strict keys() override to rely on the standard Mapping protocol instead of custom dict-like helpers.

</details>