### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -281,7 +281,9 @@ export function ChatWindow({
     },
   });
 
-  const markdownComponents = useMarkdownComponents(streamSources);
+  // 클릭 핸들러가 없을 때 `useMarkdownComponents`가 비인터랙티브한 citation 배지를
+  // 렌더링할 수 있도록, 명시적으로 `undefined`를 넘겨줍니다.
+  const markdownComponents = useMarkdownComponents(streamSources, undefined);
 
   useEffect(() => {
     if (!sessionId) return;

--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -10,10 +10,8 @@ import { cn } from '@/lib/utils';
 import type { UIMessage } from 'ai';
 import { SourcePanel } from './SourcePanel';
 import { type SourceItem } from '@/types/chat';
-import type { Components } from 'react-markdown';
 import { stabilizeIncompleteMarkdown } from '@/lib/markdown';
 import { 
-  CITATION_VALIDATION_REGEX, 
   extractSources,
   buildProcessedContent,
   areTextPartsEqual,

--- a/web_ui/src/components/chat/markdown-components.tsx
+++ b/web_ui/src/components/chat/markdown-components.tsx
@@ -82,14 +82,12 @@ export function useMarkdownComponents(
             return <FallbackCitation className={className}>{children}</FallbackCitation>;
           }
 
+          const commonBadgeClasses = "inline-flex items-center justify-center mx-0.5 px-1 min-w-[1rem] h-4 rounded align-top mt-0.5 select-none";
+          
           if (!onBadgeClick) {
             return (
               <sup
-                className={cn(
-                  "inline-flex items-center justify-center mx-0.5 px-1 min-w-[1rem] h-4",
-                  "bg-slate-100 text-slate-500 font-medium text-[9px] rounded border border-slate-200",
-                  "align-top mt-0.5 select-none"
-                )}
+                className={cn(commonBadgeClasses, "bg-slate-100 text-slate-500 font-medium text-[9px] border border-slate-200")}
                 title={source.title ? `출처: ${source.title}` : `출처: ${source.id}`}
               >
                 {children}
@@ -97,7 +95,7 @@ export function useMarkdownComponents(
             );
           }
 
-          const handleCitationClick = (e: React.MouseEvent | React.KeyboardEvent) => {
+          const handleCitationAction = (e: React.SyntheticEvent) => {
             e.preventDefault();
             onBadgeClick(source);
           };
@@ -106,17 +104,16 @@ export function useMarkdownComponents(
             <sup
               role="button"
               tabIndex={0}
-              onClick={handleCitationClick}
+              onClick={handleCitationAction}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
-                  handleCitationClick(e as unknown as React.MouseEvent);
+                  handleCitationAction(e);
                 }
               }}
               className={cn(
-                "inline-flex items-center justify-center mx-0.5 px-1 min-w-[1rem] h-4",
-                "bg-blue-50 text-blue-700 font-bold text-[9px] rounded border border-blue-200",
-                "cursor-pointer hover:bg-blue-100 hover:border-blue-300 transition-colors",
-                "align-top mt-0.5 select-none focus:outline-none focus:ring-1 focus:ring-blue-400"
+                commonBadgeClasses,
+                "bg-blue-50 text-blue-700 font-bold text-[9px] border border-blue-200",
+                "cursor-pointer hover:bg-blue-100 hover:border-blue-300 transition-colors focus:outline-none focus:ring-1 focus:ring-blue-400"
               )}
               title={source.title ? `출처: ${source.title}` : `출처: ${source.id}`}
             >

--- a/web_ui/src/components/chat/markdown-components.tsx
+++ b/web_ui/src/components/chat/markdown-components.tsx
@@ -39,87 +39,103 @@ function FallbackCitation({
  * - 소스(sources) 데이터와 클릭 핸들러(onBadgeClick)는 인용구 렌더링에 사용됩니다.
  */
 export function useMarkdownComponents(
-  sources: SourceItem[] = [],
+  sources?: SourceItem[],
   onBadgeClick?: (src: SourceItem) => void
 ): Components {
-  return useMemo(() => ({
-    code({ className, children, ...props }: CodeProps) {
-      const match = /language-(\w+)/.exec(className || '');
-      const isBlock = Boolean(match);
-      return isBlock ? (
-        <SyntaxHighlighter
-          style={vscDarkPlus as Record<string, React.CSSProperties>}
-          language={match![1]}
-          PreTag="div"
-          className="rounded-md my-2 text-xs"
-        >
-          {String(children).replace(/\n$/, '')}
-        </SyntaxHighlighter>
-      ) : (
-        <code
-          className="bg-black/10 px-1 py-0.5 rounded text-xs font-mono"
-          {...props}
-        >
-          {children}
-        </code>
-      );
-    },
-    a({ children, href, className, ...props }) {
-      if (href?.startsWith('cite:')) {
-        const indexStr = href.replace('cite:', '').trim();
+  return useMemo(() => {
+    const safeSources = sources ?? [];
 
-        if (!CITATION_VALIDATION_REGEX.test(indexStr)) {
-          return <FallbackCitation className={className}>{children}</FallbackCitation>;
-        }
-
-        const index = parseInt(indexStr, 10) - 1;
-        const source = sources[index];
-        
-        if (!source) {
-          return <FallbackCitation className={className}>{children}</FallbackCitation>;
-        }
-
-        const handleCitationClick = (e: React.MouseEvent | React.KeyboardEvent) => {
-          e.preventDefault();
-          onBadgeClick?.(source);
-        };
-
-        return (
-          <sup
-            role="button"
-            tabIndex={0}
-            onClick={handleCitationClick}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                handleCitationClick(e as unknown as React.MouseEvent);
-              }
-            }}
-            className="
-              inline-flex items-center justify-center
-              mx-0.5 px-1 min-w-[1rem] h-4
-              bg-blue-50 text-blue-700 font-bold text-[9px]
-              rounded border border-blue-200
-              cursor-pointer hover:bg-blue-100 hover:border-blue-300
-              transition-colors align-top mt-0.5
-              select-none focus:outline-none focus:ring-1 focus:ring-blue-400
-            "
-            title={source.title ? `출처: ${source.title}` : `출처: ${source.id}`}
+    return {
+      code({ className, children, ...props }: CodeProps) {
+        const match = /language-(\w+)/.exec(className || '');
+        const isBlock = Boolean(match);
+        return isBlock ? (
+          <SyntaxHighlighter
+            style={vscDarkPlus as Record<string, React.CSSProperties>}
+            language={match![1]}
+            PreTag="div"
+            className="rounded-md my-2 text-xs"
+          >
+            {String(children).replace(/\n$/, '')}
+          </SyntaxHighlighter>
+        ) : (
+          <code
+            className={cn("bg-black/10 px-1 py-0.5 rounded text-xs font-mono", className)}
+            {...props}
           >
             {children}
-          </sup>
+          </code>
         );
-      }
-      return (
-        <a 
-          href={href} 
-          className={cn("text-blue-600 underline", className)} 
-          target="_blank" 
-          rel="noopener noreferrer" 
-          {...props}
-        >
-          {children}
-        </a>
-      );
-    },
-  }), [sources, onBadgeClick]);
+      },
+      a({ children, href, className, ...props }) {
+        if (href?.startsWith('cite:')) {
+          const indexStr = href.replace('cite:', '').trim();
+
+          if (!CITATION_VALIDATION_REGEX.test(indexStr)) {
+            return <FallbackCitation className={className}>{children}</FallbackCitation>;
+          }
+
+          const index = parseInt(indexStr, 10) - 1;
+          const source = safeSources[index];
+          
+          if (!source) {
+            return <FallbackCitation className={className}>{children}</FallbackCitation>;
+          }
+
+          if (!onBadgeClick) {
+            return (
+              <sup
+                className={cn(
+                  "inline-flex items-center justify-center mx-0.5 px-1 min-w-[1rem] h-4",
+                  "bg-slate-100 text-slate-500 font-medium text-[9px] rounded border border-slate-200",
+                  "align-top mt-0.5 select-none"
+                )}
+                title={source.title ? `출처: ${source.title}` : `출처: ${source.id}`}
+              >
+                {children}
+              </sup>
+            );
+          }
+
+          const handleCitationClick = (e: React.MouseEvent | React.KeyboardEvent) => {
+            e.preventDefault();
+            onBadgeClick(source);
+          };
+
+          return (
+            <sup
+              role="button"
+              tabIndex={0}
+              onClick={handleCitationClick}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  handleCitationClick(e as unknown as React.MouseEvent);
+                }
+              }}
+              className={cn(
+                "inline-flex items-center justify-center mx-0.5 px-1 min-w-[1rem] h-4",
+                "bg-blue-50 text-blue-700 font-bold text-[9px] rounded border border-blue-200",
+                "cursor-pointer hover:bg-blue-100 hover:border-blue-300 transition-colors",
+                "align-top mt-0.5 select-none focus:outline-none focus:ring-1 focus:ring-blue-400"
+              )}
+              title={source.title ? `출처: ${source.title}` : `출처: ${source.id}`}
+            >
+              {children}
+            </sup>
+          );
+        }
+        return (
+          <a 
+            href={href} 
+            className={cn("text-blue-600 underline", className)} 
+            target="_blank" 
+            rel="noopener noreferrer" 
+            {...props}
+          >
+            {children}
+          </a>
+        );
+      },
+    };
+  }, [sources, onBadgeClick]);
 }


