### PR TITLE
✨ feat [#12.2.23]: Phase 3.2 - ➂ 관측성 및 안정성 강화(Hardening) 및 공통 로직 리팩터링

### DIFF
--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -111,17 +111,24 @@ async def stream_chat_endpoint(
                   yield chunk
             """
             try:
-                # TODO(3단계): 실제 LangGraph graph, inputs, config 주입
-                # graph = await get_compiled_graph()
-                # inputs = {"query": body.query, "user_id": hashed_user_id}
-                # config = RunnableConfig(configurable={"thread_id": session_id})
-                # async for chunk in stream_agent_response(graph, inputs, config):
-                #     yield chunk
+                from backend.services.chat_service import get_chat_service
+                from backend.agent.streaming import stream_agent_response
+                from langchain_core.runnables import RunnableConfig  # type: ignore[import]
 
-                # 2단계 스캐폴딩: 어댑터 인터페이스 검증용 더미 청크
-                await asyncio.sleep(0)  # 이벤트 루프 양보 (비동기 코루틴 시뮬레이션)
-                yield TokenChunk(data="[2단계 연결 완료: LangGraph 어댑터 인터페이스 준비됨]")
-                yield DoneChunk()
+                chat_service = get_chat_service()
+
+                # 기존 /api/chat 엔드포인트와 공통 로직 리팩터링 (재사용)
+                initial_state, agent_graph, _ = await chat_service.build_agent_state_and_graph(
+                    query=body.query,
+                    user_id=body.user_id,
+                    session_id=body.session_id,
+                )
+
+                config = RunnableConfig(configurable={"thread_id": body.session_id})
+
+                # 실제 LangGraph 스트리밍 어댑터 호출
+                async for chunk in stream_agent_response(agent_graph, initial_state, config):
+                    yield chunk
 
             except Exception as exc:  # noqa: BLE001
                 # 청크 발행 중 예상치 못한 예외

--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -26,6 +26,7 @@ SSE 스트리밍 채팅 엔드포인트 (Phase 3 — 2단계: Integration)
 import asyncio
 import logging
 import time
+import uuid
 from typing import AsyncGenerator
 
 from fastapi import APIRouter, Request
@@ -118,13 +119,15 @@ async def stream_chat_endpoint(
                 chat_service = get_chat_service()
 
                 # 기존 /api/chat 엔드포인트와 공통 로직 리팩터링 (재사용)
-                initial_state, agent_graph, _ = await chat_service.build_agent_state_and_graph(
+                initial_state, agent_graph = await chat_service.build_agent_state_and_graph(
                     query=body.query,
                     user_id=body.user_id,
                     session_id=body.session_id,
                 )
 
-                config = RunnableConfig(configurable={"thread_id": body.session_id})
+                # downstream 컴포넌트 오류 방지를 위한 식별자 정규화
+                effective_session_id = body.session_id if body.session_id and body.session_id.strip() else f"temp_{uuid.uuid4().hex}"
+                config = RunnableConfig(configurable={"thread_id": effective_session_id})
 
                 # 실제 LangGraph 스트리밍 어댑터 호출
                 async for chunk in stream_agent_response(agent_graph, initial_state, config):

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -8,7 +8,11 @@ import time
 import hashlib
 from functools import lru_cache
 from itertools import islice
-from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple, TypedDict, cast
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional, Tuple, TypedDict, cast
+
+if TYPE_CHECKING:
+    from langgraph.graph.state import CompiledStateGraph  # type: ignore[import, import-untyped]
+
 
 from langchain_core.callbacks.manager import CallbackManagerForRetrieverRun  # type: ignore[import, import-untyped, reportMissingImports]
 from langchain_core.documents import Document  # type: ignore[import, import-untyped, reportMissingImports]
@@ -395,23 +399,23 @@ Standalone Question:"""
         query: str,
         user_id: str,
         session_id: Optional[str] = None,
-    ) -> Tuple[Dict[str, Any], Any, float]:
+    ) -> Tuple[Dict[str, Any], "CompiledStateGraph"]:
         """
         RAG 파이프라인(LangGraph) 실행을 위한 초기 상태와 그래프를 생성합니다.
         스트리밍과 비스트리밍 엔드포인트 간의 공통 로직을 분리하여 중복을 방지합니다.
+
+        Returns:
+            Tuple[Dict[str, Any], CompiledStateGraph]: 에이전트 초기 상태와 LangGraph 그래프 객체.
         """
         history: List[ChatMessage] = []
         feedback_history: List[FeedbackEntry] = []
         effective_query = query
