### PR TITLE
☘️ refactor [#12.2.18]: 2차 개선 - `ENV_* ClassVar` 전환 및 기본값 범위 선행 검증(Assertion) 추가

### DIFF
--- a/backend/core/config/streaming.py
+++ b/backend/core/config/streaming.py
@@ -194,32 +194,41 @@ class StreamingConfig:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 모듈 로드 시점 기본값 범위 전검 (Fail-fast 선행 조건 검사)
-# 기본값과 범위 상수가 독립적으로 변경될 때 조용한 버그를 즉각 감지함
+# 모듈 로드 시점 기본값 범위 전검 (항상 실행되는 명시적 예외 발생)
+#
+# [주의] `assert` 대신 `if ... raise ValueError` 패턴을 사용합니다.
+# Python을 `-O` (최적화) 플래그와 함께 실행하면 `assert`는 건너뛰게 되므로,
+# 프로덕션 환경에서도 반드시 검증이 수행되도록 명시적 예외 발생 방식을 채택합니다.
 # ─────────────────────────────────────────────────────────────────────────────
-assert (
-    _KEEPALIVE_INTERVAL_RANGE.min
-    <= _DEFAULT_KEEPALIVE_INTERVAL_SECS
-    <= _KEEPALIVE_INTERVAL_RANGE.max
-), (
-    f"DEFAULT_KEEPALIVE_INTERVAL_SECS={_DEFAULT_KEEPALIVE_INTERVAL_SECS} is outside "
-    f"KEEPALIVE_INTERVAL_RANGE=[{_KEEPALIVE_INTERVAL_RANGE.min}, {_KEEPALIVE_INTERVAL_RANGE.max}]"
+
+
+def _verify_default_in_range(name: str, default: int, range_: ConfigRange) -> None:
+    """
+    기본값이 ConfigRange 내에 있는지 검증한다.
+    범위를 벗어나면 ValueError를 발생시킨다.
+    `-O` 플래그 환경에서도 항상 실행되도록 assert 대신 명시적 예외를 사용한다.
+    """
+    if not (range_.min <= default <= range_.max):
+        raise ValueError(
+            f"[CONFIG INVARIANT] {name}={default} is outside "
+            f"safe range [{range_.min}, {range_.max}]. "
+            f"Update the default or the range to maintain consistency."
+        )
+
+
+# (변수명, 기본값, 유효 범위) 순서로 검증 목록을 정의 — 항목 추가 시 이 목록만 수정
+_INT_DEFAULT_CHECKS: tuple[tuple[str, int, ConfigRange], ...] = (
+    ("DEFAULT_KEEPALIVE_INTERVAL_SECS", _DEFAULT_KEEPALIVE_INTERVAL_SECS, _KEEPALIVE_INTERVAL_RANGE),
+    ("DEFAULT_BUFFER_MAX_SIZE", _DEFAULT_BUFFER_MAX_SIZE, _BUFFER_MAX_SIZE_RANGE),
+    ("DEFAULT_TIMEOUT_SECS", _DEFAULT_TIMEOUT_SECS, _TIMEOUT_RANGE),
 )
-assert (
-    _BUFFER_MAX_SIZE_RANGE.min
-    <= _DEFAULT_BUFFER_MAX_SIZE
-    <= _BUFFER_MAX_SIZE_RANGE.max
-), (
-    f"DEFAULT_BUFFER_MAX_SIZE={_DEFAULT_BUFFER_MAX_SIZE} is outside "
-    f"BUFFER_MAX_SIZE_RANGE=[{_BUFFER_MAX_SIZE_RANGE.min}, {_BUFFER_MAX_SIZE_RANGE.max}]"
-)
-assert (
-    _TIMEOUT_RANGE.min <= _DEFAULT_TIMEOUT_SECS <= _TIMEOUT_RANGE.max
-), (
-    f"DEFAULT_TIMEOUT_SECS={_DEFAULT_TIMEOUT_SECS} is outside "
-    f"TIMEOUT_RANGE=[{_TIMEOUT_RANGE.min}, {_TIMEOUT_RANGE.max}]"
-)
-assert _DEFAULT_STREAM_VERSION in _VALID_STREAM_VERSIONS, (
-    f"DEFAULT_STREAM_VERSION={_DEFAULT_STREAM_VERSION!r} is not in "
-    f"VALID_STREAM_VERSIONS={_VALID_STREAM_VERSIONS}"
-)
+
+for _name, _default, _range in _INT_DEFAULT_CHECKS:
+    _verify_default_in_range(_name, _default, _range)
+
+# 문자열 열거형 기본값 검증 (별도 처리)
+if _DEFAULT_STREAM_VERSION not in _VALID_STREAM_VERSIONS:
+    raise ValueError(
+        f"[CONFIG INVARIANT] DEFAULT_STREAM_VERSION={_DEFAULT_STREAM_VERSION!r} "
+        f"is not in VALID_STREAM_VERSIONS={_VALID_STREAM_VERSIONS}."
+    )

--- a/backend/core/config/streaming.py
+++ b/backend/core/config/streaming.py
@@ -21,6 +21,7 @@ StreamingConfig — Phase 3 (Realtime Streaming) 설정 스키마 및 기본값 
 import os
 import logging
 from dataclasses import dataclass, field
+from typing import ClassVar
 
 from backend.config import ConfigRange, _clamp
 
@@ -155,19 +156,11 @@ class StreamingConfig:
         default_factory=lambda: _DEFAULT_STREAM_VERSION
     )
 
-    # ── 스키마/범위 상수 노출 (외부 참조용 — 변경 금지) ──────────────────
-    ENV_KEEPALIVE_INTERVAL: str = field(
-        default=_ENV_KEEPALIVE_INTERVAL, init=False, repr=False, compare=False
-    )
-    ENV_BUFFER_MAX_SIZE: str = field(
-        default=_ENV_BUFFER_MAX_SIZE, init=False, repr=False, compare=False
-    )
-    ENV_TIMEOUT: str = field(
-        default=_ENV_TIMEOUT, init=False, repr=False, compare=False
-    )
-    ENV_STREAM_VERSION: str = field(
-        default=_ENV_STREAM_VERSION, init=False, repr=False, compare=False
-    )
+    # ── 스키마/범위 상수 노출 (외부 참조용 — ClassVar로 선언하여 인스턴스 필드에서 완전 제외) ────
+    ENV_KEEPALIVE_INTERVAL: ClassVar[str] = _ENV_KEEPALIVE_INTERVAL
+    ENV_BUFFER_MAX_SIZE: ClassVar[str] = _ENV_BUFFER_MAX_SIZE
+    ENV_TIMEOUT: ClassVar[str] = _ENV_TIMEOUT
+    ENV_STREAM_VERSION: ClassVar[str] = _ENV_STREAM_VERSION
 
     @classmethod
     def load(cls) -> "StreamingConfig":
@@ -198,3 +191,35 @@ class StreamingConfig:
                 valid_values=_VALID_STREAM_VERSIONS,
             ),
         )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 모듈 로드 시점 기본값 범위 전검 (Fail-fast 선행 조건 검사)
