### PR TITLE
✨ feat [#12.2.27]: Phase 3-4 - ① 타이핑 인디케이터(Typing Indicator) 구현

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -447,6 +447,18 @@ export function ChatWindow({
                 sessionId={sessionId}
               />
             ))}
+            {/* [스트리밍 모드] 첫 토큰 도착 전 타이핑 인디케이터 */}
+            {isStreamingMode && isStreaming && !streamTokens && (
+              <div className="flex justify-start px-1 py-2">
+                <div className="max-w-[80%] rounded-2xl rounded-tl-sm bg-slate-50 border border-slate-100 px-4 py-4 flex items-center gap-1.5">
+                  <div className="w-2 h-2 bg-slate-400 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} aria-hidden="true" />
+                  <div className="w-2 h-2 bg-slate-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} aria-hidden="true" />
+                  <div className="w-2 h-2 bg-slate-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} aria-hidden="true" />
+                  <span className="sr-only">응답 작성 중...</span>
+                </div>
+              </div>
+            )}
+
             {/* [스트리밍 모드] 누적 토큰을 실시간으로 렌더링 */}
             {isStreamingMode && streamTokens && (
               <div className="flex justify-start px-1 py-2">

--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -448,12 +448,20 @@ export function ChatWindow({
               />
             ))}
             {/* [스트리밍 모드] 첫 토큰 도착 전 타이핑 인디케이터 */}
-            {isStreamingMode && isStreaming && !streamTokens && (
+            {isStreamingMode && isStreaming && streamTokens.length === 0 && (
               <div className="flex justify-start px-1 py-2">
-                <div className="max-w-[80%] rounded-2xl rounded-tl-sm bg-slate-50 border border-slate-100 px-4 py-4 flex items-center gap-1.5">
-                  <div className="w-2 h-2 bg-slate-400 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} aria-hidden="true" />
-                  <div className="w-2 h-2 bg-slate-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} aria-hidden="true" />
-                  <div className="w-2 h-2 bg-slate-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} aria-hidden="true" />
+                <div 
+                  className="max-w-[80%] rounded-2xl rounded-tl-sm bg-slate-50 border border-slate-100 px-4 py-4 flex items-center gap-1.5"
+                  role="status"
+                  aria-live="polite"
+                >
+                  {['[animation-delay:-0.3s]', '[animation-delay:-0.15s]', ''].map((delayClass, index) => (
+                    <div 
+                      key={index}
+                      className={`w-2 h-2 bg-slate-400 rounded-full animate-bounce ${delayClass}`} 
+                      aria-hidden="true" 
+                    />
+                  ))}
                   <span className="sr-only">응답 작성 중...</span>
                 </div>
               </div>


### PR DESCRIPTION
- **[UX 개선] 스트리밍 대기 지연 시 시각적 피드백 제공**
  - 스트리밍 요청 후 첫 번째 토큰이 도착하기 전까지 대기 상태를 나타내는 타이핑 인디케이터(`●●●`) 추가.
  - `isStreaming === true`이고 `!streamTokens`인 조건에서만 표시되어, 첫 응답 수신 시 즉시 자연스럽게 숨김 처리됨.
  - Tailwind CSS의 `animate-bounce`와 JIT 임의 값(`[animation-delay:-0.3s]` 등)을 활용해 인라인 스타일 없이 성능에 최적화된 애니메이션(Pulse/Blink 계열) 구현.
  - 스크린 리더용 `sr-only` 안내 텍스트 추가로 접근성(a11y) 확보.

🔗 Related: Issue [#1047]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

채팅에서 첫 번째 스트리밍 토큰을 기다리는 동안 입력 중 표시 말풍선을 추가합니다.

New Features:
- 스트리밍이 활성화되어 있으나 아직 토큰이 수신되지 않은 경우, 채팅에 점 3개(…) 입력 중 표시를 보여줍니다.

Enhancements:
- 첫 번째 토큰이 도착하기 전에 응답이 생성되고 있음을 시각적으로, 그리고 스크린 리더에서도 인지할 수 있도록 피드백을 제공하여 채팅 스트리밍 UX를 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a typing indicator message bubble while waiting for the first streaming token in chat.

New Features:
- Display a three-dot typing indicator in the chat when streaming is active but no tokens have been received yet.

Enhancements:
- Improve chat streaming UX by providing visual and screen-reader-friendly feedback that a response is being generated before the first token arrives.

</details>