### PR DESCRIPTION
☘️ refactor [#12.2.28]: 2차 개선 - 마크다운 컴포넌트 렌더링 안정성 및 UX 고도화 
☘️ refactor [#12.2.28]: 3차 개선 - 마크다운 Citation 렌더러 클린 코드 및 타입 안정성 리팩토링

## Summary by Sourcery

채팅 인터페이스에서 마크다운 렌더링의 안정성과 인용 UX를 개선합니다.

향상 사항:
- 안전한 인용 표시로 폴백하도록 하여, 마크다운 컴포넌트가 누락된 소스 데이터와 잘못된 인용 인덱스에도 견고하게 동작하도록 개선.
- 클릭 핸들러의 존재 여부에 따라 인터랙티브(클릭 가능) 모드와 비인터랙티브 모드를 모두 지원하도록 인용 배지 동작을 다듬고, 접근성과 스타일링을 개선.
- 메시지 전반에서 일관된 외관을 위해 마크다운 내 인라인 코드와 링크 렌더링 스타일을 조정.
- 상황에 따라 인용이 비인터랙티브 모드로 렌더링되도록, `ChatWindow`에서 클릭 핸들러를 명시적으로 `undefined`로 전달하도록 업데이트.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve markdown rendering robustness and citation UX in the chat interface.

Enhancements:
- Make markdown components resilient to missing source data and invalid citation indices by falling back to a safe citation display.
- Refine citation badge behavior to support both interactive (clickable) and non-interactive modes depending on the presence of a click handler, with improved accessibility and styling.
- Adjust inline code and link rendering styles in markdown for more consistent appearance across messages.
- Update ChatWindow to explicitly pass an undefined click handler so that citations render in non-interactive mode when appropriate.

</details>