+# 기본값과 범위 상수가 독립적으로 변경될 때 조용한 버그를 즉각 감지함
+# ─────────────────────────────────────────────────────────────────────────────
+assert (
+    _KEEPALIVE_INTERVAL_RANGE.min
+    <= _DEFAULT_KEEPALIVE_INTERVAL_SECS
+    <= _KEEPALIVE_INTERVAL_RANGE.max
+), (
+    f"DEFAULT_KEEPALIVE_INTERVAL_SECS={_DEFAULT_KEEPALIVE_INTERVAL_SECS} is outside "
+    f"KEEPALIVE_INTERVAL_RANGE=[{_KEEPALIVE_INTERVAL_RANGE.min}, {_KEEPALIVE_INTERVAL_RANGE.max}]"
+)
+assert (
+    _BUFFER_MAX_SIZE_RANGE.min
+    <= _DEFAULT_BUFFER_MAX_SIZE
+    <= _BUFFER_MAX_SIZE_RANGE.max
+), (
+    f"DEFAULT_BUFFER_MAX_SIZE={_DEFAULT_BUFFER_MAX_SIZE} is outside "
+    f"BUFFER_MAX_SIZE_RANGE=[{_BUFFER_MAX_SIZE_RANGE.min}, {_BUFFER_MAX_SIZE_RANGE.max}]"
+)
+assert (
+    _TIMEOUT_RANGE.min <= _DEFAULT_TIMEOUT_SECS <= _TIMEOUT_RANGE.max
+), (
+    f"DEFAULT_TIMEOUT_SECS={_DEFAULT_TIMEOUT_SECS} is outside "
+    f"TIMEOUT_RANGE=[{_TIMEOUT_RANGE.min}, {_TIMEOUT_RANGE.max}]"
+)
+assert _DEFAULT_STREAM_VERSION in _VALID_STREAM_VERSIONS, (
+    f"DEFAULT_STREAM_VERSION={_DEFAULT_STREAM_VERSION!r} is not in "
+    f"VALID_STREAM_VERSIONS={_VALID_STREAM_VERSIONS}"
+)


