### PR TITLE
☘️ refactor [#12.2.28]: 2차 개선 - 마크다운 컴포넌트 렌더링 안정성 및 UX 고도화

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -281,7 +281,9 @@ export function ChatWindow({
     },
   });
 
-  const markdownComponents = useMarkdownComponents(streamSources);
+  // 클릭 핸들러가 없을 때 `useMarkdownComponents`가 비인터랙티브한 citation 배지를
+  // 렌더링할 수 있도록, 명시적으로 `undefined`를 넘겨줍니다.
+  const markdownComponents = useMarkdownComponents(streamSources, undefined);
 
   useEffect(() => {
     if (!sessionId) return;

--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -10,10 +10,8 @@ import { cn } from '@/lib/utils';
 import type { UIMessage } from 'ai';
 import { SourcePanel } from './SourcePanel';
 import { type SourceItem } from '@/types/chat';
-import type { Components } from 'react-markdown';
 import { stabilizeIncompleteMarkdown } from '@/lib/markdown';
 import { 
-  CITATION_VALIDATION_REGEX, 
   extractSources,
   buildProcessedContent,
   areTextPartsEqual,

--- a/web_ui/src/components/chat/markdown-components.tsx
+++ b/web_ui/src/components/chat/markdown-components.tsx
@@ -82,14 +82,12 @@ export function useMarkdownComponents(
             return <FallbackCitation className={className}>{children}</FallbackCitation>;
           }
 
+          const commonBadgeClasses = "inline-flex items-center justify-center mx-0.5 px-1 min-w-[1rem] h-4 rounded align-top mt-0.5 select-none";
+          
           if (!onBadgeClick) {
             return (
               <sup
-                className={cn(
-                  "inline-flex items-center justify-center mx-0.5 px-1 min-w-[1rem] h-4",
-                  "bg-slate-100 text-slate-500 font-medium text-[9px] rounded border border-slate-200",
-                  "align-top mt-0.5 select-none"
-                )}
+                className={cn(commonBadgeClasses, "bg-slate-100 text-slate-500 font-medium text-[9px] border border-slate-200")}
                 title={source.title ? `출처: ${source.title}` : `출처: ${source.id}`}
               >
                 {children}
@@ -97,7 +95,7 @@ export function useMarkdownComponents(
             );
           }
 
-          const handleCitationClick = (e: React.MouseEvent | React.KeyboardEvent) => {
+          const handleCitationAction = (e: React.SyntheticEvent) => {
             e.preventDefault();
             onBadgeClick(source);
           };
@@ -106,17 +104,16 @@ export function useMarkdownComponents(
             <sup
               role="button"
               tabIndex={0}
-              onClick={handleCitationClick}
+              onClick={handleCitationAction}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
-                  handleCitationClick(e as unknown as React.MouseEvent);
+                  handleCitationAction(e);
                 }
               }}
               className={cn(
-                "inline-flex items-center justify-center mx-0.5 px-1 min-w-[1rem] h-4",
-                "bg-blue-50 text-blue-700 font-bold text-[9px] rounded border border-blue-200",
-                "cursor-pointer hover:bg-blue-100 hover:border-blue-300 transition-colors",
-                "align-top mt-0.5 select-none focus:outline-none focus:ring-1 focus:ring-blue-400"
+                commonBadgeClasses,
+                "bg-blue-50 text-blue-700 font-bold text-[9px] border border-blue-200",
+                "cursor-pointer hover:bg-blue-100 hover:border-blue-300 transition-colors focus:outline-none focus:ring-1 focus:ring-blue-400"
               )}
               title={source.title ? `출처: ${source.title}` : `출처: ${source.id}`}
             >

--- a/web_ui/src/components/chat/markdown-components.tsx
+++ b/web_ui/src/components/chat/markdown-components.tsx
@@ -39,87 +39,103 @@ function FallbackCitation({
  * - 소스(sources) 데이터와 클릭 핸들러(onBadgeClick)는 인용구 렌더링에 사용됩니다.
  */
 export function useMarkdownComponents(
-  sources: SourceItem[] = [],
+  sources?: SourceItem[],
   onBadgeClick?: (src: SourceItem) => void
 ): Components {
-  return useMemo(() => ({
-    code({ className, children, ...props }: CodeProps) {
-      const match = /language-(\w+)/.exec(className || '');
-      const isBlock = Boolean(match);
-      return isBlock ? (
-        <SyntaxHighlighter
-          style={vscDarkPlus as Record<string, React.CSSProperties>}
-          language={match![1]}
-          PreTag="div"
-          className="rounded-md my-2 text-xs"
-        >
-          {String(children).replace(/\n$/, '')}
-        </SyntaxHighlighter>
-      ) : (
-        <code
-          className="bg-black/10 px-1 py-0.5 rounded text-xs font-mono"
-          {...props}
-        >
-          {children}
-        </code>
-      );
-    },
-    a({ children, href, className, ...props }) {
-      if (href?.startsWith('cite:')) {
-        const indexStr = href.replace('cite:', '').trim();
+  return useMemo(() => {
+    const safeSources = sources ?? [];
 
-        if (!CITATION_VALIDATION_REGEX.test(indexStr)) {
-          return <FallbackCitation className={className}>{children}</FallbackCitation>;
-        }
-
-        const index = parseInt(indexStr, 10) - 1;
-        const source = sources[index];
-        
-        if (!source) {
-          return <FallbackCitation className={className}>{children}</FallbackCitation>;
-        }
-
-        const handleCitationClick = (e: React.MouseEvent | React.KeyboardEvent) => {
-          e.preventDefault();
-          onBadgeClick?.(source);
-        };
-
-        return (
-          <sup
-            role="button"
-            tabIndex={0}
-            onClick={handleCitationClick}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                handleCitationClick(e as unknown as React.MouseEvent);
-              }
-            }}
-            className="
-              inline-flex items-center justify-center
-              mx-0.5 px-1 min-w-[1rem] h-4
-              bg-blue-50 text-blue-700 font-bold text-[9px]
-              rounded border border-blue-200
-              cursor-pointer hover:bg-blue-100 hover:border-blue-300
-              transition-colors align-top mt-0.5
-              select-none focus:outline-none focus:ring-1 focus:ring-blue-400
-            "
-            title={source.title ? `출처: ${source.title}` : `출처: ${source.id}`}
+    return {
+      code({ className, children, ...props }: CodeProps) {
+        const match = /language-(\w+)/.exec(className || '');
+        const isBlock = Boolean(match);
+        return isBlock ? (
+          <SyntaxHighlighter
+            style={vscDarkPlus as Record<string, React.CSSProperties>}
+            language={match![1]}
+            PreTag="div"
+            className="rounded-md my-2 text-xs"
+          >
+            {String(children).replace(/\n$/, '')}
+          </SyntaxHighlighter>
+        ) : (
+          <code
+            className={cn("bg-black/10 px-1 py-0.5 rounded text-xs font-mono", className)}
+            {...props}
           >
             {children}
-          </sup>
+          </code>
         );
-      }
-      return (
-        <a 
-          href={href} 
-          className={cn("text-blue-600 underline", className)} 
-          target="_blank" 
-          rel="noopener noreferrer" 
-          {...props}
-        >
-          {children}
-        </a>
-      );
-    },
-  }), [sources, onBadgeClick]);
+      },
+      a({ children, href, className, ...props }) {
+        if (href?.startsWith('cite:')) {
+          const indexStr = href.replace('cite:', '').trim();
+
+          if (!CITATION_VALIDATION_REGEX.test(indexStr)) {
+            return <FallbackCitation className={className}>{children}</FallbackCitation>;
+          }
+
+          const index = parseInt(indexStr, 10) - 1;
+          const source = safeSources[index];
+          
+          if (!source) {
+            return <FallbackCitation className={className}>{children}</FallbackCitation>;
+          }
+
+          if (!onBadgeClick) {
+            return (
+              <sup
+                className={cn(
+                  "inline-flex items-center justify-center mx-0.5 px-1 min-w-[1rem] h-4",
+                  "bg-slate-100 text-slate-500 font-medium text-[9px] rounded border border-slate-200",
+                  "align-top mt-0.5 select-none"
+                )}
+                title={source.title ? `출처: ${source.title}` : `출처: ${source.id}`}
+              >
+                {children}
+              </sup>
+            );
+          }
+
+          const handleCitationClick = (e: React.MouseEvent | React.KeyboardEvent) => {
+            e.preventDefault();
+            onBadgeClick(source);
+          };
+
+          return (
+            <sup
+              role="button"
+              tabIndex={0}
+              onClick={handleCitationClick}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  handleCitationClick(e as unknown as React.MouseEvent);
+                }
+              }}
+              className={cn(
+                "inline-flex items-center justify-center mx-0.5 px-1 min-w-[1rem] h-4",
+                "bg-blue-50 text-blue-700 font-bold text-[9px] rounded border border-blue-200",
+                "cursor-pointer hover:bg-blue-100 hover:border-blue-300 transition-colors",
+                "align-top mt-0.5 select-none focus:outline-none focus:ring-1 focus:ring-blue-400"
+              )}
+              title={source.title ? `출처: ${source.title}` : `출처: ${source.id}`}
+            >
+              {children}
+            </sup>
+          );
+        }
+        return (
+          <a 
+            href={href} 
+            className={cn("text-blue-600 underline", className)} 
+            target="_blank" 
+            rel="noopener noreferrer" 
+            {...props}
+          >
+            {children}
+          </a>
+        );
+      },
+    };
+  }, [sources, onBadgeClick]);
 }


