### PR TITLE
🐛 fix [#12.2.15]: 4차 개선 - 익명화 실패 시 내부 예외 클래스명 노출 차단 (보안 강화)

### DIFF
--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -37,6 +37,7 @@ import functools
 import logging
 import os
 import re
+from enum import Enum
 from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -147,6 +148,16 @@ class EraseRequest(BaseModel):
         return v
 
 
+class AnonymizationFailureReason(str, Enum):
+    """
+    익명화 실패 시 클라이언트에 노출해도 안전한 정규화된 사유 코드.
+    내부 구현 세부사항(예: 예외 클래스명)을 숨기고 API 스키마를 안정화합니다.
+    """
+    INVALID_INPUT = "invalid_input"
+    INTERNAL_ERROR = "internal_error"
+    ANONYMIZATION_FAILED = "anonymization_failed"
+
+
 class AnonymizationSummary(BaseModel):
     """
     개별 로그 필드에 대한 익명화 처리 결과 요약 스키마.
@@ -174,9 +185,9 @@ class AnonymizationSummary(BaseModel):
         default=None,
         description="사용된 해시 알고리즘 이름 (성공 시에만 설정)",
     )
-    reason: Optional[str] = Field(
+    reason: Optional[AnonymizationFailureReason] = Field(
         default=None,
-        description="실패 또는 부분 성공 시 사유 코드 (PII 미포함, 예: 'invalid_input', 'internal_error')",
+        description="실패 또는 부분 성공 시 사유 코드 (PII 및 내부 세부사항 미포함)",
     )
 
 
@@ -218,7 +229,10 @@ def _build_anonymization_summary(
     PII 원문(anonymized_value, salt_hex)은 포함하지 않습니다.
     """
     if not result.success:
-        return _build_failed_summary(field_index, "anonymization_failed")
+        return _build_failed_summary(
+            field_index,
+            AnonymizationFailureReason.ANONYMIZATION_FAILED,
+        )
 
     return AnonymizationSummary(
         field_index=field_index,
@@ -230,7 +244,10 @@ def _build_anonymization_summary(
     )
 
 
-def _build_failed_summary(field_index: int, reason: str) -> AnonymizationSummary:
+def _build_failed_summary(
+    field_index: int,
+    reason: AnonymizationFailureReason,
+) -> AnonymizationSummary:
     """
     실패한 익명화 항목을 AnonymizationSummary 타입 모델로 생성합니다.
     성공 경로와 동일한 스키마를 유지하여 클라이언트 일관성을 보장합니다.
@@ -368,7 +385,7 @@ async def erase_user_data(
                 masked, field_index,
             )
             anonymization_summaries.append(
-                _build_failed_summary(field_index, "invalid_input")
+                _build_failed_summary(field_index, AnonymizationFailureReason.INVALID_INPUT)
             )
         except Exception as exc:
             # 예기치 않은 오류 — 해당 필드만 실패, Graceful Degradation
@@ -380,7 +397,7 @@ async def erase_user_data(
             # 내부 구현 세부사항(예외 클래스명)을 API 응답 스키마에 노출하지 않기 위해
             # 예기치 않은 오류는 안정적인 공통 코드로 매핑합니다.
             anonymization_summaries.append(
-                _build_failed_summary(field_index, "internal_error")
+                _build_failed_summary(field_index, AnonymizationFailureReason.INTERNAL_ERROR)
             )
 
     # ── 4. 최종 처리 결과 감사 로그 (실제 기록 성공 여부 추적) ──────────────

--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -176,7 +176,7 @@ class AnonymizationSummary(BaseModel):
     )
     reason: Optional[str] = Field(
         default=None,
-        description="실패 또는 부분 성공 시 사유 코드 (PII 미포함, 예: 'invalid_input')",
+        description="실패 또는 부분 성공 시 사유 코드 (PII 미포함, 예: 'invalid_input', 'internal_error')",
     )
 
 
@@ -377,8 +377,10 @@ async def erase_user_data(
                 "field_index=%d, error_type=%s",
                 masked, field_index, type(exc).__name__,
             )
+            # 내부 구현 세부사항(예외 클래스명)을 API 응답 스키마에 노출하지 않기 위해
+            # 예기치 않은 오류는 안정적인 공통 코드로 매핑합니다.
             anonymization_summaries.append(
-                _build_failed_summary(field_index, type(exc).__name__)
+                _build_failed_summary(field_index, "internal_error")
             )
 
     # ── 4. 최종 처리 결과 감사 로그 (실제 기록 성공 여부 추적) ──────────────


### PR DESCRIPTION
- **[보안] API 응답의 내부 추상화 누수(Abstraction Leak) 방지**
  - 기존: 익명화 처리 중 예기치 않은 예외 발생 시, `type(exc).__name__`을 그대로 반환하여 클라이언트 응답에 백엔드의 내부 기술 스택 및 구체적 에러 상황이 노출됨.
  - 수정: 서버 관측성(OBS) 로그에는 실제 예외 클래스명(`error_type`)을 상세히 기록하여 디버깅을 보장하되, 외부 API 응답(`AnonymizationSummary.reason`)에는 정규화된 `"internal_error"` 공통 코드만 반환하도록 매핑하여 내부 구현 세부사항 노출 차단.

- **[문서화] 응답 모델 Pydantic 스키마 설명 갱신**
  - `AnonymizationSummary.reason` 필드의 문서화된 예시에 `"internal_error"` 추가.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1308#pullrequestreview-4225386082)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

비식별화 실패 응답을 표준화하여, 내부 예외 세부 정보가 노출되지 않도록 하고, 이에 맞춰 해당 API 스키마 문서를 업데이트합니다.

버그 수정:
- 예기치 않은 오류를 일반화된 "internal_error" 사유 코드에 매핑하여, 비식별화 실패 응답에서 내부 예외 클래스 이름이 노출되지 않도록 방지합니다.

문서화:
- 예제에서 표준화된 "internal_error" 코드를 포함하도록 AnonymizationSummary.reason 필드를 문서화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize anonymization failure responses to avoid leaking internal exception details while updating the corresponding API schema documentation.

Bug Fixes:
- Prevent exposure of internal exception class names in anonymization failure responses by mapping unexpected errors to a generic "internal_error" reason code.

Documentation:
- Document the AnonymizationSummary.reason field to include the standardized "internal_error" code in examples.

</details>