### PR DESCRIPTION
- **[타입 안전성] `ENV_* 상수`를 `ClassVar[str]`로 전환 (per-instance 필드 제거)**
  - 기존: `ENV_*` 속성을 `field(init=False, repr=False, compare=False)`로 선언하여 인스턴스마다 불필요한 메모리를 할당하고 `dataclasses.fields()` 등에 노출.
  - 수정: `ClassVar[str]`로 선언하여 `dataclass` 생성 메서드(`__init__`, `__repr__`, `__eq__`)에서 완전히 제외. 클래스 레벨 접근(`StreamingConfig.ENV_KEEPALIVE_INTERVAL`)은 그대로 유지됨.

- **[안정성] 모듈 로드 시점 기본값 범위 선행 검증 Assertion 추가**
  - 기존: `_load_int`는 환경변수가 있을 때만 Clamping을 수행하여, 기본값 자체가 범위를 벗어나는 경우를 감지하지 못함.
  - 수정: 모듈 로드 시점에 모든 기본값이 대응하는 `ConfigRange` 내에 있는지 `assert`로 검증. 기본값 또는 범위를 독립적으로 수정할 때 발생하는 조용한 버그를 즉각 `AssertionError`로 노출.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1344#pullrequestreview-4241046837)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

스트리밍 구성 상수를 클래스 레벨로 리팩터링하고, 모듈 로드 시점에 기본값이 설정된 범위에 맞는지 즉시(fail-fast) 검증하도록 추가했습니다.

Enhancements:
- 인스턴스별 dataclass 필드 대신 `ClassVar` 상수로 스트리밍 `ENV_*` 식별자를 노출하여 인스턴스 메모리 사용량을 줄이고, 이 필드들이 자동 생성 메서드에 포함되지 않도록 했습니다.
- 모듈 로드 시점에 어설션을 도입하여 스트리밍 기본값이 해당 설정 범위 내에 유지되는지 보장함으로써, 잘못 구성된 기본값을 조기에 발견할 수 있도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor streaming configuration constants to be class-level and add fail-fast validation of default values against their configured ranges at module load time.

Enhancements:
- Expose streaming ENV_* identifiers as ClassVar constants instead of per-instance dataclass fields to reduce instance footprint and keep them out of generated methods.
- Introduce module-load assertions to ensure streaming defaults remain within their corresponding config ranges, catching misconfigured defaults early.

</details>