### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/api/endpoints/__init__.py
+++ b/backend/api/endpoints/__init__.py
@@ -8,6 +8,7 @@ from .metadata import router as metadata_router
 from .automation import router as automation_router
 from .chat import router as chat_router
 from .admin import router as admin_router
+from .privacy import router as privacy_router
 
 __all__ = [
     "classify_router",
@@ -16,4 +17,5 @@ __all__ = [
     "automation_router",
     "chat_router",
     "admin_router",
+    "privacy_router",
 ]

--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -10,14 +10,18 @@ GDPR Right-to-Erasure API Endpoint — v9.0 Phase 2-4 (Integration & Compliance)
     순서를 오케스트레이션합니다.
 
 [보안 설계]
-  - hashed_user_id만 내부 파이프라인에 전달하며, user_id 원문은 이 레이어에 진입하지 않습니다.
+  - hashed_user_id는 SHA-256 결과인 64자리 hex 고정 포맷을 Pydantic에서 강제 검증합니다.
+    user_id 원문은 이 레이어에 절대 진입하지 않습니다.
+  - PII가 포함될 수 있는 예외 메시지(str(exception))는 로그에 기록하지 않으며,
+    예외 타입명만 기록합니다.
   - 모든 처리 결과는 audit_logger를 통해 감사 로그에 기록됩니다.
   - 인증 의존성(get_current_user)은 기존 deps.py 패턴을 재사용합니다.
 
 [Graceful Degradation 정책]
-  - FAISS/Redis 삭제 실패 → DB 삭제 유지 + 감사 로그 FAILURE 기록 + 재시도 큐 적재 권장
-  - 익명화 실패 → 삭제 결과는 반환, 익명화 실패 감사 로그 별도 기록
-  - 감사 로그 기록 실패 → audit_logger 내부에서 표준 로거 폴백 처리 (파이프라인 중단 없음)
+  - `delete_user_data()` 내부 예외 → 파이프라인 전체 중단, 500 반환 + FAILURE 감사 로그
+    (FAISS/Redis 삭제 실패는 delete_user_data 내부에서 부분 성공으로 처리)
+  - 익명화 실패 → 해당 필드만 실패 처리, 전체 파이프라인 유지
+  - 감사 로그 기록 실패 → `audit_logged=False`로 응답에 정확히 반영, 프로세스 중단 없음
 
 [환경 변수 의존성]
   - AUDIT_LOG_BACKEND, PBKDF2_ITERATIONS 등 — privacy_service.py / audit_logger.py 참조
@@ -26,13 +30,14 @@ GDPR Right-to-Erasure API Endpoint — v9.0 Phase 2-4 (Integration & Compliance)
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from backend.api.deps import get_current_user
-from backend.core.audit_logger import AuditEventType, mask_uid, write_audit_log
+from backend.core.audit_logger import AuditConfigError, AuditEventType, mask_uid, write_audit_log
 from backend.services.privacy_service import (
     AnonymizationResult,
     DeletionResult,
@@ -44,6 +49,9 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/privacy", tags=["privacy"])
 
+# SHA-256 결과: 64자리 16진수 (대소문자 허용)
+_SHA256_HEX_PATTERN: re.Pattern[str] = re.compile(r"^[0-9a-fA-F]{64}$")
+
 
 # =============================================================================
 # 요청/응답 모델
@@ -54,19 +62,32 @@ class EraseRequest(BaseModel):
     삭제 요청 페이로드.
 
     [보안 원칙]
-      - hashed_user_id: SHA-256 등으로 해시된 사용자 식별자. user_id 원문 절대 금지.
+      - hashed_user_id: SHA-256 해시 결과인 64자리 hex 고정 포맷만 허용.
+        원본 user_id 또는 임의 문자열은 Pydantic 검증 단계에서 거부됩니다.
       - log_fields_to_anonymize: 익명화 대상 Interaction Log 필드 값 목록.
         (각 항목은 이미 추출된 필드 값이어야 하며, PII 원문 포함 금지)
     """
     hashed_user_id: str = Field(
         ...,
-        min_length=1,
-        description="SHA-256 해시된 사용자 식별자 (user_id 원문 금지)",
+        min_length=64,
+        max_length=64,
+        description="SHA-256 해시된 사용자 식별자 (64자리 hex, user_id 원문 금지)",
     )
     log_fields_to_anonymize: list[str] = Field(
         default_factory=list,
         description="익명화할 Interaction Log 필드 값 목록 (PII 원문 포함 금지)",
     )
+
+    @field_validator("hashed_user_id")
+    @classmethod
+    def validate_sha256_hex(cls, v: str) -> str:
+        """hashed_user_id가 SHA-256 hex(64자리) 포맷인지 검증합니다."""
+        if not _SHA256_HEX_PATTERN.match(v):
+            raise ValueError(
+                "hashed_user_id must be a 64-character hexadecimal string (SHA-256 format). "
+                "Raw user_id is not accepted."
+            )
+        return v.lower()  # 일관성을 위해 소문자로 정규화
 
 
 class EraseResponse(BaseModel):
@@ -81,7 +102,13 @@ class EraseResponse(BaseModel):
         default_factory=list,
         description="각 로그 필드 익명화 처리 결과 요약 (PII 미포함)",
     )
-    audit_logged: bool = Field(..., description="감사 로그 기록 성공 여부")
+    audit_logged: bool = Field(
+        ...,
+        description=(
+            "최종 감사 로그 기록 성공 여부. "
+            "False인 경우 AuditConfigError가 발생하여 감사 파일 저장이 보장되지 않습니다."
+        ),
+    )
     message: str = Field(..., description="처리 결과 요약 메시지")
 
 
@@ -92,15 +119,53 @@ class EraseResponse(BaseModel):
 def _build_anonymization_summary(result: AnonymizationResult) -> dict[str, Any]:
     """
     AnonymizationResult를 응답용 요약 딕셔너리로 변환합니다.
-    PII 원문(anonymized_value 실제값)은 응답에 포함하지 않습니다.
+    PII 원문(anonymized_value, salt_hex)은 응답에 포함하지 않습니다.
     """
     return {
         "success": result.success,
         "key_version": result.key_version,
         "rotation_policy": result.key_rotation_policy.value,
         "hash_name": result.hash_name,
-        # anonymized_value와 salt_hex는 응답에 노출하지 않음 (내부 감사 전용)
+        # anonymized_value와 salt_hex는 내부 감사 전용 — 응답에 노출 금지
     }
+
+
+def _try_write_audit_log(**kwargs: Any) -> bool:
+    """
+    write_audit_log를 안전하게 호출하고 실제 기록 성공 여부를 반환합니다.
+
+    [반환 정책]
+      - True: 감사 로그 기록이 정상적으로 수행됨.
+      - False: AuditConfigError(불변식 위반)가 발생하여 감사 로그 기록 실패.
+        (audit_logger 내부 파일 I/O 오류 폴백은 True를 반환 — 표준 로거에 기록됨)
+    """
+    try:
+        write_audit_log(**kwargs)
+        return True
+    except AuditConfigError as e:
+        logger.error(
+            "[OBS][PRIVACY][API] Audit log write failed (AuditConfigError): %s",
+            type(e).__name__,
+        )
+        return False
+
+
+def _build_erase_message(
+    deletion_success: bool,
+    anonymization_failed_count: int,
+) -> str:
+    """
+    삭제 및 익명화 결과를 모두 반영한 정확한 처리 결과 메시지를 생성합니다.
+    deletion_success와 익명화 실패 건수를 모두 고려하여 호출자를 오도하지 않습니다.
+    """
+    if not deletion_success:
+        return "삭제가 부분적으로 처리되었습니다. 감사 로그를 확인해 주세요."
+    if anonymization_failed_count > 0:
+        return (
+            f"삭제는 완료되었으나 {anonymization_failed_count}건의 익명화가 실패했습니다. "
+            "감사 로그를 확인해 주세요."
+        )
+    return "삭제 및 익명화 처리가 완료되었습니다."
 
 
 # =============================================================================
@@ -128,17 +193,18 @@ async def erase_user_data(
       1. 요청 수신 감사 로그 기록 (DATA_DELETE_REQUESTED)
       2. 2단계: Vector Data 삭제 (delete_user_data)
       3. 3단계: Interaction Log 익명화 (anonymize_log_entry, 각 필드별)
-      4. 최종 처리 결과 감사 로그 기록
+      4. 최종 처리 결과 감사 로그 기록 — 실제 기록 성공 여부를 audit_logged에 반영
 
     [Graceful Degradation]
-      - 삭제 서비스 내부 예외 → 500 반환 및 감사 로그 FAILURE 기록
-      - 익명화 실패 → 개별 필드 실패로 기록, 전체 파이프라인 중단 없음
+      - delete_user_data() 예외 → 500 반환 + FAILURE 감사 로그
+      - 익명화 실패 → 해당 필드만 실패, 전체 파이프라인 유지
+      - 감사 로그 기록 실패 → audit_logged=False 반환, 프로세스 중단 없음
     """
     hashed_uid = request.hashed_user_id
     masked = mask_uid(hashed_uid)
 
     # ── 1. 요청 수신 감사 로그 ──────────────────────────────────────────────
-    write_audit_log(
+    _try_write_audit_log(
         event_type=AuditEventType.DATA_DELETE_REQUESTED,
         masked_uid=masked,
         result="erase_request_received",
@@ -153,11 +219,12 @@ async def erase_user_data(
     try:
         deletion_result = await delete_user_data(hashed_uid)
     except Exception as exc:
+        # 예외 타입명만 로그 — str(exc) 제외로 PII 유출 방지
         logger.exception(
-            "[OBS][PRIVACY][API] Vector data deletion failed: masked_uid=%s, error=%s",
+            "[OBS][PRIVACY][API] Vector data deletion failed: masked_uid=%s, error_type=%s",
             masked, type(exc).__name__,
         )
-        write_audit_log(
+        _try_write_audit_log(
             event_type=AuditEventType.DATA_DELETE_FAILURE,
             masked_uid=masked,
             result=f"deletion_pipeline_error: {type(exc).__name__}",
@@ -176,31 +243,34 @@ async def erase_user_data(
                 log_field_value=field_value,
             )
             anonymization_summaries.append(_build_anonymization_summary(anon_result))
-        except ValueError as ve:
-            # 입력값 오류 (빈 값 등) — 해당 필드만 실패 처리, 파이프라인 유지
+        except ValueError:
+            # str(ve) 제외 — ValueError 메시지에 PII 포함 가능성 차단
             logger.warning(
-                "[OBS][PRIVACY][API] Anonymization skipped for a field: masked_uid=%s, reason=%s",
-                masked, str(ve),
+                "[OBS][PRIVACY][API] Anonymization skipped: masked_uid=%s, reason=invalid_input",
+                masked,
             )
             anonymization_summaries.append({"success": False, "reason": "invalid_input"})
         except Exception as exc:
             # 예기치 않은 오류 — 해당 필드만 실패, Graceful Degradation
             logger.exception(
-                "[OBS][PRIVACY][API] Anonymization error for a field: masked_uid=%s, error=%s",
+                "[OBS][PRIVACY][API] Anonymization error: masked_uid=%s, error_type=%s",
                 masked, type(exc).__name__,
             )
             anonymization_summaries.append(
                 {"success": False, "reason": type(exc).__name__}
             )
 
-    # ── 4. 최종 처리 결과 감사 로그 ─────────────────────────────────────────
-    all_anon_success = all(s.get("success", False) for s in anonymization_summaries)
+    # ── 4. 최종 처리 결과 감사 로그 (실제 기록 성공 여부 추적) ──────────────
+    anonymization_failed_count: int = sum(
+        1 for s in anonymization_summaries if not s.get("success", False)
+    )
+    all_anon_success: bool = anonymization_failed_count == 0
     final_event = (
         AuditEventType.DATA_DELETE_SUCCESS
         if deletion_result.success and all_anon_success
         else AuditEventType.DATA_DELETE_FAILURE
     )
-    write_audit_log(
+    audit_logged: bool = _try_write_audit_log(
         event_type=final_event,
         masked_uid=masked,
         result="erase_pipeline_complete",
@@ -208,9 +278,7 @@ async def erase_user_data(
             "deletion_success": deletion_result.success,
             "db_rows_deleted": deletion_result.db_rows_deleted,
             "anonymization_total": len(anonymization_summaries),
-            "anonymization_failed": sum(
-                1 for s in anonymization_summaries if not s.get("success", False)
-            ),
+            "anonymization_failed": anonymization_failed_count,
             "vacuum_triggered": deletion_result.vacuum_triggered,
             "compaction_recommended": deletion_result.compaction_recommended,
         },
@@ -218,11 +286,13 @@ async def erase_user_data(
 
     logger.info(
         "[OBS][PRIVACY][API] Erase pipeline complete: masked_uid=%s, "
-        "deletion_success=%s, db_rows=%d, anon_total=%d",
+        "deletion_success=%s, db_rows=%d, anon_total=%d, anon_failed=%d, audit_logged=%s",
         masked,
         deletion_result.success,
         deletion_result.db_rows_deleted,
         len(anonymization_summaries),
+        anonymization_failed_count,
+        audit_logged,
     )
 
     return EraseResponse(
@@ -230,10 +300,9 @@ async def erase_user_data(
         deletion_success=deletion_result.success,
         db_rows_deleted=deletion_result.db_rows_deleted,
         anonymization_results=anonymization_summaries,
-        audit_logged=True,
-        message=(
-            "삭제 및 익명화 처리가 완료되었습니다."
-            if deletion_result.success
-            else "삭제가 부분적으로 처리되었습니다. 감사 로그를 확인해 주세요."
+        audit_logged=audit_logged,
+        message=_build_erase_message(
+            deletion_success=deletion_result.success,
+            anonymization_failed_count=anonymization_failed_count,
         ),
     )

--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -1,0 +1,239 @@
+# backend/api/endpoints/privacy.py
+
+"""
+GDPR Right-to-Erasure API Endpoint — v9.0 Phase 2-4 (Integration & Compliance)
+=================================================================================
+
+[역할]
+  - 사용자 삭제 요청(Right to Erasure, GDPR 제17조)의 단일 API 진입점.
+  - 2단계(Vector Data 삭제) → 3단계(Interaction Log 익명화) → 1단계(감사 로그 기록)
+    순서를 오케스트레이션합니다.
+
+[보안 설계]
+  - hashed_user_id만 내부 파이프라인에 전달하며, user_id 원문은 이 레이어에 진입하지 않습니다.
+  - 모든 처리 결과는 audit_logger를 통해 감사 로그에 기록됩니다.
+  - 인증 의존성(get_current_user)은 기존 deps.py 패턴을 재사용합니다.
+
+[Graceful Degradation 정책]
+  - FAISS/Redis 삭제 실패 → DB 삭제 유지 + 감사 로그 FAILURE 기록 + 재시도 큐 적재 권장
+  - 익명화 실패 → 삭제 결과는 반환, 익명화 실패 감사 로그 별도 기록
+  - 감사 로그 기록 실패 → audit_logger 내부에서 표준 로거 폴백 처리 (파이프라인 중단 없음)
+
+[환경 변수 의존성]
+  - AUDIT_LOG_BACKEND, PBKDF2_ITERATIONS 등 — privacy_service.py / audit_logger.py 참조
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from backend.api.deps import get_current_user
+from backend.core.audit_logger import AuditEventType, mask_uid, write_audit_log
+from backend.services.privacy_service import (
+    AnonymizationResult,
+    DeletionResult,
+    anonymize_log_entry,
+    delete_user_data,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/privacy", tags=["privacy"])
+
+
+# =============================================================================
+# 요청/응답 모델
+# =============================================================================
+
+class EraseRequest(BaseModel):
+    """
+    삭제 요청 페이로드.
+
+    [보안 원칙]
+      - hashed_user_id: SHA-256 등으로 해시된 사용자 식별자. user_id 원문 절대 금지.
+      - log_fields_to_anonymize: 익명화 대상 Interaction Log 필드 값 목록.
+        (각 항목은 이미 추출된 필드 값이어야 하며, PII 원문 포함 금지)
+    """
+    hashed_user_id: str = Field(
+        ...,
+        min_length=1,
+        description="SHA-256 해시된 사용자 식별자 (user_id 원문 금지)",
+    )
+    log_fields_to_anonymize: list[str] = Field(
+        default_factory=list,
+        description="익명화할 Interaction Log 필드 값 목록 (PII 원문 포함 금지)",
+    )
+
+
+class EraseResponse(BaseModel):
+    """
+    삭제 요청 처리 결과 응답 페이로드.
+    모든 필드는 PII 원문을 포함하지 않습니다.
+    """
+    masked_user_id: str = Field(..., description="마스킹된 UID (PII 미포함)")
+    deletion_success: bool = Field(..., description="Vector Data 삭제 성공 여부")
+    db_rows_deleted: int = Field(..., description="DB 실제 삭제 행 수")
+    anonymization_results: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="각 로그 필드 익명화 처리 결과 요약 (PII 미포함)",
+    )
+    audit_logged: bool = Field(..., description="감사 로그 기록 성공 여부")
+    message: str = Field(..., description="처리 결과 요약 메시지")
+
+
+# =============================================================================
+# E2E 오케스트레이션 헬퍼
+# =============================================================================
+
+def _build_anonymization_summary(result: AnonymizationResult) -> dict[str, Any]:
+    """
+    AnonymizationResult를 응답용 요약 딕셔너리로 변환합니다.
+    PII 원문(anonymized_value 실제값)은 응답에 포함하지 않습니다.
+    """
+    return {
+        "success": result.success,
+        "key_version": result.key_version,
+        "rotation_policy": result.key_rotation_policy.value,
+        "hash_name": result.hash_name,
+        # anonymized_value와 salt_hex는 응답에 노출하지 않음 (내부 감사 전용)
+    }
+
+
+# =============================================================================
+# 엔드포인트
+# =============================================================================
+
+@router.post(
+    "/erase",
+    response_model=EraseResponse,
+    status_code=status.HTTP_200_OK,
+    summary="사용자 데이터 삭제 요청 (GDPR 제17조)",
+    description=(
+        "Vector Data 물리 삭제 → Interaction Log 익명화 → 감사 로그 기록을 "
+        "단일 원자적 흐름으로 처리합니다. 인증 필수."
+    ),
+)
+async def erase_user_data(
+    request: EraseRequest,
+    current_user: dict[str, Any] = Depends(get_current_user),
+) -> EraseResponse:
+    """
+    GDPR Right-to-Erasure 처리 파이프라인 E2E 엔드포인트.
+
+    [처리 순서]
+      1. 요청 수신 감사 로그 기록 (DATA_DELETE_REQUESTED)
+      2. 2단계: Vector Data 삭제 (delete_user_data)
+      3. 3단계: Interaction Log 익명화 (anonymize_log_entry, 각 필드별)
+      4. 최종 처리 결과 감사 로그 기록
+
+    [Graceful Degradation]
+      - 삭제 서비스 내부 예외 → 500 반환 및 감사 로그 FAILURE 기록
+      - 익명화 실패 → 개별 필드 실패로 기록, 전체 파이프라인 중단 없음
+    """
+    hashed_uid = request.hashed_user_id
+    masked = mask_uid(hashed_uid)
+
+    # ── 1. 요청 수신 감사 로그 ──────────────────────────────────────────────
+    write_audit_log(
+        event_type=AuditEventType.DATA_DELETE_REQUESTED,
+        masked_uid=masked,
+        result="erase_request_received",
+        extra={
+            "log_fields_count": len(request.log_fields_to_anonymize),
+            "requester_role": current_user.get("role", "unknown"),
+        },
+    )
+
+    # ── 2. Vector Data 삭제 (2단계) ─────────────────────────────────────────
+    deletion_result: DeletionResult
+    try:
+        deletion_result = await delete_user_data(hashed_uid)
+    except Exception as exc:
+        logger.exception(
+            "[OBS][PRIVACY][API] Vector data deletion failed: masked_uid=%s, error=%s",
+            masked, type(exc).__name__,
+        )
+        write_audit_log(
+            event_type=AuditEventType.DATA_DELETE_FAILURE,
+            masked_uid=masked,
+            result=f"deletion_pipeline_error: {type(exc).__name__}",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="삭제 처리 중 내부 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+        ) from exc
+
+    # ── 3. Interaction Log 익명화 (3단계) ───────────────────────────────────
+    anonymization_summaries: list[dict[str, Any]] = []
+    for field_value in request.log_fields_to_anonymize:
+        try:
+            anon_result: AnonymizationResult = await anonymize_log_entry(
+                hashed_user_id=hashed_uid,
+                log_field_value=field_value,
+            )
+            anonymization_summaries.append(_build_anonymization_summary(anon_result))
+        except ValueError as ve:
+            # 입력값 오류 (빈 값 등) — 해당 필드만 실패 처리, 파이프라인 유지
+            logger.warning(
+                "[OBS][PRIVACY][API] Anonymization skipped for a field: masked_uid=%s, reason=%s",
+                masked, str(ve),
+            )
+            anonymization_summaries.append({"success": False, "reason": "invalid_input"})
+        except Exception as exc:
+            # 예기치 않은 오류 — 해당 필드만 실패, Graceful Degradation
+            logger.exception(
+                "[OBS][PRIVACY][API] Anonymization error for a field: masked_uid=%s, error=%s",
+                masked, type(exc).__name__,
+            )
+            anonymization_summaries.append(
+                {"success": False, "reason": type(exc).__name__}
+            )
+
+    # ── 4. 최종 처리 결과 감사 로그 ─────────────────────────────────────────
+    all_anon_success = all(s.get("success", False) for s in anonymization_summaries)
+    final_event = (
+        AuditEventType.DATA_DELETE_SUCCESS
+        if deletion_result.success and all_anon_success
+        else AuditEventType.DATA_DELETE_FAILURE
+    )
+    write_audit_log(
+        event_type=final_event,
+        masked_uid=masked,
+        result="erase_pipeline_complete",
+        extra={
+            "deletion_success": deletion_result.success,
+            "db_rows_deleted": deletion_result.db_rows_deleted,
+            "anonymization_total": len(anonymization_summaries),
+            "anonymization_failed": sum(
+                1 for s in anonymization_summaries if not s.get("success", False)
+            ),
+            "vacuum_triggered": deletion_result.vacuum_triggered,
+            "compaction_recommended": deletion_result.compaction_recommended,
+        },
+    )
+
+    logger.info(
+        "[OBS][PRIVACY][API] Erase pipeline complete: masked_uid=%s, "
+        "deletion_success=%s, db_rows=%d, anon_total=%d",
+        masked,
+        deletion_result.success,
+        deletion_result.db_rows_deleted,
+        len(anonymization_summaries),
+    )
+
+    return EraseResponse(
+        masked_user_id=masked,
+        deletion_success=deletion_result.success,
+        db_rows_deleted=deletion_result.db_rows_deleted,
+        anonymization_results=anonymization_summaries,
+        audit_logged=True,
+        message=(
+            "삭제 및 익명화 처리가 완료되었습니다."
+            if deletion_result.success
+            else "삭제가 부분적으로 처리되었습니다. 감사 로그를 확인해 주세요."
+        ),
+    )

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -24,3 +24,8 @@ router.include_router(endpoints.search_router)
 router.include_router(endpoints.metadata_router)
 router.include_router(endpoints.chat_router)
 router.include_router(endpoints.admin_router)
+
+# GDPR Right-to-Erasure 엔드포인트 (Phase 2-4)
+# schedule_audit_log_cleanup()은 FastAPI lifespan 또는 Celery Beat에서 등록 필요
+# 참조: backend.core.audit_logger.schedule_audit_log_cleanup
+router.include_router(endpoints.privacy_router)


### PR DESCRIPTION
✨ feat [#12.2.15]: Phase 2.4 - ➃ GDPR 삭제 요청 E2E 통합 엔드포인트 구현 (Integration & Compliance)
🐛 fix [#12.2.15]: 1차 개선 - `hashed_user_id` 포맷 검증 강화 및 `audit_logged` 실제 추적

## Summary by Sourcery

GDPR를 준수하는 사용자 데이터 삭제 API 엔드포인트를 추가하여, 벡터 데이터 삭제, 상호작용 로그 익명화, 감사 로그 기록을 조율하고, 더 엄격한 해시된 사용자 ID 검증 및 감사 로그 성공 여부를 명시적으로 추적합니다.

New Features:
- 데이터 삭제, 로그 익명화, 감사 로그 기록을 통합적으로 처리하는 GDPR 삭제권(right-to-erasure) 요청을 위한 단일 진입점으로 `/privacy/erase` 엔드포인트를 도입합니다.

Bug Fixes:
- `hashed_user_id` 형식 검증을 강화하여, SHA-256 64자 길이의 16진수 값만 허용하고, 원본 사용자 ID나 유효하지 않은 문자열은 거부하도록 합니다.
- 삭제 API 응답에 `audit_logged` 플래그를 추가하여 감사 로그 기록이 실제로 성공했는지 여부를 추적하고 노출합니다.

Enhancements:
- 새로운 privacy 라우터를 메인 API 라우팅 구조에 통합하고, 점진적 기능 저하(graceful degradation) 및 비-PII(개인 식별 정보 비포함) 안전 로깅을 포함해, 엔드투엔드 삭제 파이프라인 전반에 대한 관측 가능성을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a GDPR-compliant user data erasure API endpoint that orchestrates vector data deletion, interaction log anonymization, and audit logging with stricter hashed user ID validation and explicit audit log success tracking.

New Features:
- Introduce a /privacy/erase endpoint as a single entry point for GDPR right-to-erasure requests, coordinating data deletion, log anonymization, and audit logging.

Bug Fixes:
- Strengthen hashed_user_id format validation to only accept SHA-256 64-character hexadecimal values and reject raw user IDs or invalid strings.
- Track and expose whether audit logging actually succeeded via an audit_logged flag in the erasure API response.

Enhancements:
- Integrate the new privacy router into the main API routing structure and add observability around the end-to-end erasure pipeline, including graceful degradation and non-PII-safe logging.

</details>