### PR TITLE
☘️ refactor [#12.2.22]: 2차 개선 - 보안 강화 및 SSE 페이로드 형식 통일

### DIFF
--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -24,7 +24,6 @@ SSE 스트리밍 채팅 엔드포인트 (Phase 3 — 2단계: Integration)
 """
 
 import asyncio
-import json
 import logging
 import time
 from typing import AsyncGenerator
@@ -54,6 +53,12 @@ _SSE_EVENT_ERROR: str = "error"
 _SSE_EVENT_DONE: str = "done"
 
 _LOG_TAG: str = "[STREAM]"
+
+# 클라이언트에 전달할 일반화된 에러 메시지 (하드코딩 방지)
+# 내부 구현 세부사항(스택 트레이스 등) 클라이언트 노출 방지 — Information Disclosure 예방
+_GENERIC_STREAM_ERROR_MESSAGE: str = (
+    "Unexpected error occurred during streaming. Please try again later."
+)
 
 
 @router.post(
@@ -119,14 +124,20 @@ async def stream_chat_endpoint(
                 yield DoneChunk()
 
             except Exception as exc:  # noqa: BLE001
-                # 청크 발행 중 예상치 못한 예외 — 클라이언트에는 일반화된 에러만 전달
+                # 청크 발행 중 예상치 못한 예외
+                # 서버 로그에는 상세 정보 기록, 클라이언트에는 일반화된 메시지만 전달
+                # str(exc)를 클라이언트에 직접 노출하면 내부 경로·데이터가 유출될 수 있음
                 logger.error(
-                    "%s[ERROR] _chunk_stream raised unexpected error: type=%s",
+                    "%s[ERROR] _chunk_stream raised unexpected error: type=%s, detail=%s",
                     _LOG_TAG,
                     type(exc).__name__,
+                    str(exc),  # 상세 정보는 서버 로그에만 기록
                     exc_info=True,
                 )
-                yield ErrorChunk(code="PRODUCER_ERROR", message=str(exc))
+                yield ErrorChunk(
+                    code="PRODUCER_ERROR",
+                    message=_GENERIC_STREAM_ERROR_MESSAGE,  # 클라이언트에는 일반화된 메시지만
+                )
 
         # ── 메인 컨슈머 루프 ─────────────────────────────────────────────────
         try:
@@ -177,13 +188,33 @@ async def stream_chat_endpoint(
                         }
                         break
 
+                    # ── 알 수 없는 청크 타입 처리 (안전망) ────────────────────
+                    # TokenChunk / DoneChunk / ErrorChunk 외의 타입이 발행되면
+                    # 조용히 드랍되지 않도록 경고 로그 + 에러 이벤트로 가시화
+                    else:
+                        logger.warning(
+                            "%s[SCHEMA] Unknown chunk type received: %s. "
+                            "Possible schema mismatch.",
+                            _LOG_TAG,
+                            type(chunk).__name__,
+                        )
+                        yield {
+                            "event": _SSE_EVENT_ERROR,
+                            "data": ErrorChunk(
+                                code="UNKNOWN_CHUNK",
+                                message=_GENERIC_STREAM_ERROR_MESSAGE,
+                            ).model_dump_json(),
+                        }
+                        break
+
                     # ── 클라이언트 disconnect 감지 (각 청크 처리 후 즉시 확인) ──
                     if await request.is_disconnected():
                         logger.info("%s Client disconnected. Stopping stream.", _LOG_TAG)
                         break
 
-        except TimeoutError:
-            # asyncio.timeout() 초과 시 TimeoutError 발생 (Python 3.11+)
+        except asyncio.TimeoutError:
+            # asyncio.timeout() 초과 시 asyncio.TimeoutError 발생 (Python 3.11+)
+            # 명시적으로 asyncio.TimeoutError를 잡아 무관한 TimeoutError와 구분
             logger.warning(
                 "%s Session timed out after %ds.",
                 _LOG_TAG,
@@ -191,7 +222,10 @@ async def stream_chat_endpoint(
             )
             yield {
                 "event": _SSE_EVENT_ERROR,
-                "data": json.dumps({"error": "Stream timed out. Please retry."}),
+                "data": ErrorChunk(
+                    code="STREAM_TIMEOUT",
+                    message=_GENERIC_STREAM_ERROR_MESSAGE,
+                ).model_dump_json(),
             }
 
         except asyncio.CancelledError:

--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -190,13 +190,15 @@ async def stream_chat_endpoint(
 
                     # ── 알 수 없는 청크 타입 처리 (안전망) ────────────────────
                     # TokenChunk / DoneChunk / ErrorChunk 외의 타입이 발행되면
-                    # 조용히 드랍되지 않도록 경고 로그 + 에러 이벤트로 가시화
+                    # 조용히 드랍되지 않도록 경고 로그 + 에러 이벤트로 가시화.
+                    # 스키마 불일치 발생 시 스트림 무결성을 위해 즉시 중단(break)합니다.
                     else:
                         logger.warning(
                             "%s[SCHEMA] Unknown chunk type received: %s. "
-                            "Possible schema mismatch.",
+                            "payload=%r. Possible schema mismatch.",
                             _LOG_TAG,
                             type(chunk).__name__,
+                            chunk,
                         )
                         yield {
                             "event": _SSE_EVENT_ERROR,


### PR DESCRIPTION
- **[보안] str(exc) 클라이언트 직접 노출 제거 (Information Disclosure 수정)**
  - `_chunk_stream()` 예외 처리에서 `str(exc)`를 클라이언트에 그대로 전달하던 보안 버그 수정.
  - 서버 로그에는 type + detail 상세 기록, 클라이언트에는 `_GENERIC_STREAM_ERROR_MESSAGE` 상수만 전달.

- **[일관성] asyncio.TimeoutError 명시 및 SSE 페이로드 형식 통일**
  - `except TimeoutError` → `except asyncio.TimeoutError` 로 교체하여 의도를 명확히 하고 무관한 TimeoutError와 구분.
  - 타임아웃 분기의 `raw json.dumps` 페이로드를 `ErrorChunk.model_dump_json()`으로 교체하여 클라이언트가 받는 SSE 이벤트 형식 완전 통일.
  - 더 이상 사용되지 않는 `import json` 제거.

- **[안전망] 알 수 없는 청크 타입에 대한 else 분기 추가**
  - TokenChunk / DoneChunk / ErrorChunk 외 타입이 발행될 경우 조용히 드랍되지 않도록 경고 로그 + UNKNOWN_CHUNK ErrorChunk SSE 이벤트로 가시화.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1375#pullrequestreview-4261457473)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

chat_stream 엔드포인트에서 채팅 스트리밍 에러 처리의 안정성을 강화하고, SSE 에러 페이로드를 표준화합니다.

버그 수정:
- `str(exc)` 응답을 일반적인 스트리밍 에러 메시지로 대체하여, 내부 예외 상세 정보가 클라이언트에 노출되지 않도록 방지합니다.
- `asyncio.TimeoutError`를 명시적으로 대상으로 하여 타임아웃을 처리함으로써, 관련 없는 `TimeoutError` 예외가 함께 포착되지 않도록 합니다.

개선사항:
- 스트리밍 에러 응답 전반에서 사용되는 공용 일반 스트림 에러 메시지 상수를 도입합니다.
- 스트림 타임아웃 에러를 포함해 SSE 에러 페이로드가 항상 `ErrorChunk.model_dump_json()`을 사용하도록 표준화하여, 클라이언트가 항상 일관된 에러 이벤트 형식을 받도록 합니다.
- 예상치 못한 청크 타입이 발생했을 때 이를 조용히 무시하는 대신, 로그를 남기고 `UNKNOWN_CHUNK` 에러를 노출하는 보호용 분기 로직을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden chat streaming error handling and standardize SSE error payloads in the chat_stream endpoint.

Bug Fixes:
- Prevent internal exception details from being exposed to clients by replacing str(exc) responses with a generic streaming error message.
- Ensure timeout handling targets asyncio.TimeoutError explicitly to avoid catching unrelated TimeoutError exceptions.

Enhancements:
- Introduce a shared generic stream error message constant used across streaming error responses.
- Standardize SSE error payloads to use ErrorChunk.model_dump_json(), including for stream timeout errors, so clients always receive a consistent error event format.
- Add a safeguard branch that logs and surfaces an UNKNOWN_CHUNK error when an unexpected chunk type is emitted instead of silently dropping it.

</details>