### PR TITLE
☘️ refactor [#12.2.30]: 2차 개선 - onFinish 콜백 인터페이스 확장 및 cancelStream 폴백 리셋 구현

### DIFF
--- a/web_ui/src/hooks/useStreamingChat.ts
+++ b/web_ui/src/hooks/useStreamingChat.ts
@@ -46,10 +46,12 @@ export interface UseStreamingChatOptions {
    */
   onError?: (error: StreamError, raw: unknown) => void;
   /**
-   * 스트림이 성공적으로 완료되었을 때 호출되는 콜백.
-   * 스트리밍된 결과물을 메인 대화 이력 등에 영구 저장할 때 유용합니다.
+   * 스트림이 완료되었을 때 호출되는 콜백.
+   * @param content 스트리밍된 전체/일부 결과물
+   * @param sources 수신된 소스 문서 목록
+   * @param isPartial 사용자 중지 또는 오류 등으로 인해 스트림이 중단된 부분 응답인지 여부
    */
-  onFinish?: (content: string, sources: SourceItem[]) => void;
+  onFinish?: (content: string, sources: SourceItem[], isPartial: boolean) => void;
 }
 
 // =============================================================================
@@ -111,6 +113,9 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
   const cancelStream = useCallback(() => {
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
+    } else {
+      // abortController가 없더라도 UI 상태 교착 방지를 위해 스트리밍 상태 강제 강하
+      setIsStreaming(false);
     }
   }, []);
 
@@ -146,7 +151,7 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
             const interruptedTokens =
               accumulatedTokens.length > 0 ? `${accumulatedTokens}...` : accumulatedTokens;
             setTokens(interruptedTokens);
-            onFinishRef.current?.(interruptedTokens, finalSources);
+            onFinishRef.current?.(interruptedTokens, finalSources, true);
           }
         };
 
@@ -178,7 +183,7 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
               case 'done':
                 // 정상 완료 - 누적된 토큰과 소스를 부모에게 전달
                 isSuccess = true;
-                onFinishRef.current?.(accumulatedTokens, finalSources);
+                onFinishRef.current?.(accumulatedTokens, finalSources, false);
                 break;
             }
           }

--- a/web_ui/src/hooks/useStreamingChat.ts
+++ b/web_ui/src/hooks/useStreamingChat.ts
@@ -49,9 +49,10 @@ export interface UseStreamingChatOptions {
    * 스트림이 완료되었을 때 호출되는 콜백.
    * @param content 스트리밍된 전체/일부 결과물
    * @param sources 수신된 소스 문서 목록
-   * @param isPartial 사용자 중지 또는 오류 등으로 인해 스트림이 중단된 부분 응답인지 여부
+   * @param isPartial 사용자 중지 또는 오류 등으로 인해 스트림이 중단된 부분 응답인지 여부.
+   *                  전달되지 않은(undefined) 경우 기본적으로 `false`로 간주됩니다.
    */
-  onFinish?: (content: string, sources: SourceItem[], isPartial: boolean) => void;
+  onFinish?: (content: string, sources: SourceItem[], isPartial?: boolean) => void;
 }
 
 // =============================================================================
@@ -114,8 +115,11 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
     } else {
-      // abortController가 없더라도 UI 상태 교착 방지를 위해 스트리밍 상태 강제 강하
+      // abortController가 없더라도 UI 상태 교착 방지 및 데이터 오염 방지를 위해 전체 스트리밍 상태 초기화
       setIsStreaming(false);
+      setTokens('');
+      setSources([]);
+      setError(null);
     }
   }, []);
 


### PR DESCRIPTION
- **[web_ui/src/hooks/useStreamingChat.ts]**:
  - `UseStreamingChatOptions` 인터페이스의 `onFinish` 콜백 서명을 `(content: string, sources: SourceItem[], isPartial: boolean) => void`로 확장
  - 스트림 정상 완료(done 청크 수신) 시 `isPartial: false`를 전달하고, 사용자 취소 및 비정상 루프 종료(handleInterrupt) 시 `isPartial: true`를 전달하도록 로직 고도화
  - `cancelStream`에서 `abortController`가 없는 상태로 트리거되더라도 `isStreaming` 상태를 `false`로 격하하는 `else` 분기 폴백 추가 (UI 교착 잠금 방지)

🔗 Related: 
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1433#pullrequestreview-4330314577)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.5 Flash (High)

## Summary by Sourcery

부분 응답과 완전한 응답을 구분할 수 있도록 스트리밍 채팅 컴플리션 콜백을 확장하고, abort controller가 없더라도 UI 스트리밍 상태가 항상 초기화되도록 합니다.

New Features:
- 스트리밍된 응답이 완전한 것인지, 중단된 것인지를 나타내기 위해 `onFinish` 콜백에 `isPartial` 플래그를 추가했습니다.

Bug Fixes:
- abort controller가 존재하지 않는 경우에도 `cancelStream`에서 스트리밍 상태를 정리하도록 하여 UI가 멈춘 상태로 남지 않도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the streaming chat completion callback to distinguish partial vs fully completed responses and ensure UI streaming state is reset even when no abort controller is present.

New Features:
- Add an isPartial flag to the onFinish callback to indicate whether the streamed response is complete or was interrupted.

Bug Fixes:
- Ensure streaming state is cleared in cancelStream even when no abort controller exists to prevent UI lockups.

</details>