### PR TITLE
☘️ refactor [#12.2.22]: 6차 개선 - `UnboundLocalError` 방지를 위한 제너레이터 초기화 위치 수정

### DIFF
--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -138,8 +138,9 @@ async def stream_chat_endpoint(
                 )
 
         # ── 메인 컨슈머 루프 ─────────────────────────────────────────────────
-        stream_gen = _chunk_stream()  # 제너레이터 객체 생성
+        stream_gen: AsyncGenerator[StreamChunk, None] | None = None
         try:
+            stream_gen = _chunk_stream()  # 제너레이터 객체 생성
             # asyncio.timeout: 전체 스트림에 명확한 타임아웃 범위 지정 (Python 3.11+)
             async with asyncio.timeout(timeout_secs):
                 async for chunk in stream_gen:


### PR DESCRIPTION
- **[안정성] 리소스 정리(Cleanup) 과정의 결함 내성 강화**
  - `stream_gen` 변수를 try 블록 이전에 None으로 명시적 초기화하여, 제너레이터 객체 생성 시점에 예외가 발생하더라도 finally 절에서 `UnboundLocalError` 없이 안전한 참조가 가능하도록 개선.
  - 이를 통해 어떤 실패 경로에서도 2차 에러 없이 리소스 정리 및 로그 기록이 보장됨.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1379#pullrequestreview-4262279678)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

버그 수정:
- 채팅 스트림 핸들러에서 `try/finally` 블록 전에 스트림 생성기 변수를 초기화하여, 정리(cleanup) 과정에서 발생할 수 있는 `UnboundLocalError`를 방지했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent UnboundLocalError during cleanup by initializing the stream generator variable before the try/finally block in the chat stream handler.

</details>