### PR TITLE
✨ feat [#12.2.19]: Phase 3.5 - ➀ 스트리밍 설정 로딩 및 검증 파이프라인 구현 (공통 아키텍처)

### DIFF
--- a/backend/core/config/streaming.py
+++ b/backend/core/config/streaming.py
@@ -186,28 +186,38 @@ class StreamingConfig:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 모듈 로드 시점 기본값 범위 전검 (Fail-fast 선행 조건 검사)
-# 기본값과 범위 상수가 독립적으로 변경될 때 조용한 버그를 즉각 감지함
+# 모듈 로드 시점 기본값 범위 점검 (Fail-fast 선행 조건 검사)
+# assert 대신 명시적 예외를 사용하여 Python -O 모드에서도 검증 수행 보장
 # ─────────────────────────────────────────────────────────────────────────────
-assert (
-    _KEEPALIVE_INTERVAL_RANGE.min
-    <= _DEFAULT_KEEPALIVE_INTERVAL_SECS
-    <= _KEEPALIVE_INTERVAL_RANGE.max
-), (
-    f"DEFAULT_KEEPALIVE_INTERVAL_SECS={_DEFAULT_KEEPALIVE_INTERVAL_SECS} is outside "
-    f"KEEPALIVE_INTERVAL_RANGE=[{_KEEPALIVE_INTERVAL_RANGE.min}, {_KEEPALIVE_INTERVAL_RANGE.max}]"
+
+
+def _ensure_default_in_range(name: str, val: int, r: ConfigRange) -> None:
+    """기본값이 정의된 안전 범위 내에 있는지 강제한다 (Production-safe)."""
+    if not (r.min <= val <= r.max):
+        raise RuntimeError(
+            f"[STREAM][CONFIG][INVARIANT ERROR] Default {name}={val} is outside "
+            f"allowed range [{r.min}, {r.max}]. Check streaming.py constants."
+        )
+
+
+def _ensure_default_in_list(name: str, val: str, allowed: tuple[str, ...]) -> None:
+    """기본값이 허용된 목록에 있는지 강제한다 (Production-safe)."""
+    if val not in allowed:
+        raise RuntimeError(
+            f"[STREAM][CONFIG][INVARIANT ERROR] Default {name}={val!r} is not in "
+            f"allowed list {allowed}. Check streaming.py constants."
+        )
+
+
+# 기본값 정적 정합성 검사 실행
+# (assert 대신 명시적 예외를 사용하여 Python -O 모드에서도 검증 수행 보장)
+_ensure_default_in_range(
+    "KEEPALIVE_INTERVAL", _DEFAULT_KEEPALIVE_INTERVAL_SECS, _KEEPALIVE_INTERVAL_RANGE
 )
-assert (
-    _BUFFER_MAX_SIZE_RANGE.min <= _DEFAULT_BUFFER_MAX_SIZE <= _BUFFER_MAX_SIZE_RANGE.max
-), (
-    f"DEFAULT_BUFFER_MAX_SIZE={_DEFAULT_BUFFER_MAX_SIZE} is outside "
-    f"BUFFER_MAX_SIZE_RANGE=[{_BUFFER_MAX_SIZE_RANGE.min}, {_BUFFER_MAX_SIZE_RANGE.max}]"
+_ensure_default_in_range(
+    "BUFFER_MAX_SIZE", _DEFAULT_BUFFER_MAX_SIZE, _BUFFER_MAX_SIZE_RANGE
 )
-assert _TIMEOUT_RANGE.min <= _DEFAULT_TIMEOUT_SECS <= _TIMEOUT_RANGE.max, (
-    f"DEFAULT_TIMEOUT_SECS={_DEFAULT_TIMEOUT_SECS} is outside "
-    f"TIMEOUT_RANGE=[{_TIMEOUT_RANGE.min}, {_TIMEOUT_RANGE.max}]"
-)
-assert _DEFAULT_STREAM_VERSION in _VALID_STREAM_VERSIONS, (
-    f"DEFAULT_STREAM_VERSION={_DEFAULT_STREAM_VERSION!r} is not in "
-    f"VALID_STREAM_VERSIONS={_VALID_STREAM_VERSIONS}"
+_ensure_default_in_range("TIMEOUT", _DEFAULT_TIMEOUT_SECS, _TIMEOUT_RANGE)
+_ensure_default_in_list(
+    "STREAM_VERSION", _DEFAULT_STREAM_VERSION, _VALID_STREAM_VERSIONS
 )

--- a/backend/core/config/streaming.py
+++ b/backend/core/config/streaming.py
@@ -95,9 +95,7 @@ def _load_int(key: str, default: int, range_: ConfigRange) -> int:
     return clamped
 
 
-def _load_str_enum(
-    key: str, default: str, valid_values: tuple[str, ...]
-) -> str:
+def _load_str_enum(key: str, default: str, valid_values: tuple[str, ...]) -> str:
     """
     문자열 열거형 환경 변수를 로드한다.
     환경 변수가 설정되지 않은 경우 default를 그대로 반환하여,
@@ -146,15 +144,9 @@ class StreamingConfig:
     keepalive_interval_secs: int = field(
         default_factory=lambda: _DEFAULT_KEEPALIVE_INTERVAL_SECS
     )
-    buffer_max_size: int = field(
-        default_factory=lambda: _DEFAULT_BUFFER_MAX_SIZE
-    )
-    timeout_secs: int = field(
-        default_factory=lambda: _DEFAULT_TIMEOUT_SECS
-    )
-    stream_version: str = field(
-        default_factory=lambda: _DEFAULT_STREAM_VERSION
-    )
+    buffer_max_size: int = field(default_factory=lambda: _DEFAULT_BUFFER_MAX_SIZE)
+    timeout_secs: int = field(default_factory=lambda: _DEFAULT_TIMEOUT_SECS)
+    stream_version: str = field(default_factory=lambda: _DEFAULT_STREAM_VERSION)
 
     # ── 스키마/범위 상수 노출 (외부 참조용 — ClassVar로 선언하여 인스턴스 필드에서 완전 제외) ────
     ENV_KEEPALIVE_INTERVAL: ClassVar[str] = _ENV_KEEPALIVE_INTERVAL
@@ -194,41 +186,28 @@ class StreamingConfig:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 모듈 로드 시점 기본값 범위 전검 (항상 실행되는 명시적 예외 발생)
-#
-# [주의] `assert` 대신 `if ... raise ValueError` 패턴을 사용합니다.
-# Python을 `-O` (최적화) 플래그와 함께 실행하면 `assert`는 건너뛰게 되므로,
-# 프로덕션 환경에서도 반드시 검증이 수행되도록 명시적 예외 발생 방식을 채택합니다.
+# 모듈 로드 시점 기본값 범위 전검 (Fail-fast 선행 조건 검사)
+# 기본값과 범위 상수가 독립적으로 변경될 때 조용한 버그를 즉각 감지함
 # ─────────────────────────────────────────────────────────────────────────────
-
-
-def _verify_default_in_range(name: str, default: int, range_: ConfigRange) -> None:
-    """
-    기본값이 ConfigRange 내에 있는지 검증한다.
-    범위를 벗어나면 ValueError를 발생시킨다.
-    `-O` 플래그 환경에서도 항상 실행되도록 assert 대신 명시적 예외를 사용한다.
-    """
-    if not (range_.min <= default <= range_.max):
-        raise ValueError(
-            f"[CONFIG INVARIANT] {name}={default} is outside "
-            f"safe range [{range_.min}, {range_.max}]. "
-            f"Update the default or the range to maintain consistency."
-        )
-
-
-# (변수명, 기본값, 유효 범위) 순서로 검증 목록을 정의 — 항목 추가 시 이 목록만 수정
-_INT_DEFAULT_CHECKS: tuple[tuple[str, int, ConfigRange], ...] = (
-    ("DEFAULT_KEEPALIVE_INTERVAL_SECS", _DEFAULT_KEEPALIVE_INTERVAL_SECS, _KEEPALIVE_INTERVAL_RANGE),
-    ("DEFAULT_BUFFER_MAX_SIZE", _DEFAULT_BUFFER_MAX_SIZE, _BUFFER_MAX_SIZE_RANGE),
-    ("DEFAULT_TIMEOUT_SECS", _DEFAULT_TIMEOUT_SECS, _TIMEOUT_RANGE),
+assert (
+    _KEEPALIVE_INTERVAL_RANGE.min
+    <= _DEFAULT_KEEPALIVE_INTERVAL_SECS
+    <= _KEEPALIVE_INTERVAL_RANGE.max
+), (
+    f"DEFAULT_KEEPALIVE_INTERVAL_SECS={_DEFAULT_KEEPALIVE_INTERVAL_SECS} is outside "
+    f"KEEPALIVE_INTERVAL_RANGE=[{_KEEPALIVE_INTERVAL_RANGE.min}, {_KEEPALIVE_INTERVAL_RANGE.max}]"
 )
-
-for _name, _default, _range in _INT_DEFAULT_CHECKS:
-    _verify_default_in_range(_name, _default, _range)
-
-# 문자열 열거형 기본값 검증 (별도 처리)
-if _DEFAULT_STREAM_VERSION not in _VALID_STREAM_VERSIONS:
-    raise ValueError(
-        f"[CONFIG INVARIANT] DEFAULT_STREAM_VERSION={_DEFAULT_STREAM_VERSION!r} "
-        f"is not in VALID_STREAM_VERSIONS={_VALID_STREAM_VERSIONS}."
-    )
+assert (
+    _BUFFER_MAX_SIZE_RANGE.min <= _DEFAULT_BUFFER_MAX_SIZE <= _BUFFER_MAX_SIZE_RANGE.max
+), (
+    f"DEFAULT_BUFFER_MAX_SIZE={_DEFAULT_BUFFER_MAX_SIZE} is outside "
+    f"BUFFER_MAX_SIZE_RANGE=[{_BUFFER_MAX_SIZE_RANGE.min}, {_BUFFER_MAX_SIZE_RANGE.max}]"
+)
+assert _TIMEOUT_RANGE.min <= _DEFAULT_TIMEOUT_SECS <= _TIMEOUT_RANGE.max, (
+    f"DEFAULT_TIMEOUT_SECS={_DEFAULT_TIMEOUT_SECS} is outside "
+    f"TIMEOUT_RANGE=[{_TIMEOUT_RANGE.min}, {_TIMEOUT_RANGE.max}]"
+)
+assert _DEFAULT_STREAM_VERSION in _VALID_STREAM_VERSIONS, (
+    f"DEFAULT_STREAM_VERSION={_DEFAULT_STREAM_VERSION!r} is not in "
+    f"VALID_STREAM_VERSIONS={_VALID_STREAM_VERSIONS}"
+)

--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -526,7 +526,6 @@ class RealtimeStreamingConfig:
         """
         # StreamingConfig 스키마에서 정의된 상수를 참조 (하드코딩 금지)
         from backend.core.config.streaming import (
-            StreamingConfig,
             _DEFAULT_KEEPALIVE_INTERVAL_SECS,
             _DEFAULT_BUFFER_MAX_SIZE,
             _DEFAULT_TIMEOUT_SECS,

--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -1,8 +1,8 @@
 # backend/core/config_validator.py
 
 """
-Global Configuration Validation Policy — v9.0 Phase 2 (Personalized RAG)
-=========================================================================
+Global Configuration Validation Policy — v9.0 Phase 2 (Personalized RAG) / Phase 3 (Realtime Streaming)
+=========================================================================================================
 
 장애 전파 범위(Blast Radius) 정책:
 
@@ -11,7 +11,8 @@ Global Configuration Validation Policy — v9.0 Phase 2 (Personalized RAG)
     → 보안 오염 방지를 위해 SystemExit(1)으로 전체 애플리케이션 기동 즉시 중단.
 
   [Subsystem Hard Failure]
-    선택적 부가 설정(FAISS_COMPACTION_*, TOPIC_CLUSTER_CACHE_TTL 등) 파싱 오류 시
+    선택적 부가 설정(FAISS_COMPACTION_*, TOPIC_CLUSTER_CACHE_TTL,
+    SSE_KEEPALIVE_INTERVAL_SECS 등) 파싱 오류 시
     → Silent Fallback 금지. 해당 서브시스템만 비활성화하고 핵심 REST API는 유지.
     → HealthRegistry를 통해 DEGRADED 상태를 노출하여 상태 은폐 방지.
 
@@ -49,6 +50,7 @@ class Subsystem(str, Enum):
     TOPIC_CLUSTERING = "topic_clustering"
     HYBRID_SEARCH = "hybrid_search"
     PERSONALIZED_INDEX = "personalized_index"
+    REALTIME_STREAMING = "realtime_streaming"  # Phase 3: 실시간 스트리밍 서브시스템
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -462,5 +464,146 @@ class PersonalizedRAGConfig:
             personalized_index_weight=p_weight,
             global_index_weight=g_weight,
             aws_wrapper_max_workers=aws_workers,
+            subsystem_ok=subsystem_ok,
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 3 스트리밍 설정 검증 클래스
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class RealtimeStreamingConfig:
+    """
+    v9.0 Phase 3 Realtime Streaming 전용 검증 설정 클래스.
+
+    사용법:
+        cfg = RealtimeStreamingConfig.from_env()  # bootstrap 단계에서 1회 호출
+
+    책임 (3-0/3-5 SSOT 정책 준수):
+        - StreamingConfig(backend/core/config/streaming.py)에서 정의된
+          스키마와 기본값을 바탕으로 OS 환경 변수를 로드한다.
+        - 바운더리 체크(Clamping) 및 유효성 검증을 중앙에서 강제한다.
+        - 파싱 오류 시 REALTIME_STREAMING 서브시스템만 DEGRADED 처리하고
+          기존 비스트리밍 엔드포인트 생존성을 유지한다 (Subsystem Hard Failure).
+
+    검증 시점 (Fail-Fast):
+        사용자 요청 시점(Request-time)이 아닌 애플리케이션 시작(Bootstrap/Startup)
+        시점에 즉각 수행되어야 한다.
+
+    선택적 환경 변수 (파싱 오류 시 해당 서브시스템만 비활성화):
+        SSE_KEEPALIVE_INTERVAL_SECS  (int, 기본: 15, 범위: 5~60)
+        STREAM_BUFFER_MAX_SIZE       (int, 기본: 100, 범위: 10~1000)
+        STREAM_TIMEOUT_SECS          (int, 기본: 120, 범위: 30~600)
+        LANGGRAPH_STREAM_VERSION     (str, 기본: "v2", 허용: "v1"/"v2")
+
+    보안 원칙:
+        민감 정보(사용자 ID, 토큰 등)는 절대 로그에 기록하지 않는다.
+    """
+
+    def __init__(
+        self,
+        *,
+        keepalive_interval_secs: int,
+        buffer_max_size: int,
+        timeout_secs: int,
+        stream_version: str,
+        subsystem_ok: Dict[str, bool],
+    ) -> None:
+        self.keepalive_interval_secs = keepalive_interval_secs
+        self.buffer_max_size = buffer_max_size
+        self.timeout_secs = timeout_secs
+        self.stream_version = stream_version
+        # 서브시스템 가동 여부 맵 (True=활성, False=비활성)
+        self.subsystem_ok: Dict[str, bool] = subsystem_ok
+
+    @classmethod
+    def from_env(cls) -> "RealtimeStreamingConfig":
+        """
+        환경 변수에서 스트리밍 설정을 파싱하여 RealtimeStreamingConfig 인스턴스를 반환한다.
+        파싱 오류 시 REALTIME_STREAMING 서브시스템 비활성화 — Subsystem Hard Failure.
+        전체 서버 부팅을 중단하지 않으며 기존 비스트리밍 API는 정상 유지된다.
+        """
+        # StreamingConfig 스키마에서 정의된 상수를 참조 (하드코딩 금지)
+        from backend.core.config.streaming import (
+            StreamingConfig,
+            _DEFAULT_KEEPALIVE_INTERVAL_SECS,
+            _DEFAULT_BUFFER_MAX_SIZE,
+            _DEFAULT_TIMEOUT_SECS,
+            _DEFAULT_STREAM_VERSION,
+            _KEEPALIVE_INTERVAL_RANGE,
+            _BUFFER_MAX_SIZE_RANGE,
+            _TIMEOUT_RANGE,
+            _VALID_STREAM_VERSIONS,
+            _ENV_KEEPALIVE_INTERVAL,
+            _ENV_BUFFER_MAX_SIZE,
+            _ENV_TIMEOUT,
+            _ENV_STREAM_VERSION,
+        )
+
+        subsystem_ok: Dict[str, bool] = {}
+
+        # ── 서브시스템 설정 (Subsystem Hard Failure) ──────────────────────
+        keepalive, ok_ka = _parse_int_subsystem(
+            _ENV_KEEPALIVE_INTERVAL,
+            default=_DEFAULT_KEEPALIVE_INTERVAL_SECS,
+            range_=_KEEPALIVE_INTERVAL_RANGE,
+            subsystem=Subsystem.REALTIME_STREAMING,
+        )
+        buffer_size, ok_buf = _parse_int_subsystem(
+            _ENV_BUFFER_MAX_SIZE,
+            default=_DEFAULT_BUFFER_MAX_SIZE,
+            range_=_BUFFER_MAX_SIZE_RANGE,
+            subsystem=Subsystem.REALTIME_STREAMING,
+        )
+        timeout, ok_to = _parse_int_subsystem(
+            _ENV_TIMEOUT,
+            default=_DEFAULT_TIMEOUT_SECS,
+            range_=_TIMEOUT_RANGE,
+            subsystem=Subsystem.REALTIME_STREAMING,
+        )
+
+        # 문자열 열거형 검증 (허용 버전 이외 값 → 기본값 폴백)
+        # ENV key 존재 여부를 먼저 확인하여 기본값에 불필요한 .strip() 방지
+        if _ENV_STREAM_VERSION in os.environ:
+            raw_version = os.environ[_ENV_STREAM_VERSION].strip()
+        else:
+            raw_version = _DEFAULT_STREAM_VERSION
+
+        if raw_version not in _VALID_STREAM_VERSIONS:
+            logger.error(
+                "[CONFIG][SUBSYSTEM HARD FAILURE][%s] '%s'=%r is not a valid version. "
+                "Allowed: %s. Subsystem disabled. Core REST API remains operational.",
+                Subsystem.REALTIME_STREAMING.value,
+                _ENV_STREAM_VERSION,
+                raw_version,
+                _VALID_STREAM_VERSIONS,
+            )
+            stream_version = _DEFAULT_STREAM_VERSION
+            ok_ver = False
+        else:
+            stream_version = raw_version
+            ok_ver = True
+
+
+        # 하나라도 실패하면 REALTIME_STREAMING 서브시스템 비활성화
+        subsystem_ok[Subsystem.REALTIME_STREAMING.value] = (
+            ok_ka and ok_buf and ok_to and ok_ver
+        )
+
+        # ── 비활성화된 서브시스템 운영 가시성 로깅 ────────────────────────
+        for sub, ok in subsystem_ok.items():
+            if not ok:
+                logger.error(
+                    "[CONFIG][SUBSYSTEM DISABLED] '%s' subsystem is DISABLED due to "
+                    "invalid configuration. Register via HealthRegistry for /health exposure.",
+                    sub,
+                )
+
+        return cls(
+            keepalive_interval_secs=keepalive,
+            buffer_max_size=buffer_size,
+            timeout_secs=timeout,
+            stream_version=stream_version,
             subsystem_ok=subsystem_ok,
         )


### PR DESCRIPTION
- **[검증 파이프라인] RealtimeStreamingConfig.from_env() 신설**
  - `backend/core/config_validator.py`에 Phase 3 전용 검증 클래스 `RealtimeStreamingConfig` 추가.
  - 3-0에서 정의된 `StreamingConfig` 스키마의 모듈 레벨 상수(`_DEFAULT_*`, `_ENV_*`, `_RANGE_*`)를 직접 임포트하여 참조. 하드코딩 원천 차단.

- **[Subsystem 등록] Subsystem.REALTIME_STREAMING 추가**
  - `Subsystem` Enum에 `REALTIME_STREAMING = "realtime_streaming"` 추가.
  - 파싱 오류 시 해당 서브시스템만 `DEGRADED` 처리하고, 기존 비스트리밍 엔드포인트 생존성을 유지 (Subsystem Hard Failure 정책 준수).

- **[Fail-Fast 원칙 준수] Startup 시점 검증 강제**
  - 사용자 요청(Request-time)이 아닌 애플리케이션 부팅(Bootstrap) 단계에서 `from_env()`를 1회 호출하여 즉각 오류 노출.
  - 헬스 체크 시스템에 `DEGRADED` 상태를 부팅 즉시 노출하여 운영 가시성 확보.

- **[보안] ENV 키 존재 여부 선확인 패턴 적용**
  - `LANGGRAPH_STREAM_VERSION` 읽기 시 기본값에 `.strip()`이 적용되지 않도록 두 단계 읽기 패턴(`key in os.environ`) 적용.

🔗 Related: Issue [#1047]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

실시간 스트리밍 설정에 대한 중앙 집중식 검증 파이프라인과 서브시스템 연결을 도입하여, 잘못된 설정 시 빠르게 실패(fail-fast)하는 시작 시점 검사와 격리된 성능 저하 처리(isolated degradation)를 보장합니다.

New Features:
- 애플리케이션 부트스트랩 시 환경 변수를 통해 실시간 스트리밍 설정을 로드 및 검증하기 위해 `RealtimeStreamingConfig`를 추가합니다.
- 스트리밍에 대한 격리된 상태(health) 및 성능 저하(degradation) 처리를 가능하게 하기 위해 `REALTIME_STREAMING`을 새로운 Subsystem으로 등록합니다.

Enhancements:
- 글로벌 설정 검증 정책(global configuration validation policy)에 Phase 3 실시간 스트리밍 범위를 문서화하고, 선택적 서브시스템 설정(optional subsystem settings)에 `SSE_KEEPALIVE_INTERVAL_SECS`를 포함합니다.
- 문자열 정규화(string normalization)를 적용하기 전에 환경 변수 키 존재 여부를 확인하여 `LANGGRAPH_STREAM_VERSION` 로딩에 대한 보안을 강화합니다.
- `StreamingConfig` 기본값을 단순화하고, 불변 조건(invariant) 검사를 모듈 수준 assertion으로 전환하여 잘못된 기본값/범위 조합을 시작 시점에 빠르게 감지(fail-fast)합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a centralized validation pipeline and subsystem wiring for realtime streaming configuration, ensuring fail-fast startup checks and isolated degradation on misconfiguration.

New Features:
- Add RealtimeStreamingConfig to load and validate realtime streaming settings from environment variables at application bootstrap.
- Register REALTIME_STREAMING as a new Subsystem to allow isolated health and degradation handling for streaming.

Enhancements:
- Document Phase 3 realtime streaming scope in the global configuration validation policy and include SSE_KEEPALIVE_INTERVAL_SECS in optional subsystem settings.
- Tighten security around LANGGRAPH_STREAM_VERSION loading by checking environment key existence before applying string normalization.
- Simplify StreamingConfig defaults and convert invariant checks to module-level assertions for fail-fast detection of invalid default/range combinations.

</details>