### PR TITLE
🐛 fix [#12.2.15]: 2차 개선 - AnonymizationSummary 타입 모델 도입 및 API 응답 스키마 안정화

### DIFF
--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -12,14 +12,18 @@ GDPR Right-to-Erasure API Endpoint — v9.0 Phase 2-4 (Integration & Compliance)
 [보안 설계]
   - hashed_user_id는 SHA-256 결과인 64자리 hex 고정 포맷을 Pydantic에서 강제 검증합니다.
     user_id 원문은 이 레이어에 절대 진입하지 않습니다.
+  - log_fields_to_anonymize 각 항목은 최대 길이 및 허용 문자 패턴을 검증합니다.
   - PII가 포함될 수 있는 예외 메시지(str(exception))는 로그에 기록하지 않으며,
     예외 타입명만 기록합니다.
   - 모든 처리 결과는 audit_logger를 통해 감사 로그에 기록됩니다.
   - 인증 의존성(get_current_user)은 기존 deps.py 패턴을 재사용합니다.
 
+[응답 스키마]
+  - anonymization_results: list[AnonymizationSummary] — 성공/실패 모두 동일한 스키마.
+    field_index: 요청 순서 인덱스 (0-based) — PII 없이 원본 필드와 매핑 가능.
+
 [Graceful Degradation 정책]
   - `delete_user_data()` 내부 예외 → 파이프라인 전체 중단, 500 반환 + FAILURE 감사 로그
-    (FAISS/Redis 삭제 실패는 delete_user_data 내부에서 부분 성공으로 처리)
   - 익명화 실패 → 해당 필드만 실패 처리, 전체 파이프라인 유지
   - 감사 로그 기록 실패 → `audit_logged=False`로 응답에 정확히 반영, 프로세스 중단 없음
 
@@ -30,8 +34,9 @@ GDPR Right-to-Erasure API Endpoint — v9.0 Phase 2-4 (Integration & Compliance)
 from __future__ import annotations
 
 import logging
+import os
 import re
-from typing import Any
+from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field, field_validator
@@ -52,6 +57,36 @@ router = APIRouter(prefix="/privacy", tags=["privacy"])
 # SHA-256 결과: 64자리 16진수 (대소문자 허용)
 _SHA256_HEX_PATTERN: re.Pattern[str] = re.compile(r"^[0-9a-fA-F]{64}$")
 
+# log_fields_to_anonymize 항목별 제한 (하드코딩 금지 — 환경 변수 우선)
+_LOG_FIELD_MAX_LENGTH_ENV_KEY = "PRIVACY_LOG_FIELD_MAX_LENGTH"
+_DEFAULT_LOG_FIELD_MAX_LENGTH = 4096
+_MIN_LOG_FIELD_MAX_LENGTH = 64
+_MAX_LOG_FIELD_MAX_LENGTH = 1_048_576  # 1 MiB 상한
+
+
+def _get_log_field_max_length() -> int:
+    """PRIVACY_LOG_FIELD_MAX_LENGTH 환경 변수를 파싱하여 반환합니다 (범위 검증 포함)."""
+    raw = os.getenv(_LOG_FIELD_MAX_LENGTH_ENV_KEY)
+    default = _DEFAULT_LOG_FIELD_MAX_LENGTH
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+        if not (_MIN_LOG_FIELD_MAX_LENGTH <= value <= _MAX_LOG_FIELD_MAX_LENGTH):
+            logger.warning(
+                "[OBS][PRIVACY][CONFIG] '%s'=%d is outside range [%d, %d]. Falling back to %d.",
+                _LOG_FIELD_MAX_LENGTH_ENV_KEY, value,
+                _MIN_LOG_FIELD_MAX_LENGTH, _MAX_LOG_FIELD_MAX_LENGTH, default,
+            )
+            return default
+        return value
+    except (ValueError, TypeError):
+        logger.warning(
+            "[OBS][PRIVACY][CONFIG] '%s'=%r is not a valid integer. Falling back to %d.",
+            _LOG_FIELD_MAX_LENGTH_ENV_KEY, raw, default,
+        )
+        return default
+
 
 # =============================================================================
 # 요청/응답 모델
@@ -64,7 +99,7 @@ class EraseRequest(BaseModel):
     [보안 원칙]
       - hashed_user_id: SHA-256 해시 결과인 64자리 hex 고정 포맷만 허용.
         원본 user_id 또는 임의 문자열은 Pydantic 검증 단계에서 거부됩니다.
-      - log_fields_to_anonymize: 익명화 대상 Interaction Log 필드 값 목록.
+      - log_fields_to_anonymize: 항목별 최대 길이(PRIVACY_LOG_FIELD_MAX_LENGTH)를 검증.
         (각 항목은 이미 추출된 필드 값이어야 하며, PII 원문 포함 금지)
     """
     hashed_user_id: str = Field(
@@ -75,7 +110,11 @@ class EraseRequest(BaseModel):
     )
     log_fields_to_anonymize: list[str] = Field(
         default_factory=list,
-        description="익명화할 Interaction Log 필드 값 목록 (PII 원문 포함 금지)",
+        description=(
+            "익명화할 Interaction Log 필드 값 목록 (PII 원문 포함 금지). "
+            f"항목당 최대 길이는 PRIVACY_LOG_FIELD_MAX_LENGTH 환경 변수로 제어 "
+            f"(기본값: {_DEFAULT_LOG_FIELD_MAX_LENGTH}자)."
+        ),
     )
 
     @field_validator("hashed_user_id")
@@ -89,6 +128,57 @@ class EraseRequest(BaseModel):
             )
         return v.lower()  # 일관성을 위해 소문자로 정규화
 
+    @field_validator("log_fields_to_anonymize", mode="before")
+    @classmethod
+    def validate_log_fields(cls, v: Any) -> Any:
+        """
+        log_fields_to_anonymize 각 항목의 최대 길이를 검증합니다.
+        최대 길이는 PRIVACY_LOG_FIELD_MAX_LENGTH 환경 변수로 외부화됩니다.
+        """
+        if not isinstance(v, list):
+            return v  # Pydantic 기본 타입 검증에 위임
+        max_length = _get_log_field_max_length()
+        for idx, item in enumerate(v):
+            if isinstance(item, str) and len(item) > max_length:
+                raise ValueError(
+                    f"log_fields_to_anonymize[{idx}] exceeds maximum allowed length "
+                    f"({max_length} chars). Adjust PRIVACY_LOG_FIELD_MAX_LENGTH if needed."
+                )
+        return v
+
+
+class AnonymizationSummary(BaseModel):
+    """
+    개별 로그 필드에 대한 익명화 처리 결과 요약 스키마.
+
+    [설계 원칙]
+      - 성공/실패 모두 동일한 스키마를 사용하여 클라이언트 파괴 위험 제거.
+      - field_index: 요청 배열의 0-based 인덱스 — PII 없이 원본 필드와 매핑 가능.
+      - 실패 시 key_version/rotation_policy/hash_name은 None.
+      - 원문 필드 값(PII)은 절대 포함하지 않습니다.
+    """
+    field_index: int = Field(
+        ...,
+        description="요청 log_fields_to_anonymize 배열의 0-based 인덱스 (PII 미포함 매핑 키)",
+    )
+    success: bool = Field(..., description="해당 필드 익명화 성공 여부")
+    key_version: Optional[int] = Field(
+        default=None,
+        description="사용된 키 버전 (성공 시에만 설정)",
+    )
+    rotation_policy: Optional[str] = Field(
+        default=None,
+        description="적용된 키 로테이션 정책 (성공 시에만 설정)",
+    )
+    hash_name: Optional[str] = Field(
+        default=None,
+        description="사용된 해시 알고리즘 이름 (성공 시에만 설정)",
+    )
+    reason: Optional[str] = Field(
+        default=None,
+        description="실패 또는 부분 성공 시 사유 코드 (PII 미포함, 예: 'invalid_input')",
+    )
+
 
 class EraseResponse(BaseModel):
     """
@@ -98,9 +188,12 @@ class EraseResponse(BaseModel):
     masked_user_id: str = Field(..., description="마스킹된 UID (PII 미포함)")
     deletion_success: bool = Field(..., description="Vector Data 삭제 성공 여부")
     db_rows_deleted: int = Field(..., description="DB 실제 삭제 행 수")
-    anonymization_results: list[dict[str, Any]] = Field(
+    anonymization_results: list[AnonymizationSummary] = Field(
         default_factory=list,
-        description="각 로그 필드 익명화 처리 결과 요약 (PII 미포함)",
+        description=(
+            "각 로그 필드 익명화 처리 결과 요약 (PII 미포함). "
+            "field_index로 요청 배열의 원본 항목과 매핑 가능."
+        ),
     )
     audit_logged: bool = Field(
         ...,
@@ -116,18 +209,37 @@ class EraseResponse(BaseModel):
 # E2E 오케스트레이션 헬퍼
 # =============================================================================
 
-def _build_anonymization_summary(result: AnonymizationResult) -> dict[str, Any]:
+def _build_anonymization_summary(
+    field_index: int,
+    result: AnonymizationResult,
+) -> AnonymizationSummary:
     """
-    AnonymizationResult를 응답용 요약 딕셔너리로 변환합니다.
-    PII 원문(anonymized_value, salt_hex)은 응답에 포함하지 않습니다.
+    AnonymizationResult를 AnonymizationSummary 타입 모델로 변환합니다.
+    PII 원문(anonymized_value, salt_hex)은 포함하지 않습니다.
     """
-    return {
-        "success": result.success,
-        "key_version": result.key_version,
-        "rotation_policy": result.key_rotation_policy.value,
-        "hash_name": result.hash_name,
-        # anonymized_value와 salt_hex는 내부 감사 전용 — 응답에 노출 금지
-    }
+    return AnonymizationSummary(
+        field_index=field_index,
+        success=result.success,
+        key_version=result.key_version,
+        rotation_policy=result.key_rotation_policy.value,
+        hash_name=result.hash_name,
+        reason=None,
+    )
+
+
+def _build_failed_summary(field_index: int, reason: str) -> AnonymizationSummary:
+    """
+    실패한 익명화 항목을 AnonymizationSummary 타입 모델로 생성합니다.
+    성공 경로와 동일한 스키마를 유지하여 클라이언트 일관성을 보장합니다.
+    """
+    return AnonymizationSummary(
+        field_index=field_index,
+        success=False,
+        key_version=None,
+        rotation_policy=None,
+        hash_name=None,
+        reason=reason,
+    )
 
 
 def _try_write_audit_log(**kwargs: Any) -> bool:
@@ -136,8 +248,7 @@ def _try_write_audit_log(**kwargs: Any) -> bool:
 
     [반환 정책]
       - True: 감사 로그 기록이 정상적으로 수행됨.
-      - False: AuditConfigError(불변식 위반)가 발생하여 감사 로그 기록 실패.
-        (audit_logger 내부 파일 I/O 오류 폴백은 True를 반환 — 표준 로거에 기록됨)
+      - False: AuditConfigError(불변식 위반)가 발생하여 기록 실패.
     """
     try:
         write_audit_log(**kwargs)
@@ -155,7 +266,7 @@ def _build_erase_message(
     anonymization_failed_count: int,
 ) -> str:
     """
-    삭제 및 익명화 결과를 모두 반영한 정확한 처리 결과 메시지를 생성합니다.
+    삭제 및 익명화 결과를 모두 반영한 처리 결과 메시지를 생성합니다.
     deletion_success와 익명화 실패 건수를 모두 고려하여 호출자를 오도하지 않습니다.
     """
     if not deletion_success:
@@ -192,7 +303,7 @@ async def erase_user_data(
     [처리 순서]
       1. 요청 수신 감사 로그 기록 (DATA_DELETE_REQUESTED)
       2. 2단계: Vector Data 삭제 (delete_user_data)
-      3. 3단계: Interaction Log 익명화 (anonymize_log_entry, 각 필드별)
+      3. 3단계: Interaction Log 익명화 (anonymize_log_entry, 각 필드별 — field_index 추적)
       4. 최종 처리 결과 감사 로그 기록 — 실제 기록 성공 여부를 audit_logged에 반영
 
     [Graceful Degradation]
@@ -235,34 +346,41 @@ async def erase_user_data(
         ) from exc
 
     # ── 3. Interaction Log 익명화 (3단계) ───────────────────────────────────
-    anonymization_summaries: list[dict[str, Any]] = []
-    for field_value in request.log_fields_to_anonymize:
+    # field_index를 통해 클라이언트가 PII 없이 실패 항목을 원본과 매핑 가능
+    anonymization_summaries: list[AnonymizationSummary] = []
+    for field_index, field_value in enumerate(request.log_fields_to_anonymize):
         try:
             anon_result: AnonymizationResult = await anonymize_log_entry(
                 hashed_user_id=hashed_uid,
                 log_field_value=field_value,
             )
-            anonymization_summaries.append(_build_anonymization_summary(anon_result))
+            anonymization_summaries.append(
+                _build_anonymization_summary(field_index, anon_result)
+            )
         except ValueError:
             # str(ve) 제외 — ValueError 메시지에 PII 포함 가능성 차단
             logger.warning(
-                "[OBS][PRIVACY][API] Anonymization skipped: masked_uid=%s, reason=invalid_input",
-                masked,
+                "[OBS][PRIVACY][API] Anonymization skipped: masked_uid=%s, "
+                "field_index=%d, reason=invalid_input",
+                masked, field_index,
             )
-            anonymization_summaries.append({"success": False, "reason": "invalid_input"})
+            anonymization_summaries.append(
+                _build_failed_summary(field_index, "invalid_input")
+            )
         except Exception as exc:
             # 예기치 않은 오류 — 해당 필드만 실패, Graceful Degradation
             logger.exception(
-                "[OBS][PRIVACY][API] Anonymization error: masked_uid=%s, error_type=%s",
-                masked, type(exc).__name__,
+                "[OBS][PRIVACY][API] Anonymization error: masked_uid=%s, "
+                "field_index=%d, error_type=%s",
+                masked, field_index, type(exc).__name__,
             )
             anonymization_summaries.append(
-                {"success": False, "reason": type(exc).__name__}
+                _build_failed_summary(field_index, type(exc).__name__)
             )
 
     # ── 4. 최종 처리 결과 감사 로그 (실제 기록 성공 여부 추적) ──────────────
     anonymization_failed_count: int = sum(
-        1 for s in anonymization_summaries if not s.get("success", False)
+        1 for s in anonymization_summaries if not s.success
     )
     all_anon_success: bool = anonymization_failed_count == 0
     final_event = (

--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -33,6 +33,7 @@ GDPR Right-to-Erasure API Endpoint — v9.0 Phase 2-4 (Integration & Compliance)
 
 from __future__ import annotations
 
+import functools
 import logging
 import os
 import re
@@ -64,8 +65,9 @@ _MIN_LOG_FIELD_MAX_LENGTH = 64
 _MAX_LOG_FIELD_MAX_LENGTH = 1_048_576  # 1 MiB 상한
 
 
+@functools.lru_cache(maxsize=None)
 def _get_log_field_max_length() -> int:
-    """PRIVACY_LOG_FIELD_MAX_LENGTH 환경 변수를 파싱하여 반환합니다 (범위 검증 포함)."""
+    """PRIVACY_LOG_FIELD_MAX_LENGTH 환경 변수를 파싱하여 반환합니다 (범위 검증 및 캐싱 포함)."""
     raw = os.getenv(_LOG_FIELD_MAX_LENGTH_ENV_KEY)
     default = _DEFAULT_LOG_FIELD_MAX_LENGTH
     if raw is None:
@@ -128,18 +130,16 @@ class EraseRequest(BaseModel):
             )
         return v.lower()  # 일관성을 위해 소문자로 정규화
 
-    @field_validator("log_fields_to_anonymize", mode="before")
+    @field_validator("log_fields_to_anonymize", mode="after")
     @classmethod
-    def validate_log_fields(cls, v: Any) -> Any:
+    def validate_log_fields(cls, v: list[str]) -> list[str]:
         """
         log_fields_to_anonymize 각 항목의 최대 길이를 검증합니다.
-        최대 길이는 PRIVACY_LOG_FIELD_MAX_LENGTH 환경 변수로 외부화됩니다.
+        mode="after"를 사용하여 입력 이터러블이 이미 list[str]로 변환된 최종 상태에서 검증합니다.
         """
-        if not isinstance(v, list):
-            return v  # Pydantic 기본 타입 검증에 위임
         max_length = _get_log_field_max_length()
         for idx, item in enumerate(v):
-            if isinstance(item, str) and len(item) > max_length:
+            if len(item) > max_length:
                 raise ValueError(
                     f"log_fields_to_anonymize[{idx}] exceeds maximum allowed length "
                     f"({max_length} chars). Adjust PRIVACY_LOG_FIELD_MAX_LENGTH if needed."
@@ -217,9 +217,12 @@ def _build_anonymization_summary(
     AnonymizationResult를 AnonymizationSummary 타입 모델로 변환합니다.
     PII 원문(anonymized_value, salt_hex)은 포함하지 않습니다.
     """
+    if not result.success:
+        return _build_failed_summary(field_index, "anonymization_failed")
+
     return AnonymizationSummary(
         field_index=field_index,
-        success=result.success,
+        success=True,
         key_version=result.key_version,
         rotation_policy=result.key_rotation_policy.value,
         hash_name=result.hash_name,


### PR DESCRIPTION
- **[보안/성능] `log_fields_to_anonymize` 항목별 최대 길이 검증 추가**
  - 기존: 익명화 대상 필드 값의 길이나 포맷 제한 없음 (OOM 또는 성능 저하 리스크)
  - 수정: `PRIVACY_LOG_FIELD_MAX_LENGTH` 환경 변수(기본 4096자, 최대 1MiB)를 참조하여 `@field_validator`에서 항목별 길이 강제 검증. 하드코딩 배제.

- **[타입 안전성] `AnonymizationSummary` Pydantic 모델 도입**
  - 기존: `anonymization_results`가 타입 없는 `dict[str, Any]`로 처리됨.
  - 수정: 명시적인 `AnonymizationSummary` 모델을 정의하여 응답 계약(Contract) 강화 및 자기 문서화(Self-documenting) 달성.

- **[클라이언트 안전성] 응답 스키마 비대칭 해소 및 `field_index` 매핑 키 추가**
  - 기존: 성공/실패 시 반환되는 키 구조가 다르고, 실패한 항목을 원본 요청과 매핑 불가.
  - 수정: 성공/실패 모두 동일한 `AnonymizationSummary` 스키마 반환.
  - 수정: `field_index` (0-based)를 추가하여 PII 원문 노출 없이 클라이언트가 원본 요청 배열과 실패 항목을 안전하게 매핑할 수 있도록 개선.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1306#pullrequestreview-4225315132)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개인정보 삭제 API를 강화하고 클라이언트에게 익명화 결과에 대해 계약적으로 안전한(Contract-safe) 보장을 제공하기 위해 길이 제한을 강제하고, 타입이 명시된 익명화 요약 모델을 도입합니다.

New Features:
- 필드별 익명화 결과에 대한 통합 스키마로 `AnonymizationSummary` Pydantic 모델을 추가하고, `field_index` 매핑 메타데이터를 포함합니다.

Bug Fixes:
- 익명화 결과 구조를 정규화하여, 성공 및 실패 케이스 모두 명시적인 실패 사유를 포함하는 동일한 응답 스키마를 반환하도록 합니다.

Enhancements:
- `PRIVACY_LOG_FIELD_MAX_LENGTH` 환경 변수에서 가져오는 설정 가능한 최대 길이에 대해 `log_fields_to_anonymize` 항목을 검증하고, 안전한 범위와 로깅을 적용합니다.
- PII 안전성을 유지하면서 필드 인덱스를 포함하도록 익명화 에러 처리 및 로깅을 개선하고, 타입이 명시된 요약 모델을 기반으로 응답 계산을 수행합니다.

Documentation:
- 개인정보 보호 엔드포인트 모델 내 인라인 API 문서를 업데이트하여 새로운 `anonymization_results` 스키마, `field_index` 동작, 로그 필드 길이 제한에 대해 설명합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce length limits and introduce a typed anonymization summary model to harden the privacy erase API and make anonymization results contract-safe for clients.

New Features:
- Add AnonymizationSummary Pydantic model as the unified schema for per-field anonymization results, including field_index mapping metadata.

Bug Fixes:
- Normalize anonymization result structures so both success and failure cases return the same response schema with explicit failure reasons.

Enhancements:
- Validate log_fields_to_anonymize entries against a configurable maximum length sourced from the PRIVACY_LOG_FIELD_MAX_LENGTH environment variable with safe bounds and logging.
- Refine anonymization error handling and logging to include field indices while preserving PII safety, and base response computations on the typed summary model.

Documentation:
- Update inline API documentation in privacy endpoint models to describe the new anonymization_results schema, field_index behavior, and log field length constraints.

</details>