### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -21,7 +21,6 @@ function ErrorBanner({ message, onRetry }: { message: string; onRetry?: () => vo
   return (
     <div
       role="alert"
-      aria-live="polite"
       className="p-4 mb-4 bg-red-50 border border-red-100 rounded-xl text-xs text-red-600 flex items-center gap-2 animate-in fade-in slide-in-from-top-2"
     >
       <span className="font-bold">Error:</span>

--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -14,6 +14,32 @@ import { Button } from '@/components/ui/button';
 import { Send, Loader2, ChevronDown } from 'lucide-react';
 import { toast } from 'sonner';
 
+/**
+ * 공용 에러 배너 컴포넌트
+ */
+function ErrorBanner({ message, onRetry }: { message: string; onRetry?: () => void }) {
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="p-4 mb-4 bg-red-50 border border-red-100 rounded-xl text-xs text-red-600 flex items-center gap-2 animate-in fade-in slide-in-from-top-2"
+    >
+      <span className="font-bold">Error:</span>
+      <span>{message}</span>
+      {onRetry && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onRetry}
+          className="ml-auto h-6 text-[10px] hover:bg-red-100"
+        >
+          재시도
+        </Button>
+      )}
+    </div>
+  );
+}
+
 /** 초기 환영 메시지 */
 const WELCOME_MESSAGE: UIMessage = {
   id: 'welcome',
@@ -211,6 +237,19 @@ export function ChatWindow({
       toast.error('스트리밍 중 오류가 발생했습니다.', {
         description: err.message,
       });
+    },
+    onFinish: (content) => {
+      // 스트리밍이 끝나면 영구적인 messages 배열에 추가하여 
+      // 리렌더링이나 히스토리에서 일관되게 보이도록 합니다.
+      if (!content) return;
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: generateId('ast'),
+          role: 'assistant',
+          parts: [{ type: 'text', text: content }],
+        },
+      ]);
     },
   });
 
@@ -422,36 +461,15 @@ export function ChatWindow({
               </div>
             )}
 
-            {/* 에러 UI: 스트리밍 모드와 기존 모드를 분기 */}
+            {/* 에러 UI: 스트리밍 모드와 기존 모드를 분기하지만 일관된 UI 컴포넌트 사용 */}
             {isStreamingMode ? (
-              streamError && (
-                <div
-                  role="alert"
-                  aria-live="polite"
-                  className="p-4 mb-4 bg-red-50 border border-red-100 rounded-xl text-xs text-red-600 flex items-center gap-2 animate-in fade-in slide-in-from-top-2"
-                >
-                  <span className="font-bold">Error:</span>
-                  <span>{streamError.message}</span>
-                </div>
-              )
+              streamError && <ErrorBanner message={streamError.message} />
             ) : (
               error && (
-                <div
-                  role="alert"
-                  aria-live="polite"
-                  className="p-4 mb-4 bg-red-50 border border-red-100 rounded-xl text-xs text-red-600 flex items-center gap-2 animate-in fade-in slide-in-from-top-2"
-                >
-                  <span className="font-bold">Error:</span>
-                  <span>{error.message || '메시지 전송 중 오류가 발생했습니다.'}</span>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={handleRetry}
-                    className="ml-auto h-6 text-[10px] hover:bg-red-100"
-                  >
-                    재시도
-                  </Button>
-                </div>
+                <ErrorBanner
+                  message={error.message || '메시지 전송 중 오류가 발생했습니다.'}
+                  onRetry={handleRetry}
+                />
               )
             )}
             <div className="h-4" />

--- a/web_ui/src/hooks/useStreamingChat.ts
+++ b/web_ui/src/hooks/useStreamingChat.ts
@@ -45,6 +45,11 @@ export interface UseStreamingChatOptions {
    * [보안] StreamError 타입을 통해 내부 에러 코드와 사용자 메시지가 분리되어 전달됩니다.
    */
   onError?: (error: StreamError, raw: unknown) => void;
+  /**
+   * 스트림이 성공적으로 완료되었을 때 호출되는 콜백.
+   * 스트리밍된 결과물을 메인 대화 이력 등에 영구 저장할 때 유용합니다.
+   */
+  onFinish?: (content: string, sources: SourceItem[]) => void;
 }
 
 // =============================================================================
