### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -21,6 +21,7 @@ function ErrorBanner({ message, onRetry }: { message: string; onRetry?: () => vo
   return (
     <div
       role="alert"
+      aria-live="assertive"
       className="p-4 mb-4 bg-red-50 border border-red-100 rounded-xl text-xs text-red-600 flex items-center gap-2 animate-in fade-in slide-in-from-top-2"
     >
       <span className="font-bold">Error:</span>

--- a/web_ui/src/hooks/useStreamingChat.ts
+++ b/web_ui/src/hooks/useStreamingChat.ts
@@ -162,7 +162,8 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
                   errorCode: errChunk.error_code,
                   message: errChunk.message,
                 });
-                break;
+                // 에러 발생 시 스트림 처리를 즉각 중단하여 onFinish가 호출되는 것을 방어합니다.
+                return;
               }
               case 'done':
                 // 정상 완료 - 누적된 토큰과 소스를 부모에게 전달


### PR DESCRIPTION
☘️ refactor [#12.2.26]: 4차 개선 - 스트림 에러 단락 평가 및 접근성 속성 보강

## Summary by Sourcery

스트리밍 오류가 발생했을 때 종료 콜백이 실행되지 않도록 방지하고, 채팅 오류 배너의 접근성을 개선합니다.

버그 수정:
- 채팅 스트리밍 중 오류 청크가 수신되었을 때 스트리밍 완료 핸들러가 호출되지 않도록 중단합니다.

개선 사항:
- 오류 배너를 assertive ARIA 라이브 영역으로 만들어, 보조 기술이 채팅 오류를 인지할 수 있도록 알립니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent finishing callbacks from running when a streaming error occurs and improve accessibility of the chat error banner.

Bug Fixes:
- Stop invoking the streaming completion handler when an error chunk is received during chat streaming.

Enhancements:
- Announce chat errors to assistive technologies by making the error banner an assertive ARIA live region.

</details>