### PR TITLE
🛡️ fix [#12.2.29]: 2차 개선 - Clipboard 가용성 가드 및 dict 로그 크기 제한

### DIFF
--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -64,6 +64,8 @@ _ERROR_MSG_SCHEMA: str = "Data format mismatch detected. Please contact support.
 
 # _safe_repr 재귀 최대 깊이 (하드코딩 방지 — 비정상 중첩 객체로 인한 Stack Overflow 방어)
 _SAFE_REPR_MAX_DEPTH: int = 3
+# _safe_repr dict 최대 키 출력 수 (하드코딩 방지 — 대형 dict로 인한 로그 크기 팽창 방어)
+_SAFE_REPR_MAX_KEYS: int = 10
 
 
 def _safe_repr(obj: Any, _depth: int = 0) -> str:
@@ -93,8 +95,11 @@ def _safe_repr(obj: Any, _depth: int = 0) -> str:
             fields = list(type(obj).model_fields.keys())
             return f"{obj.__class__.__name__}(fields={fields})"
         elif isinstance(obj, dict):
-            keys = list(obj.keys())
-            return f"dict(keys={keys})"
+            # list 분기와 동일 원칙 적용: 대형 dict의 로그 크기 팽창 방어 (_SAFE_REPR_MAX_KEYS 개 제한)
+            all_keys = list(obj.keys())
+            sampled_keys = all_keys[:_SAFE_REPR_MAX_KEYS]
+            suffix = ", ..." if len(all_keys) > _SAFE_REPR_MAX_KEYS else ""
+            return f"dict(total_keys={len(all_keys)}, sampled_keys={sampled_keys}{suffix})"
         elif isinstance(obj, list):
             # 항목 3개까지만 표시하며, 각 항목도 깊이를 증가시켜 재귀 제한 적용
             elem_reprs = [_safe_repr(item, _depth + 1) for item in obj[:3]]

--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -27,6 +27,7 @@ import asyncio
 import logging
 import time
 import uuid
+from itertools import islice
 from typing import Any, AsyncGenerator
 
 from fastapi import APIRouter, Request
@@ -95,11 +96,12 @@ def _safe_repr(obj: Any, _depth: int = 0) -> str:
             fields = list(type(obj).model_fields.keys())
             return f"{obj.__class__.__name__}(fields={fields})"
         elif isinstance(obj, dict):
-            # list 분기와 동일 원칙 적용: 대형 dict의 로그 크기 팽창 방어 (_SAFE_REPR_MAX_KEYS 개 제한)
-            all_keys = list(obj.keys())
-            sampled_keys = all_keys[:_SAFE_REPR_MAX_KEYS]
-            suffix = ", ..." if len(all_keys) > _SAFE_REPR_MAX_KEYS else ""
-            return f"dict(total_keys={len(all_keys)}, sampled_keys={sampled_keys}{suffix})"
+            # [설계 결정] islice를 사용하여 전체 키를 list로 구체화하지 않고 N개만 순회 (O(N) 보장)
+            # len(obj)는 dict의 O(1) 연산이므로 전체 순회 없이 총 키 수 확인 가능
+            total_keys = len(obj)
+            sampled_keys = list(islice(obj.keys(), _SAFE_REPR_MAX_KEYS))
+            suffix = ", ..." if total_keys > _SAFE_REPR_MAX_KEYS else ""
+            return f"dict(total_keys={total_keys}, sampled_keys={sampled_keys}{suffix})"
         elif isinstance(obj, list):
             # 항목 3개까지만 표시하며, 각 항목도 깊이를 증가시켜 재귀 제한 적용
             elem_reprs = [_safe_repr(item, _depth + 1) for item in obj[:3]]

--- a/web_ui/src/components/chat/markdown-components.tsx
+++ b/web_ui/src/components/chat/markdown-components.tsx
@@ -59,11 +59,19 @@ function CopyButton({ code }: { code: string }) {
 
   const handleCopy = async () => {
     if (copied) return; // 복사 완료 상태 중 중복 클릭 방지
+
+    // [방어적 코딩] HTTP 환경이나 구형 브라우저에서 navigator.clipboard가 undefined일 수 있음.
+    // optional chaining으로 가용성을 먼저 확인하여 TypeError(미지원)와 DOMException(권한 거부)을 명확히 구분.
+    if (!navigator.clipboard?.writeText) {
+      // Clipboard API 미지원 환경 — 조용히 처리 (향후 execCommand 폴백 추가 지점)
+      return;
+    }
+
     try {
       await navigator.clipboard.writeText(code);
       setCopied(true);
     } catch {
-      // Clipboard API 실패(권한 거부 등) — 사용자 UX에 영향 없이 조용히 처리
+      // DOMException: 권한 거부(permissions-policy 등) — 사용자 UX에 영향 없이 조용히 처리
     }
   };
 

--- a/web_ui/src/components/chat/markdown-components.tsx
+++ b/web_ui/src/components/chat/markdown-components.tsx
@@ -60,9 +60,10 @@ function CopyButton({ code }: { code: string }) {
   const handleCopy = async () => {
     if (copied) return; // 복사 완료 상태 중 중복 클릭 방지
 
-    // [방어적 코딩] HTTP 환경이나 구형 브라우저에서 navigator.clipboard가 undefined일 수 있음.
-    // optional chaining으로 가용성을 먼저 확인하여 TypeError(미지원)와 DOMException(권한 거부)을 명확히 구분.
-    if (!navigator.clipboard?.writeText) {
+    // [방어적 코딩 - SSR/테스트 환경 대응]
+    // Next.js SSR 또는 jsdom 미탑재 테스트 환경에서 navigator 전역 객체 자체가 존재하지 않을 수 있음.
+    // typeof 가드로 ReferenceError를 원천 차단한 후, optional chaining으로 API 가용성을 추가 확인.
+    if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
       // Clipboard API 미지원 환경 — 조용히 처리 (향후 execCommand 폴백 추가 지점)
       return;
     }
@@ -70,8 +71,12 @@ function CopyButton({ code }: { code: string }) {
     try {
       await navigator.clipboard.writeText(code);
       setCopied(true);
-    } catch {
-      // DOMException: 권한 거부(permissions-policy 등) — 사용자 UX에 영향 없이 조용히 처리
+    } catch (err) {
+      // DOMException(권한 거부, permissions-policy 등)만 조용히 처리.
+      // 예상치 못한 에러 타입은 타입명만 로깅 (message에 PII/경로 노출 방지).
+      if (!(err instanceof DOMException)) {
+        console.error('[CopyButton] Unexpected clipboard error:', err instanceof Error ? err.constructor.name : typeof err);
+      }
     }
   };
 


### PR DESCRIPTION
- **[Frontend/방어적 코딩] CopyButton: Clipboard API 가용성 가드 추가**
  - navigator.clipboard?.writeText optional chaining으로 미지원 환경 먼저 감지
  - API 미지원(TypeError) vs 권한 거부(DOMException) 구분 명확화
  - HTTP 또는 구형 브라우저에서 silent TypeError 발생 없이 graceful 처리
  - 향후 document.execCommand 폴백 추가 지점 주석으로 명시

- **[Backend/로그 크기] _safe_repr: dict 키 수 상한선 추가**
  - _SAFE_REPR_MAX_KEYS = 10 상수 추가 (하드코딩 방지)
  - dict 분기를 list 분기와 동일 원칙으로 통일: 최대 10개 키 샘플링 + 초과 시 suffix
  - total_keys 카운트를 포함하여 디버깅 정보 유지하면서 로그 크기 상한 보장

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1421#pullrequestreview-4315529590)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

채팅 UI에서 클립보드 사용을 보호하고, 디버그 출력의 안전성을 위해 딕셔너리 키 로깅을 제한합니다.

버그 수정:
- `navigator.clipboard` 사용을 보호하여 Clipboard API를 지원하지 않는 환경에서 CopyButton이 오류를 발생시키지 않도록 합니다.

개선 사항:
- 로그 비대화를 방지하기 위해 `_safe_repr` 딕셔너리 로깅을 설정 가능한 최대 키 개수로 제한하면서, 전체 키 개수 정보는 유지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard clipboard usage in the chat UI and cap dictionary key logging for safer debug output.

Bug Fixes:
- Prevent CopyButton from throwing errors on environments without Clipboard API support by guarding navigator.clipboard usage.

Enhancements:
- Limit _safe_repr dictionary logging to a configurable maximum number of keys while preserving total key count information to avoid log bloat.

</details>