### PR TITLE
☘️ refactor [#12.2.23]: 2차 개선 - 관측성 메트릭 명명 오류 수정 및 리뷰 피드백 검토

### DIFF
--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -310,7 +310,7 @@ class ChatService:
         self,
         *,
         start_time: float,
-        rephrase_duration: float,
+        setup_duration: float,
         user_id: str,
     ) -> float:
         """
@@ -324,7 +324,7 @@ class ChatService:
             f"[Performance] TTFT recorded for user {user_id}",
             extra={
                 "ttft": ttft,
-                "rephrase_duration": rephrase_duration,
+                "setup_duration": setup_duration,
                 "user_id": user_id,
             },
         )
@@ -456,7 +456,7 @@ Standalone Question:"""
         initial_state, agent_graph = await self.build_agent_state_and_graph(
             query=query, user_id=user_id, session_id=session_id
         )
-        rephrase_duration = time.perf_counter() - build_start
+        setup_duration = time.perf_counter() - build_start
 
         # 3. Streaming 실행 (astream_events v2 사용)
         is_cancelled = False
@@ -494,7 +494,7 @@ Standalone Question:"""
                         if not ttft_recorded:
                             _ = self._log_ttft_once(
                                 start_time=start_time,
-                                rephrase_duration=rephrase_duration,
+                                setup_duration=setup_duration,
                                 user_id=user_id,
                             )
                             ttft_recorded = True


### PR DESCRIPTION
- **[관측성 지표 정확도 향상] 메트릭 이름 변경**
  - `stream_chat`에서 측정하는 시간이 단순 질의 재구성이 아닌 전체 파이프라인 초기화(상태 구성, 이력 로딩, 그래프 컴파일)를 포함하므로, 데이터 지표의 오해를 방지하기 위해 `rephrase_duration`을 `setup_duration`으로 변경.
  - `_log_ttft_once` 헬퍼의 파라미터 및 로깅 페이로드 키 값 동기화.

- **[리뷰어 피드백 검토] user_id 파라미터 제거 건 (반려)**
  - 리뷰어는 `build_agent_state_and_graph`에서 `user_id`가 미사용된다고 지적했으나, 실제로는 LangGraph `AgentState` 스키마에 정의된 필수 필드이며 `initial_state` 딕셔너리 생성 시 다운스트림을 위해 정상적으로 병합되어 사용 중임.
  - 이를 무분별하게 제거할 경우 에이전트 노드에서 스키마 검증 에러 및 런타임 크래시가 발생하므로, 시스템 안정성(Robustness)을 우선하여 해당 파라미터를 유지함.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1383#pullrequestreview-4268960948)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Enhancements:
- TTFT 가시성을 더 명확히 하기 위해 내부 로깅 헬퍼와 `stream_chat` 타이밍 메트릭을 `rephrase_duration`에서 `setup_duration`으로 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update internal logging helper and stream_chat timing metric from rephrase_duration to setup_duration for clearer TTFT observability.

</details>