### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -21,7 +21,6 @@ function ErrorBanner({ message, onRetry }: { message: string; onRetry?: () => vo
   return (
     <div
       role="alert"
-      aria-live="assertive"
       className="p-4 mb-4 bg-red-50 border border-red-100 rounded-xl text-xs text-red-600 flex items-center gap-2 animate-in fade-in slide-in-from-top-2"
     >
       <span className="font-bold">Error:</span>

--- a/web_ui/src/hooks/useStreamingChat.ts
+++ b/web_ui/src/hooks/useStreamingChat.ts
@@ -162,7 +162,8 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
                   errorCode: errChunk.error_code,
                   message: errChunk.message,
                 });
-                // 에러 발생 시 스트림 처리를 즉각 중단하여 onFinish가 호출되는 것을 방어합니다.
+                // 에러 발생 시 스트림 처리를 즉각 중단하고 연결을 끊어 onFinish 호출과 리소스 누수를 방어합니다.
+                controller.abort();
                 return;
               }
               case 'done':


### PR DESCRIPTION
☘️ refactor [#12.2.26]: 5차 개선 - 스트림 리소스 안전 해제 및 접근성 중복 속성 제거

## Summary by Sourcery

오류 발생 시 스트리밍 채팅 요청을 중단하고, 채팅 오류 배너에서 불필요한 접근성 속성을 정리합니다.

개선사항:
- 오류 발생 시 스트리밍 컨트롤러를 종료하여 onFinish가 호출되지 않도록 하고, 리소스 누수를 방지합니다.
- 중복된 `aria-live` 속성을 제거하여 채팅 오류 배너 마크업을 단순화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Abort streaming chat requests on error and clean up redundant accessibility attributes in the chat error banner.

Enhancements:
- Terminate the streaming controller on error to prevent onFinish from firing and avoid resource leaks.
- Simplify the chat error banner markup by removing a redundant aria-live attribute.

</details>