### PR TITLE
☘️ refactor [#12.2.22]: 4차 개선 - 에러 메시지 세분화 및 리소스 정리(aclose) 강화

### DIFF
--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -128,10 +128,8 @@ async def stream_chat_endpoint(
                 # 서버 로그에는 상세 정보 기록, 클라이언트에는 일반화된 메시지만 전달
                 # str(exc)를 클라이언트에 직접 노출하면 내부 경로·데이터가 유출될 수 있음
                 logger.error(
-                    "%s[ERROR] _chunk_stream raised unexpected error: type=%s, detail=%s",
+                    "%s[ERROR] _chunk_stream raised unexpected error",
                     _LOG_TAG,
-                    type(exc).__name__,
-                    str(exc),  # 상세 정보는 서버 로그에만 기록
                     exc_info=True,
                 )
                 yield ErrorChunk(
@@ -238,9 +236,8 @@ async def stream_chat_endpoint(
         except Exception as exc:  # noqa: BLE001
             # 메인 루프 예외 처리 (로그 기록 후 에러 청크 발행)
             logger.error(
-                "%s[FATAL] Event generator encountered unexpected error: %s",
+                "%s[FATAL] Event generator encountered unexpected error",
                 _LOG_TAG,
-                str(exc),
                 exc_info=True,
             )
             yield {
@@ -252,9 +249,16 @@ async def stream_chat_endpoint(
             }
 
         finally:
-            # 리소스 정리 강화: 제너레이터를 명시적으로 종료하여 
-            # 프로듀서 측의 백그라운드 태스크나 리소스 누수를 방지 (리뷰 반영)
-            await stream_gen.aclose()
+            # 리소스 정리 강화: 제너레이터를 안전하게 종료 (리뷰 반영)
+            if stream_gen is not None:
+                try:
+                    await stream_gen.aclose()
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "%s[CLEANUP] Failed to close stream generator gracefully.",
+                        _LOG_TAG,
+                        exc_info=True,
+                    )
             
             total_elapsed = time.monotonic() - request_start
             logger.info(

--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -56,9 +56,9 @@ _LOG_TAG: str = "[STREAM]"
 
 # 클라이언트에 전달할 일반화된 에러 메시지 (하드코딩 방지)
 # 내부 구현 세부사항(스택 트레이스 등) 클라이언트 노출 방지 — Information Disclosure 예방
-_GENERIC_STREAM_ERROR_MESSAGE: str = (
-    "Unexpected error occurred during streaming. Please try again later."
-)
+_ERROR_MSG_INTERNAL: str = "Internal server error occurred during streaming."
+_ERROR_MSG_TIMEOUT: str = "Streaming session timed out. Please retry."
+_ERROR_MSG_SCHEMA: str = "Data format mismatch detected. Please contact support."
 
 
 @router.post(
@@ -136,14 +136,15 @@ async def stream_chat_endpoint(
                 )
                 yield ErrorChunk(
                     code="PRODUCER_ERROR",
-                    message=_GENERIC_STREAM_ERROR_MESSAGE,  # 클라이언트에는 일반화된 메시지만
+                    message=_ERROR_MSG_INTERNAL,  # 내부 오류 메시지 사용
                 )
 
         # ── 메인 컨슈머 루프 ─────────────────────────────────────────────────
+        stream_gen = _chunk_stream()  # 제너레이터 객체 생성
         try:
             # asyncio.timeout: 전체 스트림에 명확한 타임아웃 범위 지정 (Python 3.11+)
             async with asyncio.timeout(timeout_secs):
-                async for chunk in _chunk_stream():
+                async for chunk in stream_gen:
                     # ── TokenChunk 처리 ───────────────────────────────────
                     if isinstance(chunk, TokenChunk):
                         if first_token_time is None:
@@ -204,7 +205,7 @@ async def stream_chat_endpoint(
                             "event": _SSE_EVENT_ERROR,
                             "data": ErrorChunk(
                                 code="UNKNOWN_CHUNK",
-                                message=_GENERIC_STREAM_ERROR_MESSAGE,
+                                message=_ERROR_MSG_SCHEMA,  # 스캐마 불일치 메시지
                             ).model_dump_json(),
                         }
                         break
@@ -226,7 +227,7 @@ async def stream_chat_endpoint(
                 "event": _SSE_EVENT_ERROR,
                 "data": ErrorChunk(
                     code="STREAM_TIMEOUT",
-                    message=_GENERIC_STREAM_ERROR_MESSAGE,
+                    message=_ERROR_MSG_TIMEOUT,  # 타임아웃 전용 메시지
                 ).model_dump_json(),
             }
 
@@ -234,7 +235,27 @@ async def stream_chat_endpoint(
             logger.info("%s Event generator cancelled.", _LOG_TAG)
             raise
 
+        except Exception as exc:  # noqa: BLE001
+            # 메인 루프 예외 처리 (로그 기록 후 에러 청크 발행)
+            logger.error(
+                "%s[FATAL] Event generator encountered unexpected error: %s",
+                _LOG_TAG,
+                str(exc),
+                exc_info=True,
+            )
+            yield {
+                "event": _SSE_EVENT_ERROR,
+                "data": ErrorChunk(
+                    code="FATAL_ERROR",
+                    message=_ERROR_MSG_INTERNAL,
+                ).model_dump_json(),
+            }
+
         finally:
+            # 리소스 정리 강화: 제너레이터를 명시적으로 종료하여 
+            # 프로듀서 측의 백그라운드 태스크나 리소스 누수를 방지 (리뷰 반영)
+            await stream_gen.aclose()
+            
             total_elapsed = time.monotonic() - request_start
             logger.info(
                 "%s Session closed. total_elapsed=%.2fs, chunks_sent=%d",


### PR DESCRIPTION
- **[운영] 에러 코드별 사용자 친화적 메시지 분리**
  - 타임아웃(_ERROR_MSG_TIMEOUT), 데이터 불일치(_ERROR_MSG_SCHEMA), 내부 오류(_ERROR_MSG_INTERNAL) 메시지를 분리하여 클라이언트 진단 가시성 확보.
  - 내부 구현 정보는 여전히 서버 로그에만 상세 기록하여 `Information Disclosure` 방어 유지.

- **[리소스] 제너레이터 명시적 종료(aclose)를 통한 누수 방지**
  - finally 블록에서 `stream_gen.aclose()`를 명시적으로 호출하여, 루프 중단 시 프로듀서 측의 백그라운드 태스크나 리소스가 즉시 해제되도록 개선.

- **[안정성] 메인 루프 전역 예외 핸들러 추가**
  - 예기치 못한 모든 런타임 에러 경로에서 ErrorChunk 발행 및 세션 요약 로그가 보장되도록 안전망 강화.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1377#pullrequestreview-4262199361)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

클라이언트가 보게 되는 스트리밍 오류 메시지를 세분화하고, 예기치 않은 실패 상황에서도 스트리밍 루프가 더 견고하게 동작하도록 개선했으며, 기반 제너레이터가 적절히 정리되도록 보장합니다.

버그 수정:
- 루프가 예기치 않게 종료될 때 백그라운드 작업 또는 리소스 누수를 방지하기 위해 스트리밍 제너레이터 리소스가 명시적으로 닫히도록 보장했습니다.

개선 사항:
- 스트리밍 엔드포인트에서 내부 오류, 타임아웃, 데이터 스키마 불일치에 대해 각각 구체적인 클라이언트 노출용 오류 메시지를 도입했습니다.
- 주요 스트리밍 루프 주위에 전역 예외 처리기를 추가하여 예기치 않은 실패를 로깅하고, 치명적인 오류 청크를 클라이언트에 전송하도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Differentiate client-facing streaming error messages and harden the streaming loop against unexpected failures while ensuring proper cleanup of the underlying generator.

Bug Fixes:
- Ensure streaming generator resources are explicitly closed to prevent background task or resource leaks when the loop exits unexpectedly.

Enhancements:
- Introduce specific client-facing error messages for internal errors, timeouts, and data schema mismatches in the streaming endpoint.
- Add a global exception handler around the main streaming loop to log unexpected failures and emit a fatal error chunk to the client.

</details>