### PR TITLE
✨ feat [#12.2.28]: Phase 3-4 - ➁ 마크다운 실시간 스트리밍 렌더링 및 XSS 방어 체계 구현

### DIFF
--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -32,6 +32,7 @@
         "react-syntax-highlighter": "^16.1.1",
         "reactflow": "^11.11.4",
         "recharts": "^3.6.0",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0"
@@ -8821,6 +8822,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -12191,6 +12207,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/web_ui/package.json
+++ b/web_ui/package.json
@@ -34,6 +34,7 @@
     "react-syntax-highlighter": "^16.1.1",
     "reactflow": "^11.11.4",
     "recharts": "^3.6.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"

--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -13,8 +13,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import { Send, Loader2, ChevronDown } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import rehypeSanitize from 'rehype-sanitize';
+import { REMARK_PLUGINS, REHYPE_PLUGINS, useMarkdownComponents } from './markdown-components';
 import { stabilizeIncompleteMarkdown } from '@/lib/markdown';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { toast } from 'sonner';
@@ -252,7 +251,7 @@ export function ChatWindow({
   const {
     tokens: streamTokens,
     isStreaming,
-    // sources는 향후 SourcePanel 컴포넌트 연결 시 추가 예정
+    sources: streamSources,
     error: streamError,
     startStream,
     cancelStream,
@@ -281,6 +280,8 @@ export function ChatWindow({
       ]);
     },
   });
+
+  const markdownComponents = useMarkdownComponents(streamSources);
 
   useEffect(() => {
     if (!sessionId) return;
@@ -499,8 +500,9 @@ export function ChatWindow({
                     className="px-4 py-3 rounded-2xl text-sm leading-relaxed bg-white text-slate-800 rounded-bl-sm shadow-sm border border-slate-100 w-full"
                   >
                     <ReactMarkdown
-                      remarkPlugins={[remarkGfm]}
-                      rehypePlugins={[rehypeSanitize]}
+                      remarkPlugins={REMARK_PLUGINS}
+                      rehypePlugins={REHYPE_PLUGINS}
+                      components={markdownComponents}
                     >
                       {stabilizeIncompleteMarkdown(streamTokens)}
                     </ReactMarkdown>

--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -12,6 +12,11 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import { Send, Loader2, ChevronDown } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeSanitize from 'rehype-sanitize';
+import { stabilizeIncompleteMarkdown } from '@/lib/markdown';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { toast } from 'sonner';
 
 /**
@@ -414,6 +419,7 @@ export function ChatWindow({
   };
 
   const shouldShowTypingIndicator = isStreamingMode && isStreaming && (streamTokens == null || streamTokens === '');
+  const shouldShowStreamingTokens = isStreamingMode && isStreaming && streamTokens != null && streamTokens !== '';
 
   return (
     <div 
@@ -481,13 +487,27 @@ export function ChatWindow({
             )}
 
             {/* [스트리밍 모드] 누적 토큰을 실시간으로 렌더링 */}
-            {isStreamingMode && streamTokens && (
-              <div className="flex justify-start px-1 py-2">
-                <div className="max-w-[80%] rounded-2xl rounded-tl-sm bg-slate-50 border border-slate-100 px-4 py-3 text-sm text-slate-800 whitespace-pre-wrap">
-                  {streamTokens}
-                  {isStreaming && (
-                    <span className="inline-block w-1.5 h-4 bg-slate-400 rounded-sm ml-0.5 animate-pulse" aria-hidden="true" />
-                  )}
+            {shouldShowStreamingTokens && (
+              <div className="flex gap-3 w-full justify-start mb-5 animate-in fade-in slide-in-from-bottom-2 duration-300">
+                {/* 아바타 */}
+                <Avatar className="w-8 h-8 shrink-0 mt-1 shadow-sm border border-slate-100">
+                  <AvatarFallback className="bg-blue-100 text-blue-700 text-xs font-bold">AI</AvatarFallback>
+                </Avatar>
+
+                <div className="flex flex-col gap-2 max-w-[85%] items-start w-full">
+                  <div
+                    className="px-4 py-3 rounded-2xl text-sm leading-relaxed bg-white text-slate-800 rounded-bl-sm shadow-sm border border-slate-100 w-full"
+                  >
+                    <ReactMarkdown
+                      remarkPlugins={[remarkGfm]}
+                      rehypePlugins={[rehypeSanitize]}
+                    >
+                      {stabilizeIncompleteMarkdown(streamTokens)}
+                    </ReactMarkdown>
+                    {isStreaming && (
+                      <span className="inline-block w-1.5 h-4 bg-slate-400 rounded-sm ml-0.5 animate-pulse align-middle" aria-hidden="true" />
+                    )}
+                  </div>
                 </div>
               </div>
             )}

--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useMemo, memo, useRef, useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import rehypeSanitize from 'rehype-sanitize';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
@@ -450,6 +451,7 @@ export const MessageBubble = memo(
           >
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeSanitize]}
               components={markdownComponents}
             >
               {processedContent}

--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -2,10 +2,7 @@
 
 import React, { useState, useMemo, memo, useRef, useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import rehypeSanitize from 'rehype-sanitize';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { REMARK_PLUGINS, REHYPE_PLUGINS, useMarkdownComponents } from './markdown-components';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { ThumbsUp, ThumbsDown } from 'lucide-react';
@@ -42,35 +39,11 @@ interface MessageBubbleProps {
   sessionId?: string;
 }
 
-// react-markdown v10 code 컴포넌트 타입
-type CodeProps = React.ComponentPropsWithoutRef<'code'> & {
-  inline?: boolean;
-};
-
 /**
  * [Pure Function] 스트리밍 상태를 고려하여 렌더링 가능한 마크다운 보장
  */
 function ensureRenderableMarkdown(markdown: string, shouldPatch: boolean): string {
   return shouldPatch ? stabilizeIncompleteMarkdown(markdown) : markdown;
-}
-
-/**
- * [Refactoring] 유효하지 않거나 누락된 인용 소스에 대한 일관된 폴백 렌더러
- */
-function FallbackCitation({ 
-  children, 
-  className, 
-  title = "출처 정보 없음" 
-}: { 
-  children: React.ReactNode; 
-  className?: string; 
-  title?: string;
-}) {
-  return (
-    <span className={cn("text-slate-500 font-medium cursor-help", className)} title={title}>
-      {children}
-    </span>
-  );
 }
 
 /**
@@ -326,89 +299,8 @@ export const MessageBubble = memo(
     setSelectedSource(null);
   };
 
-  // react-markdown v10 code 컴포넌트
-  const markdownComponents: Components = {
-    code({ className, children, ...props }: CodeProps) {
-      const match = /language-(\w+)/.exec(className || '');
-      const isBlock = Boolean(match);
-      return isBlock ? (
-        <SyntaxHighlighter
-          style={vscDarkPlus as Record<string, React.CSSProperties>}
-          language={match![1]}
-          PreTag="div"
-          className="rounded-md my-2 text-xs"
-        >
-          {String(children).replace(/\n$/, '')}
-        </SyntaxHighlighter>
-      ) : (
-        <code
-          className="bg-black/10 px-1 py-0.5 rounded text-xs font-mono"
-          {...props}
-        >
-          {children}
-        </code>
-      );
-    },
-    // 인라인 인용(Citation) 링크 컴포넌트
-    a({ children, href, className, ...props }) {
-      if (href?.startsWith('cite:')) {
-        const indexStr = href.replace('cite:', '').trim();
-
-        // [Validation] cite 인덱스 검증
-        if (!CITATION_VALIDATION_REGEX.test(indexStr)) {
-          return <FallbackCitation className={className}>{children}</FallbackCitation>;
-        }
-
-        const index = parseInt(indexStr, 10) - 1;
-        const source = sources[index];
-        
-        if (!source) {
-          return <FallbackCitation className={className}>{children}</FallbackCitation>;
-        }
-
-        const handleCitationClick = (e: React.MouseEvent | React.KeyboardEvent) => {
-          e.preventDefault();
-          handleBadgeClick(source);
-        };
-
-        return (
-          <sup
-            role="button"
-            tabIndex={0}
-            onClick={handleCitationClick}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                handleCitationClick(e as unknown as React.MouseEvent);
-              }
-            }}
-            className="
-              inline-flex items-center justify-center
-              mx-0.5 px-1 min-w-[1rem] h-4
-              bg-blue-50 text-blue-700 font-bold text-[9px]
-              rounded border border-blue-200
-              cursor-pointer hover:bg-blue-100 hover:border-blue-300
-              transition-colors align-top mt-0.5
-              select-none focus:outline-none focus:ring-1 focus:ring-blue-400
-            "
-            title={source.title ? `출처: ${source.title}` : `출처: ${source.id}`}
-          >
-            {children}
-          </sup>
-        );
-      }
-      return (
-        <a 
-          href={href} 
-          className={cn("text-blue-600 underline", className)} 
-          target="_blank" 
-          rel="noopener noreferrer" 
-          {...props}
-        >
-          {children}
-        </a>
-      );
-    },
-  };
+  // 공유 마크다운 컴포넌트 (Memoized)
+  const markdownComponents = useMarkdownComponents(sources, handleBadgeClick);
 
   // [Performance] 콘텐츠 가공 및 마크다운 안정화 로직 통합 호출
   const processedContent = useMemo(() => {
@@ -450,8 +342,8 @@ export const MessageBubble = memo(
             }`}
           >
             <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              rehypePlugins={[rehypeSanitize]}
+              remarkPlugins={REMARK_PLUGINS}
+              rehypePlugins={REHYPE_PLUGINS}
               components={markdownComponents}
             >
               {processedContent}

--- a/web_ui/src/components/chat/markdown-components.tsx
+++ b/web_ui/src/components/chat/markdown-components.tsx
@@ -1,0 +1,125 @@
+import React, { useMemo } from 'react';
+import remarkGfm from 'remark-gfm';
+import rehypeSanitize from 'rehype-sanitize';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import type { Components } from 'react-markdown';
+import { cn } from '@/lib/utils';
+import { CITATION_VALIDATION_REGEX } from '@/lib/chat-utils';
+import type { SourceItem } from '@/types/chat';
+
+export const REMARK_PLUGINS = [remarkGfm];
+export const REHYPE_PLUGINS = [rehypeSanitize];
+
+type CodeProps = React.ComponentPropsWithoutRef<'code'> & {
+  inline?: boolean;
+};
+
+/**
+ * 유효하지 않거나 누락된 인용 소스에 대한 일관된 폴백 렌더러
+ */
+function FallbackCitation({ 
+  children, 
+  className, 
+  title = "출처 정보 없음" 
+}: { 
+  children: React.ReactNode; 
+  className?: string; 
+  title?: string;
+}) {
+  return (
+    <span className={cn("text-slate-500 font-medium cursor-help", className)} title={title}>
+      {children}
+    </span>
+  );
+}
+
+/**
+ * MessageBubble 및 ChatWindow(스트리밍 렌더링)에서 공통으로 사용할 마크다운 컴포넌트들을 생성합니다.
+ * - 소스(sources) 데이터와 클릭 핸들러(onBadgeClick)는 인용구 렌더링에 사용됩니다.
+ */
+export function useMarkdownComponents(
+  sources: SourceItem[] = [],
+  onBadgeClick?: (src: SourceItem) => void
+): Components {
+  return useMemo(() => ({
+    code({ className, children, ...props }: CodeProps) {
+      const match = /language-(\w+)/.exec(className || '');
+      const isBlock = Boolean(match);
+      return isBlock ? (
+        <SyntaxHighlighter
+          style={vscDarkPlus as Record<string, React.CSSProperties>}
+          language={match![1]}
+          PreTag="div"
+          className="rounded-md my-2 text-xs"
+        >
+          {String(children).replace(/\n$/, '')}
+        </SyntaxHighlighter>
+      ) : (
+        <code
+          className="bg-black/10 px-1 py-0.5 rounded text-xs font-mono"
+          {...props}
+        >
+          {children}
+        </code>
+      );
+    },
+    a({ children, href, className, ...props }) {
+      if (href?.startsWith('cite:')) {
+        const indexStr = href.replace('cite:', '').trim();
+
+        if (!CITATION_VALIDATION_REGEX.test(indexStr)) {
+          return <FallbackCitation className={className}>{children}</FallbackCitation>;
+        }
+
+        const index = parseInt(indexStr, 10) - 1;
+        const source = sources[index];
+        
+        if (!source) {
+          return <FallbackCitation className={className}>{children}</FallbackCitation>;
+        }
+
+        const handleCitationClick = (e: React.MouseEvent | React.KeyboardEvent) => {
+          e.preventDefault();
+          onBadgeClick?.(source);
+        };
+
+        return (
+          <sup
+            role="button"
+            tabIndex={0}
+            onClick={handleCitationClick}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                handleCitationClick(e as unknown as React.MouseEvent);
+              }
+            }}
+            className="
+              inline-flex items-center justify-center
+              mx-0.5 px-1 min-w-[1rem] h-4
+              bg-blue-50 text-blue-700 font-bold text-[9px]
+              rounded border border-blue-200
+              cursor-pointer hover:bg-blue-100 hover:border-blue-300
+              transition-colors align-top mt-0.5
+              select-none focus:outline-none focus:ring-1 focus:ring-blue-400
+            "
+            title={source.title ? `출처: ${source.title}` : `출처: ${source.id}`}
+          >
+            {children}
+          </sup>
+        );
+      }
+      return (
+        <a 
+          href={href} 
+          className={cn("text-blue-600 underline", className)} 
+          target="_blank" 
+          rel="noopener noreferrer" 
+          {...props}
+        >
+          {children}
+        </a>
+      );
+    },
+  }), [sources, onBadgeClick]);
+}


### PR DESCRIPTION
- **[Core UX] ReactMarkdown 기반 실시간 스트리밍 렌더링 도입**
  - 기존의 12.2.28`whitespace-pre-wrap12.2.28` 단순 텍스트 출력을 12.2.28`ReactMarkdown12.2.28` 및 12.2.28`remark-gfm12.2.28` 기반의 마크다운 렌더링으로 전환.
  - **[보안] rehype-sanitize를 활용한 XSS 원천 차단**
    - 12.2.28`rehype-sanitize12.2.28` 디펜던시를 추가하고, 12.2.28`ChatWindow12.2.28` 스트리밍 버퍼와 12.2.28`MessageBubble12.2.28` 최종 렌더링 양측에 모두 적용하여 외부 입력 스트림에 대한 강력한 보안 확보.
  - **[안정성] stabilizeIncompleteMarkdown 구조적 복원 필터 연동**
    - 스트리밍 진행 중 미완성 코드 펜스( 12.2.28`12.2.28`12.2.28` )나 태그 누락으로 인한 레이아웃 깨짐을 방지하기 위해 실시간 마크다운 복원 기능 적용.
  - **[UI/UX] 렌더링 영역 분리 및 Layout Shift 최소화**
    - 스트리밍 진행 중에만 실시간 렌더링 블록(12.2.28`shouldShowStreamingTokens12.2.28`)을 노출하고, 완료 시 즉시 영구 12.2.28`messages12.2.28` 렌더링 영역으로 이관하여 이중 노출 방지.
    - 스트리밍 중에도 최종 메시지와 동일한 AI 아바타 및 버블 스타일 디자인을 일원화하여 완성도 높은 트랜지션 제공.

🔗 Related: Issue [#1047]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

실시간 마크다운 기반 스트리밍 렌더링을 통해 AI 응답을 표시하고, UX를 개선하며 XSS 방어를 강화합니다.

New Features:
- GitHub 스타일 마크다운을 지원하는 ReactMarkdown을 사용해 스트리밍되는 AI 응답을 마크다운으로 렌더링합니다.
- 응답 생성 중에 최종 AI 메시지와 동일한 아바타와 스타일을 사용하는 전용 스트리밍 메시지 말풍선을 표시합니다.

Enhancements:
- 불완전한 스트리밍 마크다운에 안정화 단계를 적용하여 렌더링 중 레이아웃이 깨지는 문제를 방지합니다.
- 스트리밍 말풍선의 레이아웃과 애니메이션을 기존 채팅 UI와 정렬하고, 전용 플래그를 통해 스트리밍 표시를 제어하여 레이아웃 시프트를 줄입니다.
- 스트리밍 및 최종 메시지 말풍선 모두에서 rehype-sanitize를 사용해 렌더링된 마크다운을 정제하여 XSS 공격에 대한 보안을 강화합니다.

Build:
- 안전한 마크다운 렌더링을 위해 rehype-sanitize를 프론트엔드 의존성으로 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement real-time, markdown-based streaming rendering for AI responses with improved UX and XSS protection.

New Features:
- Render streaming AI responses as markdown using ReactMarkdown with GitHub-flavored markdown support.
- Show a dedicated streaming message bubble that matches the final AI message avatar and styling while responses are being generated.

Enhancements:
- Apply a stabilization step to incomplete streaming markdown to prevent layout breaks during rendering.
- Align the streaming bubble layout and animation with the existing chat UI and reduce layout shifts by gating streaming visibility on a dedicated flag.
- Sanitize rendered markdown in both streaming and final message bubbles using rehype-sanitize to harden against XSS attacks.

Build:
- Add rehype-sanitize as a frontend dependency for secure markdown rendering.

</details>