### PR TITLE
📝 docs [#12.2.16]: 6차 개선 - 설정 검증(Validation) Fail-Fast 시점 명문화 및 경로 확정

### DIFF
--- a/docs/P/v9.0/v9.3_realtime_streaming_tasks.md
+++ b/docs/P/v9.0/v9.3_realtime_streaming_tasks.md
@@ -204,13 +204,14 @@ Next.js 프론트엔드를 실시간 렌더링 UX로 전환하여
 
 ### 3-5. [공통] 스트리밍 설정 로딩 및 검증 파이프라인 (Validation)
 
-- [ ] 스트리밍 관련 환경 변수 로딩 및 유효성 검사 (참조: 3-0 `StreamingConfig`)
+- [ ] 스트리밍 관련 환경 변수 로딩 및 유효성 검사 (`backend/core/config_validator.py` 활용)
   - **책임**: 3-0에서 정의된 `StreamingConfig` 스키마를 바탕으로 실제 OS 환경 변수를 로드하고, 값의 바운더리 체크(Clamping) 및 유효성을 중앙에서 강제.
   - 기존 전역 가용성 상태 레지스트리(Subsystem)에 스트리밍 모듈 추가
-  - **장애 전파 범위 원칙** (Phase 2 정책과 동일하게 적용):
-    - 설정 파싱 오류 시 침묵적 폴백(Silent Fallback) 금지
-    - 전체 서비스 중단 대신 스트리밍 서브시스템만 비활성화하고, 기존 비스트리밍 엔드포인트 생존성 유지 (Subsystem Hard Failure)
-    - 헬스 체크 시스템에 `DEGRADED` 상태 노출로 운영 가시성 확보
+  - **장애 전파 범위 원칙 및 발생 시점** (Phase 2 정책과 동일하게 적용):
+    - **검증 시점 (Fail-Fast)**: 유효성 검사는 사용자 요청 시점(Request-time)이 아닌, **애플리케이션 시작(Bootstrap/Startup) 시점**에 즉각 수행되어야 함.
+    - 설정 파싱 오류 시 침묵적 폴백(Silent Fallback) 금지.
+    - 단, 전체 백엔드 서버의 부팅(Startup)을 중단시키는 대신, 스트리밍 서브시스템(`REALTIME_STREAMING`)만 비활성화 상태로 처리하고 기존 비스트리밍 엔드포인트 생존성을 유지 (Subsystem Hard Failure).
+    - 헬스 체크 시스템에 부팅 즉시 `DEGRADED` 상태 노출로 운영 가시성 확보.
 
   - **환경 변수 목록 및 검증 규칙**:
 


### PR DESCRIPTION
- **[운영 안정성] 유효성 검증의 Fail-Fast 발생 시점 명시**
  - 기존: 'Subsystem Hard Failure'의 발생 시점(Startup vs Request-time)이 명시되지 않아, 런타임 중에 지연된 에러(Lazy Evaluation)가 발생할 위험이 있었음.
  - 수정: 3-5 섹션에 장애 발생 시점을 '애플리케이션 시작(Bootstrap/Startup) 시점'으로 명문화. 환경 변수 누락/파싱 오류 시 사용자가 API를 호출하기 전에 즉각적으로 스트리밍 서브시스템을 비활성화하고 `DEGRADED` 상태를 노출(Fail-fast)하도록 강제.

- **[책임 명확화] 검증 파이프라인의 SSOT 모듈 경로 고정**
  - 기존: 설정 정의(3-0)의 파일 경로는 확정되었으나 검증 로직의 위치가 모호했음.
  - 수정: 환경 변수 로딩 및 유효성 강제 파이프라인의 중심(SSOT)을 `backend/core/config_validator.py`로 고정 규약화하여 설계 문서의 완결성 달성.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1338#pullrequestreview-4232871053)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

운영 설계 문서에서 실시간 스트리밍 설정 검증과 관련된 fail-fast 시점과 책임 범위를 명확히 합니다.

Documentation:
- 스트리밍 환경 변수 로딩 및 검증을 위한 단일 신뢰 소스로 `backend/core/config_validator.py`를 사용하는 방법을 문서화합니다.
- 스트리밍 설정 검증이 애플리케이션 시작 시점에 실행되어야 한다는 점을 명시하고, 오류 발생 시 스트리밍 서브시스템만 비활성화하며, DEGRADED 상태의 헬스 상태를 노출하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the fail-fast timing and responsibility boundaries for realtime streaming configuration validation in the operations design docs.

Documentation:
- Document the use of backend/core/config_validator.py as the single source of truth for streaming environment variable loading and validation.
- Specify that streaming configuration validation must run at application startup to fail fast, disable only the streaming subsystem on errors, and expose a DEGRADED health state.

</details>