### PR TITLE
☘️ refactor [#12.2.24]: 4차 개선 - SSE 스펙 준수 및 타입 가드 강화

### DIFF
--- a/web_ui/src/lib/stream-client.ts
+++ b/web_ui/src/lib/stream-client.ts
@@ -39,8 +39,11 @@ export async function* fetchChatStream(
       signal,
     });
   } catch (err: unknown) {
-    const error = err as Error;
-    if (error.name === 'AbortError') {
+    // AbortError는 DOMException 또는 Error로 올 수 있으므로 두 경우를 모두 처리
+    const isAbort =
+      (err instanceof DOMException && err.name === 'AbortError') ||
+      (err instanceof Error && err.name === 'AbortError');
+    if (isAbort) {
       console.debug('[StreamClient] fetch aborted by user');
       return;
     }
@@ -76,8 +79,11 @@ export async function* fetchChatStream(
       try {
         readResult = await reader.read();
       } catch (err: unknown) {
-        const error = err as Error;
-        if (error.name === 'AbortError') {
+        // AbortError는 DOMException 또는 Error로 올 수 있으므로 두 경우를 모두 처리
+        const isAbort =
+          (err instanceof DOMException && err.name === 'AbortError') ||
+          (err instanceof Error && err.name === 'AbortError');
+        if (isAbort) {
           console.debug('[StreamClient] Stream read aborted by user');
           return;
         }
@@ -100,9 +106,12 @@ export async function* fetchChatStream(
             currentData = []; // 리셋
 
             if (currentEvent || currentId) {
-              // 추후 reconnection이나 event-type 라우팅을 지원하기 위해 파싱해둠
-              console.debug(`[StreamClient] event: ${currentEvent}, id: ${currentId}`);
-              currentEvent = null; // SSE 스펙상 event는 블록 끝에서 리셋됨
+              // 추후 reconnection이나 event-type 라우팅을 지원하기 위해 파싱해둠.
+              // [SSE 스펙] 'event'는 각 블록마다 초기화되지만 'id'(Last-Event-ID)는
+              // 새로운 id: 필드가 올 때까지 이전 값을 유지해야 하므로 여기서 리셋하지 않음.
+              console.debug(`[StreamClient] dispatching event: ${currentEvent ?? 'message'}, lastEventId: ${currentId}`);
+              currentEvent = null; // SSE 스펙: event 필드는 블록 경계에서 초기화
+              // currentId는 의도적으로 유지 (Last-Event-ID 역할)
             }
 
             if (dataStr === '[DONE]') {

--- a/web_ui/src/lib/stream-client.ts
+++ b/web_ui/src/lib/stream-client.ts
@@ -18,8 +18,20 @@ export interface StreamChatRequest {
 }
 
 /**
+ * AbortError 여부를 안전하게 판별하는 타입 가드 헬퍼.
+ *
+ * - 브라우저에서 AbortController.abort() 시 DOMException이 던져질 수 있으므로 두 케이스 모두 커버.
+ * - SSR(Next.js) 또는 테스트(Vitest) 환경에서 DOMException이 없는 경우를 대비해 typeof 가드 적용.
+ */
+function isAbortError(err: unknown): boolean {
+  if (err instanceof Error && err.name === 'AbortError') return true;
+  if (typeof DOMException !== 'undefined' && err instanceof DOMException && err.name === 'AbortError') return true;
+  return false;
+}
+
+/**
  * 표준 fetch API를 사용하여 백엔드의 SSE(Server-Sent Events) 스트림을 소비합니다.
- * EventSource 객체 대신 fetch를 사용하여 POST 요청과 커스텀 헤더 인증을 지원합니다.
+ * EventSource 개체 대신 fetch를 사용하여 POST 요청과 커스텀 헤더 인증을 지원합니다.
  */
 export async function* fetchChatStream(
   payload: StreamChatRequest,
@@ -39,11 +51,7 @@ export async function* fetchChatStream(
       signal,
     });
   } catch (err: unknown) {
-    // AbortError는 DOMException 또는 Error로 올 수 있으므로 두 경우를 모두 처리
-    const isAbort =
-      (err instanceof DOMException && err.name === 'AbortError') ||
-      (err instanceof Error && err.name === 'AbortError');
-    if (isAbort) {
+    if (isAbortError(err)) {
       console.debug('[StreamClient] fetch aborted by user');
       return;
     }
@@ -79,11 +87,7 @@ export async function* fetchChatStream(
       try {
         readResult = await reader.read();
       } catch (err: unknown) {
-        // AbortError는 DOMException 또는 Error로 올 수 있으므로 두 경우를 모두 처리
-        const isAbort =
-          (err instanceof DOMException && err.name === 'AbortError') ||
-          (err instanceof Error && err.name === 'AbortError');
-        if (isAbort) {
+        if (isAbortError(err)) {
           console.debug('[StreamClient] Stream read aborted by user');
           return;
         }


### PR DESCRIPTION
- **[SSE 스펙 준수] Last-Event-ID 유지 정책 수정**
  - 이벤트 디스패치 시 `currentEvent`만 초기화하고 `currentId`(Last-Event-ID)는 명시적인 새 `id:` 라인이 수신될 때까지 유지하도록 수정하여 W3C SSE 스펙 준수.
  - 유지 의도를 명확히 하는 주석 추가로 유지보수성 향상.

- **[타입 안전성] AbortError 타입 가드 강화**
  - `err as Error` 강제 캐스팅을 제거하고 `instanceof DOMException` 과 `instanceof Error` 를 모두 검사하는 타입 가드로 교체.
  - 브라우저가 `AbortController.abort()` 시 `DOMException`을 던지는 경우에도 안전하게 처리 가능.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1391#pullrequestreview-4278762825)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

스트리밍 클라이언트가 SSE 시맨틱스를 준수하고 abort 오류를 보다 견고하게 처리하도록 보장합니다.

버그 수정:
- SSE 사양에 맞게, 새로운 `id` 필드를 받기 전까지 SSE 이벤트 블록 전반에서 Last-Event-ID 값을 보존합니다.
- `fetch` 및 스트림 읽기 과정에서 발생하는 `AbortError`를 `DOMException`이든 `Error`이든 모두 적절히 처리하여 잘못된 오류 처리나 크래시를 방지합니다.

개선 사항:
- 디폴트 이벤트 타입과 `lastEventId` 컨텍스트를 포함하여 디스패치된 SSE 이벤트에 대한 디버그 로깅을 개선했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the streaming client complies with SSE semantics and handles abort errors more robustly.

Bug Fixes:
- Preserve the Last-Event-ID value across SSE event blocks until a new id field is received, aligning behavior with the SSE specification.
- Handle AbortError thrown as either DOMException or Error during fetch and stream reads to avoid incorrect error handling or crashes.

Enhancements:
- Improve debug logging for dispatched SSE events by including the default event type and lastEventId context.

</details>