### PR TITLE
🛡️ fix [#12.2.29]: 8차 개선 - CopyButton TypeScript 교차 타입(Intersection) 적용

### DIFF
--- a/web_ui/src/components/chat/markdown-components.tsx
+++ b/web_ui/src/components/chat/markdown-components.tsx
@@ -68,7 +68,7 @@ function CopyButton({ code }: { code: string }) {
       // Clipboard API 미지원 환경 — 콘솔 스팸과 blocking alert 없이, 한 번만 경고 로그를 남기고
       // UI 레벨에서 비차단형 안내(토스트)를 표시합니다.
       if (typeof window !== 'undefined') {
-        const win = window as unknown as Record<typeof CLIPBOARD_UNSUPPORTED_WARN_FLAG, boolean | undefined>;
+        const win = window as unknown as Window & Record<typeof CLIPBOARD_UNSUPPORTED_WARN_FLAG, boolean | undefined>;
         
         if (!win[CLIPBOARD_UNSUPPORTED_WARN_FLAG]) {
           console.warn('[CopyButton] Clipboard API is not supported in this environment (e.g., HTTP or SSR).');

--- a/web_ui/src/components/chat/markdown-components.tsx
+++ b/web_ui/src/components/chat/markdown-components.tsx
@@ -17,7 +17,11 @@ export const REHYPE_PLUGINS = [rehypeSanitize];
 const COPY_FEEDBACK_DURATION_MS = 2000;
 
 // 미지원 클립보드 환경(HTTP, SSR 등)에서의 중복 경고 방지용 전역 플래그 (Module scope)
-const CLIPBOARD_UNSUPPORTED_WARN_FLAG = '__flownote_copy_btn_unsupported_warned__' as const;
+declare global {
+  interface Window {
+    __flownote_copy_btn_unsupported_warned__?: boolean;
+  }
+}
 
 type CodeProps = React.ComponentPropsWithoutRef<'code'> & {
   inline?: boolean;
@@ -68,11 +72,9 @@ function CopyButton({ code }: { code: string }) {
       // Clipboard API 미지원 환경 — 콘솔 스팸과 blocking alert 없이, 한 번만 경고 로그를 남기고
       // UI 레벨에서 비차단형 안내(토스트)를 표시합니다.
       if (typeof window !== 'undefined') {
-        const win = window as unknown as Window & Record<typeof CLIPBOARD_UNSUPPORTED_WARN_FLAG, boolean | undefined>;
-        
-        if (!win[CLIPBOARD_UNSUPPORTED_WARN_FLAG]) {
+        if (!window.__flownote_copy_btn_unsupported_warned__) {
           console.warn('[CopyButton] Clipboard API is not supported in this environment (e.g., HTTP or SSR).');
-          win[CLIPBOARD_UNSUPPORTED_WARN_FLAG] = true;
+          window.__flownote_copy_btn_unsupported_warned__ = true;
           
           toast.warning('이 환경에서는 클립보드 복사 기능을 지원하지 않습니다.', {
             id: 'clipboard-unsupported-warning', // 동일 에러의 토스트 중복(스택) 방지


### PR DESCRIPTION
- **[Frontend/Type] 전역 플래그 캐스팅 방식 정교화 (Nitpick 반영)**
  - window 객체를 Record 단일 타입으로 캐스팅하여 기존 Window 속성 추론이 누락되는(strip) 문제 해결
  - Window & Record<typeof FLAG, boolean> 형태의 교차 타입(Intersection Type)을 적용하여, 기존 Window 객체의 본래 구조를 유지한 채 커스텀 플래그 속성만 안전하게 확장(Augmentation)
  - 타입 안정성을 위해 unknown 중간 캐스팅(intermediate cast) 규칙 준수

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1427#pullrequestreview-4315728907)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

버그 수정:
- 기존 Window 타입 추론을 유지하면서 클립보드 미지원 경고 플래그를 추가하여, 기본 제공되는 window 속성이 제거되지 않도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Preserve existing Window type inference while adding the clipboard unsupported warning flag to avoid stripping built-in window properties.

</details>