### PR TITLE
☘️ refactor [#12.2.21]: 6차 개선 - 런타임 타입 에러 방어 및 매직 넘버 제거

### DIFF
--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 INVALID_PII_SENTINEL = "<INVALID_PII>"
 ANONYMOUS_USER_ID = "anonymous"
+MAX_QUERY_PREVIEW_LEN = 200
 
 
 def safe_parse_env_int(
@@ -111,9 +112,21 @@ def get_chat_log_extra(request_or_body: Any) -> Dict[str, Any]:
     채팅 엔드포인트(동기/스트리밍)에서 공통으로 사용하는
     안전한 로깅 extra 딕셔너리를 생성합니다.
     """
-    safe_user_id = getattr(request_or_body, "user_id", None) or ANONYMOUS_USER_ID
-    safe_query = getattr(request_or_body, "query", "") or ""
-    truncated_query = safe_query[:200] + ("..." if len(safe_query) > 200 else "")
+    if isinstance(request_or_body, dict):
+        raw_user_id = request_or_body.get("user_id")
+        raw_query = request_or_body.get("query")
+    else:
+        raw_user_id = getattr(request_or_body, "user_id", None)
+        raw_query = getattr(request_or_body, "query", None)
+
+    safe_user_id = str(raw_user_id) if raw_user_id is not None else ANONYMOUS_USER_ID
+    
+    # 쿼리가 None이면 빈 문자열, 아니면 강제로 문자열 캐스팅
+    safe_query = "" if raw_query is None else str(raw_query)
+    
+    truncated_query = safe_query[:MAX_QUERY_PREVIEW_LEN] + (
+        "..." if len(safe_query) > MAX_QUERY_PREVIEW_LEN else ""
+    )
     return {
         "user_id_hash": mask_pii_id(safe_user_id),
         "query_preview": truncated_query,

--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -119,14 +119,14 @@ def get_chat_log_extra(request_or_body: Any) -> Dict[str, Any]:
         raw_user_id = getattr(request_or_body, "user_id", None)
         raw_query = getattr(request_or_body, "query", None)
 
-    safe_user_id = str(raw_user_id) if raw_user_id is not None else ANONYMOUS_USER_ID
+    # Truthy 체크를 통해 빈 문자열("")이나 0 같은 Falsy 값에 대해서도
+    # 안전하게 ANONYMOUS_USER_ID 로 폴백하도록 기존 동작 복원
+    safe_user_id = str(raw_user_id) if raw_user_id else ANONYMOUS_USER_ID
+    safe_query = str(raw_query) if raw_query else ""
     
-    # 쿼리가 None이면 빈 문자열, 아니면 강제로 문자열 캐스팅
-    safe_query = "" if raw_query is None else str(raw_query)
+    is_truncated = len(safe_query) > MAX_QUERY_PREVIEW_LEN
+    truncated_query = safe_query[:MAX_QUERY_PREVIEW_LEN] + ("..." if is_truncated else "")
     
-    truncated_query = safe_query[:MAX_QUERY_PREVIEW_LEN] + (
-        "..." if len(safe_query) > MAX_QUERY_PREVIEW_LEN else ""
-    )
     return {
         "user_id_hash": mask_pii_id(safe_user_id),
         "query_preview": truncated_query,


### PR DESCRIPTION
- **[방어적 설계] 로깅 헬퍼의 타입 캐스팅 및 딕셔너리 호환성 추가**
  - `get_chat_log_extra` 함수가 비문자열(Int, UUID 등) `user_id`나 `query`를 받았을 때 발생하는 런타임 해싱 에러(.encode) 및 슬라이싱 에러를 원천 차단하기 위해, 로직 진입 전 철저한 `str()` 캐스팅 적용.
  - 파라미터가 Pydantic 모델 형태가 아닌 순수 딕셔너리(`dict`) 형태로 인입되는 경우에도 안전하게 `.get()`으로 폴백(Fallback)하도록 타입 호환성 확장.

- **[유지보수성] 자르기 길이 매직 넘버 상수화**
  - 쿼리 미리보기를 위해 하드코딩되어 있던 리터럴 `200`을 `MAX_QUERY_PREVIEW_LEN` 상수로 분리하여 DRY 원칙 완벽 준수.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1367#pullrequestreview-4258736187)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

채팅 요청에 대한 방어적 로깅을 개선하고, 쿼리 미리보기 처리에서 매직 넘버를 제거합니다.

개선 사항:
- 런타임 오류 없이 비문자열 및 딕셔너리 기반 요청 객체를 안정적으로 처리할 수 있도록 `get_chat_log_extra`를 강화합니다.
- 쿼리 미리보기 절단 길이를 상수 `MAX_QUERY_PREVIEW_LEN`으로 분리하여, 하드코딩된 값을 대체합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve defensive logging for chat requests and remove a magic number from query preview handling.

Enhancements:
- Harden get_chat_log_extra to safely handle non-string and dictionary-based request objects without runtime errors.
- Extract the query preview truncation length into a MAX_QUERY_PREVIEW_LEN constant to replace the hardcoded value.

</details>