### PR DESCRIPTION
- **[성능] useMarkdownComponents 메모이제이션 누수 해결**
  - `sources` 파라미터의 기본값을 함수 내부(`sources ?? []`)로 이동하여, 기본 매개변수 배열 리터럴(`[]`)로 인한 `useMemo` 의존성 재생성 버그 해결.
  - **[UI/UX] 인라인 코드 렌더러 스타일 병합**
  - `react-markdown`이 넘겨주는 `className`이 무시되지 않도록 `cn()` 유틸리티를 활용하여 외부 주입 클래스와 기존 스타일을 안전하게 병합.
  - **[UX] 스트리밍 중 비인터랙티브 Citation 렌더링 분리**
  - 클릭 핸들러(`onBadgeClick`)가 없는 스트리밍 상황에서는 배지(`cite:x`)를 호버 효과나 pointer 커서가 없는 중립적 스타일로 렌더링하여 사용자 혼란 방지.
  - `ChatWindow` 호출부에서 `undefined`를 명시하여 렌더링 의도를 명확히 함.

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1417#pullrequestreview-4304814341)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

채팅 메시지에서 마크다운 렌더링 동작을 다듬어 스트리밍 중 메모이제이션 안정성, 코드 스타일링, 인용( citation ) UX를 개선합니다.

