### PR TITLE
✨ feat [#12.2.26]: Phase 3.3 - ③ 채팅 컴포넌트 마이그레이션 (점진적 롤아웃)

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -4,7 +4,9 @@ import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react'
 import { useChat } from '@ai-sdk/react';
 import type { UIMessage } from 'ai';
 import { DefaultChatTransport } from 'ai';
-import { CHAT_CONFIG, STORAGE_KEYS, UI_CONFIG } from '@/lib/constants';
+import { CHAT_CONFIG, STORAGE_KEYS, UI_CONFIG, FEATURE_FLAGS } from '@/lib/constants';
+import { useStreamingChat } from '@/hooks/useStreamingChat';
+import type { StreamChatRequest } from '@/lib/stream-client';
 import { MessageBubble } from './MessageBubble';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Textarea } from '@/components/ui/textarea';
@@ -184,6 +186,27 @@ export function ChatWindow({
 
   const { messages, sendMessage, status, setMessages, error } = useChat(chatOptions);
 
+  // =========================================================================
+  // [스트리밍 훅] FEATURE_FLAGS.USE_STREAMING 활성화 시 useStreamingChat 사용
+  // 기존 useChat 방식과 공존하며, 플래그 토글로 즉시 전환 가능합니다.
+  // =========================================================================
+  const {
+    tokens: streamTokens,
+    isStreaming,
+    sources: streamSources,
+    error: streamError,
+    startStream,
+    cancelStream,
+  } = useStreamingChat({
+    onError: (err, raw) => {
+      // [보안] StreamError 타입을 통해 내부 에러 코드 미노출
+      console.error('[ChatWindow] Stream error:', raw);
+      toast.error('스트리밍 중 오류가 발생했습니다.', {
+        description: err.message,
+      });
+    },
+  });
+
   useEffect(() => {
     if (!sessionId) return;
     let ignore = false;
@@ -262,7 +285,10 @@ export function ChatWindow({
     }
   };
 
-  const isLoading = status === 'streaming' || status === 'submitted';
+  // 플래그에 따라 로딩 상태를 통합 (기존 useChat 방식 또는 스트리밍 방식)
+  const isLoading = FEATURE_FLAGS.USE_STREAMING
+    ? isStreaming
+    : status === 'streaming' || status === 'submitted';
 
   useEffect(() => {
     if (autoScrollEnabled) {
@@ -276,9 +302,24 @@ export function ChatWindow({
     e?.preventDefault();
     const trimmed = input.trim();
     if (!trimmed || isLoading) return;
-    sendMessage({ role: 'user', parts: [{ type: 'text', text: trimmed }] });
+
+    if (FEATURE_FLAGS.USE_STREAMING) {
+      // 스트리밍 훅 방식: useStreamingChat.startStream() 호출
+      const payload: StreamChatRequest = {
+        query: trimmed,
+        user_id: userId || CHAT_CONFIG.DEFAULT_USER_ID || '',
+        session_id: sessionId,
+        k: CHAT_CONFIG.DEFAULT_K,
+        alpha: alpha,
+      };
+      startStream(payload);
+    } else {
+      // 폴백: 기존 useChat 방식
+      sendMessage({ role: 'user', parts: [{ type: 'text', text: trimmed }] });
+    }
+
     setInput('');
-  }, [input, isLoading, sendMessage]);
+  }, [input, isLoading, sendMessage, startStream, userId, sessionId, alpha]);
 
   const handleRetry = useCallback(() => {
     if (isLoading) return;
@@ -362,23 +403,49 @@ export function ChatWindow({
                 sessionId={sessionId}
               />
             ))}
-            {error && (
-              <div 
-                role="alert" 
-                aria-live="polite"
-                className="p-4 mb-4 bg-red-50 border border-red-100 rounded-xl text-xs text-red-600 flex items-center gap-2 animate-in fade-in slide-in-from-top-2"
-              >
-                <span className="font-bold">Error:</span>
-                <span>{error.message || '메시지 전송 중 오류가 발생했습니다.'}</span>
-                <Button 
-                  variant="ghost" 
-                  size="sm" 
-                  onClick={handleRetry} 
-                  className="ml-auto h-6 text-[10px] hover:bg-red-100"
-                >
-                  재시도
-                </Button>
+            {/* [스트리밍 모드] 누적 토큰을 실시간으로 렌더링 */}
+            {FEATURE_FLAGS.USE_STREAMING && streamTokens && (
+              <div className="flex justify-start px-1 py-2">
+                <div className="max-w-[80%] rounded-2xl rounded-tl-sm bg-slate-50 border border-slate-100 px-4 py-3 text-sm text-slate-800 whitespace-pre-wrap">
+                  {streamTokens}
+                  {isStreaming && (
+                    <span className="inline-block w-1.5 h-4 bg-slate-400 rounded-sm ml-0.5 animate-pulse" aria-hidden="true" />
+                  )}
+                </div>
               </div>
+            )}
+
+            {/* 에러 UI: 스트리밍 모드와 기존 모드를 분기 */}
+            {FEATURE_FLAGS.USE_STREAMING ? (
+              streamError && (
+                <div
+                  role="alert"
+                  aria-live="polite"
+                  className="p-4 mb-4 bg-red-50 border border-red-100 rounded-xl text-xs text-red-600 flex items-center gap-2 animate-in fade-in slide-in-from-top-2"
+                >
+                  <span className="font-bold">Error:</span>
+                  <span>{streamError.message}</span>
+                </div>
+              )
+            ) : (
+              error && (
+                <div
+                  role="alert"
+                  aria-live="polite"
+                  className="p-4 mb-4 bg-red-50 border border-red-100 rounded-xl text-xs text-red-600 flex items-center gap-2 animate-in fade-in slide-in-from-top-2"
+                >
+                  <span className="font-bold">Error:</span>
+                  <span>{error.message || '메시지 전송 중 오류가 발생했습니다.'}</span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleRetry}
+                    className="ml-auto h-6 text-[10px] hover:bg-red-100"
+                  >
+                    재시도
+                  </Button>
+                </div>
+              )
             )}
             <div className="h-4" />
           </div>
@@ -427,6 +494,19 @@ export function ChatWindow({
             >
               {isLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4 ml-0.5" />}
             </Button>
+
+            {/* [스트리밍 모드] 진행 중 취소 버튼 */}
+            {FEATURE_FLAGS.USE_STREAMING && isStreaming && (
+              <Button
+                type="button"
+                size="sm"
+                aria-label="스트리밍 취소"
+                onClick={cancelStream}
+                className="absolute right-14 bottom-3 h-8 px-3 rounded-lg bg-red-50 hover:bg-red-100 text-red-500 text-xs font-medium"
+              >
+                중단
+              </Button>
+            )}
           </div>
         </form>
       </div>

--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -187,20 +187,27 @@ export function ChatWindow({
   const { messages, sendMessage, status, setMessages, error } = useChat(chatOptions);
 
   // =========================================================================
-  // [스트리밍 훅] FEATURE_FLAGS.USE_STREAMING 활성화 시 useStreamingChat 사용
+  // [스트리밍 훅] 플래그 활성화 시 useStreamingChat 사용
   // 기존 useChat 방식과 공존하며, 플래그 토글로 즉시 전환 가능합니다.
   // =========================================================================
+
+  // [DRY] 플래그를 한 번만 참조하여 컴포넌트 전체에서 사용
+  const isStreamingMode = FEATURE_FLAGS.USE_STREAMING;
+
   const {
     tokens: streamTokens,
     isStreaming,
-    sources: streamSources,
+    // sources는 향후 SourcePanel 컴포넌트 연결 시 추가 예정
     error: streamError,
     startStream,
     cancelStream,
   } = useStreamingChat({
     onError: (err, raw) => {
-      // [보안] StreamError 타입을 통해 내부 에러 코드 미노출
-      console.error('[ChatWindow] Stream error:', raw);
+      // [보안] 운영 환경에서는 원본 raw 에러 객체를 콘솔에 노출하지 않습니다.
+      // 내부 스택 트레이스나 서버 세부정보 노출 위험이 있으므로, 개발 환경에서만 로깅합니다.
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('[ChatWindow] Stream error (dev only):', raw);
+      }
       toast.error('스트리밍 중 오류가 발생했습니다.', {
         description: err.message,
       });
@@ -286,7 +293,7 @@ export function ChatWindow({
   };
 
   // 플래그에 따라 로딩 상태를 통합 (기존 useChat 방식 또는 스트리밍 방식)
-  const isLoading = FEATURE_FLAGS.USE_STREAMING
+  const isLoading = isStreamingMode
     ? isStreaming
     : status === 'streaming' || status === 'submitted';
 
@@ -303,7 +310,7 @@ export function ChatWindow({
     const trimmed = input.trim();
     if (!trimmed || isLoading) return;
 
-    if (FEATURE_FLAGS.USE_STREAMING) {
+    if (isStreamingMode) {
       // 스트리밍 훅 방식: useStreamingChat.startStream() 호출
       const payload: StreamChatRequest = {
         query: trimmed,
@@ -319,7 +326,7 @@ export function ChatWindow({
     }
 
     setInput('');
-  }, [input, isLoading, sendMessage, startStream, userId, sessionId, alpha]);
+  }, [input, isLoading, isStreamingMode, sendMessage, startStream, userId, sessionId, alpha]);
 
   const handleRetry = useCallback(() => {
     if (isLoading) return;
@@ -404,7 +411,7 @@ export function ChatWindow({
               />
             ))}
             {/* [스트리밍 모드] 누적 토큰을 실시간으로 렌더링 */}
-            {FEATURE_FLAGS.USE_STREAMING && streamTokens && (
+            {isStreamingMode && streamTokens && (
               <div className="flex justify-start px-1 py-2">
                 <div className="max-w-[80%] rounded-2xl rounded-tl-sm bg-slate-50 border border-slate-100 px-4 py-3 text-sm text-slate-800 whitespace-pre-wrap">
                   {streamTokens}
@@ -416,7 +423,7 @@ export function ChatWindow({
             )}
 
             {/* 에러 UI: 스트리밍 모드와 기존 모드를 분기 */}
-            {FEATURE_FLAGS.USE_STREAMING ? (
+            {isStreamingMode ? (
               streamError && (
                 <div
                   role="alert"
@@ -496,7 +503,7 @@ export function ChatWindow({
             </Button>
 
             {/* [스트리밍 모드] 진행 중 취소 버튼 */}
-            {FEATURE_FLAGS.USE_STREAMING && isStreaming && (
+            {isStreamingMode && isStreaming && (
               <Button
                 type="button"
                 size="sm"

--- a/web_ui/src/lib/constants.ts
+++ b/web_ui/src/lib/constants.ts
@@ -32,3 +32,13 @@ export const CHAT_CONFIG = {
 export const UI_CONFIG = {
   SCROLL_THRESHOLD: 100, // UX 바닥 인식 임계치 (px)
 } as const;
+
+/**
+ * 기능 플래그(Feature Flags) - 환경변수 기반 점진적 롤아웃 관리
+ *
+ * NEXT_PUBLIC_USE_STREAMING=true 로 설정 시 SSE 기반 스트리밍 훅을 활성화합니다.
+ * 미설정 또는 'false'일 경우 기존 useChat 방식으로 폴백됩니다.
+ */
+export const FEATURE_FLAGS = {
+  USE_STREAMING: process.env.NEXT_PUBLIC_USE_STREAMING === 'true',
+} as const;


### PR DESCRIPTION
- **[신규] FEATURE_FLAGS.USE_STREAMING 환경변수 플래그 추가**
  - `constants.ts`에 `FEATURE_FLAGS` 섹션 신설.
  - `NEXT_PUBLIC_USE_STREAMING=true` 설정 시 SSE 스트리밍 훅 활성화, 미설정 시 기존 `useChat` 폴백.
  - 하드코딩 없이 환경변수로만 제어하여 점진적 롤아웃(Gradual Rollout) 지원.

- **[마이그레이션] ChatWindow - useStreamingChat 훅 연결**
  - `useStreamingChat` 훅을 `ChatWindow`에 통합, 기존 `useChat` 방식과 공존.
  - 플래그 기반 분기: `isLoading`, `handleSubmit`, 에러 UI, 전송 버튼을 각각 분기 처리.
  - 스트리밍 모드 전용 UI: 실시간 누적 토큰 렌더링, 커서 깜빡임, '중단' 취소 버튼 추가.

- **[보안] StreamError 마스킹 유지**
  - 스트리밍 에러 UI에서 `streamError.message`만 노출하고 내부 `errorCode`는 미표시.
  - `onError` 콜백에서 toast 기반 사용자 친화적 에러 메시지 표시.

- **[문서화] Phase 3.3 (3단계) 작업 현황 체크리스트 업데이트**

🔗 Related: Issue [#1047]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

기존의 비(非)스트리밍 동작을 유지하면서, 기능 플래그가 적용된 스트리밍 채팅 경험을 ChatWindow에 통합합니다.

새로운 기능:
- SSE 기반 스트리밍 채팅을 활성화하기 위한 환경 변수 기반 토글 `FEATURE_FLAGS.USE_STREAMING`을 도입합니다.
- ChatWindow에 스트리밍 전용 UI를 추가합니다. 여기에는 실시간 토큰 렌더링, 타이핑 커서, 진행 중인 스트림을 취소하기 위한 취소 버튼 등이 포함됩니다.

버그 수정:
- UI와 토스트 알림에서 사용자 친화적인 오류 메시지만 노출되도록 하여, 스트리밍 실패 시에도 오류 마스킹을 유지합니다.

개선 사항:
- 스트리밍 기능 플래그가 활성화된 경우 ChatWindow가 새로운 `useStreamingChat` 훅을 사용하도록 연결하고, 그렇지 않은 경우 기존 `useChat` 구현으로 폴백(fallback)하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate a feature-flagged streaming chat experience into the ChatWindow while preserving the existing non-streaming behavior.

New Features:
- Introduce an environment-based FEATURE_FLAGS.USE_STREAMING toggle to enable SSE-based streaming chat.
- Add streaming-specific UI in ChatWindow, including live token rendering, typing cursor, and a cancel button for in-progress streams.

Bug Fixes:
- Maintain error masking for streaming failures by exposing only user-friendly error messages in the UI and toast notifications.

Enhancements:
- Wire ChatWindow to use the new useStreamingChat hook when the streaming feature flag is enabled, falling back to the legacy useChat implementation otherwise.

</details>