### PR TITLE
☘️ refactor [#12.2.20]: 2차 개선 - 이벤트 파싱 헬퍼 추출 및 예외 처리 계층화

### DIFF
--- a/backend/agent/streaming.py
+++ b/backend/agent/streaming.py
@@ -103,7 +103,12 @@ def _extract_token_from_event(event: Mapping[str, Any]) -> str | None:
     ):
         return None
 
-    chunk_data: Mapping[str, Any] = event.get(_EVENT_DATA_KEY, {})
+    # data 필드가 None 또는 비-Mapping 타입일 경우 방어적으로 처리
+    # event.get()이 None을 반환할 수 있고, emitter가 예상치 못한 타입을 보낼 수 있음
+    raw_data = event.get(_EVENT_DATA_KEY) or {}
+    if not isinstance(raw_data, Mapping):
+        return None
+    chunk_data: Mapping[str, Any] = raw_data
     chunk = chunk_data.get(_CHUNK_KEY)
     if chunk is None:
         return None

--- a/backend/agent/streaming.py
+++ b/backend/agent/streaming.py
@@ -32,6 +32,7 @@ from collections.abc import AsyncIterator, Mapping
 from typing import TYPE_CHECKING, Any
 
 from langchain_core.runnables import RunnableConfig
+from langgraph.errors import GraphRecursionError
 
 from backend.core.config.streaming import STREAMING_DEFAULT_STREAM_VERSION
 from backend.schemas.streaming import (
@@ -57,15 +58,61 @@ _LANGGRAPH_EVENT_ON_LLM_STREAM: str = "on_llm_stream"
 # 토큰 청크 데이터 접근 키
 _CHUNK_KEY: str = "chunk"
 _CONTENT_KEY: str = "content"
+_EVENT_NAME_KEY: str = "event"
+_EVENT_DATA_KEY: str = "data"
 
 # 에러 코드 상수 (하드코딩 방지)
 _ERROR_CODE_STREAM_ERROR: str = "STREAM_ERROR"
+_ERROR_CODE_RECURSION_LIMIT: str = "RECURSION_LIMIT"
 
 # 클라이언트에 전달할 일반화된 에러 메시지
 # 내부 구현 세부사항(스택 트레이스, 경로 등) 노출 방지 — Information Disclosure 예방
 _GENERIC_STREAM_ERROR_MESSAGE: str = (
     "Unexpected error occurred during streaming. Please try again later."
 )
+_RECURSION_LIMIT_MESSAGE: str = (
+    "The response could not be completed due to a processing limit. "
+    "Please try a shorter or simpler query."
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 이벤트 파싱 헬퍼
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _extract_token_from_event(event: Mapping[str, Any]) -> str | None:
+    """
+    LangGraph 스트림 이벤트에서 토큰 텍스트를 추출한다.
+
+    이벤트 구조에 대한 가정을 한 곳에 집중하여, 이벤트 스키마 변경 시
+    수정 지점을 최소화하고 단위 테스트를 용이하게 한다.
+
+    Args:
+        event: LangGraph astream_events가 발행하는 이벤트 딕셔너리.
+
+    Returns:
+        추출된 토큰 텍스트(str). 토큰이 없거나 비어 있으면 None.
+    """
+    event_name: str = event.get(_EVENT_NAME_KEY, "")
+
+    # 모델 스트림 이벤트가 아니면 토큰 없음
+    if event_name not in (
+        _LANGGRAPH_EVENT_ON_CHAT_MODEL_STREAM,
+        _LANGGRAPH_EVENT_ON_LLM_STREAM,
+    ):
+        return None
+
+    chunk_data: Mapping[str, Any] = event.get(_EVENT_DATA_KEY, {})
+    chunk = chunk_data.get(_CHUNK_KEY)
+    if chunk is None:
+        return None
+
+    content = getattr(chunk, _CONTENT_KEY, None)
+    if not isinstance(content, str) or not content:
+        return None
+
+    return content
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -106,29 +153,14 @@ async def stream_agent_response(
             config=config,
             version=stream_version,
         ):
-            event_name: str = event.get("event", "")
-            chunk_data = event.get("data", {})
-
-            # 모델 스트림 이벤트만 추출하여 TokenChunk 발행
-            if event_name in (
-                _LANGGRAPH_EVENT_ON_CHAT_MODEL_STREAM,
-                _LANGGRAPH_EVENT_ON_LLM_STREAM,
-            ):
-                chunk = chunk_data.get(_CHUNK_KEY)
-                if chunk is None:
-                    continue
-
-                content = getattr(chunk, _CONTENT_KEY, None)
-                if not isinstance(content, str) or not content:
-                    continue
-
-                yield TokenChunk(data=content)
-
+            token = _extract_token_from_event(event)
+            if token is not None:
+                yield TokenChunk(data=token)
             else:
                 # 비스트림 이벤트: 내부 관측성 로그로만 기록 (클라이언트에 미노출)
                 logger.debug(
                     "[STREAM][INTERNAL] event=%r (not forwarded to client)",
-                    event_name,
+                    event.get(_EVENT_NAME_KEY, ""),
                 )
 
     except asyncio.CancelledError:
@@ -138,6 +170,18 @@ async def stream_agent_response(
         )
         # CancelledError를 재발생시켜 상위 태스크가 올바르게 취소될 수 있도록 함
         raise
+
+    except GraphRecursionError as exc:
+        # LangGraph 재귀 한계 초과 — 알려진 운영 오류로 별도 처리
+        logger.warning(
+            "[STREAM][RECURSION] GraphRecursionError during streaming: %s",
+            type(exc).__name__,
+        )
+        yield ErrorChunk(
+            code=_ERROR_CODE_RECURSION_LIMIT,
+            message=_RECURSION_LIMIT_MESSAGE,
+        )
+        return
 
     except Exception as exc:  # noqa: BLE001
         # 예상치 못한 예외: 서버 로그에는 상세 정보 기록, 클라이언트에는 일반화된 메시지만 전달
@@ -158,3 +202,4 @@ async def stream_agent_response(
 
     # 스트림 정상 완료
     yield DoneChunk()
+


### PR DESCRIPTION
- **[코드 품질] _extract_token_from_event() 헬퍼 신설**
  - 기존: event.get(), chunk_data.get(), getattr() 등 이벤트 구조 접근 로직이 stream_agent_response() 본문에 인라인으로 산재하여 스키마 변경 시 수정 지점 분산.
  - 수정: `_extract_token_from_event(event: Mapping[str, Any]) → str | None` 헬퍼로 이벤트 구조 접근 가정을 중앙화. 단위 테스트 용이성 확보.
  - 이벤트 키 상수 `_EVENT_NAME_KEY`, `_EVENT_DATA_KEY` 추가로 하드코딩 방지.

- **[안정성] 예외 처리 계층화 — LangGraph 알려진 예외 명시적 분리**
  - 기존: 모든 예외를 단일 `except Exception`으로 처리하여 알려진 오류와 버그를 구분 불가.
  - 수정:
    - `GraphRecursionError`(재귀 한계 초과)를 별도 핸들러로 분리하여 사용자 친화적인 메시지(`_RECURSION_LIMIT_MESSAGE`) 발행.
    - catch-all `except Exception`은 진짜 예상치 못한 예외에만 적용.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1352#pullrequestreview-4256931295)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

에이전트 스트리밍을 개선하여 이벤트 토큰 추출을 중앙화하고, 재귀 한도 초과 오류와 예기치 않은 실패를 구분합니다.

New Features:
- LangGraph 스트림 이벤트에서 토큰 텍스트를 추출하는 헬퍼를 도입하고, 그 결과를 기반으로 토큰 청크를 내보냅니다.

Enhancements:
- 스트리밍 로직에서 하드코딩된 문자열을 피하기 위해 이벤트 및 데이터 키용 상수를 추가합니다.
- 스트리밍 중 비스트림 이벤트와 재귀 관련 실패에 대한 로깅을 개선합니다.
- 일반적인 스트림 오류 대신, LangGraph `GraphRecursionError`를 별도로 처리하여 사용자 친화적인 오류 응답을 반환하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine agent streaming to centralize event token extraction and distinguish recursion limit errors from unexpected failures.

New Features:
- Introduce a helper to extract token text from LangGraph stream events and emit token chunks based on its result.

Enhancements:
- Add constants for event and data keys to avoid hardcoded strings in streaming logic.
- Improve logging for non-stream events and recursion-related failures during streaming.
- Separate handling of LangGraph GraphRecursionError to return a user-friendly error response instead of a generic stream error.

</details>