### PR TITLE
🐛 fix [#12.2.15]: 15차 개선 - 예외 핑거프린트 안정성(Stability) 강화 및 명명 규칙 교정

### DIFF
--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -60,6 +60,9 @@ router = APIRouter(prefix="/privacy", tags=["privacy"])
 # SHA-256 결과: 64자리 16진수 (대소문자 허용)
 _SHA256_HEX_PATTERN: re.Pattern[str] = re.compile(r"^[0-9a-fA-F]{64}$")
 
+# 예외 메시지 정규화용: 메모리 주소 패턴 (해시 핑거프린트 안정성 확보용)
+_MEMORY_ADDRESS_PATTERN: re.Pattern[str] = re.compile(r"0x[0-9a-fA-F]+")
+
 # 익명화 실패 시 예외 메시지 보안 해싱(Hashing)을 위해 자를 자릿수(상수)
 # (개인정보보호와 추적성 간의 Trade-off를 문서를 통해 명시)
 EXCEPTION_HASH_PREFIX_LEN = 16
@@ -268,11 +271,16 @@ def _build_anonymization_summary(
 def _hash_exception_message(exc: Exception) -> str:
     """
     보안(GDPR): 원본 에러 메시지(PII 포함 가능성)를 서버 로그에 남기지 않기 위해 
-    안정적인 구조(타입명 + args)를 기반으로 SHA-256 해시 핑거프린트를 생성합니다.
+    안정적인 구조(모듈.타입명 + 정규화된 args)를 기반으로 SHA-256 해시 핑거프린트를 생성합니다.
     """
-    # str(exc)는 메모리 주소가 포함될 수 있어 해시가 불안정(Unstable)할 수 있으므로,
-    # 예외 타입과 인자(args)를 조합하여 안정적인 지문을 생성합니다.
-    stable_repr = f"{type(exc).__name__}:{exc.args}"
+    # 1. 모듈 경로를 포함하여 서로 다른 라이브러리의 동명 예외(충돌) 방지
+    exc_type = f"{exc.__class__.__module__}.{exc.__class__.__name__}"
+    
+    # 2. 인자 내부의 동적 메모리 주소(<... at 0x...>)를 정규화하여 지문 안정성 극대화
+    raw_args_str = str(exc.args)
+    normalized_args = _MEMORY_ADDRESS_PATTERN.sub("0x...", raw_args_str)
+    
+    stable_repr = f"{exc_type}:{normalized_args}"
     return hashlib.sha256(stable_repr.encode("utf-8")).hexdigest()[:EXCEPTION_HASH_PREFIX_LEN]
 
 

--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -268,14 +268,17 @@ def _build_anonymization_summary(
 def _hash_exception_message(exc: Exception) -> str:
     """
     보안(GDPR): 원본 에러 메시지(PII 포함 가능성)를 서버 로그에 남기지 않기 위해 
-    메시지를 SHA-256 해싱하여 추적성(Traceability) 핑거프린트를 생성합니다.
+    안정적인 구조(타입명 + args)를 기반으로 SHA-256 해시 핑거프린트를 생성합니다.
     """
-    return hashlib.sha256(str(exc).encode("utf-8")).hexdigest()[:EXCEPTION_HASH_PREFIX_LEN]
+    # str(exc)는 메모리 주소가 포함될 수 있어 해시가 불안정(Unstable)할 수 있으므로,
+    # 예외 타입과 인자(args)를 조합하여 안정적인 지문을 생성합니다.
+    stable_repr = f"{type(exc).__name__}:{exc.args}"
+    return hashlib.sha256(stable_repr.encode("utf-8")).hexdigest()[:EXCEPTION_HASH_PREFIX_LEN]
 
 
 def _normalize_reason(
     reason: str | AnonymizationFailureReason | Exception | None,
-    correlation_id: str | int | None = None,
+    field_index: int | None = None,
 ) -> str:
     """
     익명화 실패 사유(reason)를 안전하고 일관된 문자열로 정규화하는 헬퍼 함수입니다.
@@ -295,8 +298,8 @@ def _normalize_reason(
         msg_hash = _hash_exception_message(reason)
         logger.error(
             "[OBS][PRIVACY][API] Implicit exception masking in _normalize_reason. "
-            "Exception type: %s, msg_hash: %s, correlation_id: %s", 
-            type(reason).__name__, msg_hash, correlation_id
+            "Exception type: %s, msg_hash: %s, field_index: %s", 
+            type(reason).__name__, msg_hash, field_index
         )
         return AnonymizationFailureReason.INTERNAL_ERROR.value
     if not isinstance(reason, str):
@@ -322,7 +325,7 @@ def _build_failed_summary(
         key_version=None,
         rotation_policy=None,
         hash_name=None,
-        reason=_normalize_reason(reason, correlation_id=field_index),
+        reason=_normalize_reason(reason, field_index=field_index),
     )
 
 


### PR DESCRIPTION
- **[관측성/추적성] 예외 해시 지문(Fingerprint)의 안정성 극대화**
  - 기존: 예외를 마스킹할 때 `str(exc)`를 해싱했으나, 파이썬 객체의 `__str__` 반환값에 동적 메모리 주소가 섞여 들어갈 경우 동일한 장애에도 매번 다른 해시값이 생성되어 모니터링 시스템(DataDog/Sentry 등)에서 에러 그룹핑이 불가능해지는 취약점이 존재함.
  - 수정: 해싱 대상을 예외의 구조적 본질인 `(type(exc).__name__, exc.args)` 조합으로 변경. PII는 여전히 안전하게 해싱으로 가려지면서도, 논리적으로 동일한 에러는 100% 동일한 해시값을 뱉어내도록 추적성 지문의 신뢰도(Reliability)를 대폭 상향.

- **[리팩터링] 헬퍼 함수 파라미터 명확화 (Renaming)**
  - 기존: 헬퍼 함수에서 에러 추적을 위해 전달받는 인자의 이름이 `correlation_id`였으나, 실제 주입되는 값은 `field_index` 정수형 데이터였음.
  - 수정: 파라미터 이름을 데이터 실체에 맞게 `field_index`로 정직하게 수정하여 전역 식별자(Request UUID 등)로 오인할 소지를 원천 차단함.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1320#pullrequestreview-4225628596)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

익명화 실패에 대한 예외 지문(fingerprinting)의 안정성과 신뢰성을 강화하고, 헬퍼 함수 파라미터 이름을 실제 의미와 일치하도록 정렬했습니다.

버그 수정:
- 동일한 실패에 대해 오류 그룹핑이 일관되도록, 예외 해시 지문이 안정적인 구조적 데이터(예외 타입 및 args)에 기반해 생성되도록 보장합니다.

개선 사항:
- 오해의 소지가 있던 상관관계 식별자(correlation identifier) 이름의 익명화 헬퍼 파라미터를 명시적인 필드 인덱스(field index)로 변경하고, 새 이름을 반영하도록 로깅을 업데이트했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen stability and reliability of exception fingerprinting for anonymization failures and align helper parameter naming with its actual semantics.

Bug Fixes:
- Ensure exception hash fingerprints are derived from stable structural data (exception type and args) to keep error grouping consistent across identical failures.

Enhancements:
- Rename anonymization helper parameter from a misleading correlation identifier to an explicit field index and update logging to reflect the new name.

</details>