### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/docs/P/v9.0/v9.3_realtime_streaming_tasks.md
+++ b/docs/P/v9.0/v9.3_realtime_streaming_tasks.md
@@ -37,7 +37,7 @@ Next.js 프론트엔드를 실시간 렌더링 UX로 전환하여
 ### 3-0. [공통] StreamChunk 데이터 스키마 (SSOT)
 
 - [ ] 양방향(Backend/Frontend) 타입 안정성을 보장하기 위한 단일 진실 공급원(SSOT) 스키마 정의
-  - **소유권**: 백엔드의 스키마 정의 모델 (예: `Pydantic` 모델 정의)
+  - **소유권**: 백엔드의 스키마 정의 모델 (`backend/schemas/streaming.py`의 `StreamChunk` Pydantic 모델)
   - **동기화**: 자동 생성된 OpenAPI 스키마를 통해 프론트엔드 타입 자동 생성. 프론트엔드 수동 타입 선언(하드코딩) 절대 금지.
   - **Variants (Discriminated Union)**:
     - `TokenChunk`: `{ "type": "token", "data": string }`
@@ -198,8 +198,8 @@ Next.js 프론트엔드를 실시간 렌더링 UX로 전환하여
 ### 3-5. [공통] 스트리밍 설정 검증 및 단일 진실 공급원(SSOT) 정책
 
 - [ ] 설정 변수의 중앙 집중식 SSOT 모듈 구축
-  - **SSOT(Single Source of Truth) 원칙**: 백엔드와 프론트엔드 간 타임아웃, 버퍼 사이즈 등 설정 파편화를 막기 위해 공유 설정 모듈(예: 백엔드의 중앙 Config 클래스)에 기본값과 클램핑(Clamping) 규칙을 단일 정의.
-  - 문서와 실제 코드 간의 괴리(Drift)를 방지하기 위해 개별 모듈 하드코딩 금지.
+  - **SSOT(Single Source of Truth) 원칙**: 백엔드와 프론트엔드 간 타임아웃, 버퍼 사이즈 등 설정 파편화를 막기 위해 단일 정식 공유 설정 모듈(`backend/core/config/streaming.py`의 `StreamingConfig` 클래스)에 기본값과 클램핑(Clamping) 규칙을 명시적으로 정의.
+  - 문서와 실제 코드 간의 괴리(Drift) 및 경쟁하는 임시 설정 도입을 방지하기 위해 개별 모듈 내 분산 하드코딩 절대 금지.
 
 - [ ] 스트리밍 관련 환경 변수에 대한 유효성 검사 구성
   - 기존 전역 가용성 상태 레지스트리(Subsystem)에 스트리밍 모듈 추가

--- a/docs/P/v9.0/v9.3_realtime_streaming_tasks.md
+++ b/docs/P/v9.0/v9.3_realtime_streaming_tasks.md
@@ -34,36 +34,29 @@ Next.js 프론트엔드를 실시간 렌더링 UX로 전환하여
 
 ## 📋 세부 작업 (Tasks)
 
+### 3-0. [공통] StreamChunk 데이터 스키마 (SSOT)
+
+- [ ] 양방향(Backend/Frontend) 타입 안정성을 보장하기 위한 단일 진실 공급원(SSOT) 스키마 정의
+  - **소유권**: 백엔드의 스키마 정의 모델 (예: `Pydantic` 모델 정의)
+  - **동기화**: 자동 생성된 OpenAPI 스키마를 통해 프론트엔드 타입 자동 생성. 프론트엔드 수동 타입 선언(하드코딩) 절대 금지.
+  - **Variants (Discriminated Union)**:
+    - `TokenChunk`: `{ "type": "token", "data": string }`
+    - `DoneChunk`: `{ "type": "done", "data": "" }`
+    - `ErrorChunk`: `{ "type": "error", "code": string, "message": string }` (메시지는 `mask_pii_id()` 적용 필수)
+
 ### 3-1. LangGraph 에이전트 스트리밍 어댑터 구현
 
