### PR TITLE
☘️ refactor [#12.2.21]: 10차 개선 - 독스트링 팩트 체크 및 Pydantic 처리 명세 정정

### DIFF
--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -113,8 +113,10 @@ def get_chat_log_extra(request_or_body: Any) -> Dict[str, Any]:
     채팅 엔드포인트(동기/스트리밍)에서 공통으로 사용하는
     안전한 로깅 extra 딕셔너리를 생성합니다.
     
-    (내부적으로 Mapping 타입인지 검사하여, dict 뿐만 아니라 Pydantic 객체나
-    FastAPI QueryDict 등 어떤 객체가 들어와도 읽기 전용으로 안전하게 처리합니다.)
+    내부적으로 인입된 객체의 형태를 검사하여:
+    1. dict, FastAPI QueryDict 등 Mapping 객체는 `.get()`으로
+    2. Pydantic BaseModel 등 일반 객체는 `getattr`로
+    안전하게 필드를 읽어와 처리합니다.
     """
     if isinstance(request_or_body, Mapping):
         raw_user_id = request_or_body.get("user_id")


### PR DESCRIPTION
- **[문서화] 실제 동작 원리와 독스트링 불일치 해소**
  - Pydantic `BaseModel`은 `collections.abc.Mapping` 인터페이스를 구현하지 않아 실제로는 `getattr` 폴백(`else` 분기)을 통해 정상 처리되고 있었으나, 독스트링에서는 Mapping으로 처리되는 것처럼 오해할 수 있게 작성되어 있던 점을 정정.
  - "Mapping 기반 객체는 `.get()`으로, Pydantic 모델 등 일반 객체는 `getattr`로 안전하게 읽어온다"고 로직의 분기 동작을 있는 그대로 정확하게 문서화하여 향후 혼란 사전 차단.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1371#pullrequestreview-4258751339)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Documentation:
- `Mapping` 객체는 안전한 필드 접근을 위해 `.get()`을 사용하고, Pydantic `BaseModel`과 같은 일반 객체는 `getattr`을 사용한다는 내용을 반영하도록 `get_chat_log_extra`의 docstring을 수정했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Correct the get_chat_log_extra docstring to reflect that Mapping objects use .get() and general objects like Pydantic BaseModel use getattr for safe field access.

</details>