### PR TITLE
📝 docs [#12.2.16]: 4차 개선 - SSOT 섹션 중앙화 및 구체적 구현 파일 경로 확정

### DIFF
--- a/docs/P/v9.0/v9.3_realtime_streaming_tasks.md
+++ b/docs/P/v9.0/v9.3_realtime_streaming_tasks.md
@@ -34,9 +34,9 @@ Next.js 프론트엔드를 실시간 렌더링 UX로 전환하여
 
 ## 📋 세부 작업 (Tasks)
 
-### 3-0. [공통] StreamChunk 데이터 스키마 (SSOT)
+### 3-0. [공통] 아키텍처 단일 진실 공급원(SSOT) 정책
 
-- [ ] 양방향(Backend/Frontend) 타입 안정성을 보장하기 위한 단일 진실 공급원(SSOT) 스키마 정의
+- [ ] **데이터 스키마 SSOT (`StreamChunk`)**
   - **소유권**: 백엔드의 스키마 정의 모델 (`backend/schemas/streaming.py`의 `StreamChunk` Pydantic 모델)
   - **동기화**: 자동 생성된 OpenAPI 스키마를 통해 프론트엔드 타입 자동 생성. 프론트엔드 수동 타입 선언(하드코딩) 절대 금지.
   - **Variants (Discriminated Union)**:
@@ -44,9 +44,13 @@ Next.js 프론트엔드를 실시간 렌더링 UX로 전환하여
     - `DoneChunk`: `{ "type": "done", "data": "" }`
     - `ErrorChunk`: `{ "type": "error", "code": string, "message": string }` (메시지는 `mask_pii_id()` 적용 필수)
 
+- [ ] **설정 변수 SSOT (`StreamingConfig`)**
+  - **소유권**: 단일 정식 공유 설정 모듈 (`backend/core/config/streaming.py`의 `StreamingConfig` 클래스)
+  - **원칙**: 백엔드와 프론트엔드 간 설정 파편화 방지. 해당 모듈에만 타임아웃, 버퍼 사이즈 등의 기본값과 클램핑(Clamping) 규칙을 명시적으로 정의. 개별 모듈 내 분산 하드코딩 절대 금지.
+
 ### 3-1. LangGraph 에이전트 스트리밍 어댑터 구현
 
-- [ ] 스트리밍 전용 어댑터 레이어 신설 (예: `streaming.py`)
+- [ ] `backend/agent/streaming.py` 신설: 스트리밍 전용 어댑터 레이어
   - LangGraph 스트리밍 API 기반의 비동기 토큰 스트리밍 구현
     - 이벤트 타입 필터링: 모델 스트림 이벤트만 추출하여 `TokenChunk` 발행
     - 기타 이벤트는 내부 관측성 로그로만 기록
@@ -70,7 +74,7 @@ Next.js 프론트엔드를 실시간 렌더링 UX로 전환하여
 
 ### 3-2. 스트리밍 API 엔드포인트 구현
 
-- [ ] 스트리밍 전용 API 라우터 신설 (예: `POST /api/chat/stream`)
+- [ ] `backend/api/endpoints/chat_stream.py` 신설 (엔드포인트: `POST /api/chat/stream`)
   - **인증 필수**: 기존 인증 미들웨어 재사용 (`hashed_user_id` 내부 전달, `user_id` 원문 로그 금지)
   - **요청 바디**: 기존 비스트리밍 요청 스키마 공유
 
@@ -195,13 +199,9 @@ Next.js 프론트엔드를 실시간 렌더링 UX로 전환하여
 
 ---
 
-### 3-5. [공통] 스트리밍 설정 검증 및 단일 진실 공급원(SSOT) 정책
+### 3-5. [공통] 스트리밍 설정 검증 정책
 
-- [ ] 설정 변수의 중앙 집중식 SSOT 모듈 구축
-  - **SSOT(Single Source of Truth) 원칙**: 백엔드와 프론트엔드 간 타임아웃, 버퍼 사이즈 등 설정 파편화를 막기 위해 단일 정식 공유 설정 모듈(`backend/core/config/streaming.py`의 `StreamingConfig` 클래스)에 기본값과 클램핑(Clamping) 규칙을 명시적으로 정의.
-  - 문서와 실제 코드 간의 괴리(Drift) 및 경쟁하는 임시 설정 도입을 방지하기 위해 개별 모듈 내 분산 하드코딩 절대 금지.
-
-- [ ] 스트리밍 관련 환경 변수에 대한 유효성 검사 구성
+- [ ] 스트리밍 관련 환경 변수에 대한 유효성 검사 구성 (참조: 3-0 `StreamingConfig`)
   - 기존 전역 가용성 상태 레지스트리(Subsystem)에 스트리밍 모듈 추가
   - **장애 전파 범위 원칙** (Phase 2 정책과 동일하게 적용):
     - 설정 파싱 오류 시 침묵적 폴백(Silent Fallback) 금지


### PR DESCRIPTION
- **[구조 최적화] 3-0. 아키텍처 단일 진실 공급원(SSOT) 정책 중앙화**
  - 기존: `StreamChunk` 스키마는 3-0, `StreamingConfig` 설정은 3-5에 분산 기술되어 정책 가독성 저하.
  - 수정: 3-0 섹션을 '공통 SSOT 정책'으로 격상하여 데이터 스키마와 설정 변수의 소유권 및 동기화 원칙을 단일 섹션으로 병합 통합. 문서 파편화 및 중복 완전 해소.

- **[명확성] 예시(Examples) 제거 및 구체적 구현 경로(Concrete Paths) 확정**
  - 기존: '스트리밍 어댑터 신설 (예: streaming.py)'처럼 모호한 제안(Suggestion) 형태로 작성됨.
  - 수정: `backend/agent/streaming.py`, `backend/api/endpoints/chat_stream.py` 등 실제 구축할 정확한 파일 경로와 라우트를 확정 명시하여, 개발자가 고민 없이 즉시 개발에 착수할 수 있는 'Exact Implementation Guide'로 문서 격상.

- **[책임 분리] 3-5 섹션 순수 유효성 검사 집중**
  - 설정 관리 주체가 3-0으로 이관됨에 따라, 3-5 섹션은 순수하게 장애 전파 제어(Subsystem Hard Failure) 및 상태 레지스트리 검증 로직에만 집중하도록 리팩토링.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1334#pullrequestreview-4232814197)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

실시간 스트리밍 SSOT 정책을 중앙집중화하고, 스트리밍 아키텍처 문서에서 구체적인 구현 포인트를 명확히 합니다.

Documentation:
- SSOT 섹션을 상위로 올려 `StreamChunk` 데이터 스키마와 `StreamingConfig` 설정의 소유권 및 동기화 규칙을 한 곳에서 정의합니다.
- 예시 수준이었던 스트리밍 어댑터 및 채팅 스트리밍 API에 대해, 구체적인 백엔드 모듈 경로와 엔드포인트 라우트를 명시합니다.
- 스트리밍 설정 섹션의 초점을 환경 검증 및 장애 전파 정책으로 재조정하고, 설정 소유권은 통합된 SSOT 섹션으로 위임합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize real-time streaming SSOT policies and clarify concrete implementation points in the streaming architecture docs.

Documentation:
- Elevate the SSOT section to define both `StreamChunk` data schema and `StreamingConfig` settings ownership and synchronization rules in one place.
- Specify concrete backend module paths and endpoint routes for the streaming adapter and chat streaming API instead of illustrative examples.
- Refocus the streaming configuration section on environment validation and failure propagation policies, delegating configuration ownership to the unified SSOT section.

</details>