-- [ ] `backend/agent/streaming.py` 신설: 스트리밍 전용 어댑터 레이어
-  - LangGraph `graph.astream_events()` 기반의 비동기 토큰 스트리밍 구현
-    - 이벤트 타입 필터링: `on_chat_model_stream` 이벤트만 추출하여 토큰 청크 발행
-    - 기타 이벤트(`on_chain_start`, `on_tool_end` 등)는 내부 관측성 로그로만 기록
+- [ ] 스트리밍 전용 어댑터 레이어 신설 (예: `streaming.py`)
+  - LangGraph 스트리밍 API 기반의 비동기 토큰 스트리밍 구현
+    - 이벤트 타입 필터링: 모델 스트림 이벤트만 추출하여 `TokenChunk` 발행
+    - 기타 이벤트는 내부 관측성 로그로만 기록
   - 스트리밍 중 발생하는 예외의 안전한 처리:
-    - `asyncio.CancelledError`: 클라이언트 연결 종료로 간주하고 조용히 정리(Graceful Teardown)
-    - 기타 예외: `[STREAM][ERROR]` 태그 로그 후 에러 이벤트(`event: error`) 발행 및 스트림 종료
+    - 클라이언트 연결 종료 감지 시 조용히 정리(Graceful Teardown)
+    - 기타 예외: `[STREAM][ERROR]` 태그 로그 후 `ErrorChunk` 발행 및 스트림 종료
 
-- [ ] `StreamingCallbackHandler` 적용 방식 선택 및 설계 결정
-  - LangChain `BaseCallbackHandler` 서브클래싱 vs LangGraph `astream_events()` Native API 비교 검토
-    - **권장**: `astream_events(version="v2")` Native API 우선 채택
-      - 콜백 핸들러 대비 이벤트 구조가 명시적이고 LangGraph 상태 머신과의 결합도가 낮음
-      - `version="v2"` 파라미터를 상수(`LANGGRAPH_STREAM_VERSION = "v2"`)로 외부화하여 하드코딩 금지
-    - 레거시 콜백 핸들러 방식은 `StreamingCallbackHandler` Wrapper로 하위 호환성 유지
-
-- [ ] 스트림 청크 직렬화 포맷 정의 및 소유권 (SSOT)
-  - 백엔드 `Pydantic` 모델(`StreamChunk`)을 단일 진실 공급원(SSOT)으로 정의.
-  - FastAPI의 자동 OpenAPI 스키마 생성을 통해 프론트엔드 클라이언트에 구조를 노출.
-  - SSE 페이로드 JSON 스키마:
-    ```json
-    // 토큰 청크
-    { "type": "token", "data": "<토큰 문자열>" }
-    // 완료 신호
-    { "type": "done", "data": "" }
-    // 에러 신호
-    { "type": "error", "code": "<ErrorCode>", "message": "<마스킹된 메시지>" }
-    ```
-  - 에러 메시지는 PII 마스킹 정책(`mask_pii_id()`)을 동일하게 적용하여 민감 정보 외부 노출 방지
+- [ ] 스트리밍 이벤트 수신 방식 설계 결정
+  - LangChain 레거시 콜백 핸들러 방식과 LangGraph Native API 방식 중 구조가 명시적이고 상태 머신과의 결합도가 낮은 방식을 채택
+  - 호환성 버전 등은 환경 변수나 공통 상수로 외부화하여 하드코딩 금지
 
 #### 세부 작업 순서
 
@@ -75,19 +68,17 @@ Next.js 프론트엔드를 실시간 렌더링 UX로 전환하여
 
 ---
 
-### 3-2. FastAPI SSE 엔드포인트 구현
+### 3-2. 스트리밍 API 엔드포인트 구현
 
-- [ ] `backend/api/endpoints/chat_stream.py` 신설
-  - **엔드포인트**: `POST /api/chat/stream`
-    - 인증 필수: 기존 인증 미들웨어 재사용 (`hashed_user_id` 내부 전달, `user_id` 원문 로그 금지)
-    - 요청 바디: 기존 `/api/chat` 요청 스키마 재사용 (Pydantic 모델 공유)
+- [ ] 스트리밍 전용 API 라우터 신설 (예: `POST /api/chat/stream`)
+  - **인증 필수**: 기존 인증 미들웨어 재사용 (`hashed_user_id` 내부 전달, `user_id` 원문 로그 금지)
+  - **요청 바디**: 기존 비스트리밍 요청 스키마 공유
 
