### PR TITLE
☘️ refactor [#12.2.26]: 2차 개선 - 에러 UI 공용화 및 메시지 영구 저장

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -21,7 +21,6 @@ function ErrorBanner({ message, onRetry }: { message: string; onRetry?: () => vo
   return (
     <div
       role="alert"
-      aria-live="polite"
       className="p-4 mb-4 bg-red-50 border border-red-100 rounded-xl text-xs text-red-600 flex items-center gap-2 animate-in fade-in slide-in-from-top-2"
     >
       <span className="font-bold">Error:</span>

--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -14,6 +14,32 @@ import { Button } from '@/components/ui/button';
 import { Send, Loader2, ChevronDown } from 'lucide-react';
 import { toast } from 'sonner';
 
+/**
+ * 공용 에러 배너 컴포넌트
+ */
+function ErrorBanner({ message, onRetry }: { message: string; onRetry?: () => void }) {
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="p-4 mb-4 bg-red-50 border border-red-100 rounded-xl text-xs text-red-600 flex items-center gap-2 animate-in fade-in slide-in-from-top-2"
+    >
+      <span className="font-bold">Error:</span>
+      <span>{message}</span>
+      {onRetry && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onRetry}
+          className="ml-auto h-6 text-[10px] hover:bg-red-100"
+        >
+          재시도
+        </Button>
+      )}
+    </div>
+  );
+}
+
 /** 초기 환영 메시지 */
 const WELCOME_MESSAGE: UIMessage = {
   id: 'welcome',
@@ -211,6 +237,19 @@ export function ChatWindow({
       toast.error('스트리밍 중 오류가 발생했습니다.', {
         description: err.message,
       });
+    },
+    onFinish: (content) => {
+      // 스트리밍이 끝나면 영구적인 messages 배열에 추가하여 
+      // 리렌더링이나 히스토리에서 일관되게 보이도록 합니다.
+      if (!content) return;
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: generateId('ast'),
+          role: 'assistant',
+          parts: [{ type: 'text', text: content }],
+        },
+      ]);
     },
   });
 
@@ -422,36 +461,15 @@ export function ChatWindow({
               </div>
             )}
 
-            {/* 에러 UI: 스트리밍 모드와 기존 모드를 분기 */}
+            {/* 에러 UI: 스트리밍 모드와 기존 모드를 분기하지만 일관된 UI 컴포넌트 사용 */}
             {isStreamingMode ? (
-              streamError && (
-                <div
-                  role="alert"
-                  aria-live="polite"
-                  className="p-4 mb-4 bg-red-50 border border-red-100 rounded-xl text-xs text-red-600 flex items-center gap-2 animate-in fade-in slide-in-from-top-2"
-                >
-                  <span className="font-bold">Error:</span>
-                  <span>{streamError.message}</span>
-                </div>
-              )
+              streamError && <ErrorBanner message={streamError.message} />
             ) : (
               error && (
-                <div
-                  role="alert"
-                  aria-live="polite"
-                  className="p-4 mb-4 bg-red-50 border border-red-100 rounded-xl text-xs text-red-600 flex items-center gap-2 animate-in fade-in slide-in-from-top-2"
-                >
-                  <span className="font-bold">Error:</span>
-                  <span>{error.message || '메시지 전송 중 오류가 발생했습니다.'}</span>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={handleRetry}
-                    className="ml-auto h-6 text-[10px] hover:bg-red-100"
-                  >
-                    재시도
-                  </Button>
-                </div>
+                <ErrorBanner
+                  message={error.message || '메시지 전송 중 오류가 발생했습니다.'}
+                  onRetry={handleRetry}
+                />
               )
             )}
             <div className="h-4" />

--- a/web_ui/src/hooks/useStreamingChat.ts
+++ b/web_ui/src/hooks/useStreamingChat.ts
@@ -45,6 +45,11 @@ export interface UseStreamingChatOptions {
    * [보안] StreamError 타입을 통해 내부 에러 코드와 사용자 메시지가 분리되어 전달됩니다.
    */
   onError?: (error: StreamError, raw: unknown) => void;
+  /**
+   * 스트림이 성공적으로 완료되었을 때 호출되는 콜백.
+   * 스트리밍된 결과물을 메인 대화 이력 등에 영구 저장할 때 유용합니다.
+   */
+  onFinish?: (content: string, sources: SourceItem[]) => void;
 }
 
 // =============================================================================
