### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/agent/streaming.py
+++ b/backend/agent/streaming.py
@@ -143,7 +143,9 @@ def _extract_token_from_event(event: Mapping[str, Any]) -> str | None:
     # 1단계: data 키 자체가 없음 → 조용히 건너뜀 (정상적인 비-스트리밍 이벤트)
     # 2단계: data 키는 있으나 값이 명시적 None → 스키마 이상 신호이므로 warning
     # 3단계: data 값이 비-Mapping → 스키마 이상 신호이므로 warning
-    run_id: str = event.get("run_id", "")  # 진단용 세션 식별자 (원문 노출 없이 컨텍스트 제공)
+    # run_id: None(키 없음)과 실제 빈 문자열을 구분하여 로그 명확성 확보
+    _raw_run_id = event.get("run_id")
+    run_id: str = str(_raw_run_id) if _raw_run_id is not None else "N/A"
     
     if _EVENT_DATA_KEY not in event:
         # data 키가 아예 없는 이벤트: 정상 케이스로 간주

--- a/backend/agent/streaming.py
+++ b/backend/agent/streaming.py
@@ -34,7 +34,10 @@ from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 from langchain_core.runnables import RunnableConfig
 from langgraph.errors import GraphRecursionError
 
-from backend.core.config.streaming import STREAMING_DEFAULT_STREAM_VERSION
+from backend.core.config.streaming import (
+    STREAMING_DEFAULT_STREAM_VERSION,
+    StreamVersion,
+)
 from backend.schemas.streaming import (
     DoneChunk,
     ErrorChunk,
@@ -136,18 +139,26 @@ def _extract_token_from_event(event: Mapping[str, Any]) -> str | None:
     ):
         return None
 
-    # data 필드 방어적 처리 — 두 단계 검증
-    # 1단계: None(data 키 없음) → 조용히 건너뜀 (정상적인 비-스트리밍 이벤트일 수 있음)
-    # 2단계: 非-None이지만 비-Mapping → 스키마 이상 신호이므로 warning 로그
-    # ※ or {}를 사용하면 [], '', 0 같은 falsy 비-Mapping 값도 {}로 변환되어
-    #   isinstance 체크가 항상 통과되고 스키마 이상 감지가 불가능해지는 버그 발생
-    # run_id: None(키 없음)과 실제 빈 문자열을 구분하여 로그 명확성 확보
-    _raw_run_id = event.get("run_id")
-    run_id: str = str(_raw_run_id) if _raw_run_id is not None else "N/A"
-    raw_data = event.get(_EVENT_DATA_KEY)
-    if raw_data is None:
-        # data 키가 없는 이벤트: 정상 케이스로 조용히 건너뜀
+    # data 필드 방어적 처리 — 세 단계 검증 (정상 스킵 vs 비정상 None 구분)
+    # 1단계: data 키 자체가 없음 → 조용히 건너뜀 (정상적인 비-스트리밍 이벤트)
+    # 2단계: data 키는 있으나 값이 명시적 None → 스키마 이상 신호이므로 warning
+    # 3단계: data 값이 비-Mapping → 스키마 이상 신호이므로 warning
+    run_id: str = event.get("run_id", "")  # 진단용 세션 식별자 (원문 노출 없이 컨텍스트 제공)
+    
+    if _EVENT_DATA_KEY not in event:
+        # data 키가 아예 없는 이벤트: 정상 케이스로 간주
         return None