-  - **SSE 응답 구현**:
-    - `fastapi-sse` 또는 `sse-starlette` 라이브러리 활용한 `EventSourceResponse` 반환
-      - 라이브러리 선택 기준: `sse-starlette`(FastAPI 공식 생태계 친화적, 의존성 최소) 우선 채택
-      - 패키지명을 상수 또는 requirements 주석으로 명시하여 버전 고정(Pin) 관리
-    - `Content-Type: text/event-stream` 헤더 자동 설정
-    - `Cache-Control: no-cache`, `X-Accel-Buffering: no` 헤더 명시 (프록시 버퍼링 방지)
+  - **SSE(Server-Sent Events) 응답 표준 구현**:
+    - 생태계 친화적인 검증된 SSE 라이브러리를 채택하여 스트리밍 응답 반환
+    - 특정 라이브러리에 과도하게 종속되지 않도록 응답 생성 래퍼(Wrapper) 패턴 적용 권장
+    - `Content-Type: text/event-stream` 헤더 설정
+    - `Cache-Control: no-cache`, `X-Accel-Buffering: no` 헤더 명시 (리버스 프록시 버퍼링 방지)
 
   - **연결 수명 주기 관리**:
     - 클라이언트 연결 종료(Disconnect) 감지: `request.is_disconnected()` 폴링 또는 `asyncio.CancelledError` 감지
@@ -129,15 +120,14 @@ Next.js 프론트엔드를 실시간 렌더링 UX로 전환하여
 
 ---
 
-### 3-3. Next.js 프론트엔드 스트리밍 클라이언트 구현
+### 3-3. 프론트엔드 스트리밍 클라이언트 구현
 
-- [ ] `frontend/src/lib/stream-client.ts` 신설: SSE 클라이언트 유틸리티
-  - `fetch` API + `ReadableStream` 방식 채택 (IE 미지원 환경 한정, `EventSource` 대비 POST body 전송 가능)
-    - `EventSource` Web API는 GET 전용이므로 인증 토큰 및 바디 전달 불가 → `fetch` 스트리밍 방식 필수
-  - 백엔드 OpenAPI 스키마 기반 자동 타입 생성 (`openapi-typescript` 등 활용)으로 `StreamChunk` 인터페이스 동기화. 프론트엔드 수동 타입 정의(하드코딩) 절대 금지.
-  - 청크 수신 → UTF-8 디코딩 → SSE 포맷 파싱 → 자동 생성된 `StreamChunk` 타입 역직렬화 파이프라인 구현
-  - 스트림 연결 에러 및 서버 에러 이벤트(`type: "error"`) 수신 시 사용자 친화적 에러 메시지 표시 전략 수립
-  - 컴포넌트 언마운트 시 `AbortController`로 진행 중인 스트림 강제 종료 (메모리 누수 방지)
+- [ ] 스트리밍 클라이언트 유틸리티 구현
+  - POST 바디 전송 및 인증 헤더 처리를 위해 표준 `EventSource` 객체 대신 `fetch` API 기반의 `ReadableStream` 파싱 방식 채택
+  - **타입 동기화**: 3-0에서 정의된 OpenAPI 스키마를 기반으로 자동 생성된 `StreamChunk` 타입만 사용
+  - 파이프라인: 청크 수신 → 디코딩 → SSE 포맷 파싱 → `StreamChunk` (Token/Done/Error) 분기 처리
+  - 에러 처리: `ErrorChunk` 수신 시 내부 에러 코드를 마스킹된 사용자 친화적 에러 UI로 변환 표시
+  - 리소스 정리: 컴포넌트 언마운트 시 명시적인 스트림 중단(Abort) 처리로 메모리 누수 방지
 
 - [ ] `frontend/src/hooks/useStreamingChat.ts` 신설: React 커스텀 훅
   - 상태 관리:
@@ -205,15 +195,18 @@ Next.js 프론트엔드를 실시간 렌더링 UX로 전환하여
 
 ---
 
-### 3-5. [공통] 스트리밍 설정 검증 정책 (Streaming Configuration Validation)
+### 3-5. [공통] 스트리밍 설정 검증 및 단일 진실 공급원(SSOT) 정책
 
