### PR TITLE
☘️ refactor [#12.2.26]: 6차 개선 - 에러 배너 접근성 라이브 리전(Live Region) 표준화

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -20,7 +20,6 @@ import { toast } from 'sonner';
 function ErrorBanner({ message, onRetry }: { message: string; onRetry?: () => void }) {
   return (
     <div
-      role="alert"
       className="p-4 mb-4 bg-red-50 border border-red-100 rounded-xl text-xs text-red-600 flex items-center gap-2 animate-in fade-in slide-in-from-top-2"
     >
       <span className="font-bold">Error:</span>
@@ -460,17 +459,19 @@ export function ChatWindow({
               </div>
             )}
 
-            {/* 에러 UI: 스트리밍 모드와 기존 모드를 분기하지만 일관된 UI 컴포넌트 사용 */}
-            {isStreamingMode ? (
-              streamError && <ErrorBanner message={streamError.message} />
-            ) : (
-              error && (
-                <ErrorBanner
-                  message={error.message || '메시지 전송 중 오류가 발생했습니다.'}
-                  onRetry={handleRetry}
-                />
-              )
-            )}
+            {/* 에러 UI: 스크린 리더가 DOM 삽입을 항상 감지할 수 있도록 라이브 리전 컨테이너를 상시 렌더링합니다. */}
+            <div aria-live="assertive" className="empty:hidden">
+              {isStreamingMode ? (
+                streamError && <ErrorBanner message={streamError.message} />
+              ) : (
+                error && (
+                  <ErrorBanner
+                    message={error.message || '메시지 전송 중 오류가 발생했습니다.'}
+                    onRetry={handleRetry}
+                  />
+                )
+              )}
+            </div>
             <div className="h-4" />
           </div>
         </ScrollArea>

--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -460,7 +460,7 @@ export function ChatWindow({
             )}
 
             {/* 에러 UI: 스크린 리더가 DOM 삽입을 항상 감지할 수 있도록 라이브 리전 컨테이너를 상시 렌더링합니다. */}
-            <div aria-live="assertive" className="empty:hidden">
+            <div aria-live="assertive" aria-atomic="true">
               {isStreamingMode ? (
                 streamError && <ErrorBanner message={streamError.message} />
               ) : (


### PR DESCRIPTION
- **[접근성(a11y) 표준화] 정적 라이브 리전(Live Region) 도입**
  - 동적으로 생성되는 `ErrorBanner` 내부의 ARIA 속성이 스크린 리더에서 누락되는 현상(회귀) 방지.
  - 에러가 렌더링될 부모 컨테이너를 `<div aria-live="assertive" className="empty:hidden">` 형태로 항상 DOM에 유지시켜, 에러 발생 시 텍스트 삽입 이벤트를 스크린 리더가 안정적으로 감지하도록 수정.
  - `ErrorBanner` 내부의 불필요한 `role="alert"`를 제거하여 속성 충돌 및 중복 알림 완전 해소.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1405#pullrequestreview-4291849314)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

향상된 접근성과 신뢰할 수 있는 스크린 리더 안내를 위해 채팅 오류 배너를 assertive 라이브 영역으로 표준화합니다.

개선 사항:
- 채팅 오류 배너를 지속적인 `aria-live="assertive"` 컨테이너로 감싸 스크린 리더가 오류 메시지 삽입을 일관되게 감지할 수 있도록 합니다.
- 라이브 영역 컨테이너에서 이미 처리하는 경고 역할(alert role)을 제거하여 ErrorBanner 마크업을 단순화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize the chat error banner as an assertive live region for improved accessibility and reliable screen reader announcements.

Enhancements:
- Wrap chat error banners in a persistent aria-live="assertive" container so screen readers consistently detect error message insertion.
- Simplify the ErrorBanner markup by removing the redundant alert role now handled by the live region container.

</details>