### PR TITLE
☘️ refactor [#12.2.21]: 2차 개선 - API 문서화 명확화 및 스트리밍 안정성 강화

### DIFF
--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -38,16 +38,27 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/chat", tags=["chat"])
 
 
-@router.post("", summary="RAG 채팅 결과 동기 반환 (비스트리밍)")
+@router.post(
+    "",
+    summary="[비활성화/실험적] RAG 채팅 결과 동기 반환 (현재 501 Not Implemented)",
+    deprecated=True,
+)
 async def sync_chat(
     request: ChatQueryRequest, chat_service: ChatService = Depends(get_chat_service)
 ):
     """
+    [비활성화/실험적 엔드포인트]
+
     스트리밍이 불가한 클라이언트를 위해 기존 동기 응답 엔드포인트는 제거하지 않고 병행 운영합니다.
+    다만 현재 구현은 항상 501 Not Implemented 를 반환하며, 실사용 가능한 비스트리밍 RAG 응답은
+    추후 구현 예정입니다.
+
+    클라이언트에서 동기 채팅이 반드시 필요한 경우, 이 엔드포인트의 501 응답을 고려하여
+    실패 처리 / 폴백 로직을 구현하거나, 권장되는 스트리밍 기반 채팅 엔드포인트를 사용해 주세요.
     """
     logger.info(
         "Chat sync requested by user: %s (query_len=%d)",
-        request.user_id,
+        mask_pii_id(request.user_id),
         len(request.query),
     )
 

--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -5,10 +5,12 @@ import asyncio
 import json
 from typing import AsyncGenerator
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, HTTPException
 from sse_starlette.sse import EventSourceResponse
 
 from backend.api.models import ChatQueryRequest
+from backend.utils import mask_pii_id
+from backend.core.config.streaming import STREAMING_DEFAULT_TIMEOUT_SECS
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +29,20 @@ async def stream_chat_endpoint(
     """
     SSE 기반 스트리밍 엔드포인트 스캐폴딩.
     """
+
+    # 기본 스키마 검증: 필수 필드 확인 및 간단한 내용 검증
+    if not body.query or not body.query.strip():
+        raise HTTPException(status_code=400, detail="`query`는 비어 있을 수 없습니다.")
+
+    # 디버깅 및 트레이싱을 위한 최소 로그 (PII 마스킹 적용)
+    truncated_query = body.query[:200] + ("..." if len(body.query) > 200 else "")
+    logger.info(
+        "Received streaming chat request",
+        extra={
+            "user_id_hash": mask_pii_id(body.user_id),
+            "query_preview": truncated_query,
+        },
+    )
     
     async def event_generator() -> AsyncGenerator[dict, None]:
         try:
@@ -40,12 +56,14 @@ async def stream_chat_endpoint(
                 }),
             }
             
-            # 클라이언트 연결 종료 감지를 위한 임시 대기 (추후 백프레셔 큐 기반 폴링으로 대체)
-            while True:
+            # 클라이언트 연결 종료 감지를 위한 임시 대기 (최대 타임아웃 적용)
+            for _ in range(STREAMING_DEFAULT_TIMEOUT_SECS):
                 if await request.is_disconnected():
                     logger.info("[STREAM] Client disconnected.")
                     break
                 await asyncio.sleep(1)
+            else:
+                logger.warning("[STREAM] Connection timed out due to inactivity.")
                 
         except asyncio.CancelledError:
             logger.info("[STREAM] Request was cancelled.")


### PR DESCRIPTION
- **[API 문서화] 동기 채팅 엔드포인트(chat.py) 명시적 비활성화**
  - `deprecated=True` 플래그 및 상세 docstring을 추가하여, 501 에러 반환이 의도된 스캐폴딩(기능 미구현) 상태임을 API 소비자에게 명확히 전달.

- **[보안 및 로깅] 스트리밍 엔드포인트(chat_stream.py) 요청 검증 및 PII 마스킹**
  - 미사용 중이던 `body` 파라미터에 대해 최소한의 스키마 검증(`query` 공백 체크) 추가.
  - 디버그 추적을 위해 `query`를 200자로 잘라 로깅하되, `user_id`는 반드시 `mask_pii_id()`를 거쳐 해시된 값으로만 로그에 남도록 보안 원칙 준수.

- **[운영 안정성] 좀비 커넥션 방지 (Max Timeout)**
  - `chat_stream.py`의 이벤트 제너레이터 내 무한 대기(`while True`) 루프를 제거하고, 시스템 설정값(`STREAMING_DEFAULT_TIMEOUT_SECS`)에 기반한 폴링 제한을 두어 활동 없는 장기 연결로 인한 서버 리소스 누수를 방지.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1362#pullrequestreview-4258700712)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

동기식 채팅 엔드포인트를 비활성화/실험용 API로 명확히 하고, 스트리밍 채팅 엔드포인트의 견고성과 관측 가능성을 개선합니다.

Bug Fixes:
- 명시적인 검증을 통해 비어 있거나 공백 문자로만 이루어진 쿼리를 사용하는 스트리밍 채팅 요청을 거부합니다.

Enhancements:
- 동기식 채팅 엔드포인트가 501 스캐폴드 상태임을 더 명확히 설명하여, API에서 해당 엔드포인트를 사용 중단/비활성화된 것으로 표시합니다.
- 동기식 및 스트리밍 채팅 로그에서 사용자 식별자를 마스킹하고, 디버깅을 위해 쿼리의 미리 보기 일부만 잘라서 기록합니다.
- SSE 연결이 무기한 대기 상태에 빠지지 않도록, 스트리밍 이벤트 루프에 최대 비활성 시간 제한을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the synchronous chat endpoint as a disabled/experimental API and improve robustness and observability of the streaming chat endpoint.

Bug Fixes:
- Reject streaming chat requests with empty or whitespace-only queries via explicit validation.

Enhancements:
- Mark the synchronous chat endpoint as deprecated/disabled in the API with clearer description of its 501 scaffold status.
- Mask user identifiers in sync and streaming chat logs while logging only a truncated preview of the query for debugging.
- Add a maximum inactivity timeout to the streaming event loop to avoid indefinitely hanging SSE connections.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

동기식 채팅 엔드포인트를 비활성화/실험용 API로 명확히 하고, 스트리밍 채팅 엔드포인트의 견고성과 관측 가능성을 개선합니다.

Bug Fixes:
- 명시적인 검증을 통해 비어 있거나 공백 문자로만 이루어진 쿼리를 사용하는 스트리밍 채팅 요청을 거부합니다.

Enhancements:
- 동기식 채팅 엔드포인트가 501 스캐폴드 상태임을 더 명확히 설명하여, API에서 해당 엔드포인트를 사용 중단/비활성화된 것으로 표시합니다.
- 동기식 및 스트리밍 채팅 로그에서 사용자 식별자를 마스킹하고, 디버깅을 위해 쿼리의 미리 보기 일부만 잘라서 기록합니다.
- SSE 연결이 무기한 대기 상태에 빠지지 않도록, 스트리밍 이벤트 루프에 최대 비활성 시간 제한을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the synchronous chat endpoint as a disabled/experimental API and improve robustness and observability of the streaming chat endpoint.

Bug Fixes:
- Reject streaming chat requests with empty or whitespace-only queries via explicit validation.

Enhancements:
- Mark the synchronous chat endpoint as deprecated/disabled in the API with clearer description of its 501 scaffold status.
- Mask user identifiers in sync and streaming chat logs while logging only a truncated preview of the query for debugging.
- Add a maximum inactivity timeout to the streaming event loop to avoid indefinitely hanging SSE connections.

</details>

</details>