### PR TITLE
✨ feat [#12.2.24]: Phase 3.3 - ① SSE 클라이언트 유틸리티 구현 (Stream Client)

### DIFF
--- a/web_ui/src/lib/stream-client.ts
+++ b/web_ui/src/lib/stream-client.ts
@@ -1,10 +1,10 @@
 // web_ui/src/lib/stream-client.ts
 
 import { API_BASE } from './api';
+import type { SourceItem } from '@/types/chat';
 
 export type StreamChunkToken = { type: 'token'; data: string };
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type StreamChunkSources = { type: 'sources'; data: any[] };
+export type StreamChunkSources = { type: 'sources'; data: SourceItem[] };
 export type StreamChunkError = { type: 'error'; error_code: string; message: string };
 export type StreamChunkDone = { type: 'done' };
 export type StreamChunk = StreamChunkToken | StreamChunkSources | StreamChunkError | StreamChunkDone;
@@ -56,32 +56,42 @@ export async function* fetchChatStream(
 
       buffer += decoder.decode(value, { stream: true });
       
-      let newlineIndex;
-      // SSE 이벤트는 \n\n으로 구분됨
-      while ((newlineIndex = buffer.indexOf('\n\n')) >= 0) {
-        const chunk = buffer.slice(0, newlineIndex).trim();
-        buffer = buffer.slice(newlineIndex + 2);
+      const lines = buffer.split(/\r?\n/);
+      // 마지막 원소는 아직 완료되지 않은 줄일 수 있으므로 버퍼에 남겨둡니다.
+      buffer = lines.pop() || '';
 
-        if (!chunk) continue;
-        
-        // SSE 규격 "data: <json>"
-        if (chunk.startsWith('data: ')) {
-          const dataStr = chunk.slice(6).trim();
-          
-          if (dataStr === '[DONE]') {
-            yield { type: 'done' };
-            return;
+      let currentData: string[] = [];
+
+      for (const line of lines) {
+        if (line === '') {
+          // 빈 줄은 SSE 블록의 끝(Dispatch)을 의미합니다.
+          if (currentData.length > 0) {
+            const dataStr = currentData.join('\n');
+            currentData = []; // 리셋
+
+            if (dataStr === '[DONE]') {
+              yield { type: 'done' };
+              return;
+            }
+
+            try {
+              const parsed = JSON.parse(dataStr) as StreamChunk;
+              // 에러 청크인 경우 여기서 변환을 추가할 수 있습니다.
+              // (보안을 위해 내부 에러 코드는 클라이언트에서 마스킹)
+              yield parsed;
+            } catch (e) {
+              console.error('[StreamClient] Failed to parse stream chunk JSON:', e, dataStr);
+            }
           }
-          
-          try {
-            const parsed = JSON.parse(dataStr) as StreamChunk;
-            // 에러 청크인 경우 여기서 변환을 추가할 수 있습니다.
-            // (보안을 위해 내부 에러 코드는 클라이언트에서 마스킹)
-            yield parsed;
-          } catch (e) {
-            console.error('[StreamClient] Failed to parse stream chunk JSON:', e, dataStr);
-          }
+          continue;
         }
+
+        if (line.startsWith('data:')) {
+          // 'data:' 바로 뒤에 공백이 있다면 하나만 제거 (스펙 준수)
+          const dataContent = line.startsWith('data: ') ? line.slice(6) : line.slice(5);
+          currentData.push(dataContent);
+        }
+        // event:, id: 등 기타 필드는 현재 무시합니다. (필요 시 확장 가능)
       }
     }
   } finally {

--- a/web_ui/src/lib/stream-client.ts
+++ b/web_ui/src/lib/stream-client.ts
@@ -1,0 +1,90 @@
+// web_ui/src/lib/stream-client.ts
+
+import { API_BASE } from './api';
+
+export type StreamChunkToken = { type: 'token'; data: string };
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type StreamChunkSources = { type: 'sources'; data: any[] };
+export type StreamChunkError = { type: 'error'; error_code: string; message: string };
+export type StreamChunkDone = { type: 'done' };
+export type StreamChunk = StreamChunkToken | StreamChunkSources | StreamChunkError | StreamChunkDone;
+
+export interface StreamChatRequest {
+  query: string;
+  user_id: string;
+  session_id?: string;
+  k?: number;
+  alpha?: number;
+}
+
+/**
+ * 표준 fetch API를 사용하여 백엔드의 SSE(Server-Sent Events) 스트림을 소비합니다.
+ * EventSource 객체 대신 fetch를 사용하여 POST 요청과 커스텀 헤더 인증을 지원합니다.
+ */
+export async function* fetchChatStream(
+  payload: StreamChatRequest,
+  signal?: AbortSignal
+): AsyncGenerator<StreamChunk, void, unknown> {
+  const url = `${API_BASE}/api/chat/stream`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'text/event-stream',
+    },
+    body: JSON.stringify(payload),
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to start stream: ${response.status} ${response.statusText}`);
+  }
+
+  if (!response.body) {
+    throw new Error('Response body is null');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder('utf-8');
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      
+      let newlineIndex;
+      // SSE 이벤트는 \n\n으로 구분됨
+      while ((newlineIndex = buffer.indexOf('\n\n')) >= 0) {
+        const chunk = buffer.slice(0, newlineIndex).trim();
+        buffer = buffer.slice(newlineIndex + 2);
+
+        if (!chunk) continue;
+        
+        // SSE 규격 "data: <json>"
+        if (chunk.startsWith('data: ')) {
+          const dataStr = chunk.slice(6).trim();
+          
+          if (dataStr === '[DONE]') {
+            yield { type: 'done' };
+            return;
+          }
+          
+          try {
+            const parsed = JSON.parse(dataStr) as StreamChunk;
+            // 에러 청크인 경우 여기서 변환을 추가할 수 있습니다.
+            // (보안을 위해 내부 에러 코드는 클라이언트에서 마스킹)
+            yield parsed;
+          } catch (e) {
+            console.error('[StreamClient] Failed to parse stream chunk JSON:', e, dataStr);
+          }
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}


### PR DESCRIPTION
- **[유틸리티] 표준 fetch API 기반 SSE 스트림 파서 구현**
  - 기존 `EventSource` 객체의 한계(POST 전송 및 커스텀 인증 헤더 지원 불가)를 극복하기 위해 `fetch` API와 `ReadableStream`을 활용한 커스텀 클라이언트(`stream-client.ts`) 신설.
  - 백엔드의 OpenAPI 스키마 규칙과 동기화된 `StreamChunk` 타입(`Token`, `Sources`, `Error`, `Done`) 정의 및 제네릭 타입 파싱 체계 구축.
  - `AbortController`를 지원하여 컴포넌트 언마운트 시 발생할 수 있는 좀비 연결 및 메모리 누수(Memory Leak) 원천 차단.

- **[문서화] Phase 3.3 (1단계) 작업 현황 체크리스트 업데이트**

🔗 Related: Issue [#1047]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

백엔드 스트리밍 응답을 소비하기 위한 fetch 기반 SSE 채팅 스트림 클라이언트 유틸리티를 도입합니다.

새 기능:
- 타입이 지정된 SSE 메시지 처리를 위해 제네릭 `StreamChunk` 타입과 관련 청크 변형 타입들을 추가합니다.
- 중단(abort) 신호를 지원하는 POST 기반 SSE 채팅 스트림을 소비하는 비동기 제너레이터 `fetchChatStream`을 구현합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a fetch-based SSE chat stream client utility for consuming backend streaming responses.

New Features:
- Add a generic StreamChunk type and related chunk variants for typed SSE message handling.
- Implement a fetchChatStream async generator that consumes POST-based SSE chat streams with abort signal support.

</details>