### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -60,6 +60,10 @@ router = APIRouter(prefix="/privacy", tags=["privacy"])
 # SHA-256 결과: 64자리 16진수 (대소문자 허용)
 _SHA256_HEX_PATTERN: re.Pattern[str] = re.compile(r"^[0-9a-fA-F]{64}$")
 
+# 익명화 실패 시 예외 메시지 보안 해싱(Hashing)을 위해 자를 자릿수(상수)
+# (개인정보보호와 추적성 간의 Trade-off를 문서를 통해 명시)
+EXCEPTION_HASH_PREFIX_LEN = 16
+
 # log_fields_to_anonymize 항목별 제한 (하드코딩 금지 — 환경 변수 우선)
 _LOG_FIELD_MAX_LENGTH_ENV_KEY = "PRIVACY_LOG_FIELD_MAX_LENGTH"
 _DEFAULT_LOG_FIELD_MAX_LENGTH = 4096
@@ -263,6 +267,7 @@ def _build_anonymization_summary(
 
 def _normalize_reason(
     reason: str | AnonymizationFailureReason | Exception | None,
+    correlation_id: str | int | None = None,
 ) -> str:
     """
     익명화 실패 사유(reason)를 안전하고 일관된 문자열로 정규화하는 헬퍼 함수입니다.
@@ -281,10 +286,11 @@ def _normalize_reason(
         # 방어: 예외 객체가 그대로 넘어오면 메시지에 포함된 PII가 노출될 수 있으므로 마스킹
         # 보안(GDPR): 원본 에러 메시지(PII 포함 가능성)를 서버 로그에 남기지 않기 위해 
         # exc_info를 제외하고 메시지를 SHA-256 해싱하여 추적성(Traceability)만 확보합니다.
-        msg_hash = hashlib.sha256(str(reason).encode("utf-8")).hexdigest()[:16]
+        msg_hash = hashlib.sha256(str(reason).encode("utf-8")).hexdigest()[:EXCEPTION_HASH_PREFIX_LEN]
         logger.error(
             "[OBS][PRIVACY][API] Implicit exception masking in _normalize_reason. "
-            "Exception type: %s, msg_hash: %s", type(reason).__name__, msg_hash
+            "Exception type: %s, msg_hash: %s, correlation_id: %s", 
+            type(reason).__name__, msg_hash, correlation_id
         )
         return AnonymizationFailureReason.INTERNAL_ERROR.value
     if not isinstance(reason, str):
@@ -310,7 +316,7 @@ def _build_failed_summary(
         key_version=None,
         rotation_policy=None,
         hash_name=None,
-        reason=_normalize_reason(reason),
+        reason=_normalize_reason(reason, correlation_id=field_index),
     )
 
 
@@ -441,10 +447,13 @@ async def erase_user_data(
             )
         except Exception as exc:
             # 예기치 않은 오류 — 해당 필드만 실패, Graceful Degradation
-            logger.exception(
+            # 보안(GDPR): logger.exception은 예외 메시지원문을 남겨 PII 유출 리스크가 있으므로,
+            # logger.error로 전환하고 보안 해싱(Hashing) 기법을 사용하여 추적성 확보.
+            msg_hash = hashlib.sha256(str(exc).encode("utf-8")).hexdigest()[:EXCEPTION_HASH_PREFIX_LEN]
+            logger.error(
                 "[OBS][PRIVACY][API] Anonymization error: masked_uid=%s, "
-                "field_index=%d, error_type=%s",
-                masked, field_index, type(exc).__name__,
+                "field_index=%d, error_type=%s, msg_hash=%s",
+                masked, field_index, type(exc).__name__, msg_hash
             )
             # 내부 구현 세부사항(예외 클래스명)을 API 응답 스키마에 노출하지 않기 위해
             # 예기치 않은 오류는 안정적인 공통 코드로 매핑합니다.

--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -265,6 +265,14 @@ def _build_anonymization_summary(
     )
 
 
+def _hash_exception_message(exc: Exception) -> str:
+    """
+    보안(GDPR): 원본 에러 메시지(PII 포함 가능성)를 서버 로그에 남기지 않기 위해 
+    메시지를 SHA-256 해싱하여 추적성(Traceability) 핑거프린트를 생성합니다.
+    """
+    return hashlib.sha256(str(exc).encode("utf-8")).hexdigest()[:EXCEPTION_HASH_PREFIX_LEN]
+
+
 def _normalize_reason(
     reason: str | AnonymizationFailureReason | Exception | None,
     correlation_id: str | int | None = None,
@@ -284,9 +292,7 @@ def _normalize_reason(
         return reason.value
     if isinstance(reason, Exception):
         # 방어: 예외 객체가 그대로 넘어오면 메시지에 포함된 PII가 노출될 수 있으므로 마스킹
-        # 보안(GDPR): 원본 에러 메시지(PII 포함 가능성)를 서버 로그에 남기지 않기 위해 
-        # exc_info를 제외하고 메시지를 SHA-256 해싱하여 추적성(Traceability)만 확보합니다.
-        msg_hash = hashlib.sha256(str(reason).encode("utf-8")).hexdigest()[:EXCEPTION_HASH_PREFIX_LEN]
+        msg_hash = _hash_exception_message(reason)
         logger.error(
             "[OBS][PRIVACY][API] Implicit exception masking in _normalize_reason. "
             "Exception type: %s, msg_hash: %s, correlation_id: %s", 
@@ -449,7 +455,7 @@ async def erase_user_data(
             # 예기치 않은 오류 — 해당 필드만 실패, Graceful Degradation
             # 보안(GDPR): logger.exception은 예외 메시지원문을 남겨 PII 유출 리스크가 있으므로,
             # logger.error로 전환하고 보안 해싱(Hashing) 기법을 사용하여 추적성 확보.
-            msg_hash = hashlib.sha256(str(exc).encode("utf-8")).hexdigest()[:EXCEPTION_HASH_PREFIX_LEN]
+            msg_hash = _hash_exception_message(exc)
             logger.error(
                 "[OBS][PRIVACY][API] Anonymization error: masked_uid=%s, "
                 "field_index=%d, error_type=%s, msg_hash=%s",


### PR DESCRIPTION
🐛 fix [#12.2.15]: 13차 개선 - 해시 길이 상수화 및 엔드포인트 예외 로깅 완벽 방어 
🐛 fix [#12.2.15]: 14차 개선 - 보안 해싱 로직 중복 제거 및 단일 책임 원칙(SRP) 달성

## Summary by Sourcery

공유 헬퍼를 사용해 예외 메시지를 해시하고 상관관계 메타데이터를 포함하되, 로그에 원본 예외 내용을 출력하지 않도록 하여 프라이버시 엔드포인트 로깅을 강화합니다.

Bug Fixes:
- 프라이버시 익명화(flow)에서 원본 예외를 그대로 로깅하던 부분을 SHA-256으로 해시된 예외 메시지 지문으로 대체하여 잠재적인 PII 노출을 방지했습니다.

Enhancements:
- 예외 해시 접두사 길이에 대한 상수를 도입하여 설정을 중앙집중화하고, 프라이버시와 추적 가능성 간의 트레이드오프를 명확히 했습니다.
- 예외 해싱 로직을 전용 헬퍼로 리팩터링하여 익명화 실패 처리 및 로깅 전반에서 재사용하도록 했습니다.
- 필드 수준 오류를 민감 정보 노출 없이 더 잘 추적할 수 있도록, 익명화 실패 로그에 상관관계 식별자(correlation identifier)를 추가했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden privacy endpoint logging by hashing exception messages with a shared helper and including correlation metadata while avoiding raw exception output in logs.

Bug Fixes:
- Prevent potential PII leakage by replacing raw exception logging with SHA-256–hashed exception message fingerprints in privacy anonymization flows.

Enhancements:
- Introduce a constant for exception hash prefix length to centralize configuration and clarify the privacy–traceability trade-off.
- Refactor exception hashing into a dedicated helper reused across anonymization failure handling and logging.
- Augment anonymization failure logs with a correlation identifier to better trace field-level errors without exposing sensitive data.

</details>