### PR TITLE
📝 docs [#12.2.16]: 5차 개선 - StreamingConfig 단일 책임 원칙 분리 및 경로 고정 규약 선언

### DIFF
--- a/docs/P/v9.0/v9.3_realtime_streaming_tasks.md
+++ b/docs/P/v9.0/v9.3_realtime_streaming_tasks.md
@@ -36,6 +36,8 @@ Next.js 프론트엔드를 실시간 렌더링 UX로 전환하여
 
 ### 3-0. [공통] 아키텍처 단일 진실 공급원(SSOT) 정책
 
+> 💡 **참고 (경로 고정 규약)**: 본 문서에 명시된 `backend/schemas/streaming.py`, `POST /api/chat/stream` 등의 경로는 Phase 3 구현을 위한 **고정 규약(Fixed Conventions)**입니다. 향후 리팩터링으로 계층이 변경되더라도, 이 섹션에 정의된 SSOT의 논리적 소유권과 책임 경계는 유지됩니다.
+
 - [ ] **데이터 스키마 SSOT (`StreamChunk`)**
   - **소유권**: 백엔드의 스키마 정의 모델 (`backend/schemas/streaming.py`의 `StreamChunk` Pydantic 모델)
   - **동기화**: 자동 생성된 OpenAPI 스키마를 통해 프론트엔드 타입 자동 생성. 프론트엔드 수동 타입 선언(하드코딩) 절대 금지.
@@ -44,9 +46,10 @@ Next.js 프론트엔드를 실시간 렌더링 UX로 전환하여
     - `DoneChunk`: `{ "type": "done", "data": "" }`
     - `ErrorChunk`: `{ "type": "error", "code": string, "message": string }` (메시지는 `mask_pii_id()` 적용 필수)
 
-- [ ] **설정 변수 SSOT (`StreamingConfig`)**
+- [ ] **설정 변수 SSOT (`StreamingConfig`) - 스키마 및 기본값 정의**
   - **소유권**: 단일 정식 공유 설정 모듈 (`backend/core/config/streaming.py`의 `StreamingConfig` 클래스)
-  - **원칙**: 백엔드와 프론트엔드 간 설정 파편화 방지. 해당 모듈에만 타임아웃, 버퍼 사이즈 등의 기본값과 클램핑(Clamping) 규칙을 명시적으로 정의. 개별 모듈 내 분산 하드코딩 절대 금지.
+  - **책임**: 타임아웃, 버퍼 사이즈 등의 환경 변수 모델링, 타입 캐스팅 규격 및 **기본값 정의**만 담당. (실제 환경 변수 로딩 및 범위 검증은 3-5의 중앙 Validator에 위임)
+  - **원칙**: 백엔드와 프론트엔드 간 설정 파편화 방지. 개별 모듈 내 분산 하드코딩 절대 금지.
 
 ### 3-1. LangGraph 에이전트 스트리밍 어댑터 구현
 
@@ -199,9 +202,10 @@ Next.js 프론트엔드를 실시간 렌더링 UX로 전환하여
 
 ---
 
-### 3-5. [공통] 스트리밍 설정 검증 정책
+### 3-5. [공통] 스트리밍 설정 로딩 및 검증 파이프라인 (Validation)
 
-- [ ] 스트리밍 관련 환경 변수에 대한 유효성 검사 구성 (참조: 3-0 `StreamingConfig`)
+- [ ] 스트리밍 관련 환경 변수 로딩 및 유효성 검사 (참조: 3-0 `StreamingConfig`)
+  - **책임**: 3-0에서 정의된 `StreamingConfig` 스키마를 바탕으로 실제 OS 환경 변수를 로드하고, 값의 바운더리 체크(Clamping) 및 유효성을 중앙에서 강제.
   - 기존 전역 가용성 상태 레지스트리(Subsystem)에 스트리밍 모듈 추가
   - **장애 전파 범위 원칙** (Phase 2 정책과 동일하게 적용):
     - 설정 파싱 오류 시 침묵적 폴백(Silent Fallback) 금지


### PR DESCRIPTION
- **[책임 분리] StreamingConfig의 스키마 정의와 검증(Validation) 파이프라인 명시적 분리**
  - 기존: 3-0과 3-5 섹션에서 설정 관리 책임이 혼재되어 구현 시 로직 스파게티화(Drift) 위험 존재.
  - 수정: 3-0 섹션은 순수하게 `StreamingConfig`의 '스키마 및 기본값 정의'만 담당하도록 제한하고, 실제 OS 환경 변수 로딩 및 바운더리 체크(Clamping)는 3-5의 '검증 파이프라인'으로 위임(Delegate)하여 단일 책임 원칙(SRP) 확립.

- **[문서 수명 연장] 파일 경로 고정 규약(Fixed Conventions) Disclaimer 추가**
  - 구체적으로 명시된 `backend/schemas/streaming.py` 등의 파일 경로가 향후 리팩터링 시 문서 드리프트를 유발하지 않도록, 해당 경로들이 Phase 3 초기 구현을 위한 `고정 규약`임을 선언. 물리적 계층이 변경되더라도 논리적 책임 경계(SSOT)는 변함없음을 문서 최상단에 보호 장치로 명시.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1336#pullrequestreview-4232827168)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

StreamingConfig의 단일 책임 범위를 명확히 하고, 실시간 스트리밍 태스크 아키텍처에 대한 고정 경로 규칙을 문서화합니다.

Documentation:
- 실시간 스트리밍을 위한 참조 백엔드 경로와 API 라우트가 Phase 3 동안 고정된 규칙(convention)임을 문서화하면서, SSOT(Single Source of Truth) 책임은 안정적으로 유지합니다.
- StreamingConfig 섹션을 스키마와 기본값 정의에 초점을 맞추도록 다듬고, 환경 로딩 및 검증은 별도의 파이프라인 섹션으로 위임합니다.
- StreamingConfig를 기반으로 하는 중앙 집중식 환경 로딩 및 검증 파이프라인을 설명하도록 스트리밍 설정 검증 섹션을 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the single-responsibility boundaries of StreamingConfig and document fixed path conventions for the realtime streaming task architecture.

Documentation:
- Document that referenced backend paths and API routes for realtime streaming are fixed conventions for Phase 3 while keeping SSOT responsibilities stable.
- Refine the StreamingConfig section to focus on schema and default value definition, delegating environment loading and validation to a separate pipeline section.
- Update the streaming settings validation section to describe a centralized environment loading and validation pipeline based on StreamingConfig.

</details>