### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -30,6 +30,7 @@ import uuid
 from typing import Any, AsyncGenerator
 
 from fastapi import APIRouter, Request
+from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
 
 from backend.agent.streaming import stream_agent_response  # noqa: F401 (3단계 연동 예정)
@@ -60,24 +61,43 @@ _LOG_TAG: str = "[STREAM]"
 _ERROR_MSG_INTERNAL: str = "Internal server error occurred during streaming."
 _ERROR_MSG_TIMEOUT: str = "Streaming session timed out. Please retry."
 _ERROR_MSG_SCHEMA: str = "Data format mismatch detected. Please contact support."
-def _safe_repr(obj: Any) -> str:
+
+# _safe_repr 재귀 최대 깊이 (하드코딩 방지 — 비정상 중첩 객체로 인한 Stack Overflow 방어)
+_SAFE_REPR_MAX_DEPTH: int = 3
+
+
+def _safe_repr(obj: Any, _depth: int = 0) -> str:
     """
     민감 데이터(PII)의 로깅 노출 위험 없이 스키마 불일치 디버깅을 돕기 위해
     객체의 구조(필드/키/타입/길이) 정보만 안전하게 추출하여 반환합니다.
+
+    Args:
+        obj: 안전하게 표현할 대상 객체
+        _depth: 내부 재귀 깊이 추적용 (외부에서 직접 전달하지 않음)
+
+    [설계 결정 - 재귀 깊이 제한]:
+    비정상적으로 깊은 중첩 객체(list of list of list...)가 인입될 경우
+    Stack Overflow 또는 로그 크기 무제한 팽창을 방지하기 위해
+    _SAFE_REPR_MAX_DEPTH 상수로 최대 깊이를 제한합니다.
     """
     if obj is None:
         return "None"
 
-    from pydantic import BaseModel
+    # 재귀 깊이 초과 시 즉시 타입 정보만 반환 (안전망)
+    if _depth >= _SAFE_REPR_MAX_DEPTH:
+        return f"<max_depth_reached: {type(obj).__name__}>"
+
     try:
         if isinstance(obj, BaseModel):
-            fields = list(obj.model_fields.keys())
+            # model_fields는 클래스 속성이므로 인스턴스 접근 대신 타입으로 조회 (Pydantic V3 호환)
+            fields = list(type(obj).model_fields.keys())
             return f"{obj.__class__.__name__}(fields={fields})"
         elif isinstance(obj, dict):
             keys = list(obj.keys())
             return f"dict(keys={keys})"
         elif isinstance(obj, list):
-            elem_reprs = [_safe_repr(item) for item in obj[:3]]
+            # 항목 3개까지만 표시하며, 각 항목도 깊이를 증가시켜 재귀 제한 적용
+            elem_reprs = [_safe_repr(item, _depth + 1) for item in obj[:3]]
             if len(obj) > 3:
                 elem_reprs.append("...")
             return f"list(size={len(obj)}, items={elem_reprs})"

--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -27,7 +27,7 @@ import asyncio
 import logging
 import time
 import uuid
-from typing import AsyncGenerator
+from typing import Any, AsyncGenerator
 
 from fastapi import APIRouter, Request
 from sse_starlette.sse import EventSourceResponse
@@ -60,6 +60,36 @@ _LOG_TAG: str = "[STREAM]"
 _ERROR_MSG_INTERNAL: str = "Internal server error occurred during streaming."
 _ERROR_MSG_TIMEOUT: str = "Streaming session timed out. Please retry."
 _ERROR_MSG_SCHEMA: str = "Data format mismatch detected. Please contact support."
