### PR TITLE
☘️ refactor [#12.2.21]: 3차 개선 - 검증 로직 중앙화 및 비동기 대기 최적화

### DIFF
--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -5,7 +5,7 @@ import asyncio
 import json
 from typing import AsyncGenerator
 
-from fastapi import APIRouter, Request, HTTPException
+from fastapi import APIRouter, Request
 from sse_starlette.sse import EventSourceResponse
 
 from backend.api.models import ChatQueryRequest
@@ -30,10 +30,6 @@ async def stream_chat_endpoint(
     SSE 기반 스트리밍 엔드포인트 스캐폴딩.
     """
 
-    # 기본 스키마 검증: 필수 필드 확인 및 간단한 내용 검증
-    if not body.query or not body.query.strip():
-        raise HTTPException(status_code=400, detail="`query`는 비어 있을 수 없습니다.")
-
     # 디버깅 및 트레이싱을 위한 최소 로그 (PII 마스킹 적용)
     truncated_query = body.query[:200] + ("..." if len(body.query) > 200 else "")
     logger.info(
@@ -56,13 +52,16 @@ async def stream_chat_endpoint(
                 }),
             }
             
-            # 클라이언트 연결 종료 감지를 위한 임시 대기 (최대 타임아웃 적용)
-            for _ in range(STREAMING_DEFAULT_TIMEOUT_SECS):
-                if await request.is_disconnected():
-                    logger.info("[STREAM] Client disconnected.")
-                    break
-                await asyncio.sleep(1)
-            else:
+            # 클라이언트 연결 종료 감지를 위한 임시 대기 (asyncio.wait_for 활용)
+            # 타임아웃을 걸어두고, 긴 주기로 연결 상태만 폴링하여 서버 자원(CPU, Event Loop)을 절약합니다.
+            async def check_disconnect() -> None:
+                while not await request.is_disconnected():
+                    await asyncio.sleep(5)
+                    
+            try:
+                await asyncio.wait_for(check_disconnect(), timeout=STREAMING_DEFAULT_TIMEOUT_SECS)
+                logger.info("[STREAM] Client disconnected.")
+            except asyncio.TimeoutError:
                 logger.warning("[STREAM] Connection timed out due to inactivity.")
                 
         except asyncio.CancelledError:

--- a/backend/api/models/__init__.py
+++ b/backend/api/models/__init__.py
@@ -7,7 +7,7 @@ API Models Package
 from enum import Enum
 from functools import lru_cache
 from typing import cast, Iterable, List, Dict, Any, Optional
-from pydantic import BaseModel, Field  # type: ignore[import]
+from pydantic import BaseModel, Field, field_validator  # type: ignore[import]
 
 from backend.api.models.shared import (  # type: ignore[import]
     ApiStatus,
@@ -212,6 +212,13 @@ class ChatQueryRequest(BaseModel):
     alpha: float = Field(
         default=0.5, ge=0.0, le=1.0, description="하이브리드 검색 FAISS 가중치"
     )
+
+    @field_validator("query")
+    @classmethod
+    def validate_query(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("`query`는 비어 있을 수 없습니다.")
+        return v
 
 
 class ChatMessage(BaseModel):


### PR DESCRIPTION
- **[구조 개선] Pydantic 기반 모델 중앙 검증**
  - 스트리밍 엔드포인트 내에 존재하던 `query` 빈 문자열 검사 로직을 제거하고, `backend/api/models/__init__.py`의 `ChatQueryRequest` Pydantic `@field_validator`로 이동.
  - 이로써 모든 채팅 관련 엔드포인트가 일관된 유효성 검사를 거치도록 Thin Controller 패턴 달성.

- **[성능 최적화] 타이트 폴링(Tight Polling) 완화**
  - `chat_stream.py`의 이벤트 제너레이터 대기 로직을 1초 간격의 무한 for-loop 방식에서 `asyncio.wait_for` 기반의 긴 주기(5초) 대기로 리팩토링.
  - 이벤트 루프(Event Loop)의 불필요한 컨텍스트 스위칭 및 CPU 자원 낭비를 방지.

- **[안정성 점검] PII 마스킹 의존성 확인**
  - `chat.py` 및 `chat_stream.py` 모두에 `mask_pii_id`가 정상 임포트되어 있어 런타임 `NameError` 발생 위험이 없음을 더블 체크 완료.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1363#pullrequestreview-4258724449)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

공유 Pydantic 요청 모델에서 채팅 쿼리 검증을 중앙화하고, 채팅 스트리밍 엔드포인트의 클라이언트 연결 종료(polling) 방식을 최적화하여 리소스 사용을 줄입니다.

Enhancements:
- 채팅 엔드포인트 전반에서 일관된 입력 검사를 위해, 스트리밍 엔드포인트에 있던 `query` 빈 문자열 검증을 `ChatQueryRequest` Pydantic 모델로 이동합니다.
- 이벤트 루프와 CPU 오버헤드를 줄이기 위해, 스트리밍 엔드포인트의 연결 종료 감지를 더 긴 간격의 비동기 폴링과 제한된 타임아웃을 사용하는 방식으로 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize chat query validation in the shared Pydantic request model and optimize the chat streaming endpoint’s client disconnect polling to reduce resource usage.

Enhancements:
- Move `query` empty-string validation from the streaming endpoint into the `ChatQueryRequest` Pydantic model for consistent input checks across chat endpoints.
- Refine the streaming endpoint’s disconnect detection to use longer-interval asynchronous polling with a bounded timeout to lower event-loop and CPU overhead.

</details>