### PR TITLE
☘️ refactor [#12.2.24]: 2차 개선 - 스트림 안정성 강화 및 크리티컬 버그 수정

### DIFF
--- a/web_ui/src/lib/stream-client.ts
+++ b/web_ui/src/lib/stream-client.ts
@@ -41,19 +41,19 @@ export async function* fetchChatStream(
   } catch (err: unknown) {
     const error = err as Error;
     if (error.name === 'AbortError') {
-      console.log('[StreamClient] fetch aborted by user');
+      console.debug('[StreamClient] fetch aborted by user');
       return;
     }
     throw err;
   }
 
+  if (!response.ok) {
+    throw new Error(`Failed to start stream: ${response.status} ${response.statusText}`);
+  }
+
   const contentType = response.headers.get('content-type');
   if (!contentType || !contentType.includes('text/event-stream')) {
     throw new Error(`Expected text/event-stream but received ${contentType}`);
-  }
-
-  if (!response.ok) {
-    throw new Error(`Failed to start stream: ${response.status} ${response.statusText}`);
   }
 
   if (!response.body) {
@@ -78,7 +78,7 @@ export async function* fetchChatStream(
       } catch (err: unknown) {
         const error = err as Error;
         if (error.name === 'AbortError') {
-          console.log('[StreamClient] Stream read aborted by user');
+          console.debug('[StreamClient] Stream read aborted by user');
           return;
         }
         throw err;

--- a/web_ui/src/lib/stream-client.ts
+++ b/web_ui/src/lib/stream-client.ts
@@ -27,15 +27,30 @@ export async function* fetchChatStream(
 ): AsyncGenerator<StreamChunk, void, unknown> {
   const url = `${API_BASE}/api/chat/stream`;
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Accept': 'text/event-stream',
-    },
-    body: JSON.stringify(payload),
-    signal,
-  });
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'text/event-stream',
+      },
+      body: JSON.stringify(payload),
+      signal,
+    });
+  } catch (err: unknown) {
+    const error = err as Error;
+    if (error.name === 'AbortError') {
+      console.log('[StreamClient] fetch aborted by user');
+      return;
+    }
+    throw err;
+  }
+
+  const contentType = response.headers.get('content-type');
+  if (!contentType || !contentType.includes('text/event-stream')) {
+    throw new Error(`Expected text/event-stream but received ${contentType}`);
+  }
 
   if (!response.ok) {
     throw new Error(`Failed to start stream: ${response.status} ${response.statusText}`);
@@ -49,18 +64,33 @@ export async function* fetchChatStream(
   const decoder = new TextDecoder('utf-8');
   let buffer = '';
 
+  // [Bugfix] 상태 변수들을 while 루프 외부로 이동하여 
+  // 네트워크 청크(frame) 분할 시에도 데이터가 유실되지 않고 온전히 누적되도록 수정
+  let currentData: string[] = [];
+  let currentEvent: string | null = null;
+  let currentId: string | null = null;
+
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      let readResult;
+      try {
+        readResult = await reader.read();
+      } catch (err: unknown) {
+        const error = err as Error;
+        if (error.name === 'AbortError') {
+          console.log('[StreamClient] Stream read aborted by user');
+          return;
+        }
+        throw err;
+      }
+
+      const { done, value } = readResult;
       if (done) break;
 
       buffer += decoder.decode(value, { stream: true });
       
       const lines = buffer.split(/\r?\n/);
-      // 마지막 원소는 아직 완료되지 않은 줄일 수 있으므로 버퍼에 남겨둡니다.
       buffer = lines.pop() || '';
-
-      let currentData: string[] = [];
 
       for (const line of lines) {
         if (line === '') {
@@ -69,6 +99,12 @@ export async function* fetchChatStream(
             const dataStr = currentData.join('\n');
             currentData = []; // 리셋
 
+            if (currentEvent || currentId) {
+              // 추후 reconnection이나 event-type 라우팅을 지원하기 위해 파싱해둠
+              console.debug(`[StreamClient] event: ${currentEvent}, id: ${currentId}`);
+              currentEvent = null; // SSE 스펙상 event는 블록 끝에서 리셋됨
+            }
+
             if (dataStr === '[DONE]') {
               yield { type: 'done' };
               return;
@@ -76,8 +112,6 @@ export async function* fetchChatStream(
 
             try {
               const parsed = JSON.parse(dataStr) as StreamChunk;
-              // 에러 청크인 경우 여기서 변환을 추가할 수 있습니다.
-              // (보안을 위해 내부 에러 코드는 클라이언트에서 마스킹)
               yield parsed;
             } catch (e) {
               console.error('[StreamClient] Failed to parse stream chunk JSON:', e, dataStr);
@@ -87,11 +121,13 @@ export async function* fetchChatStream(
         }
 
         if (line.startsWith('data:')) {
-          // 'data:' 바로 뒤에 공백이 있다면 하나만 제거 (스펙 준수)
           const dataContent = line.startsWith('data: ') ? line.slice(6) : line.slice(5);
           currentData.push(dataContent);
+        } else if (line.startsWith('event:')) {
+          currentEvent = line.startsWith('event: ') ? line.slice(7) : line.slice(6);
+        } else if (line.startsWith('id:')) {
+          currentId = line.startsWith('id: ') ? line.slice(4) : line.slice(3);
         }
-        // event:, id: 등 기타 필드는 현재 무시합니다. (필요 시 확장 가능)
       }
     }
   } finally {


### PR DESCRIPTION
- **[버그 픽스] 네트워크 청크 분할 시 데이터 유실 버그 수정 (Critical)**
  - `currentData` 배열이 `reader.read()` 루프 내부에서 매번 초기화되어, 하나의 SSE 이벤트가 여러 청크에 걸쳐 수신될 경우 데이터가 파편화되고 버려지는 치명적 버그 수정.
  - 해당 상태 변수들을 루프 외부로 이동하여 이벤트 블록 단위(빈 줄)가 완성될 때까지 안전하게 누적되도록 개선.

- **[네트워크 안정성] AbortError 명시적 예외 처리**
  - 사용자가 스트림을 강제 중단(`cancelStream`)할 때 발생하는 `AbortError`를 일반 에러와 분리하여 처리. 콘솔에 의도된 중단임을 알리고 불필요한 크래시나 에러 리포팅을 방지.

- **[Fail-Fast] Content-Type 사전 검증**
  - 스트림 파싱을 시작하기 전에 `Content-Type` 헤더가 `text/event-stream`인지 검증하여, 서버 장애나 엉뚱한 HTML 에러 페이지가 응답으로 왔을 때 파서가 오작동하기 전에 즉시 실패(Fail-Fast)하도록 방어 로직 추가.

- **[확장성] 이벤트 및 ID 수집**
  - 향후 Reconnection 로직이나 Event-Type 라우팅 도입을 대비하여, 무시되던 `event:`와 `id:` 필드를 파싱하고 수집(현재는 디버그 로깅으로 활용)하도록 스펙 커버리지 확보.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1389#pullrequestreview-4278612560)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

네트워크 오류 처리 강화와 청크 간 데이터 손실 수정으로 SSE 채팅 스트림 처리를 보다 견고하게 합니다.

버그 수정:
- 하나의 SSE 이벤트가 여러 네트워크 청크에 걸쳐 전달될 때, 읽기 간 파싱 상태를 유지하여 이벤트 데이터가 손실되는 문제를 수정했습니다.

개선 사항:
- `fetch` 및 스트림 읽기 중 발생하는 `AbortError`를 별도로 처리하여, 사용자가 의도적으로 취소한 경우를 치명적 오류로 간주하지 않도록 했습니다.
- SSE 파싱을 시작하기 전에 응답의 `Content-Type`이 `text/event-stream`인지 검증하여, 잘못된 응답에 대해 빠르게 실패하도록 했습니다.
- 향후 재연결 및 이벤트 타입 기반 라우팅 지원을 위해 SSE 이벤트의 `event` 및 `id` 필드를 파싱하고 로그로 남기도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen SSE chat stream handling by hardening network error handling and fixing data loss across chunks.

Bug Fixes:
- Fix loss of SSE event data when a single event spans multiple network chunks by preserving parsing state across reads.

Enhancements:
- Handle AbortError separately during fetch and stream reads to treat user-initiated cancellations as non-fatal.
- Validate the response Content-Type as text/event-stream before starting SSE parsing to fail fast on invalid responses.
- Parse and log SSE event and id fields to prepare for future reconnection and event-type routing support.

</details>