@@ -73,7 +78,6 @@ export interface UseStreamingChatOptions {
  * ```
  */
 export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStreamingChatReturn {
-  const { onError } = options;
   const [tokens, setTokens] = useState<string>('');
   const [isStreaming, setIsStreaming] = useState<boolean>(false);
   const [sources, setSources] = useState<SourceItem[]>([]);
@@ -83,11 +87,13 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
   // 상태 업데이트를 트리거하지 않고 안전하게 접근 가능
   const abortControllerRef = useRef<AbortController | null>(null);
 
-  // onError 콜백을 ref로 보관하여, 콜백이 바뀌어도 startStream 재생성을 방지
-  const onErrorRef = useRef(onError);
+  // 콜백들을 ref로 보관하여 콜백이 바뀌어도 startStream 재생성을 방지
+  const onErrorRef = useRef(options.onError);
+  const onFinishRef = useRef(options.onFinish);
   useEffect(() => {
-    onErrorRef.current = onError;
-  }, [onError]);
+    onErrorRef.current = options.onError;
+    onFinishRef.current = options.onFinish;
+  }, [options.onError, options.onFinish]);
 
   // [언마운트 클린업] 컴포넌트 해제 시 진행 중인 스트림을 자동으로 중단하여
   // 언마운트된 컴포넌트에서 setState가 호출되는 것을 방지합니다.
@@ -132,6 +138,9 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
 
       // 비동기 스트림 소비 (async IIFE)
       (async () => {
+        let accumulatedTokens = '';
+        let finalSources: SourceItem[] = [];
+
         try {
           for await (const chunk of fetchChatStream(payload, controller.signal)) {
             // 컨트롤러가 교체된 경우(다른 startStream 호출) 이 스트림 결과는 무시
@@ -139,10 +148,12 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
 
             switch (chunk.type) {
               case 'token':
-                setTokens((prev) => prev + chunk.data);
+                accumulatedTokens += chunk.data;
+                setTokens(accumulatedTokens);
                 break;
               case 'sources':
-                setSources(chunk.data);
+                finalSources = chunk.data;
+                setSources(finalSources);
                 break;
               case 'error': {
                 // [보안] 내부 에러 코드는 상태에만 저장하고 직접 렌더링하지 않음
@@ -154,7 +165,8 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
                 break;
               }
               case 'done':
-                // 정상 완료 - 별도 처리 불필요
+                // 정상 완료 - 누적된 토큰과 소스를 부모에게 전달
+                onFinishRef.current?.(accumulatedTokens, finalSources);
                 break;
             }
           }

--- a/web_ui/src/lib/constants.ts
+++ b/web_ui/src/lib/constants.ts
@@ -38,6 +38,7 @@ export const UI_CONFIG = {
  *
  * NEXT_PUBLIC_USE_STREAMING=true 로 설정 시 SSE 기반 스트리밍 훅을 활성화합니다.
  * 미설정 또는 'false'일 경우 기존 useChat 방식으로 폴백됩니다.
+ * 주의: NEXT_PUBLIC_* 환경변수는 빌드 타임에 인라인되므로 런타임에 즉시 전환되지 않습니다.
  */
 export const FEATURE_FLAGS = {
   USE_STREAMING: process.env.NEXT_PUBLIC_USE_STREAMING === 'true',


### PR DESCRIPTION
☘️ refactor [#12.2.26]: 2차 개선 - 에러 UI 공용화 및 메시지 영구 저장 
☘️ refactor [#12.2.26]: 3차 개선 - 에러 배너 접근성 속성 충돌 해결

## Summary by Sourcery

채팅 오류 처리 UI를 통합하고, 스트리밍된 어시스턴트 응답을 메인 메시지 히스토리에 영구 저장하도록 합니다.

새 기능:
- 최종 스트리밍된 콘텐츠와 소스를 호출자에게 노출하기 위해, 스트리밍 채팅 훅에 `onFinish` 콜백을 추가합니다.

버그 수정:
- 스트리밍이 완료될 때, 스트리밍된 어시스턴트 응답이 지속되는 채팅 메시지 목록에 추가되도록 보장합니다.

개선 사항:
- 공유 `ErrorBanner` 컴포넌트를 도입하고, 스트리밍 및 비스트리밍 채팅 오류 모두에 이를 사용하여 일관되고 접근 가능한 오류 UI를 유지합니다.
- 상태를 업데이트하기 전에 스트리밍 토큰과 소스 메타데이터를 내부적으로 누적하여, 최종 스트리밍 콘텐츠 처리에 대한 제어를 향상합니다.
- 런타임 동작에 대한 기대치를 명확히 하기 위해, `USE_STREAMING` 기능 플래그의 빌드 타임 동작을 문서화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify chat error handling UI and persist streamed assistant responses into the main message history.

New Features:
- Add an onFinish callback to the streaming chat hook to expose the final streamed content and sources to callers.

Bug Fixes:
- Ensure streamed assistant responses are added to the persistent chat messages list when streaming completes.

Enhancements:
- Introduce a shared ErrorBanner component and use it for both streaming and non-streaming chat errors to maintain consistent, accessible error UI.
- Accumulate streaming tokens and source metadata internally before updating state, improving control over final streamed content handling.
- Document build-time behavior of the USE_STREAMING feature flag for clearer runtime expectations.

</details>