### PR TITLE
☘️ refactor [#12.2.26]: 4차 개선 - 스트림 에러 단락 평가 및 접근성 속성 보강

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -21,6 +21,7 @@ function ErrorBanner({ message, onRetry }: { message: string; onRetry?: () => vo
   return (
     <div
       role="alert"
+      aria-live="assertive"
       className="p-4 mb-4 bg-red-50 border border-red-100 rounded-xl text-xs text-red-600 flex items-center gap-2 animate-in fade-in slide-in-from-top-2"
     >
       <span className="font-bold">Error:</span>

--- a/web_ui/src/hooks/useStreamingChat.ts
+++ b/web_ui/src/hooks/useStreamingChat.ts
@@ -162,7 +162,8 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
                   errorCode: errChunk.error_code,
                   message: errChunk.message,
                 });
-                break;
+                // 에러 발생 시 스트림 처리를 즉각 중단하여 onFinish가 호출되는 것을 방어합니다.
+                return;
               }
               case 'done':
                 // 정상 완료 - 누적된 토큰과 소스를 부모에게 전달


### PR DESCRIPTION
- **[버그 수정] 스트리밍 에러 시 즉각 중단 (단락 평가)**
  - `useStreamingChat` 루프에서 `error` 청크 수신 시 `return`으로 즉시 실행을 종료하도록 수정.
  - 에러 발생 이후 뒤늦게 도착한 `done` 청크에 의해 `onFinish`가 잘못 호출되어 빈 메시지가 영구 저장되는 논리적 버그 원천 차단.

- **[접근성(a11y) 보강] ErrorBanner 스크린 리더 호환성 강화**
  - 이전 PR 피드백(충돌 속성 제거)으로 인해 누락될 수 있는 스크린 리더 알림 회귀를 방지하고자 `aria-live="assertive"` 명시적 추가.
  - `role="alert"`의 기본 스펙과 일치시켜 모순 없이 즉각적인 에러 음성 안내 보장.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1401#pullrequestreview-4291757187)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

스트리밍 채팅 오류 처리를 개선하고 오류 알림의 접근성을 향상합니다.

버그 수정:
- 오류 청크가 수신되면 스트리밍 채팅 처리를 즉시 중단하여 잘못된 `onFinish` 호출 및 빈 메시지가 유지되는 문제를 방지합니다.

개선 사항:
- 오류 배너 알림에 `aria-live="assertive"`를 명시적으로 추가하여 스크린 리더가 오류를 빠르고 일관되게 안내하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine streaming chat error handling and improve accessibility of error notifications.

Bug Fixes:
- Stop streaming chat processing immediately when an error chunk is received to prevent erroneous onFinish invocation and empty message persistence.

Enhancements:
- Add explicit aria-live="assertive" to the error banner alert to ensure prompt, consistent screen reader announcements.

</details>