@@ -73,7 +78,6 @@ export interface UseStreamingChatOptions {
  * ```
  */
 export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStreamingChatReturn {
-  const { onError } = options;
   const [tokens, setTokens] = useState<string>('');
   const [isStreaming, setIsStreaming] = useState<boolean>(false);
   const [sources, setSources] = useState<SourceItem[]>([]);
@@ -83,11 +87,13 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
   // 상태 업데이트를 트리거하지 않고 안전하게 접근 가능
   const abortControllerRef = useRef<AbortController | null>(null);
 
-  // onError 콜백을 ref로 보관하여, 콜백이 바뀌어도 startStream 재생성을 방지
-  const onErrorRef = useRef(onError);
+  // 콜백들을 ref로 보관하여 콜백이 바뀌어도 startStream 재생성을 방지
+  const onErrorRef = useRef(options.onError);
+  const onFinishRef = useRef(options.onFinish);
   useEffect(() => {
-    onErrorRef.current = onError;
-  }, [onError]);
+    onErrorRef.current = options.onError;
+    onFinishRef.current = options.onFinish;
+  }, [options.onError, options.onFinish]);
 
   // [언마운트 클린업] 컴포넌트 해제 시 진행 중인 스트림을 자동으로 중단하여
   // 언마운트된 컴포넌트에서 setState가 호출되는 것을 방지합니다.
@@ -132,6 +138,9 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
 
       // 비동기 스트림 소비 (async IIFE)
       (async () => {
+        let accumulatedTokens = '';
+        let finalSources: SourceItem[] = [];
+
         try {
           for await (const chunk of fetchChatStream(payload, controller.signal)) {
             // 컨트롤러가 교체된 경우(다른 startStream 호출) 이 스트림 결과는 무시
@@ -139,10 +148,12 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
 
             switch (chunk.type) {
               case 'token':
-                setTokens((prev) => prev + chunk.data);
+                accumulatedTokens += chunk.data;
+                setTokens(accumulatedTokens);
                 break;
               case 'sources':
-                setSources(chunk.data);
+                finalSources = chunk.data;
+                setSources(finalSources);
                 break;
               case 'error': {
                 // [보안] 내부 에러 코드는 상태에만 저장하고 직접 렌더링하지 않음
@@ -154,7 +165,8 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
                 break;
               }
               case 'done':
-                // 정상 완료 - 별도 처리 불필요
+                // 정상 완료 - 누적된 토큰과 소스를 부모에게 전달
+                onFinishRef.current?.(accumulatedTokens, finalSources);
                 break;
             }
           }

--- a/web_ui/src/lib/constants.ts
+++ b/web_ui/src/lib/constants.ts
@@ -38,6 +38,7 @@ export const UI_CONFIG = {
  *
  * NEXT_PUBLIC_USE_STREAMING=true 로 설정 시 SSE 기반 스트리밍 훅을 활성화합니다.
  * 미설정 또는 'false'일 경우 기존 useChat 방식으로 폴백됩니다.
+ * 주의: NEXT_PUBLIC_* 환경변수는 빌드 타임에 인라인되므로 런타임에 즉시 전환되지 않습니다.
  */
 export const FEATURE_FLAGS = {
   USE_STREAMING: process.env.NEXT_PUBLIC_USE_STREAMING === 'true',


### PR DESCRIPTION
- **[UX/유지보수] 에러 UI 컴포넌트화 (DRY)**
  - 스트리밍 / 비스트리밍 에러 배너 마크업이 90% 일치하던 것을 `ErrorBanner` 헬퍼 컴포넌트로 추출하여 중복을 제거하고 UI 일관성 확보.

- **[기능 개선] 스트리밍 완료 후 메시지 영구 저장**
  - 스트리밍 모드에서 생성된 `streamTokens`가 일회성으로 렌더링되어 리렌더링 시 사라지던 현상 수정.
  - `useStreamingChat` 훅에 `onFinish` 콜백을 도입하여, 스트림 종료 시 누적된 토큰을 메인 `messages` 배열에 푸시(`setMessages`)하도록 개선.

- **[문서화] FEATURE_FLAGS 주석 명확화**
  - `NEXT_PUBLIC_USE_STREAMING` 환경변수가 빌드 타임에 인라인되므로 런타임 '즉시 전환'이 아님을 주석에 명시하여 개발자 오해 방지.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1399#pullrequestreview-4291583660)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

UI 일관성을 개선하고, 스트리밍으로 생성된 응답을 메인 메시지 히스토리에 지속적으로 저장하기 위해 채팅 에러 처리 및 스트리밍 completion 로직을 리팩터링합니다.

New Features:
- 스트리밍을 통해 생성된 assistant 메시지를 스트림이 종료될 때 메인 `messages` 배열에 영구적으로 저장합니다.

Bug Fixes:
- 스트림 완료 시 최종적으로 누적된 토큰을 영구 메시지 히스토리에 저장하여, 리렌더링 시 스트리밍된 콘텐츠가 유실되지 않도록 합니다.

Enhancements:
- 스트리밍/비스트리밍 채팅 모드 전반에서 에러를 일관성 있게 표시하기 위한 재사용 가능한 `ErrorBanner` 컴포넌트를 도입합니다.
- 스트리밍 채팅 훅에 `onFinish` 콜백을 추가하여, 토큰 누적을 소비자 측에서 직접 관리하지 않아도 최종 스트리밍 콘텐츠와 소스를 전달받을 수 있도록 확장합니다.

Documentation:
- `FEATURE_FLAGS` 문서에서 `NEXT_PUBLIC_USE_STREAMING` 이 빌드 시점에 인라인되며 런타임에 토글할 수 없다는 점을 명확히 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor chat error handling and streaming completion to improve UI consistency and persist streamed responses in the main message history.

New Features:
- Persist assistant messages produced via streaming into the main messages array when a stream finishes.

Bug Fixes:
- Ensure streamed content is not lost on re-renders by saving the final accumulated tokens to the permanent message history on stream completion.

Enhancements:
- Introduce a reusable ErrorBanner component for consistent error display across streaming and non-streaming chat modes.
- Extend the streaming chat hook with an onFinish callback that exposes the final streamed content and sources without forcing consumers to manage token accumulation themselves.

Documentation:
- Clarify FEATURE_FLAGS documentation to note that NEXT_PUBLIC_USE_STREAMING is inlined at build time and cannot be toggled at runtime.

</details>