### PR TITLE
🐛 fix [#12.2.20]: 6차 개선 - or{} 마스킹 버그 수정, 진단 컨텍스트 강화, 타입 정밀도 향상

### DIFF
--- a/backend/agent/streaming.py
+++ b/backend/agent/streaming.py
@@ -141,7 +141,9 @@ def _extract_token_from_event(event: Mapping[str, Any]) -> str | None:
     # 2단계: 非-None이지만 비-Mapping → 스키마 이상 신호이므로 warning 로그
     # ※ or {}를 사용하면 [], '', 0 같은 falsy 비-Mapping 값도 {}로 변환되어
     #   isinstance 체크가 항상 통과되고 스키마 이상 감지가 불가능해지는 버그 발생
-    run_id: str = event.get("run_id", "")  # 진단용 세션 식별자 (원문 노출 없이 컨텍스트 제공)
+    # run_id: None(키 없음)과 실제 빈 문자열을 구분하여 로그 명확성 확보
+    _raw_run_id = event.get("run_id")
+    run_id: str = str(_raw_run_id) if _raw_run_id is not None else "N/A"
     raw_data = event.get(_EVENT_DATA_KEY)
     if raw_data is None:
         # data 키가 없는 이벤트: 정상 케이스로 조용히 건너뜀
@@ -186,9 +188,7 @@ async def stream_agent_response(
     inputs: Mapping[str, Any],
     config: RunnableConfig,
     *,
-    stream_version: Literal["v1", "v2"] = cast(
-        Literal["v1", "v2"], STREAMING_DEFAULT_STREAM_VERSION
-    ),
+    stream_version: Literal["v1", "v2"] = STREAMING_DEFAULT_STREAM_VERSION,
 ) -> AsyncIterator[StreamChunk]:
     """
     LangGraph 그래프를 실행하고 모델이 생성하는 토큰을 `StreamChunk`로 발행한다.

--- a/backend/agent/streaming.py
+++ b/backend/agent/streaming.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import AsyncIterator, Mapping
-from typing import TYPE_CHECKING, Any, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 
 from langchain_core.runnables import RunnableConfig
 from langgraph.errors import GraphRecursionError
@@ -136,14 +136,22 @@ def _extract_token_from_event(event: Mapping[str, Any]) -> str | None:
     ):
         return None
 
-    # data 필드가 None 또는 비-Mapping 타입일 경우 방어적으로 처리
-    # 스트리밍 이벤트 내부에서 예상치 못한 구조는 관측성 로그로 기록
-    raw_data = event.get(_EVENT_DATA_KEY) or {}
+    # data 필드 방어적 처리 — 두 단계 검증
+    # 1단계: None(data 키 없음) → 조용히 건너뜀 (정상적인 비-스트리밍 이벤트일 수 있음)
+    # 2단계: 非-None이지만 비-Mapping → 스키마 이상 신호이므로 warning 로그
+    # ※ or {}를 사용하면 [], '', 0 같은 falsy 비-Mapping 값도 {}로 변환되어
+    #   isinstance 체크가 항상 통과되고 스키마 이상 감지가 불가능해지는 버그 발생
+    run_id: str = event.get("run_id", "")  # 진단용 세션 식별자 (원문 노출 없이 컨텍스트 제공)
+    raw_data = event.get(_EVENT_DATA_KEY)
+    if raw_data is None:
+        # data 키가 없는 이벤트: 정상 케이스로 조용히 건너뜀
+        return None
     if not isinstance(raw_data, Mapping):
         logger.warning(
-            "[STREAM][SCHEMA] Unexpected data type in streaming event '%s': "
-            "expected Mapping, got %s. Possible schema change.",
+            "[STREAM][SCHEMA] Unexpected data type in streaming event '%s' "
+            "(run_id=%s): expected Mapping, got %s. Possible schema change.",
             event_name,
+            run_id,
             type(raw_data).__name__,
         )
         return None
@@ -152,12 +160,14 @@ def _extract_token_from_event(event: Mapping[str, Any]) -> str | None:
     chunk = chunk_data.get(_CHUNK_KEY)
     if chunk is None:
         logger.warning(
-            "[STREAM][SCHEMA] No '%s' key in data of streaming event '%s'. "
-            "Possible schema change.",
+            "[STREAM][SCHEMA] No '%s' key in data of streaming event '%s' "
+            "(run_id=%s). Possible schema change.",
             _CHUNK_KEY,
             event_name,
+            run_id,
         )
         return None
+
 
     content = getattr(chunk, _CONTENT_KEY, None)
     if not isinstance(content, str) or not content:
@@ -176,7 +186,9 @@ async def stream_agent_response(
     inputs: Mapping[str, Any],
     config: RunnableConfig,
     *,
-    stream_version: str = STREAMING_DEFAULT_STREAM_VERSION,
+    stream_version: Literal["v1", "v2"] = cast(
+        Literal["v1", "v2"], STREAMING_DEFAULT_STREAM_VERSION
+    ),
 ) -> AsyncIterator[StreamChunk]:
     """
     LangGraph 그래프를 실행하고 모델이 생성하는 토큰을 `StreamChunk`로 발행한다.

--- a/backend/core/config/streaming.py
+++ b/backend/core/config/streaming.py
@@ -21,7 +21,7 @@ StreamingConfig — Phase 3 (Realtime Streaming) 설정 스키마 및 기본값 
 import os
 import logging
 from dataclasses import dataclass, field
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 from backend.config import ConfigRange, _clamp
 
@@ -52,7 +52,7 @@ _VALID_STREAM_VERSIONS: tuple[str, ...] = ("v1", "v2")
 _DEFAULT_KEEPALIVE_INTERVAL_SECS: int = 15
 _DEFAULT_BUFFER_MAX_SIZE: int = 100
 _DEFAULT_TIMEOUT_SECS: int = 120
-_DEFAULT_STREAM_VERSION: str = "v2"
+_DEFAULT_STREAM_VERSION: Literal["v1", "v2"] = "v2"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 공개 상수 별칭 (외부 모듈 참조용 — 내부 구현과의 결합도 최소화)
@@ -67,7 +67,7 @@ STREAMING_ENV_STREAM_VERSION: str = _ENV_STREAM_VERSION
 STREAMING_DEFAULT_KEEPALIVE_INTERVAL_SECS: int = _DEFAULT_KEEPALIVE_INTERVAL_SECS
 STREAMING_DEFAULT_BUFFER_MAX_SIZE: int = _DEFAULT_BUFFER_MAX_SIZE
 STREAMING_DEFAULT_TIMEOUT_SECS: int = _DEFAULT_TIMEOUT_SECS
-STREAMING_DEFAULT_STREAM_VERSION: str = _DEFAULT_STREAM_VERSION
+STREAMING_DEFAULT_STREAM_VERSION: Literal["v1", "v2"] = _DEFAULT_STREAM_VERSION
 
 STREAMING_KEEPALIVE_INTERVAL_RANGE: ConfigRange = _KEEPALIVE_INTERVAL_RANGE
 STREAMING_BUFFER_MAX_SIZE_RANGE: ConfigRange = _BUFFER_MAX_SIZE_RANGE


### PR DESCRIPTION
- **[버그 수정] or {} 연산자가 falsy 비-Mapping 값을 은폐하는 silent bug 수정**
  - 기존:
    - `event.get(_EVENT_DATA_KEY) or {}` 는 [], '', 0 같은 falsy 비-Mapping 값을 {}로 강제 변환하여 isinstance(raw_data, Mapping)이 항상 통과됨.
    - 결과적으로 "Unexpected data type" 경고가 발화되지 않는 silent bug.
  - 수정:
    - `raw_data is None` → 조용히 return None (정상 케이스)
    - `not isinstance(raw_data, Mapping)` → warning 로그 후 return None (스키마 이상)

- **[관측성] run_id 컨텍스트 추가로 경고 로그 진단 능력 향상**
  - 양쪽 [STREAM][SCHEMA] warning 로그에 run_id 필드 추가.
  - 어느 스트리밍 세션에서 스키마 이상이 발생했는지 즉각 식별 가능.

- **[타입 안전성] stream_version 파라미터 타입 str → Literal['v1','v2'] 정밀화**
  - LangGraph astream_events의 version 파라미터와 타입 일치.
  - Literal import 추가.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1356#pullrequestreview-4256987319)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

잘못된 페이로드가 가려지지 않도록 스트리밍 이벤트 데이터 처리를 수정하고, 스키마 이상 현상 진단을 개선하며, 스트리밍 API의 타입 안정성을 강화합니다.

Bug Fixes:
- 스트리밍 이벤트에서 falsy이지만 매핑이 아닌 데이터 값이 빈 매핑으로 강제 변환되지 않도록 방지하여, 스키마 위반이 올바르게 감지되고 무시되도록 합니다.

Enhancements:
- 문제가 되는 스트리밍 세션을 더 쉽게 식별할 수 있도록 스트리밍 스키마 경고 로그에 `run_id` 컨텍스트를 포함합니다.
- 에이전트 스트리밍 API의 `stream_version` 파라미터 타입을 `Literal['v1','v2']`로 한정하여 타입 안정성을 높이고 LangGraph와의 정렬성을 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix streaming event data handling to avoid masking invalid payloads, improve schema anomaly diagnostics, and tighten streaming API type safety.

Bug Fixes:
- Prevent falsy non-mapping data values in streaming events from being coerced to empty mappings, ensuring schema violations are correctly detected and ignored.

Enhancements:
- Include run_id context in streaming schema warning logs to make problematic streaming sessions easier to identify.
- Narrow the stream_version parameter type in the agent streaming API to Literal['v1','v2'] for better type safety and alignment with LangGraph.

</details>