+def _safe_repr(obj: Any) -> str:
+    """
+    민감 데이터(PII)의 로깅 노출 위험 없이 스키마 불일치 디버깅을 돕기 위해
+    객체의 구조(필드/키/타입/길이) 정보만 안전하게 추출하여 반환합니다.
+    """
+    if obj is None:
+        return "None"
+
+    from pydantic import BaseModel
+    try:
+        if isinstance(obj, BaseModel):
+            fields = list(obj.model_fields.keys())
+            return f"{obj.__class__.__name__}(fields={fields})"
+        elif isinstance(obj, dict):
+            keys = list(obj.keys())
+            return f"dict(keys={keys})"
+        elif isinstance(obj, list):
+            elem_reprs = [_safe_repr(item) for item in obj[:3]]
+            if len(obj) > 3:
+                elem_reprs.append("...")
+            return f"list(size={len(obj)}, items={elem_reprs})"
+        elif isinstance(obj, str):
+            # 문자열은 길이 정보만 제공하여 PII 노출 방지
+            return f"str(length={len(obj)})"
+        elif isinstance(obj, (int, float, bool)):
+            return repr(obj)
+        else:
+            return f"{obj.__class__.__name__}(type={type(obj)})"
+    except Exception as e:
+        return f"<repr_error: {type(e).__name__}>"
 
 
 @router.post(
@@ -200,21 +230,28 @@ async def stream_chat_endpoint(
 
                     # ── 알 수 없는 청크 타입 처리 (안전망) ────────────────────
                     # TokenChunk / DoneChunk / ErrorChunk 외의 타입이 발행되면
-                    # 조용히 드랍되지 않도록 경고 로그 + 에러 이벤트로 가시화.
-                    # 스키마 불일치 발생 시 스트림 무결성을 위해 즉시 중단(break)합니다.
+                    # 조용히 드랍되지 않도록 경고 로그 + 에러 이벤트로 가시화합니다.
+                    #
+                    # [설계 결정 - 즉시 중단(break)의 의도된 거동 및 안전성 검증]:
+                    # 1. 스트림 무결성 보장: 스키마 불일치(SCHEMA MISMATCH)가 한 번 발생하면, 이후의 후속 데이터들 역시 비정상적이거나
+                    #    클라이언트(프론트엔드)에서 파싱 및 렌더링에 실패하여 애플리케이션 오동작을 초래할 수 있으므로 스트림을 즉시 중단합니다.
+                    # 2. 리소스 누수 방지: 즉시 break하여 루프를 탈출하면, finally 블록으로 넘어가 `stream_gen.aclose()`가 안전하게 실행되며,
+                    #    이로 인해 generator가 즉시 회수되어 어떠한 리소스 누수도 발생하지 않습니다.
+                    # 3. 버퍼 비워짐 영향 없음: 현재 구조는 인메모리 큐를 거치지 않고 제너레이터로부터 청크를 직접 온디맨드식으로
+                    #    비동기 순회하므로, 스킵된 '버퍼링된 잔여 청크'가 존재하지 않아 클라이언트에 혼선을 유발하지 않습니다.
                     else:
                         logger.warning(
                             "%s[SCHEMA] Unknown chunk type received: %s. "
-                            "payload=%r. Possible schema mismatch.",
+                            "safe_payload=%s. Possible schema mismatch.",
                             _LOG_TAG,
                             type(chunk).__name__,
-                            chunk,
+                            _safe_repr(chunk),  # PII 유출 위험이 전혀 없는 구조 정보와 비민감 메타데이터 로깅 (안전성 우선 원칙)
                         )
                         yield {
                             "event": _SSE_EVENT_ERROR,
                             "data": ErrorChunk(
                                 code="UNKNOWN_CHUNK",
-                                message=_ERROR_MSG_SCHEMA,  # 스캐마 불일치 메시지
+                                message=_ERROR_MSG_SCHEMA,  # 스키마 불일치용 일반화 에러 메시지
                             ).model_dump_json(),
                         }
                         break

--- a/web_ui/src/components/chat/ChatWindow.tsx
+++ b/web_ui/src/components/chat/ChatWindow.tsx
@@ -283,7 +283,8 @@ export function ChatWindow({
 
   // 클릭 핸들러가 없을 때 `useMarkdownComponents`가 비인터랙티브한 citation 배지를
   // 렌더링할 수 있도록, 명시적으로 `undefined`를 넘겨줍니다.
-  const markdownComponents = useMarkdownComponents(streamSources, undefined);
+  // isStreaming=true 동안은 plain <pre> 렌더링으로 미완성 코드 펜스 레이아웃 깨짐 방지
+  const markdownComponents = useMarkdownComponents(streamSources, undefined, isStreaming);
 
   useEffect(() => {
     if (!sessionId) return;

--- a/web_ui/src/components/chat/MessageBubble.tsx
+++ b/web_ui/src/components/chat/MessageBubble.tsx
@@ -298,7 +298,9 @@ export const MessageBubble = memo(
   };
 
   // 공유 마크다운 컴포넌트 (Memoized)
-  const markdownComponents = useMarkdownComponents(sources, handleBadgeClick);
+  // [설계 결정] isLast && isStreaming: 마지막 메시지가 스트리밍 중인 경우에만 하이라이팅 지연
+  // 히스토리의 완료된 메시지들은 항상 isStreaming=false → SyntaxHighlighter + 복사 버튼 적용
+  const markdownComponents = useMarkdownComponents(sources, handleBadgeClick, isLast && isStreaming);
 
   // [Performance] 콘텐츠 가공 및 마크다운 안정화 로직 통합 호출
   const processedContent = useMemo(() => {

--- a/web_ui/src/components/chat/markdown-components.tsx
+++ b/web_ui/src/components/chat/markdown-components.tsx
@@ -1,15 +1,19 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useCallback, useRef } from 'react';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import type { Components } from 'react-markdown';
+import { Check, Copy } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { CITATION_VALIDATION_REGEX } from '@/lib/chat-utils';
 import type { SourceItem } from '@/types/chat';
 
 export const REMARK_PLUGINS = [remarkGfm];
 export const REHYPE_PLUGINS = [rehypeSanitize];
+
+// 복사 완료 피드백 표시 지속 시간 (ms) — 하드코딩 방지
+const COPY_FEEDBACK_DURATION_MS = 2000;
 
 type CodeProps = React.ComponentPropsWithoutRef<'code'> & {
   inline?: boolean;
@@ -35,12 +39,87 @@ function FallbackCitation({
 }
 
 /**
+ * 코드 블록 복사 버튼 컴포넌트
+ *
+ * - 복사 성공 시 2초간 체크마크 피드백 표시 후 원래 아이콘으로 복원
+ * - setTimeout은 컴포넌트 언마운트 시 자동 취소(메모리 누수 방지)
+ * - 개인정보(PII)를 직접 다루지 않으며, clipboard API를 통해서만 코드 문자열을 처리
+ */
+function CopyButton({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false);
+  // 언마운트 시 타이머를 안전하게 취소하기 위해 ref로 관리
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleCopy = useCallback(async () => {
+    if (copied) return; // 중복 클릭 방지
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      // 기존 타이머가 있으면 초기화 후 재등록
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        setCopied(false);
+        timerRef.current = null;
+      }, COPY_FEEDBACK_DURATION_MS);
+    } catch {
+      // Clipboard API 실패(권한 거부 등) — 사용자 UX에 영향 없이 조용히 처리
+    }
+  }, [code, copied]);
+
+  // 컴포넌트 언마운트 시 타이머 정리
+  React.useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label={copied ? '복사 완료' : '코드 복사'}
+      title={copied ? '복사 완료!' : '클립보드에 복사'}
+      className={cn(
+        'absolute top-2 right-2 z-10',
+        'flex items-center gap-1 px-2 py-1 rounded text-[10px] font-medium',
+        'transition-all duration-150',
+        copied
+          ? 'bg-green-600/80 text-white'
+          : 'bg-white/10 text-slate-300 hover:bg-white/20 hover:text-white',
+      )}
+    >
+      {copied ? (
+        <>
+          <Check className="w-3 h-3" aria-hidden="true" />
+          <span>Copied!</span>
+        </>
+      ) : (
+        <>
+          <Copy className="w-3 h-3" aria-hidden="true" />
+          <span>Copy</span>
+        </>
+      )}
+    </button>
+  );
+}
+
+/**
  * MessageBubble 및 ChatWindow(스트리밍 렌더링)에서 공통으로 사용할 마크다운 컴포넌트들을 생성합니다.
- * - 소스(sources) 데이터와 클릭 핸들러(onBadgeClick)는 인용구 렌더링에 사용됩니다.
+ *
+ * @param sources - 인용 소스 목록 (citation badge 렌더링에 사용)
+ * @param onBadgeClick - 인용 뱃지 클릭 핸들러
+ * @param isStreaming - true이면 코드 블록을 plain <pre>로 렌더링 (스트리밍 중 미완성 코드 펜스 대응)
+ *                     false(기본값)이면 SyntaxHighlighter + 복사 버튼을 활성화
+ *
+ * [설계 결정 - 완료 이벤트 기반 하이라이팅]:
+ * 스트리밍 중(isStreaming=true) SyntaxHighlighter를 적용하면 미완성 코드 블록(닫히지 않은 ```)이
+ * 파서 오류로 이어져 레이아웃 깨짐이 발생합니다. type:"done" 수신(isStreaming=false) 이후에만
+ * 하이라이팅을 적용하여 UX 안정성을 보장합니다.
  */
 export function useMarkdownComponents(
   sources?: SourceItem[],
-  onBadgeClick?: (src: SourceItem) => void
+  onBadgeClick?: (src: SourceItem) => void,
+  isStreaming?: boolean,
 ): Components {
   return useMemo(() => {
     const safeSources = sources ?? [];
@@ -49,22 +128,43 @@ export function useMarkdownComponents(
       code({ className, children, ...props }: CodeProps) {
         const match = /language-(\w+)/.exec(className || '');
         const isBlock = Boolean(match);
-        return isBlock ? (
-          <SyntaxHighlighter
-            style={vscDarkPlus as Record<string, React.CSSProperties>}
-            language={match![1]}
-            PreTag="div"
-            className="rounded-md my-2 text-xs"
-          >
-            {String(children).replace(/\n$/, '')}
-          </SyntaxHighlighter>
-        ) : (
-          <code
-            className={cn("bg-black/10 px-1 py-0.5 rounded text-xs font-mono", className)}
-            {...props}
-          >
-            {children}
-          </code>
+        const codeText = String(children).replace(/\n$/, '');
+
+        if (!isBlock) {
+          // 인라인 코드: 항상 일반 스타일 적용 (하이라이팅 불필요)
+          return (
+            <code
+              className={cn("bg-black/10 px-1 py-0.5 rounded text-xs font-mono", className)}
+              {...props}
+            >
+              {children}
+            </code>
+          );
+        }
+
+        // [설계 결정] 스트리밍 중에는 plain <pre>로 렌더링
+        // 미완성 코드 펜스로 인한 SyntaxHighlighter 파서 오류 및 레이아웃 깨짐 방지
+        if (isStreaming) {
+          return (
+            <pre className="rounded-md my-2 text-xs bg-[#1e1e1e] text-[#d4d4d4] p-4 overflow-x-auto">
+              <code>{codeText}</code>
+            </pre>
+          );
+        }
+
+        // 스트리밍 완료(type:"done" 수신) 후: SyntaxHighlighter + 복사 버튼 활성화
+        return (
+          <div className="relative group/codeblock my-2">
+            <CopyButton code={codeText} />
+            <SyntaxHighlighter
+              style={vscDarkPlus as Record<string, React.CSSProperties>}
+              language={match![1]}
+              PreTag="div"
+              className="rounded-md text-xs !mt-0"
+            >
+              {codeText}
+            </SyntaxHighlighter>
+          </div>
         );
       },
       a({ children, href, className, ...props }) {
@@ -134,5 +234,5 @@ export function useMarkdownComponents(
         );
       },
     };
-  }, [sources, onBadgeClick]);
+  }, [sources, onBadgeClick, isStreaming]);
 }

--- a/web_ui/src/components/chat/markdown-components.tsx
+++ b/web_ui/src/components/chat/markdown-components.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useCallback, useRef } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
@@ -41,37 +41,31 @@ function FallbackCitation({
 /**
  * 코드 블록 복사 버튼 컴포넌트
  *
- * - 복사 성공 시 2초간 체크마크 피드백 표시 후 원래 아이콘으로 복원
- * - setTimeout은 컴포넌트 언마운트 시 자동 취소(메모리 누수 방지)
+ * - 복사 성공 시 COPY_FEEDBACK_DURATION_MS 동안 체크마크 피드백 표시 후 원복
+ * - copied 상태 변화에 반응하는 단일 useEffect로 타이머를 관리하여
+ *   timerRef + useCallback 의존성 복잡성 제거 (컴포넌트 언마운트 시 자동 정리 보장)
  * - 개인정보(PII)를 직접 다루지 않으며, clipboard API를 통해서만 코드 문자열을 처리
  */
 function CopyButton({ code }: { code: string }) {
   const [copied, setCopied] = useState(false);
-  // 언마운트 시 타이머를 안전하게 취소하기 위해 ref로 관리
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleCopy = useCallback(async () => {
-    if (copied) return; // 중복 클릭 방지
+  // copied=true가 되면 타이머를 등록하고, 만료 시 false로 복원.
+  // useEffect 클린업이 언마운트 시 타이머를 자동 취소하므로 별도 timerRef 불필요.
+  useEffect(() => {
+    if (!copied) return;
+    const timerId = setTimeout(() => setCopied(false), COPY_FEEDBACK_DURATION_MS);
+    return () => clearTimeout(timerId);
+  }, [copied]);
+
+  const handleCopy = async () => {
+    if (copied) return; // 복사 완료 상태 중 중복 클릭 방지
     try {
       await navigator.clipboard.writeText(code);
       setCopied(true);
-      // 기존 타이머가 있으면 초기화 후 재등록
-      if (timerRef.current) clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => {
-        setCopied(false);
-        timerRef.current = null;
-      }, COPY_FEEDBACK_DURATION_MS);
     } catch {
       // Clipboard API 실패(권한 거부 등) — 사용자 UX에 영향 없이 조용히 처리
     }
-  }, [code, copied]);
-
-  // 컴포넌트 언마운트 시 타이머 정리
-  React.useEffect(() => {
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-    };
-  }, []);
+  };
 
   return (
     <button
@@ -100,6 +94,46 @@ function CopyButton({ code }: { code: string }) {
         </>
       )}
     </button>
+  );
+}
+
+/**
+ * 코드 블록 렌더링 컴포넌트 (블록 코드 전용)
+ *
+ * code() 핸들러로부터 블록 렌더링 책임을 분리하여 단일 책임 원칙(SRP)을 준수합니다.
+ * - isStreaming=true: plain <pre>로 렌더링 (미완성 코드 펜스 파서 오류 방지)
+ * - isStreaming=false: SyntaxHighlighter + CopyButton 활성화 (type:"done" 수신 후)
+ */
+type CodeBlockProps = {
+  language: string;
+  codeText: string;
+  isStreaming?: boolean;
+};
+
+function CodeBlock({ language, codeText, isStreaming }: CodeBlockProps) {
+  // [설계 결정] 스트리밍 중에는 plain <pre>로 렌더링
+  // 미완성 코드 펜스로 인한 SyntaxHighlighter 파서 오류 및 레이아웃 깨짐 방지
+  if (isStreaming) {
+    return (
+      <pre className="rounded-md my-2 text-xs bg-[#1e1e1e] text-[#d4d4d4] p-4 overflow-x-auto">
+        <code>{codeText}</code>
+      </pre>
+    );
+  }
+
+  // 스트리밍 완료(type:"done" 수신) 후: SyntaxHighlighter + 복사 버튼 활성화
+  return (
+    <div className="relative group/codeblock my-2">
+      <CopyButton code={codeText} />
+      <SyntaxHighlighter
+        style={vscDarkPlus as Record<string, React.CSSProperties>}
+        language={language}
+        PreTag="div"
+        className="rounded-md text-xs !mt-0"
+      >
+        {codeText}
+      </SyntaxHighlighter>
+    </div>
   );
 }
 
@@ -142,29 +176,13 @@ export function useMarkdownComponents(
           );
         }
 
-        // [설계 결정] 스트리밍 중에는 plain <pre>로 렌더링
-        // 미완성 코드 펜스로 인한 SyntaxHighlighter 파서 오류 및 레이아웃 깨짐 방지
-        if (isStreaming) {
-          return (
-            <pre className="rounded-md my-2 text-xs bg-[#1e1e1e] text-[#d4d4d4] p-4 overflow-x-auto">
-              <code>{codeText}</code>
-            </pre>
-          );
-        }
-
-        // 스트리밍 완료(type:"done" 수신) 후: SyntaxHighlighter + 복사 버튼 활성화
+        // 블록 코드: CodeBlock에 렌더링 책임 위임 (isStreaming에 따른 분기는 CodeBlock 내부에서 처리)
         return (
-          <div className="relative group/codeblock my-2">
-            <CopyButton code={codeText} />
-            <SyntaxHighlighter
-              style={vscDarkPlus as Record<string, React.CSSProperties>}
-              language={match![1]}
-              PreTag="div"
-              className="rounded-md text-xs !mt-0"
-            >
-              {codeText}
-            </SyntaxHighlighter>
-          </div>
+          <CodeBlock
+            language={match![1]}
+            codeText={codeText}
+            isStreaming={isStreaming}
+          />
         );
       },
       a({ children, href, className, ...props }) {


### PR DESCRIPTION
✨ feat [#12.2.29]: Phase 3-4 - ➂ 코드 하이라이팅 + 복사 버튼 (Polish) 
☘️ refactor [#12.2.29]: 1차 개선 - safe_repr 방어 강화 및 코드블록 컴포넌트 분리

## Summary by Sourcery

채팅 UI에 구문 강조 코드 블록 렌더링과 클립보드 복사 기능을 추가하고, 안전성과 견고성을 위해 백엔드 스트리밍 스키마 불일치 로깅을 강화했습니다.

New Features:
- 채팅 마크다운 콘텐츠에서 전용 코드 블록 렌더링을 활성화하고, 구문 강조와 인라인 복사 버튼을 지원합니다.

Enhancements:
- 응답이 스트리밍되는 동안에는 코드 구문 강조를 지연시켜, 미완성 코드 펜스로 인해 발생하는 레이아웃 문제를 방지합니다.
- 재사용 가능한 코드 블록 컴포넌트를 추출하고, 채팅 뷰의 마크다운 컴포넌트 연결을 업데이트하여 스트리밍 인식 렌더링과 복사 기능을 지원합니다.
- 백엔드에서 예상치 못한 스트리밍 청크를 안전하게 표현할 수 있도록, 깊이 제한 및 PII-안전 로깅을 통해 로깅을 강화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add syntax-highlighted code block rendering with copy-to-clipboard support in the chat UI, and harden backend streaming schema mismatch logging for safety and robustness.

New Features:
- Enable dedicated code block rendering with syntax highlighting and an inline copy button in chat markdown content.

Enhancements:
- Defer code syntax highlighting while responses are streaming to avoid layout issues from incomplete code fences.
- Extract a reusable code block component and update markdown component wiring in chat views to support streaming-aware rendering and copy controls.
- Strengthen safe representation of unexpected streaming chunks with depth-limited, PII-safe logging in the backend.

</details>