### PR TITLE
🐛 fix [#12.2.15]: 13차 개선 - 해시 길이 상수화 및 엔드포인트 예외 로깅 완벽 방어

### DIFF
--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -60,6 +60,10 @@ router = APIRouter(prefix="/privacy", tags=["privacy"])
 # SHA-256 결과: 64자리 16진수 (대소문자 허용)
 _SHA256_HEX_PATTERN: re.Pattern[str] = re.compile(r"^[0-9a-fA-F]{64}$")
 
+# 익명화 실패 시 예외 메시지 보안 해싱(Hashing)을 위해 자를 자릿수(상수)
+# (개인정보보호와 추적성 간의 Trade-off를 문서를 통해 명시)
+EXCEPTION_HASH_PREFIX_LEN = 16
+
 # log_fields_to_anonymize 항목별 제한 (하드코딩 금지 — 환경 변수 우선)
 _LOG_FIELD_MAX_LENGTH_ENV_KEY = "PRIVACY_LOG_FIELD_MAX_LENGTH"
 _DEFAULT_LOG_FIELD_MAX_LENGTH = 4096
@@ -263,6 +267,7 @@ def _build_anonymization_summary(
 
 def _normalize_reason(
     reason: str | AnonymizationFailureReason | Exception | None,
+    correlation_id: str | int | None = None,
 ) -> str:
     """
     익명화 실패 사유(reason)를 안전하고 일관된 문자열로 정규화하는 헬퍼 함수입니다.
@@ -281,10 +286,11 @@ def _normalize_reason(
         # 방어: 예외 객체가 그대로 넘어오면 메시지에 포함된 PII가 노출될 수 있으므로 마스킹
         # 보안(GDPR): 원본 에러 메시지(PII 포함 가능성)를 서버 로그에 남기지 않기 위해 
         # exc_info를 제외하고 메시지를 SHA-256 해싱하여 추적성(Traceability)만 확보합니다.
-        msg_hash = hashlib.sha256(str(reason).encode("utf-8")).hexdigest()[:16]
+        msg_hash = hashlib.sha256(str(reason).encode("utf-8")).hexdigest()[:EXCEPTION_HASH_PREFIX_LEN]
         logger.error(
             "[OBS][PRIVACY][API] Implicit exception masking in _normalize_reason. "
-            "Exception type: %s, msg_hash: %s", type(reason).__name__, msg_hash
+            "Exception type: %s, msg_hash: %s, correlation_id: %s", 
+            type(reason).__name__, msg_hash, correlation_id
         )
         return AnonymizationFailureReason.INTERNAL_ERROR.value
     if not isinstance(reason, str):
@@ -310,7 +316,7 @@ def _build_failed_summary(
         key_version=None,
         rotation_policy=None,
         hash_name=None,
-        reason=_normalize_reason(reason),
+        reason=_normalize_reason(reason, correlation_id=field_index),
     )
 
 
@@ -441,10 +447,13 @@ async def erase_user_data(
             )
         except Exception as exc:
             # 예기치 않은 오류 — 해당 필드만 실패, Graceful Degradation
-            logger.exception(
+            # 보안(GDPR): logger.exception은 예외 메시지원문을 남겨 PII 유출 리스크가 있으므로,
+            # logger.error로 전환하고 보안 해싱(Hashing) 기법을 사용하여 추적성 확보.
+            msg_hash = hashlib.sha256(str(exc).encode("utf-8")).hexdigest()[:EXCEPTION_HASH_PREFIX_LEN]
+            logger.error(
                 "[OBS][PRIVACY][API] Anonymization error: masked_uid=%s, "
-                "field_index=%d, error_type=%s",
-                masked, field_index, type(exc).__name__,
+                "field_index=%d, error_type=%s, msg_hash=%s",
+                masked, field_index, type(exc).__name__, msg_hash
             )
             # 내부 구현 세부사항(예외 클래스명)을 API 응답 스키마에 노출하지 않기 위해
             # 예기치 않은 오류는 안정적인 공통 코드로 매핑합니다.

--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -265,6 +265,14 @@ def _build_anonymization_summary(
     )
 
 
+def _hash_exception_message(exc: Exception) -> str:
+    """
+    보안(GDPR): 원본 에러 메시지(PII 포함 가능성)를 서버 로그에 남기지 않기 위해 
+    메시지를 SHA-256 해싱하여 추적성(Traceability) 핑거프린트를 생성합니다.
+    """
+    return hashlib.sha256(str(exc).encode("utf-8")).hexdigest()[:EXCEPTION_HASH_PREFIX_LEN]
+
+
 def _normalize_reason(
     reason: str | AnonymizationFailureReason | Exception | None,
     correlation_id: str | int | None = None,
@@ -284,9 +292,7 @@ def _normalize_reason(
         return reason.value
     if isinstance(reason, Exception):
         # 방어: 예외 객체가 그대로 넘어오면 메시지에 포함된 PII가 노출될 수 있으므로 마스킹
-        # 보안(GDPR): 원본 에러 메시지(PII 포함 가능성)를 서버 로그에 남기지 않기 위해 
-        # exc_info를 제외하고 메시지를 SHA-256 해싱하여 추적성(Traceability)만 확보합니다.
-        msg_hash = hashlib.sha256(str(reason).encode("utf-8")).hexdigest()[:EXCEPTION_HASH_PREFIX_LEN]
+        msg_hash = _hash_exception_message(reason)
         logger.error(
             "[OBS][PRIVACY][API] Implicit exception masking in _normalize_reason. "
             "Exception type: %s, msg_hash: %s, correlation_id: %s", 
@@ -449,7 +455,7 @@ async def erase_user_data(
             # 예기치 않은 오류 — 해당 필드만 실패, Graceful Degradation
             # 보안(GDPR): logger.exception은 예외 메시지원문을 남겨 PII 유출 리스크가 있으므로,
             # logger.error로 전환하고 보안 해싱(Hashing) 기법을 사용하여 추적성 확보.
-            msg_hash = hashlib.sha256(str(exc).encode("utf-8")).hexdigest()[:EXCEPTION_HASH_PREFIX_LEN]
+            msg_hash = _hash_exception_message(exc)
             logger.error(
                 "[OBS][PRIVACY][API] Anonymization error: masked_uid=%s, "
                 "field_index=%d, error_type=%s, msg_hash=%s",


### PR DESCRIPTION
- **[리팩터링] 매직 넘버(Magic Number) 상수화**
  - 예외 메시지의 해시를 자르는 `16`이라는 길이를 하드코딩하지 않고, 모듈 레벨 상수인 `EXCEPTION_HASH_PREFIX_LEN`으로 추출하여 가독성과 유지보수성을 확보.

- **[추적성] 에러 발생 컨텍스트(Correlation) 그룹화 기능 추가**
  - `_normalize_reason` 헬퍼 함수에 `correlation_id`를 추가로 받도록 확장하고, 호출부에서 `field_index`를 주입하여, 에러의 해시값이 변경되더라도 동일한 필드에서 발생한 문제를 논리적으로 그룹핑하고 디버깅할 수 있는 고리(Link) 제공.

- **[보안/GDPR] 엔드포인트 본문의 잠재적 PII 유출 구멍(Loophole) 완벽 차단**
  - 기존: 헬퍼 함수 쪽은 해싱 방어막이 쳐졌으나, 엔드포인트(`except Exception:`) 블록에 여전히 `logger.exception`이 남아있어 예외 원문(PII 포함 가능성)이 유출되고 있었음.
  - 수정: 해당 구문을 즉시 `logger.error`로 전환하고, 동일한 보안 해싱 기법을 일관되게 적용. 이로써 `privacy.py` 전체에서 단 1개의 PII 유출 취약점도 허용하지 않음.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1318#pullrequestreview-4225574159)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

프라이버시 API 예외 처리의 안정성을 강화하고 비식별화 실패에 대한 추적 가능성을 개선했습니다.

새로운 기능:
- 상관관계 식별자를 정규화된 실패 사유에 전파하여, 비식별화 오류에 대해 상관관계 기반 그룹화를 추가했습니다.

버그 수정:
- 프라이버시 엔드포인트에서 원시 예외를 그대로 로깅하던 방식을 해시된 오류 메시지로 대체하여 잠재적인 PII 유출 가능성을 제거했습니다.

개선 사항:
- 매직 넘버를 피하고 오류 해싱의 유지보수성을 높이기 위해 예외 해시 접두사 길이에 대한 전용 상수를 추출했습니다.
- 보다 안전한 디버깅과 관측 가능성을 지원하기 위해 프라이버시 관련 오류 로그에 상관관계 식별자와 해시된 메시지 데이터를 포함했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden privacy API exception handling and improve traceability of anonymization failures.

New Features:
- Add correlation-based grouping for anonymization errors by propagating a correlation identifier into normalized failure reasons.

Bug Fixes:
- Eliminate potential PII leakage by replacing raw exception logging in the privacy endpoint with hashed error messages.

Enhancements:
- Extract a dedicated constant for exception hash prefix length to avoid magic numbers and improve maintainability of error hashing.
- Include correlation identifiers and hashed message data in privacy-related error logs to support safer debugging and observability.

</details>