### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/hooks/useStreamingChat.ts
+++ b/web_ui/src/hooks/useStreamingChat.ts
@@ -46,10 +46,12 @@ export interface UseStreamingChatOptions {
    */
   onError?: (error: StreamError, raw: unknown) => void;
   /**
-   * 스트림이 성공적으로 완료되었을 때 호출되는 콜백.
-   * 스트리밍된 결과물을 메인 대화 이력 등에 영구 저장할 때 유용합니다.
+   * 스트림이 완료되었을 때 호출되는 콜백.
+   * @param content 스트리밍된 전체/일부 결과물
+   * @param sources 수신된 소스 문서 목록
+   * @param isPartial 사용자 중지 또는 오류 등으로 인해 스트림이 중단된 부분 응답인지 여부
    */
-  onFinish?: (content: string, sources: SourceItem[]) => void;
+  onFinish?: (content: string, sources: SourceItem[], isPartial: boolean) => void;
 }
 
 // =============================================================================
@@ -111,6 +113,9 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
   const cancelStream = useCallback(() => {
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
+    } else {
+      // abortController가 없더라도 UI 상태 교착 방지를 위해 스트리밍 상태 강제 강하
+      setIsStreaming(false);
     }
   }, []);
 
@@ -146,7 +151,7 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
             const interruptedTokens =
               accumulatedTokens.length > 0 ? `${accumulatedTokens}...` : accumulatedTokens;
             setTokens(interruptedTokens);
-            onFinishRef.current?.(interruptedTokens, finalSources);
+            onFinishRef.current?.(interruptedTokens, finalSources, true);
           }
         };
 
@@ -178,7 +183,7 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
               case 'done':
                 // 정상 완료 - 누적된 토큰과 소스를 부모에게 전달
                 isSuccess = true;
-                onFinishRef.current?.(accumulatedTokens, finalSources);
+                onFinishRef.current?.(accumulatedTokens, finalSources, false);
                 break;
             }
           }

--- a/web_ui/src/hooks/useStreamingChat.ts
+++ b/web_ui/src/hooks/useStreamingChat.ts
@@ -49,9 +49,10 @@ export interface UseStreamingChatOptions {
    * 스트림이 완료되었을 때 호출되는 콜백.
    * @param content 스트리밍된 전체/일부 결과물
    * @param sources 수신된 소스 문서 목록
-   * @param isPartial 사용자 중지 또는 오류 등으로 인해 스트림이 중단된 부분 응답인지 여부
+   * @param isPartial 사용자 중지 또는 오류 등으로 인해 스트림이 중단된 부분 응답인지 여부.
+   *                  전달되지 않은(undefined) 경우 기본적으로 `false`로 간주됩니다.
    */
-  onFinish?: (content: string, sources: SourceItem[], isPartial: boolean) => void;
+  onFinish?: (content: string, sources: SourceItem[], isPartial?: boolean) => void;
 }
 
 // =============================================================================
@@ -114,8 +115,11 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
     } else {
-      // abortController가 없더라도 UI 상태 교착 방지를 위해 스트리밍 상태 강제 강하
+      // abortController가 없더라도 UI 상태 교착 방지 및 데이터 오염 방지를 위해 전체 스트리밍 상태 초기화
       setIsStreaming(false);
+      setTokens('');
+      setSources([]);
+      setError(null);
     }
   }, []);
 


### PR DESCRIPTION
☘️ refactor [#12.2.30]: 2차 개선 - onFinish 콜백 인터페이스 확장 및 cancelStream 폴백 리셋 구현
☘️ refactor [#12.2.30]: 3차 개선 - onFinish 선택적 파라미터 전환 및 cancelStream 상태 일괄 리셋

## Summary by Sourcery

스트리밍 채팅 완료 콜백을 확장하고 취소 상태 처리를 개선합니다.

개선 사항:
- 스트리밍 채팅의 `onFinish` 콜백을 확장하여, 응답이 중단 또는 오류로 인해 부분적인(partial) 상태인지 여부를 선택적으로 나타낼 수 있도록 합니다.
- 활성화된 abort controller가 없더라도, `cancelStream`이 스트리밍과 관련된 모든 UI 및 오류 상태를 재설정하도록 보장합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expand streaming chat completion callbacks and improve cancellation state handling.

Enhancements:
- Extend the streaming chat onFinish callback to optionally indicate whether the response is partial due to interruption or error.
- Ensure cancelStream resets all streaming-related UI and error state even when no active abort controller exists.

</details>