### PR TITLE
🐛 fix [#12.2.15]: 6차 개선 - API 하위 호환성 복구 및 Enum 유연성 확보

### DIFF
--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -190,6 +190,21 @@ class AnonymizationSummary(BaseModel):
         description="실패 또는 부분 성공 시 사유 코드 (PII 미포함). 하위 호환성을 위해 str 유지 (예: 'invalid_input')",
     )
 
+    @field_validator("reason", mode="before")
+    @classmethod
+    def normalize_reason(cls, v: Any) -> Optional[str]:
+        """
+        reason 필드에 어떤 타입이 들어오든 안전한 문자열로 중앙에서 정규화합니다.
+        Enum이 들어오면 .value를 추출하고, 그 외의 알 수 없는 타입은 str()로 캐스팅하여 방어합니다.
+        """
+        if v is None:
+            return None
+        if isinstance(v, AnonymizationFailureReason):
+            return v.value
+        if not isinstance(v, str):
+            return str(v)
+        return v
+
 
 class EraseResponse(BaseModel):
     """
@@ -246,21 +261,19 @@ def _build_anonymization_summary(
 
 def _build_failed_summary(
     field_index: int,
-    reason: str | AnonymizationFailureReason,
+    reason: Any,
 ) -> AnonymizationSummary:
     """
     실패한 익명화 항목을 AnonymizationSummary 타입 모델로 생성합니다.
     성공 경로와 동일한 스키마를 유지하여 클라이언트 일관성을 보장합니다.
-    하위 호환성을 위해 Enum이 입력되면 문자열(.value)로 변환합니다.
     """
-    reason_str = reason.value if isinstance(reason, AnonymizationFailureReason) else reason
     return AnonymizationSummary(
         field_index=field_index,
         success=False,
         key_version=None,
         rotation_policy=None,
         hash_name=None,
-        reason=reason_str,
+        reason=reason,
     )
 
 

--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -185,9 +185,9 @@ class AnonymizationSummary(BaseModel):
         default=None,
         description="사용된 해시 알고리즘 이름 (성공 시에만 설정)",
     )
-    reason: Optional[AnonymizationFailureReason] = Field(
+    reason: Optional[str] = Field(
         default=None,
-        description="실패 또는 부분 성공 시 사유 코드 (PII 및 내부 세부사항 미포함)",
+        description="실패 또는 부분 성공 시 사유 코드 (PII 미포함). 하위 호환성을 위해 str 유지 (예: 'invalid_input')",
     )
 
 
@@ -246,19 +246,21 @@ def _build_anonymization_summary(
 
 def _build_failed_summary(
     field_index: int,
-    reason: AnonymizationFailureReason,
+    reason: str | AnonymizationFailureReason,
 ) -> AnonymizationSummary:
     """
     실패한 익명화 항목을 AnonymizationSummary 타입 모델로 생성합니다.
     성공 경로와 동일한 스키마를 유지하여 클라이언트 일관성을 보장합니다.
+    하위 호환성을 위해 Enum이 입력되면 문자열(.value)로 변환합니다.
     """
+    reason_str = reason.value if isinstance(reason, AnonymizationFailureReason) else reason
     return AnonymizationSummary(
         field_index=field_index,
         success=False,
         key_version=None,
         rotation_policy=None,
         hash_name=None,
-        reason=reason,
+        reason=reason_str,
     )
 
 


### PR DESCRIPTION
- **[호환성] API 스키마 Breaking Change 방지**
  - 기존: 5차 개선에서 `reason` 필드의 OpenAPI 스펙이 `Enum`으로 고정되어, 기존 자유 문자열 파싱을 기대하는 클라이언트(다운스트림 서비스)와 계약이 충돌할 위험 발생.
  - 수정: `AnonymizationSummary.reason` 타입을 `Optional[str]`로 되돌려 하위 호환성 보장.

- **[리팩터링] 내부 Enum 활용 및 형변환 레이어 구성**
  - 기존: 코드 내부의 타입 안정성과 외부 API 유연성이 충돌함.
  - 수정:
    - 팩토리 헬퍼 함수(`_build_failed_summary`)의 매개변수를 `str | AnonymizationFailureReason` 으로 확장.
    - `Enum` 인스턴스가 주입되면 자동으로 `.value`를 추출해 반환함으로써 내부 하드코딩 방지 → 이점은 유지하고 클라이언트 충돌 위험은 완벽히 제거.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1310#pullrequestreview-4225413119)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

익명화 실패 사유에 대해 API의 하위 호환성을 복원하면서, 내부에서는 enum 사용을 유지합니다.

버그 수정:
- 자유 형식의 실패 사유를 기대하는 클라이언트가 깨지는 문제를 방지하기 위해 `AnonymizationSummary.reason`을 선택적 문자열(optional string)로 되돌립니다.

개선 사항:
- 실패 요약 빌더가 원시 문자열(raw string)과 `AnonymizationFailureReason` enum을 모두 입력으로 받아들일 수 있도록 하고, API 응답을 위해 이를 문자열로 정규화(normalize)합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore API backward compatibility for anonymization failure reasons while preserving internal enum usage.

Bug Fixes:
- Revert AnonymizationSummary.reason to an optional string to avoid breaking clients expecting free-form failure reasons.

Enhancements:
- Allow the failed summary builder to accept either raw strings or AnonymizationFailureReason enums and normalize them to strings for API responses.

</details>