### PR TITLE
☘️ refactor [#12.2.27]: 2차 개선 - 타이핑 인디케이터 컴포넌트 분리 및 런타임 가드 추가

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -38,6 +38,30 @@ function ErrorBanner({ message, onRetry }: { message: string; onRetry?: () => vo
   );
 }
 
+/**
+ * 스트리밍 대기 시 보여지는 타이핑 인디케이터
+ */
+function TypingIndicator() {
+  return (
+    <div className="flex justify-start px-1 py-2">
+      <div 
+        className="max-w-[80%] rounded-2xl rounded-tl-sm bg-slate-50 border border-slate-100 px-4 py-4 flex items-center gap-1.5"
+        role="status"
+        aria-live="polite"
+      >
+        {['[animation-delay:-0.3s]', '[animation-delay:-0.15s]', ''].map((delayClass, index) => (
+          <div 
+            key={index}
+            className={`w-2 h-2 bg-slate-400 rounded-full animate-bounce ${delayClass}`} 
+            aria-hidden="true" 
+          />
+        ))}
+        <span className="sr-only">응답 작성 중...</span>
+      </div>
+    </div>
+  );
+}
+
 /** 초기 환영 메시지 */
 const WELCOME_MESSAGE: UIMessage = {
   id: 'welcome',
@@ -448,23 +472,8 @@ export function ChatWindow({
               />
             ))}
             {/* [스트리밍 모드] 첫 토큰 도착 전 타이핑 인디케이터 */}
-            {isStreamingMode && isStreaming && streamTokens.length === 0 && (
-              <div className="flex justify-start px-1 py-2">
-                <div 
-                  className="max-w-[80%] rounded-2xl rounded-tl-sm bg-slate-50 border border-slate-100 px-4 py-4 flex items-center gap-1.5"
-                  role="status"
-                  aria-live="polite"
-                >
-                  {['[animation-delay:-0.3s]', '[animation-delay:-0.15s]', ''].map((delayClass, index) => (
-                    <div 
-                      key={index}
-                      className={`w-2 h-2 bg-slate-400 rounded-full animate-bounce ${delayClass}`} 
-                      aria-hidden="true" 
-                    />
-                  ))}
-                  <span className="sr-only">응답 작성 중...</span>
-                </div>
-              </div>
+            {isStreamingMode && isStreaming && (!streamTokens || streamTokens.length === 0) && (
+              <TypingIndicator />
             )}
 
             {/* [스트리밍 모드] 누적 토큰을 실시간으로 렌더링 */}

--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -38,21 +38,23 @@ function ErrorBanner({ message, onRetry }: { message: string; onRetry?: () => vo
   );
 }
 
+const TYPING_ANIMATION_DELAYS = ['[animation-delay:-0.3s]', '[animation-delay:-0.15s]', ''];
+
 /**
  * 스트리밍 대기 시 보여지는 타이핑 인디케이터
  */
-function TypingIndicator() {
+function TypingIndicator({ className = '' }: { className?: string }) {
   return (
-    <div className="flex justify-start px-1 py-2">
+    <div className={`flex justify-start px-1 py-2 ${className}`.trim()}>
       <div 
         className="max-w-[80%] rounded-2xl rounded-tl-sm bg-slate-50 border border-slate-100 px-4 py-4 flex items-center gap-1.5"
         role="status"
         aria-live="polite"
       >
-        {['[animation-delay:-0.3s]', '[animation-delay:-0.15s]', ''].map((delayClass, index) => (
+        {TYPING_ANIMATION_DELAYS.map((delayClass, index) => (
           <div 
             key={index}
-            className={`w-2 h-2 bg-slate-400 rounded-full animate-bounce ${delayClass}`} 
+            className={`w-2 h-2 bg-slate-400 rounded-full animate-bounce ${delayClass}`.trim()} 
             aria-hidden="true" 
           />
         ))}
@@ -472,7 +474,7 @@ export function ChatWindow({
               />
             ))}
             {/* [스트리밍 모드] 첫 토큰 도착 전 타이핑 인디케이터 */}
-            {isStreamingMode && isStreaming && (!streamTokens || streamTokens.length === 0) && (
+            {isStreamingMode && isStreaming && streamTokens === '' && (
               <TypingIndicator />
             )}
 


### PR DESCRIPTION
- **[버그 방어] 런타임 에러(Crash) 원천 차단**
  - 인디케이터 렌더링 조건인 `streamTokens.length` 접근 시 발생할 수 있는 잠재적 `TypeError (Cannot read properties of undefined)`를 방어하기 위해 `(!streamTokens || streamTokens.length === 0)` 가드 조건 추가.

- **[코드 구조 개선] 관심사 분리(SoC)**
  - 비대해질 수 있는 메인 렌더링 파이프라인에서 타이핑 인디케이터 UI 로직을 독립적인 `<TypingIndicator />` 컴포넌트로 추출.
  - `ChatWindow.tsx`의 코드 가독성 향상 및 컴포넌트 재사용성/유지보수성 확보.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1409#pullrequestreview-4303057274)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

채팅 창 타이핑 인디케이터를 재사용 가능한 컴포넌트로 리팩터링하고, 스트리밍 토큰이 `undefined`이거나 비어 있을 때 런타임 오류가 발생하지 않도록 렌더링 조건을 강화했습니다.

Bug Fixes:
- 스트리밍 토큰이 `undefined`이거나 비어 있을 때 타이핑 인디케이터 렌더링을 보호하여 잠재적인 `TypeError` 크래시를 방지했습니다.

Enhancements:
- 가독성과 재사용성을 높이기 위해 ChatWindow에서 타이핑 인디케이터 UI를 분리하여 전용 TypingIndicator 컴포넌트로 추출했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the chat window typing indicator into a reusable component and harden its rendering conditions to prevent runtime errors when streaming tokens are undefined or empty.

Bug Fixes:
- Prevent potential TypeError crashes by guarding typing indicator rendering when streaming tokens are undefined or empty.

Enhancements:
- Extract the typing indicator UI from ChatWindow into a dedicated TypingIndicator component for improved readability and reuse.

</details>