+        
+    raw_data = event[_EVENT_DATA_KEY]
+    if raw_data is None:
+        logger.warning(
+            "[STREAM][SCHEMA] Explicit data=None in streaming event '%s' "
+            "(run_id=%s). Possible schema change.",
+            event_name,
+            run_id,
+        )
+        return None
+        
     if not isinstance(raw_data, Mapping):
         logger.warning(
             "[STREAM][SCHEMA] Unexpected data type in streaming event '%s' "
@@ -188,7 +199,7 @@ async def stream_agent_response(
     inputs: Mapping[str, Any],
     config: RunnableConfig,
     *,
-    stream_version: Literal["v1", "v2"] = STREAMING_DEFAULT_STREAM_VERSION,
+    stream_version: StreamVersion = STREAMING_DEFAULT_STREAM_VERSION,
 ) -> AsyncIterator[StreamChunk]:
     """
     LangGraph 그래프를 실행하고 모델이 생성하는 토큰을 `StreamChunk`로 발행한다.

--- a/backend/core/config/streaming.py
+++ b/backend/core/config/streaming.py
@@ -21,7 +21,7 @@ StreamingConfig — Phase 3 (Realtime Streaming) 설정 스키마 및 기본값 
 import os
 import logging
 from dataclasses import dataclass, field
-from typing import ClassVar, Literal
+from typing import ClassVar, Literal, cast, get_args
 
 from backend.config import ConfigRange, _clamp
 
@@ -43,15 +43,15 @@ _ENV_STREAM_VERSION: str = "LANGGRAPH_STREAM_VERSION"
 _KEEPALIVE_INTERVAL_RANGE: ConfigRange = ConfigRange(min=5, max=60)
 _BUFFER_MAX_SIZE_RANGE: ConfigRange = ConfigRange(min=10, max=1000)
 _TIMEOUT_RANGE: ConfigRange = ConfigRange(min=30, max=600)
-_VALID_STREAM_VERSIONS: tuple[str, ...] = ("v1", "v2")
-
 # ─────────────────────────────────────────────────────────────────────────────
-# StreamVersion 타입 별칭 (SSOT)
+# StreamVersion 타입 별칭 및 지원 버전 SSOT
 # LangGraph astream_events의 version 파라미터와 일치하는 지원 버전 목록
-# 새 버전 표준화 시 이 정의만 수정하면 전체 코드베이스에 반영됨
+# 지원 버전의 SSOT은 `StreamVersion`이며, 이 정의만 수정하면
+# 런타임 검증 로직(`_VALID_STREAM_VERSIONS`)에도 자동으로 반영됨
 # ─────────────────────────────────────────────────────────────────────────────
 
 StreamVersion = Literal["v1", "v2"]
+_VALID_STREAM_VERSIONS: tuple[str, ...] = cast(tuple[str, ...], get_args(StreamVersion))
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 기본값 상수 (Magic Numbers 제거 — 모듈 수준 정의)

--- a/backend/core/config/streaming.py
+++ b/backend/core/config/streaming.py
@@ -46,13 +46,21 @@ _TIMEOUT_RANGE: ConfigRange = ConfigRange(min=30, max=600)
 _VALID_STREAM_VERSIONS: tuple[str, ...] = ("v1", "v2")
 
 # ─────────────────────────────────────────────────────────────────────────────
+# StreamVersion 타입 별칭 (SSOT)
+# LangGraph astream_events의 version 파라미터와 일치하는 지원 버전 목록
+# 새 버전 표준화 시 이 정의만 수정하면 전체 코드베이스에 반영됨
+# ─────────────────────────────────────────────────────────────────────────────
+
+StreamVersion = Literal["v1", "v2"]
+
+# ─────────────────────────────────────────────────────────────────────────────
 # 기본값 상수 (Magic Numbers 제거 — 모듈 수준 정의)
 # ─────────────────────────────────────────────────────────────────────────────
 
 _DEFAULT_KEEPALIVE_INTERVAL_SECS: int = 15
 _DEFAULT_BUFFER_MAX_SIZE: int = 100
 _DEFAULT_TIMEOUT_SECS: int = 120
-_DEFAULT_STREAM_VERSION: Literal["v1", "v2"] = "v2"
+_DEFAULT_STREAM_VERSION: StreamVersion = "v2"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 공개 상수 별칭 (외부 모듈 참조용 — 내부 구현과의 결합도 최소화)
@@ -67,7 +75,7 @@ STREAMING_ENV_STREAM_VERSION: str = _ENV_STREAM_VERSION
 STREAMING_DEFAULT_KEEPALIVE_INTERVAL_SECS: int = _DEFAULT_KEEPALIVE_INTERVAL_SECS
 STREAMING_DEFAULT_BUFFER_MAX_SIZE: int = _DEFAULT_BUFFER_MAX_SIZE
 STREAMING_DEFAULT_TIMEOUT_SECS: int = _DEFAULT_TIMEOUT_SECS
-STREAMING_DEFAULT_STREAM_VERSION: Literal["v1", "v2"] = _DEFAULT_STREAM_VERSION
+STREAMING_DEFAULT_STREAM_VERSION: StreamVersion = _DEFAULT_STREAM_VERSION
 
 STREAMING_KEEPALIVE_INTERVAL_RANGE: ConfigRange = _KEEPALIVE_INTERVAL_RANGE
 STREAMING_BUFFER_MAX_SIZE_RANGE: ConfigRange = _BUFFER_MAX_SIZE_RANGE


### PR DESCRIPTION
☘️ refactor [#12.2.20]: 8차 개선 - data=None 처리 명확화 및 StreamVersion 타입 별칭 도입
☘️ refactor [#12.2.20]: 9차 개선 - 지원 버전 SSOT 확립 및 run_id 센티널 적용

## Summary by Sourcery

스트리밍 이벤트 데이터 처리 방식을 명확히 하고, 지원되는 스트림 버전에 대한 타입 정의를 중앙집중화합니다.

버그 수정:
- 스키마 이상 탐지를 개선하기 위해 스트리밍 이벤트에서 데이터 키 누락, `data=None`이 명시된 경우, 잘못된 데이터 타입을 서로 구분하여 처리합니다.

개선 사항:
- 지원되는 스트림 버전에 대한 단일 신뢰 소스로 사용하는 `StreamVersion` 타입 별칭을 도입하고, 이를 스트리밍 설정 및 API 전반에 걸쳐 전파합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify streaming event data handling and centralize supported stream version typing.

Bug Fixes:
- Differentiate between missing data keys, explicit data=None, and invalid data types in streaming events to improve schema anomaly detection.

Enhancements:
- Introduce a StreamVersion type alias as the single source of truth for supported stream versions and propagate it through streaming configuration and APIs.

</details>