-- [ ] 스트리밍 관련 환경 변수에 대한 중앙 집중식 유효성 검사 구성
-  - `backend/core/config_validator.py`의 기존 `Subsystem` Enum에 `REALTIME_STREAMING` 항목 추가
+- [ ] 설정 변수의 중앙 집중식 SSOT 모듈 구축
+  - **SSOT(Single Source of Truth) 원칙**: 백엔드와 프론트엔드 간 타임아웃, 버퍼 사이즈 등 설정 파편화를 막기 위해 공유 설정 모듈(예: 백엔드의 중앙 Config 클래스)에 기본값과 클램핑(Clamping) 규칙을 단일 정의.
+  - 문서와 실제 코드 간의 괴리(Drift)를 방지하기 위해 개별 모듈 하드코딩 금지.
+
+- [ ] 스트리밍 관련 환경 변수에 대한 유효성 검사 구성
+  - 기존 전역 가용성 상태 레지스트리(Subsystem)에 스트리밍 모듈 추가
   - **장애 전파 범위 원칙** (Phase 2 정책과 동일하게 적용):
-    - 선택적 설정(`SSE_KEEPALIVE_INTERVAL_SECS`, `STREAM_BUFFER_MAX_SIZE`, `STREAM_TIMEOUT_SECS`) 파싱 오류 시:
-      - Silent Fallback 금지
-      - 스트리밍 서브시스템(`REALTIME_STREAMING`)만 비활성화하고 기존 비스트리밍 `/api/chat` 엔드포인트 생존성 유지 (Subsystem Hard Failure)
-      - HealthRegistry에 `DEGRADED` 상태 노출로 운영자 즉시 감지 가능
+    - 설정 파싱 오류 시 침묵적 폴백(Silent Fallback) 금지
+    - 전체 서비스 중단 대신 스트리밍 서브시스템만 비활성화하고, 기존 비스트리밍 엔드포인트 생존성 유지 (Subsystem Hard Failure)
+    - 헬스 체크 시스템에 `DEGRADED` 상태 노출로 운영 가시성 확보
 
   - **환경 변수 목록 및 검증 규칙**:
 


### PR DESCRIPTION
📝 docs [#12.2.16]: 2차 개선 - 아키텍처 설계와 구현 상세 분리 및 SSOT 정책 전면 도입 
📝 docs [#12.2.16]: 3차 개선 - 내부 도메인 SSOT(단일 진실 공급원)의 권위 있는 경로 명시화

## Summary by Sourcery

실시간 스트리밍 채팅 파이프라인의 아키텍처와 SSOT 정책을 문서화합니다. 여기에는 공유 스키마, 백엔드 어댑터, API 엔드포인트, 프론트엔드 클라이언트, 설정 검증이 포함됩니다.

Documentation:
- 백엔드와 프론트엔드 간 양방향 스트리밍을 위한 단일 진실 공급원(SSOT) 스키마로서 `StreamChunk`를 명확히 정의합니다.
- LangGraph 기반 스트리밍 어댑터와 이벤트 처리 전략의 설계를 다듬어, 타입이 지정된 `Token`/`Done`/`Error` 청크와 견고한 에러 전파에 초점을 맞춥니다.
- 특정 라이브러리에 종속되지 않도록 SSE 시맨틱, 인증, 응답 헤더를 중심으로 스트리밍 API 엔드포인트 설계를 일반화합니다.
- `fetch` 기반 SSE 처리, OpenAPI 기반 타입 생성, 사용자에게 노출되는 에러 처리 등을 포함하여 프론트엔드 스트리밍 클라이언트의 책임을 상세히 기술합니다.
- 스트리밍 서브시스템으로만 실패를 제한하고 구성 드리프트를 방지하기 위해, 중앙집중식 SSOT 기반 스트리밍 설정 및 검증 정책을 정의합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the architecture and SSOT policies for the realtime streaming chat pipeline, covering shared schemas, backend adapter, API endpoint, frontend client, and configuration validation.

Documentation:
- Clarify StreamChunk as the single source of truth schema for bidirectional streaming between backend and frontend.
- Refine the design of the LangGraph-based streaming adapter and event handling strategy to focus on typed Token/Done/Error chunks and robust error propagation.
- Generalize the streaming API endpoint design around SSE semantics, authentication, and response headers without binding to a specific library.
- Detail the frontend streaming client responsibilities, including fetch-based SSE handling, OpenAPI-driven type generation, and user-facing error handling.
- Define centralized SSOT-based streaming configuration and validation policies to prevent drift and limit failures to the streaming subsystem.

</details>