### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 INVALID_PII_SENTINEL = "<INVALID_PII>"
 ANONYMOUS_USER_ID = "anonymous"
+MAX_QUERY_PREVIEW_LEN = 200
 
 
 def safe_parse_env_int(
@@ -111,9 +112,21 @@ def get_chat_log_extra(request_or_body: Any) -> Dict[str, Any]:
     채팅 엔드포인트(동기/스트리밍)에서 공통으로 사용하는
     안전한 로깅 extra 딕셔너리를 생성합니다.
     """
-    safe_user_id = getattr(request_or_body, "user_id", None) or ANONYMOUS_USER_ID
-    safe_query = getattr(request_or_body, "query", "") or ""
-    truncated_query = safe_query[:200] + ("..." if len(safe_query) > 200 else "")
+    if isinstance(request_or_body, dict):
+        raw_user_id = request_or_body.get("user_id")
+        raw_query = request_or_body.get("query")
+    else:
+        raw_user_id = getattr(request_or_body, "user_id", None)
+        raw_query = getattr(request_or_body, "query", None)
+
+    safe_user_id = str(raw_user_id) if raw_user_id is not None else ANONYMOUS_USER_ID
+    
+    # 쿼리가 None이면 빈 문자열, 아니면 강제로 문자열 캐스팅
+    safe_query = "" if raw_query is None else str(raw_query)
+    
+    truncated_query = safe_query[:MAX_QUERY_PREVIEW_LEN] + (
+        "..." if len(safe_query) > MAX_QUERY_PREVIEW_LEN else ""
+    )
     return {
         "user_id_hash": mask_pii_id(safe_user_id),
         "query_preview": truncated_query,

--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -119,14 +119,14 @@ def get_chat_log_extra(request_or_body: Any) -> Dict[str, Any]:
         raw_user_id = getattr(request_or_body, "user_id", None)
         raw_query = getattr(request_or_body, "query", None)
 
-    safe_user_id = str(raw_user_id) if raw_user_id is not None else ANONYMOUS_USER_ID
+    # Truthy 체크를 통해 빈 문자열("")이나 0 같은 Falsy 값에 대해서도
+    # 안전하게 ANONYMOUS_USER_ID 로 폴백하도록 기존 동작 복원
+    safe_user_id = str(raw_user_id) if raw_user_id else ANONYMOUS_USER_ID
+    safe_query = str(raw_query) if raw_query else ""
     
-    # 쿼리가 None이면 빈 문자열, 아니면 강제로 문자열 캐스팅
-    safe_query = "" if raw_query is None else str(raw_query)
+    is_truncated = len(safe_query) > MAX_QUERY_PREVIEW_LEN
+    truncated_query = safe_query[:MAX_QUERY_PREVIEW_LEN] + ("..." if is_truncated else "")
     
-    truncated_query = safe_query[:MAX_QUERY_PREVIEW_LEN] + (
-        "..." if len(safe_query) > MAX_QUERY_PREVIEW_LEN else ""
-    )
     return {
         "user_id_hash": mask_pii_id(safe_user_id),
         "query_preview": truncated_query,


### PR DESCRIPTION
☘️ refactor [#12.2.21]: 6차 개선 - 런타임 타입 에러 방어 및 매직 넘버 제거 
☘️ refactor [#12.2.21]: 7차 개선 - Falsy 평가 폴백 복원 및 연산 최적화

## Summary by Sourcery

로깅을 위한 채팅 로그 메타데이터 추출을 강화하기 위해, 견고한 폴백(fallback)을 복원하고 쿼리 미리보기 길이를 상수로 중앙집중화했습니다.

버그 수정:
- `user_id` 또는 `query`가 누락되었거나 falsy일 때 익명 사용자 ID와 빈 쿼리로 폴백하도록 복원하고, 채팅 로깅에서 딕셔너리 및 속성 기반(request body) 두 방식 모두를 지원합니다.

개선 사항:
- `MAX_QUERY_PREVIEW_LEN` 상수를 도입하고, 이를 사용해 채팅 로깅을 위한 잘린(truncated) 쿼리 미리보기를 계산합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden chat log metadata extraction for logging by restoring robust fallbacks and centralizing query preview length as a constant.

Bug Fixes:
- Restore fallback to anonymous user IDs and empty queries when user_id or query are missing or falsy, and support both dict and attribute-based request bodies in chat logging.

Enhancements:
- Introduce a MAX_QUERY_PREVIEW_LEN constant and use it to compute truncated query previews for chat logging.

</details>