### PR TITLE
☘️ refactor [#12.2.21]: 4차 개선 - 엣지 케이스 방어 및 로깅 일관성 확보

### DIFF
--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -31,7 +31,7 @@ from backend.services.chat_history_service import (  # type: ignore[import]
     MAX_FEEDBACK_STATS_LIMIT,
 )
 from backend.config import AdminConfig, AlertConfig
-from backend.utils import mask_pii_id  # type: ignore[import]
+from backend.utils import mask_pii_id, get_chat_log_extra  # type: ignore[import]
 
 logger = logging.getLogger(__name__)
 
@@ -56,15 +56,9 @@ async def sync_chat(
     클라이언트에서 동기 채팅이 반드시 필요한 경우, 이 엔드포인트의 501 응답을 고려하여
     실패 처리 / 폴백 로직을 구현하거나, 권장되는 스트리밍 기반 채팅 엔드포인트를 사용해 주세요.
     """
-    safe_user_id = getattr(request, "user_id", None) or "anonymous"
-    safe_query = getattr(request, "query", "") or ""
-    truncated_query = safe_query[:200] + ("..." if len(safe_query) > 200 else "")
     logger.info(
         "Chat sync requested",
-        extra={
-            "user_id_hash": mask_pii_id(safe_user_id),
-            "query_preview": truncated_query,
-        },
+        extra=get_chat_log_extra(request),
     )
 
     # 비스트리밍(동기) 채팅 서비스 로직 연동 전까지 명시적인 501 에러 반환

--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -56,10 +56,15 @@ async def sync_chat(
     클라이언트에서 동기 채팅이 반드시 필요한 경우, 이 엔드포인트의 501 응답을 고려하여
     실패 처리 / 폴백 로직을 구현하거나, 권장되는 스트리밍 기반 채팅 엔드포인트를 사용해 주세요.
     """
+    safe_user_id = getattr(request, "user_id", None) or "anonymous"
+    safe_query = getattr(request, "query", "") or ""
+    truncated_query = safe_query[:200] + ("..." if len(safe_query) > 200 else "")
     logger.info(
-        "Chat sync requested by user: %s (query_len=%d)",
-        mask_pii_id(request.user_id),
-        len(request.query),
+        "Chat sync requested",
+        extra={
+            "user_id_hash": mask_pii_id(safe_user_id),
+            "query_preview": truncated_query,
+        },
     )
 
     # 비스트리밍(동기) 채팅 서비스 로직 연동 전까지 명시적인 501 에러 반환

--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Request
 from sse_starlette.sse import EventSourceResponse
 
 from backend.api.models import ChatQueryRequest
-from backend.utils import mask_pii_id
+from backend.utils import get_chat_log_extra
 from backend.core.config.streaming import STREAMING_DEFAULT_TIMEOUT_SECS
 
 logger = logging.getLogger(__name__)
@@ -32,15 +32,9 @@ async def stream_chat_endpoint(
 
     # 디버깅 및 트레이싱을 위한 최소 로그 (PII 마스킹 적용)
     # body.user_id가 누락되거나 None인 경우에 대비하여 안전하게 처리합니다.
-    safe_user_id = getattr(body, "user_id", None) or "anonymous"
-    safe_query = getattr(body, "query", "") or ""
-    truncated_query = safe_query[:200] + ("..." if len(safe_query) > 200 else "")
     logger.info(
         "Received streaming chat request",
-        extra={
-            "user_id_hash": mask_pii_id(safe_user_id),
-            "query_preview": truncated_query,
-        },
+        extra=get_chat_log_extra(body),
     )
     
     async def event_generator() -> AsyncGenerator[dict, None]:

--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -31,11 +31,14 @@ async def stream_chat_endpoint(
     """
 
     # 디버깅 및 트레이싱을 위한 최소 로그 (PII 마스킹 적용)
-    truncated_query = body.query[:200] + ("..." if len(body.query) > 200 else "")
+    # body.user_id가 누락되거나 None인 경우에 대비하여 안전하게 처리합니다.
+    safe_user_id = getattr(body, "user_id", None) or "anonymous"
+    safe_query = getattr(body, "query", "") or ""
+    truncated_query = safe_query[:200] + ("..." if len(safe_query) > 200 else "")
     logger.info(
         "Received streaming chat request",
         extra={
-            "user_id_hash": mask_pii_id(body.user_id),
+            "user_id_hash": mask_pii_id(safe_user_id),
             "query_preview": truncated_query,
         },
     )
@@ -53,7 +56,9 @@ async def stream_chat_endpoint(
             }
             
             # 클라이언트 연결 종료 감지를 위한 임시 대기 (asyncio.wait_for 활용)
-            # 타임아웃을 걸어두고, 긴 주기로 연결 상태만 폴링하여 서버 자원(CPU, Event Loop)을 절약합니다.
+            # 주의: 이는 스캐폴딩 상태에서의 '하드 타임아웃(최대 연결 유지 시간)' 제한입니다.
+            # 추후 실제 LangGraph 구현이 연동되면, 무조건적인 종료가 아닌 
+            # '마지막 청크 전송 이후의 유휴 시간(Idle Timeout)'을 기준으로 폴링이 종료되도록 변경해야 합니다.
             async def check_disconnect() -> None:
                 while not await request.is_disconnected():
                     await asyncio.sleep(5)

--- a/backend/api/models/__init__.py
+++ b/backend/api/models/__init__.py
@@ -111,7 +111,7 @@ class PARACategory(str, Enum):
 # `list[property] is not assignable to list[str]` Type Error (False Positive)를 우회하기 위한 조치.
 # (유사 이슈: https://github.com/facebook/pyre-check/issues/224). 
 # list(PARACategory)에 명시적인 Iterable 캐스팅을 적용합니다.
-PARA_CATEGORIES: List[str] = [str(cat.value) for cat in cast(Iterable[PARACategory], list(PARACategory))]
+PARA_CATEGORIES: List[str] = [cat.value for cat in cast(Iterable[PARACategory], list(PARACategory))]
 
 
 class HybridSearchRequest(BaseModel):
@@ -216,9 +216,10 @@ class ChatQueryRequest(BaseModel):
     @field_validator("query")
     @classmethod
     def validate_query(cls, v: str) -> str:
-        if not v or not v.strip():
+        stripped = v.strip() if v else ""
+        if not stripped:
             raise ValueError("`query`는 비어 있을 수 없습니다.")
-        return v
+        return stripped
 
 
 class ChatMessage(BaseModel):

--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 INVALID_PII_SENTINEL = "<INVALID_PII>"
+ANONYMOUS_USER_ID = "anonymous"
 
 
 def safe_parse_env_int(
@@ -99,11 +100,24 @@ def mask_pii_id(value: Optional[str], truncate_len: int = 12) -> str:
     # [Security Validation] 음수 방어(Safe Wrapper)
     safe_len = max(0, truncate_len)
 
-    hashed = str(hashlib.sha256(value.encode("utf-8")).hexdigest())
+    hashed = hashlib.sha256(value.encode("utf-8")).hexdigest()
     if safe_len > 0:
         return hashed[:safe_len]  # type: ignore[index]
     return hashed
 
+
+def get_chat_log_extra(request_or_body: Any) -> Dict[str, Any]:
+    """
+    채팅 엔드포인트(동기/스트리밍)에서 공통으로 사용하는
+    안전한 로깅 extra 딕셔너리를 생성합니다.
+    """
+    safe_user_id = getattr(request_or_body, "user_id", None) or ANONYMOUS_USER_ID
+    safe_query = getattr(request_or_body, "query", "") or ""
+    truncated_query = safe_query[:200] + ("..." if len(safe_query) > 200 else "")
+    return {
+        "user_id_hash": mask_pii_id(safe_user_id),
+        "query_preview": truncated_query,
+    }
 
 def check_metadata_match(
     doc_metadata: Optional[Dict[str, Any]], metadata_filter: Optional[Dict[str, Any]]


### PR DESCRIPTION
- **[타입 최적화] 불필요한 형변환 제거**
  - `backend/api/models/__init__.py`에서 이미 `str`인 Enum 값에 대한 불필요한 `str()` 호출을 제거하여 린터 경고(IDE) 해소.

- **[안정성 강화] Pydantic 검증 정규화 및 PII 폴백**
  - `ChatQueryRequest`의 `query` 검증 시 양쪽 공백을 제거(strip)한 깔끔한 문자열을 반환하도록 수정하여 시스템 전반의 입력값 정규화 보장.
  - `user_id`가 `None`이거나 누락된 엣지 케이스에서도 `mask_pii_id`가 크래시나지 않도록 `"anonymous"` 폴백 로직 추가.

- **[운영 관측성] 엔드포인트 로깅 구조 통일 및 주석 명확화**
  - 동기 채팅 엔드포인트(`chat.py`)의 로그 포맷을 스트리밍 엔드포인트와 완벽히 동일한 구조화된 `extra` 딕셔너리 형태로 변경하여 로그 추적(Traceability) 향상.
  - 현재 스캐폴딩의 타임아웃이 'Idle'이 아닌 'Hard Max' 제한임을 주석으로 명시하여 향후 기능 구현 시 발생할 수 있는 혼란 사전 차단.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1365#pullrequestreview-4258729052)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

동기 및 스트리밍 채팅 엔드포인트 전반에서 채팅 요청 검증을 표준화하고, 로깅 구조를 일치시키며, PII 처리 및 엣지 케이스를 강화합니다.

버그 수정:
- `user_id`가 없거나 `None`인 경우, 익명 식별자로 대체하여 스트리밍 채팅 로깅에서 크래시가 발생하지 않도록 방지합니다.

개선 사항:
- 마스킹된 사용자 ID와 잘린 쿼리 미리 보기를 포함한 구조화된 `extra` 페이로드를 사용하여 동기 채팅 엔드포인트 로깅을 스트리밍 엔드포인트와 통합합니다.
- 양쪽 공백을 제거하고 사실상 비어 있는 쿼리를 거부하도록 `ChatQueryRequest.query`를 정규화합니다.
- 중복된 문자열 변환을 제거하여 `PARA_CATEGORIES` enum 값 추출을 단순화합니다.
- 하드 최대 타임아웃과 향후 유휴 타임아웃 동작을 구분하는 문서를 추가하여 스트리밍 채팅 타임아웃 동작을 명확히 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize chat request validation and align logging structure across sync and streaming chat endpoints while hardening PII handling and edge cases.

Bug Fixes:
- Prevent crashes in streaming chat logging when user_id is missing or None by falling back to an anonymous identifier.

Enhancements:
- Unify sync chat endpoint logging with streaming endpoint using a structured extra payload with masked user ID and truncated query preview.
- Normalize ChatQueryRequest.query by stripping surrounding whitespace and rejecting effectively empty queries.
- Simplify PARA_CATEGORIES enum value extraction by removing redundant string conversions.
- Clarify streaming chat timeout behavior with documentation distinguishing hard max timeout from future idle-timeout behavior.

</details>