### PR TITLE
🐛 fix [#12.2.15]: 22차 개선 - 정규식 Greedy 오탐 방지 및 구조 최적화

### DIFF
--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -61,12 +61,9 @@ router = APIRouter(prefix="/privacy", tags=["privacy"])
 _SHA256_HEX_PATTERN: re.Pattern[str] = re.compile(r"^[0-9a-fA-F]{64}$")
 
 # 예외 메시지 정규화용: 메모리 주소 패턴 (해시 핑거프린트 안정성 확보용)
-# - Python repr 등에서 자주 보이는 형태: "<ClassName object at 0x...>", "<function my_func at 0x...>"
-# - 주소처럼 보이는 모든 16진수 리터럴이 아니라, 파이썬 객체/함수 repr 스타일에 한정해 과도한 정규화 방지
-# - \w를 사용하여 유니코드(한글 등) 식별자를 지원하고, \s 대신 명시적 띄어쓰기(' ')로 멀티라인 오탐 방지
-# - 파이썬 내부 함수(<locals>) 및 제네릭(<MyClass[Type]>) 지원을 위해 특수 기호(<, >, [, ], :) 추가
-# - 제네릭 타입 목록(<MyClass[Type1, Type2]>) 및 디폴트 인자 표현 등을 위해 ',', '?', '=' 추가
-_MEMORY_ADDRESS_PATTERN: re.Pattern[str] = re.compile(r"(<[\w. <>\[\]:,?=]+ at )0x[0-9a-fA-F]+(>)")
+# - 파이썬 내부 함수(<locals>) 및 제네릭(<MyClass[Type]>) 지원을 위해 특수 기호([, ], :, ,, ?, =) 추가
+# - 무분별한 꺾쇠(<, >) 허용으로 인한 Greedy 과잉 매칭(Swallowing)을 막기 위해 <locals>만 명시적 허용
+_MEMORY_ADDRESS_PATTERN: re.Pattern[str] = re.compile(r"(<(?:[\w. \[\]:,?=]|<locals>)+ at )0x[0-9a-fA-F]+(>)")
 
 # 익명화 실패 시 예외 메시지 보안 해싱(Hashing)을 위해 자를 자릿수(상수)
 # (개인정보보호와 추적성 간의 Trade-off를 문서를 통해 명시)

--- a/backend/api/endpoints/privacy.py
+++ b/backend/api/endpoints/privacy.py
@@ -63,7 +63,24 @@ _SHA256_HEX_PATTERN: re.Pattern[str] = re.compile(r"^[0-9a-fA-F]{64}$")
 # 예외 메시지 정규화용: 메모리 주소 패턴 (해시 핑거프린트 안정성 확보용)
 # - 파이썬 내부 함수(<locals>) 및 제네릭(<MyClass[Type]>) 지원을 위해 특수 기호([, ], :, ,, ?, =) 추가
 # - 무분별한 꺾쇠(<, >) 허용으로 인한 Greedy 과잉 매칭(Swallowing)을 막기 위해 <locals>만 명시적 허용
-_MEMORY_ADDRESS_PATTERN: re.Pattern[str] = re.compile(r"(<(?:[\w. \[\]:,?=]|<locals>)+ at )0x[0-9a-fA-F]+(>)")
+# - 유지보수성을 위해 re.VERBOSE를 적용하고, 안전한 치환을 위해 Named Group(?P<prefix>, ?P<suffix>) 사용
+_MEMORY_ADDRESS_PATTERN: re.Pattern[str] = re.compile(
+    r"""
+    (?P<prefix>
+        <                           # 파이썬 repr 시작 꺾쇠
+        (?:
+            [\w.\ \[\]:,?=]         # 클래스명, 모듈명, 제네릭 타입 기호 등 (공백 포함)
+            | <locals>              # 내부 함수(Closure)의 <locals> 명시적 허용
+        )+                          # 위 패턴들의 조합이 1번 이상 반복
+        \ at\                       # 주소를 나타내는 ' at ' (앞뒤 공백)
+    )
+    0x[0-9a-fA-F]+                  # 마스킹 대상인 실제 16진수 메모리 주소
+    (?P<suffix>
+        >                           # 파이썬 repr 종료 꺾쇠
+    )
+    """,
+    re.VERBOSE,
+)
 
 # 익명화 실패 시 예외 메시지 보안 해싱(Hashing)을 위해 자를 자릿수(상수)
 # (개인정보보호와 추적성 간의 Trade-off를 문서를 통해 명시)
@@ -281,7 +298,7 @@ def _hash_exception_message(exc: Exception) -> str:
     # 2. 인자 내부의 동적 메모리 주소(<... at 0x...>)만 선택적으로 정규화하여 
     # 정상적인 16진수 데이터(예: 트랜잭션 ID)가 뭉개지는 과잉 정규화 방지
     raw_args_str = str(exc.args)
-    normalized_args = _MEMORY_ADDRESS_PATTERN.sub(r"\g<1>0x...\g<2>", raw_args_str)
+    normalized_args = _MEMORY_ADDRESS_PATTERN.sub(r"\g<prefix>0x...\g<suffix>", raw_args_str)
     
     stable_repr = f"{exc_type}:{normalized_args}"
     return hashlib.sha256(stable_repr.encode("utf-8")).hexdigest()[:EXCEPTION_HASH_PREFIX_LEN]


### PR DESCRIPTION
- **[버그 수정] 정규식 Greedy(탐욕적 매칭)로 인한 문자열 훼손(Swallowing) 방어**
  - 기존: 제네릭/내부 함수 지원을 위해 문자 클래스에 꺾쇠(`<, >`)를 추가하면서, `<A> and <B at 0x...>`와 같이 꺾쇠가 여러 번 등장하는 문자열이 들어올 경우 첫 번째 `<`부터 마지막 `>`까지의 중간 텍스트 전체를 삼켜버리는 치명적 오탐 발생.
  - 수정:
    - 무분별한 꺾쇠 허용을 폐기하고, 논캡처링 그룹을 활용하여 `<locals>`라는 정확한 리터럴만 선택적으로 허용(`(?:[\w. \[\]:,?=]|<locals>)+`)하는 서브패턴 도입.
    - 이를 통해 엉뚱한 문자열이 정규화되는 오작동을 차단하고 주변 컨텍스트를 100% 원형 보존함.
  - 별도 테스트 스크립트를 통해 중첩 꺾쇠, 다중 제네릭 등 복합 엣지 케이스들의 안전성을 직접 교차 검증 완료.

🔗 Related:
- Issue [#1046]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1328#pullrequestreview-4225893947)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

버그 수정:
- 지나치게 탐욕적인 메모리 주소 정규식이 여러 개의 꺾쇠 괄호를 포함한 문자열을 손상시키는 문제를 방지하기 위해, 객체 표현에서 허용되는 내용을 명시적인 `<locals>` 및 안전한 문자들로만 제한했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent over-greedy memory address regex from corrupting strings containing multiple angle brackets by restricting allowed content to explicit <locals> and safe characters in the object representation.

</details>