버그 수정:
- 변경 가능한 기본 배열 의존성 때문에 발생하던 `useMarkdownComponents`의 불필요한 `useMemo` 재계산을 방지합니다.

개선 사항:
- `react-markdown`의 `className`을 기존 인라인 코드 스타일과 병합하여 외부 인라인 코드 스타일을 유지합니다.
- 클릭 핸들러가 제공되지 않았을 때는 인터랙션이 없는 인용 배지를 중립적인 스타일로 렌더링하고, 핸들러가 존재할 때만 인터랙티브 스타일을 유지합니다.
- 스트리밍 인용에 대해 `ChatWindow`에서 `useMarkdownComponents`를 사용할 때 클릭 핸들러를 명시적으로 `undefined`로 전달하여 사용 방식을 명확히 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine markdown rendering behavior in chat messages to improve memoization stability, code styling, and citation UX during streaming.

Bug Fixes:
- Prevent unnecessary useMemo recomputation in useMarkdownComponents by avoiding a mutable default array dependency.

Enhancements:
- Preserve external inline code styling by merging react-markdown className with existing inline code styles.
- Render non-interactive citation badges with neutral styling when no click handler is provided, while keeping interactive styling only when a handler exists.
- Clarify ChatWindow usage of useMarkdownComponents by explicitly passing an undefined click handler for streaming citations.

</details>