### PR TITLE
☘️ refactor [#12.2.26]: 5차 개선 - 스트림 리소스 안전 해제 및 접근성 중복 속성 제거

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -21,7 +21,6 @@ function ErrorBanner({ message, onRetry }: { message: string; onRetry?: () => vo
   return (
     <div
       role="alert"
-      aria-live="assertive"
       className="p-4 mb-4 bg-red-50 border border-red-100 rounded-xl text-xs text-red-600 flex items-center gap-2 animate-in fade-in slide-in-from-top-2"
     >
       <span className="font-bold">Error:</span>

--- a/web_ui/src/hooks/useStreamingChat.ts
+++ b/web_ui/src/hooks/useStreamingChat.ts
@@ -162,7 +162,8 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
                   errorCode: errChunk.error_code,
                   message: errChunk.message,
                 });
-                // 에러 발생 시 스트림 처리를 즉각 중단하여 onFinish가 호출되는 것을 방어합니다.
+                // 에러 발생 시 스트림 처리를 즉각 중단하고 연결을 끊어 onFinish 호출과 리소스 누수를 방어합니다.
+                controller.abort();
                 return;
               }
               case 'done':


### PR DESCRIPTION
- **[메모리/네트워크 최적화] 에러 시 명시적 스트림 종료**
  - `useStreamingChat` 루프 에러 시 단락 평가 전 `controller.abort()`를 호출하여, 브라우저 백그라운드에 남아있을 수 있는 SSE HTTP 연결 리소스를 즉시 안전하게 해제.

- **[접근성(a11y) 최적화] Overly Verbose 알림 방지**
  - `ErrorBanner`에서 `role="alert"`와 중복되는 `aria-live="assertive"` 속성 제거.
  - `role="alert"`만으로도 충분히 강제 알림이 동작하며, 일부 스크린리더에서 에러 메시지를 두 번 반복해서 읽어주는 현상을 방지.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1403#pullrequestreview-4291810756)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

에러 발생 시 스트리밍 채팅 연결을 중단하여 리소스 누수를 방지하고, 오류 배너의 접근성을 조정해 중복 안내를 피했습니다.

버그 수정:
- 에러 청크를 수신하면 스트리밍 채팅 루프를 중단하고 하위 컨트롤러를 중단(abort)하여, SSE 연결이 남아 있거나 의도치 않은 `onFinish` 호출이 발생하지 않도록 했습니다.
- 일부 스크린 리더에서 오류가 중복으로 안내되는 문제를 방지하기 위해 오류 배너에서 중복된 `aria-live` 속성을 제거했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Abort streaming chat connections on error to prevent resource leaks and adjust error banner accessibility to avoid redundant announcements.

Bug Fixes:
- Stop the streaming chat loop and abort the underlying controller when an error chunk is received to prevent lingering SSE connections and unintended onFinish calls.
- Remove the redundant aria-live attribute from the error banner to avoid duplicate error announcements in some screen readers.

</details>