### PR TITLE
☘️ refactor [#12.2.23]: 3차 개선 - 관측성 메트릭 일관성 확보를 위한 변수명 통일

### DIFF
--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -452,11 +452,11 @@ Standalone Question:"""
         logger.info(f"Stream chat started for user {user_id}")
 
         # 1. 공통 에이전트 실행 로직 재사용
-        build_start = time.perf_counter()
+        setup_start = time.perf_counter()
         initial_state, agent_graph = await self.build_agent_state_and_graph(
             query=query, user_id=user_id, session_id=session_id
         )
-        setup_duration = time.perf_counter() - build_start
+        setup_duration = time.perf_counter() - setup_start
 
         # 3. Streaming 실행 (astream_events v2 사용)
         is_cancelled = False


### PR DESCRIPTION
- **[변수명 일관성 확보] 측정 시작 변수명 변경**
  - 이전 개선에서 `setup_duration`으로 변경된 관측성 지표의 명명 규칙과 일관성을 맞추기 위해, 측정 시작 시간을 저장하는 지역 변수명을 `build_start`에서 `setup_start`로 변경.
  - 이를 통해 파이프라인의 '설정(Setup) 단계' 경계를 코드로 더욱 명확하게 표현하고 가독성 증대.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1385#pullrequestreview-4268983899)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

향상 사항:
- 채팅 스트리밍 설정에서 사용되는 로컬 타이밍 변수를 기존 `setup_duration` 관측 메트릭 명명 규칙과 일치하도록 이름을 변경합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Rename the local timing variable in the chat streaming setup to match the existing setup_duration observability metric naming convention.

</details>