### PR TITLE
🐛 fix [#12.2.15]: 9차 개선 - 팩토리 함수 내 명시적 정규화 로직 적용 및 Pydantic 의존성 분리

### DIFF
--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -259,34 +259,49 @@ def _build_anonymization_summary(
     )
 
 
+def _normalize_reason(
+    reason: str | AnonymizationFailureReason | Exception | None,
+) -> str:
+    """
+    익명화 실패 사유(reason)를 안전하고 일관된 문자열로 정규화하는 헬퍼 함수입니다.
+    
+    [보안 및 방어 로직]
+    - Enum: .value 추출
+    - Exception: PII 유출 및 내부 세부사항 노출을 막기 위해 강제로 INTERNAL_ERROR 처리
+    - None: 모호성을 없애기 위해 "unknown_error" 기본값 사용
+    - 그 외: 강제 str() 캐스팅
+    """
+    if reason is None:
+        return "unknown_error"
+    if isinstance(reason, AnonymizationFailureReason):
+        return reason.value
+    if isinstance(reason, Exception):
+        # 방어: 예외 객체가 그대로 넘어오면 메시지에 포함된 PII가 노출될 수 있으므로 마스킹
+        return AnonymizationFailureReason.INTERNAL_ERROR.value
+    if not isinstance(reason, str):
+        return str(reason)
+    return reason
+
+
 def _build_failed_summary(
     field_index: int,
-    reason: Any,
+    reason: str | AnonymizationFailureReason | Exception | None,
 ) -> AnonymizationSummary:
     """
     실패한 익명화 항목을 AnonymizationSummary 타입 모델로 생성합니다.
     성공 경로와 동일한 스키마를 유지하여 클라이언트 일관성을 보장합니다.
 
-    [타입 계약 및 명시적 방어 로직]
-    호출자는 `reason`으로 AnonymizationFailureReason 또는 일반 문자열을 전달하는 것이 권장됩니다.
-    예외 객체 등 다른 타입이 전달될 경우, Pydantic 검증기(Magic)에만 의존하지 않고
-    팩토리 함수에서 명시적으로 str() 캐스팅을 수행하여 방어적 폴백을 처리합니다.
+    [타입 계약]
+    _normalize_reason 헬퍼를 통해 어떠한 예기치 않은 타입이 들어오더라도 
+    안전한 문자열로 캐스팅되어 모델에 주입됩니다.
     """
-    # 명시적 정규화(Normalization) 및 캐스팅
-    if isinstance(reason, AnonymizationFailureReason):
-        normalized_reason = reason.value
-    elif not isinstance(reason, str) and reason is not None:
-        normalized_reason = str(reason)
-    else:
-        normalized_reason = reason
-
     return AnonymizationSummary(
         field_index=field_index,
         success=False,
         key_version=None,
         rotation_policy=None,
         hash_name=None,
-        reason=normalized_reason,
+        reason=_normalize_reason(reason),
     )
 
 

--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -261,24 +261,32 @@ def _build_anonymization_summary(
 
 def _build_failed_summary(
     field_index: int,
-    reason: str | AnonymizationFailureReason,
+    reason: Any,
 ) -> AnonymizationSummary:
     """
     실패한 익명화 항목을 AnonymizationSummary 타입 모델로 생성합니다.
     성공 경로와 동일한 스키마를 유지하여 클라이언트 일관성을 보장합니다.
 
-    [타입 계약 및 방어 로직]
-    호출자는 `reason`으로 AnonymizationFailureReason(권장) 또는 일반 문자열을 전달해야 합니다.
-    만약 예외 객체 등 그 외의 타입이 전달될 경우, 모델 내부의 검증기가
-    str() 캐스팅을 통해 방어적 폴백(Fallback)으로 취급합니다.
+    [타입 계약 및 명시적 방어 로직]
+    호출자는 `reason`으로 AnonymizationFailureReason 또는 일반 문자열을 전달하는 것이 권장됩니다.
+    예외 객체 등 다른 타입이 전달될 경우, Pydantic 검증기(Magic)에만 의존하지 않고
+    팩토리 함수에서 명시적으로 str() 캐스팅을 수행하여 방어적 폴백을 처리합니다.
     """
+    # 명시적 정규화(Normalization) 및 캐스팅
+    if isinstance(reason, AnonymizationFailureReason):
+        normalized_reason = reason.value
+    elif not isinstance(reason, str) and reason is not None:
+        normalized_reason = str(reason)
+    else:
+        normalized_reason = reason
+
     return AnonymizationSummary(
         field_index=field_index,
         success=False,
         key_version=None,
         rotation_policy=None,
         hash_name=None,
-        reason=reason,
+        reason=normalized_reason,
     )
 
 


### PR DESCRIPTION
- **[리팩터링] 방어적 프로그래밍의 명시성(Explicitness) 강화**
  - 기존: 예외 객체 등 알 수 없는 타입이 주입될 때의 방어적 폴백(`str()` 캐스팅)을 Pydantic 모델의 `@field_validator` 내부(Magic)에 전적으로 의존하여, 호출부만 봤을 때 에러 처리 흐름을 파악하기 어려웠음.
  - 수정:
    - 팩토리 헬퍼 함수(`_build_failed_summary`) 내부에서 `AnonymizationSummary` 객체를 인스턴스화하기 직전에 명시적으로 타입 정규화 및 캐스팅 분기를 구현.
    - 파이썬의 철학인 "명시적인 것이 암시적인 것보다 낫다"를 충실히 따름.

- **[타입 안전성] 유연한 팩토리 시그니처 및 문서화**
  - 팩토리 함수의 `reason` 파라미터를 `Any`로 확장하면서도, Docstring에 권장 타입과 명시적 캐스팅 정책을 상세히 기록하여 런타임 유연성과 가독성을 동시에 확보.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1314#pullrequestreview-4225485027)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

실패한 요약 팩토리에서 익명화 실패 사유를 명시적이고 방어적으로 처리하도록 강화하고, 이를 Pydantic 검증기 매직에서 분리합니다.

Enhancements:
- 실패한 익명화 요약 팩토리가 `reason` 매개변수에 대해 어떤 타입이든 허용하도록 완화하면서, 선호되는 타입들을 문서화합니다.
- AnonymizationSummary 모델을 생성하기 전에 팩토리 내에서 문자열도 enum도 아닌 이유 값을 문자열로 정규화 및 캐스팅하여, 에러 처리를 더 명시적으로 만듭니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen explicit, defensive handling of anonymization failure reasons in the failed summary factory while decoupling it from Pydantic validator magic.

Enhancements:
- Relax the failed anonymization summary factory to accept any type for the reason parameter while documenting preferred types.
- Normalize and cast non-string, non-enum reasons to string within the factory before constructing the AnonymizationSummary model to make error handling more explicit.

</details>