### PR TITLE
☘️ refactor [#12.2.27]: 4차 개선 - 타이핑 인디케이터 조건 롤백 및 문자열 연산 최적화

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -474,7 +474,7 @@ export function ChatWindow({
               />
             ))}
             {/* [스트리밍 모드] 첫 토큰 도착 전 타이핑 인디케이터 */}
-            {isStreamingMode && isStreaming && !streamTokens && (
+            {isStreamingMode && isStreaming && (streamTokens == null || streamTokens === '') && (
               <TypingIndicator />
             )}
 

--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -45,7 +45,7 @@ const TYPING_ANIMATION_DELAYS = ['[animation-delay:-0.3s]', '[animation-delay:-0
  */
 function TypingIndicator({ className = '' }: { className?: string }) {
   return (
-    <div className={`flex justify-start px-1 py-2 ${className}`.trim()}>
+    <div className={`flex justify-start px-1 py-2 ${className}`}>
       <div 
         className="max-w-[80%] rounded-2xl rounded-tl-sm bg-slate-50 border border-slate-100 px-4 py-4 flex items-center gap-1.5"
         role="status"
@@ -54,7 +54,7 @@ function TypingIndicator({ className = '' }: { className?: string }) {
         {TYPING_ANIMATION_DELAYS.map((delayClass, index) => (
           <div 
             key={index}
-            className={`w-2 h-2 bg-slate-400 rounded-full animate-bounce ${delayClass}`.trim()} 
+            className={`w-2 h-2 bg-slate-400 rounded-full animate-bounce ${delayClass}`} 
             aria-hidden="true" 
           />
         ))}
@@ -474,7 +474,7 @@ export function ChatWindow({
               />
             ))}
             {/* [스트리밍 모드] 첫 토큰 도착 전 타이핑 인디케이터 */}
-            {isStreamingMode && isStreaming && streamTokens === '' && (
+            {isStreamingMode && isStreaming && !streamTokens && (
               <TypingIndicator />
             )}
 


### PR DESCRIPTION
- **[버그 방어] 런타임 Falsy 가드 롤백**
  - 인디케이터 렌더링 조건을 `streamTokens === ''`에서 더 포괄적인 `!streamTokens`로 롤백.
  - 런타임에 예상치 못하게 `null`이나 `undefined`가 유입될 경우 `===` 엄격 비교가 실패하여 UI가 누락되는 회귀(Regression) 방지.

- **[성능 최적화] 불필요한 문자열 연산 제거**
  - `TypingIndicator` 컴포넌트의 템플릿 리터럴(`className`) 결합 시 포함되었던 `.trim()` 호출 2곳 제거.
  - 브라우저는 HTML 클래스의 후행 공백을 자연스럽게 무시하므로, 매 렌더링 시 발생하는 불필요한 함수 호출 비용(Noise) 절감.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1411#pullrequestreview-4303115005)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

채팅 입력 표시기의 렌더링 신뢰성을 개선하고 스타일 계산 과정을 간소화합니다.

버그 수정:
- 스트리밍 토큰에 대해 더 견고한 falsy 체크를 복원하여 `null` 또는 `undefined` 값이 들어와도 입력 표시기가 계속 렌더링되도록 합니다.

향상 사항:
- 렌더링마다 반복되는 불필요한 작업을 줄이기 위해 `TypingIndicator`의 `className` 생성 과정에서 불필요한 문자열 `trim` 처리를 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the chat typing indicator’s rendering reliability and streamline its styling computation.

Bug Fixes:
- Restore a more robust falsy check for streaming tokens so the typing indicator still renders when null or undefined values are received.

Enhancements:
- Remove unnecessary string trimming in the TypingIndicator className construction to reduce redundant per-render work.

</details>