### PR TITLE
🐛 fix [#12.2.15]: 8차 개선 - 팩토리 함수 타입 시그니처 정교화 및 방어적 폴백 문서화

### DIFF
--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -261,11 +261,16 @@ def _build_anonymization_summary(
 
 def _build_failed_summary(
     field_index: int,
-    reason: Any,
+    reason: str | AnonymizationFailureReason,
 ) -> AnonymizationSummary:
     """
     실패한 익명화 항목을 AnonymizationSummary 타입 모델로 생성합니다.
     성공 경로와 동일한 스키마를 유지하여 클라이언트 일관성을 보장합니다.
+
+    [타입 계약 및 방어 로직]
+    호출자는 `reason`으로 AnonymizationFailureReason(권장) 또는 일반 문자열을 전달해야 합니다.
+    만약 예외 객체 등 그 외의 타입이 전달될 경우, 모델 내부의 검증기가
+    str() 캐스팅을 통해 방어적 폴백(Fallback)으로 취급합니다.
     """
     return AnonymizationSummary(
         field_index=field_index,


### PR DESCRIPTION
- **[타입 안전성] 팩토리 함수(`_build_failed_summary`) 시그니처 개선**
  - 기존: 7차 개선에서 방어적 폴백을 모델 내부로 옮기며 매개변수를 `Any`로 선언하여, 정적 분석기(mypy 등)가 의도된 타입 계약을 강제하지 못하는 문제(타입 느슨함) 발생.
  - 수정: 매개변수 타입을 `reason: str | AnonymizationFailureReason`으로 구체화하여, API의 명확한 의도를 표현하고 정적 타입 에러를 사전에 포착할 수 있도록 안전성 복구.

- **[문서화] 하위 호환성 및 방어적 폴백 전략 문서화**
  - 팩토리 함수의 Docstring에 "정상적인 입력은 Enum 또는 일반 문자열이며, 예기치 않은 객체가 들어오더라도 모델의 `@field_validator`가 `str()` 캐스팅을 통해 방어적 폴백을 보장한다"는 아키텍처 의도를 명시.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1312#pullrequestreview-4225462589)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

비식별화 실패 요약 팩토리 함수의 API를 명확히 하고, 방어적인 폴백(fallback) 동작을 문서화합니다.

Enhancements:
- 타입 안정성을 높이기 위해 `_build_failed_summary` 팩토리 함수의 파라미터 타입을 문자열 또는 `AnonymizationFailureReason`만 허용하도록 강화합니다.
- 함수 docstring에 예상되는 `reason` 입력값과, 모델 밸리데이터가 `str()` 기반 폴백을 사용하는 방어적 동작을 문서화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the anonymization failure summary factory function’s API and document its defensive fallback behavior.

Enhancements:
- Tighten the `_build_failed_summary` factory function parameter type to accept only strings or `AnonymizationFailureReason` for improved type safety.
- Document the expected `reason` inputs and the model validator’s defensive `str()`-based fallback behavior in the function docstring.

</details>