-        rephrase_duration = 0.0
 
         if session_id and session_id.strip():
             history = await self.chat_history_service.get_history(session_id)
             feedback_history = await self.chat_history_service.get_session_feedback(session_id, limit=3)
             if history:
-                rephrase_start = time.perf_counter()
                 effective_query = await self._rephrase_query(query, history)
-                rephrase_duration = time.perf_counter() - rephrase_start
 
         from langchain_core.messages import HumanMessage, AIMessage, BaseMessage  # type: ignore[import, import-untyped, reportMissingImports]
         langchain_history: List[BaseMessage] = []
@@ -433,7 +437,7 @@ Standalone Question:"""
         from backend.agent.chat.graph import create_chat_workflow  # type: ignore[import, import-untyped, reportMissingImports]
         agent_graph = create_chat_workflow(checkpointer=None)
 
-        return initial_state, agent_graph, rephrase_duration
+        return initial_state, agent_graph
 
     async def stream_chat(
         self,
@@ -448,9 +452,11 @@ Standalone Question:"""
         logger.info(f"Stream chat started for user {user_id}")
 
         # 1. 공통 에이전트 실행 로직 재사용
-        initial_state, agent_graph, rephrase_duration = await self.build_agent_state_and_graph(
+        build_start = time.perf_counter()
+        initial_state, agent_graph = await self.build_agent_state_and_graph(
             query=query, user_id=user_id, session_id=session_id
         )
+        rephrase_duration = time.perf_counter() - build_start
 
         # 3. Streaming 실행 (astream_events v2 사용)
         is_cancelled = False

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -125,10 +125,11 @@ class ChatService:
         import os
 
         # 런타임마다 읽지 않고 서비스 초기화 시점에 한 번만 읽고 검증(Fail Fast)
+        raw_docs = os.getenv("RAG_MAX_DOCS", "10")
+        raw_chars = os.getenv("RAG_MAX_DOC_CHARS", "2000")
+        raw_total = os.getenv("RAG_MAX_TOTAL_CHARS", "16000")
+
         try:
-            raw_docs = os.getenv("RAG_MAX_DOCS", "10")
-            raw_chars = os.getenv("RAG_MAX_DOC_CHARS", "2000")
-            raw_total = os.getenv("RAG_MAX_TOTAL_CHARS", "16000")
 
             self.rag_max_docs = int(raw_docs)
             self.rag_max_doc_chars = int(raw_chars)
@@ -389,19 +390,16 @@ Standalone Question:"""
         # JSON 직렬화 불가 객체(UUID, datetime 등) 방어를 위해 default=str 파라미터 적용
         return f"data: {json.dumps(payload, ensure_ascii=False, default=str)}\n\n"
 
-    async def stream_chat(
+    async def build_agent_state_and_graph(
         self,
         query: str,
         user_id: str,
         session_id: Optional[str] = None,
-        k: int = 5,
-        alpha: Optional[float] = None,
-    ) -> AsyncGenerator[str, None]:
-        """질의를 받아 RAG 체인을 실행하고 SSE 규격에 맞게 결과 청크를 반환하는 비동기 제너레이터"""
-        start_time = time.perf_counter()
-        logger.info(f"Stream chat started for user {user_id}")
-
-        # 0. 히스토리 로드 및 질의 재구성
+    ) -> Tuple[Dict[str, Any], Any, float]:
+        """
+        RAG 파이프라인(LangGraph) 실행을 위한 초기 상태와 그래프를 생성합니다.
+        스트리밍과 비스트리밍 엔드포인트 간의 공통 로직을 분리하여 중복을 방지합니다.
+        """
         history: List[ChatMessage] = []
         feedback_history: List[FeedbackEntry] = []
         effective_query = query
@@ -415,7 +413,6 @@ Standalone Question:"""
                 effective_query = await self._rephrase_query(query, history)
                 rephrase_duration = time.perf_counter() - rephrase_start
 
-        # 1. 메시지 컨텍스트 및 초기 State 구성
         from langchain_core.messages import HumanMessage, AIMessage, BaseMessage  # type: ignore[import, import-untyped, reportMissingImports]
         langchain_history: List[BaseMessage] = []
         for msg in history:
@@ -433,9 +430,27 @@ Standalone Question:"""
             "feedback_history": feedback_history,
         }
 
-        # 2. workflow 컴파일 및 의존성 주입
         from backend.agent.chat.graph import create_chat_workflow  # type: ignore[import, import-untyped, reportMissingImports]
         agent_graph = create_chat_workflow(checkpointer=None)
+
+        return initial_state, agent_graph, rephrase_duration
+
+    async def stream_chat(
+        self,
+        query: str,
+        user_id: str,
+        session_id: Optional[str] = None,
+        k: int = 5,
+        alpha: Optional[float] = None,
+    ) -> AsyncGenerator[str, None]:
+        """질의를 받아 RAG 체인을 실행하고 SSE 규격에 맞게 결과 청크를 반환하는 비동기 제너레이터"""
+        start_time = time.perf_counter()
+        logger.info(f"Stream chat started for user {user_id}")
+
+        # 1. 공통 에이전트 실행 로직 재사용
+        initial_state, agent_graph, rephrase_duration = await self.build_agent_state_and_graph(
+            query=query, user_id=user_id, session_id=session_id
+        )
 
         # 3. Streaming 실행 (astream_events v2 사용)
         is_cancelled = False


### PR DESCRIPTION
- **[리팩터링] 공통 에이전트 실행 로직 분리 및 재사용**
  - 기존 동기/비스트리밍 엔드포인트와 스트리밍 엔드포인트 간의 비즈니스 로직 중복을 방지하기 위해, LangGraph 초기 상태(State) 및 그래프 컴파일 로직을 `ChatService.build_agent_state_and_graph` 헬퍼로 추출.

- **[통합] 실제 LangGraph 스트리밍 어댑터 연동**
  - `chat_stream.py`의 스캐폴딩 더미 제너레이터를 제거하고, 추출한 공통 헬퍼를 통해 `stream_agent_response`를 호출하도록 변경.
  - 인증된 `user_id` 및 `session_id`를 기반으로 실제 RAG 파이프라인 토큰 스트리밍 동작 보장.

- **[버그 수정] IDE UnboundLocalError 경고 해결**
  - `chat_service.py` 초기화 과정에서 `os.getenv()` 호출을 `try` 블록 외부로 이동하여 예외 발생 시 `raw_docs` 등의 환경 변수가 초기화되지 않은 상태로 로그에 참조되는 문제 원천 차단.

- **[문서화] Phase 3.2 작업 현황 업데이트**
  - 3단계 관련 체크리스트 및 라우터 등록 항목 완료 처리.

🔗 Related: Issue [#1047]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

채팅 에이전트 초기화를 재사용 가능한 헬퍼로 리팩터링하고, 스트리밍 엔드포인트를 실제 LangGraph 파이프라인에 연결하는 동시에 설정 처리의 안정성을 강화했습니다.

버그 수정:
- 채팅 서비스 초기화 과정에서 `try/except` 블록 이전에 RAG 관련 환경 변수를 읽도록 하여 `UnboundLocalError`가 발생하지 않도록 방지했습니다.

개선 사항:
- 공통으로 사용하는 LangGraph 상태 및 그래프 구성을 재사용 가능하도록 `ChatService.build_agent_state_and_graph`로 추출하여 여러 채팅 엔드포인트에서 사용할 수 있게 했습니다.
- 이전의 더미 스캐폴드 대신, 공통 헬퍼와 실제 LangGraph 스트리밍 어댑터를 사용하도록 채팅 스트리밍 API를 업데이트했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor chat agent initialization into a reusable helper and wire the streaming endpoint to the real LangGraph pipeline while hardening configuration handling.

Bug Fixes:
- Prevent UnboundLocalError by reading RAG-related environment variables before the try/except during chat service initialization.

Enhancements:
- Extract shared LangGraph state and graph construction into ChatService.build_agent_state_and_graph for reuse across chat endpoints.
- Update the chat streaming API to use the common helper and actual LangGraph streaming adapter instead of the previous dummy scaffold.

</details>