### PR TITLE
🛡️ fix [#12.2.30]: 4차 개선 - cancelStream 완료 상태 보호 및 resetStreamingState 헬퍼 추출

### DIFF
--- a/web_ui/src/hooks/useStreamingChat.ts
+++ b/web_ui/src/hooks/useStreamingChat.ts
@@ -110,13 +110,14 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
   /**
    * isStreaming, tokens, sources, error를 초기값으로 일괄 초기화합니다.
    * 컨트롤러 없이 isStreaming이 true인 비정상 교착 상태에서만 호출해야 합니다.
+   * (setIsStreaming 등 안정적인 상태 setter만 사용하므로 useCallback 불필요)
    */
-  const resetStreamingState = useCallback(() => {
+  const resetStreamingState = () => {
     setIsStreaming(false);
     setTokens('');
     setSources([]);
     setError(null);
-  }, []);
+  };
 
   /**
    * 진행 중인 스트림을 안전하게 중단합니다.
@@ -132,7 +133,8 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
       // (정상 완료 후 cancelStream 호출 시 완료된 tokens/sources를 지우지 않도록 보호)
       resetStreamingState();
     }
-  }, [isStreaming, resetStreamingState]);
+  }, [isStreaming]); // resetStreamingState는 안정적인 setter만 참조하므로 deps 불필요
+
 
   /**
    * 스트리밍을 시작합니다.

--- a/web_ui/src/hooks/useStreamingChat.ts
+++ b/web_ui/src/hooks/useStreamingChat.ts
@@ -108,20 +108,31 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
   }, []);
 
   /**
+   * isStreaming, tokens, sources, error를 초기값으로 일괄 초기화합니다.
+   * 컨트롤러 없이 isStreaming이 true인 비정상 교착 상태에서만 호출해야 합니다.
+   */
+  const resetStreamingState = useCallback(() => {
+    setIsStreaming(false);
+    setTokens('');
+    setSources([]);
+    setError(null);
+  }, []);
+
+  /**
    * 진행 중인 스트림을 안전하게 중단합니다.
-   * 이미 완료되었거나 없는 경우 무시합니다.
+   * - 컨트롤러가 있으면: abort()를 통해 스트림 취소 (finally 블록이 isStreaming을 정리)
+   * - 컨트롤러가 없고 isStreaming이 true면: 비정상 교착 상태로 전체 상태를 강제 초기화
+   * - 컨트롤러도 없고 isStreaming도 false면: 이미 완료된 상태이므로 무시 (결과 보존)
    */
   const cancelStream = useCallback(() => {
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
-    } else {
-      // abortController가 없더라도 UI 상태 교착 방지 및 데이터 오염 방지를 위해 전체 스트리밍 상태 초기화
-      setIsStreaming(false);
-      setTokens('');
-      setSources([]);
-      setError(null);
+    } else if (isStreaming) {
+      // isStreaming=true이지만 컨트롤러가 없는 비정상 교착 상태에서만 전체 리셋
+      // (정상 완료 후 cancelStream 호출 시 완료된 tokens/sources를 지우지 않도록 보호)
+      resetStreamingState();
     }
-  }, []);
+  }, [isStreaming, resetStreamingState]);
 
   /**
    * 스트리밍을 시작합니다.


### PR DESCRIPTION
- **[web_ui/src/hooks/useStreamingChat.ts]**:
  - 스트리밍 상태 초기화 로직을 `resetStreamingState` useCallback 헬퍼로 추출
  - `cancelStream`의 폴백 분기를 `else if (isStreaming)`으로 강화하여 스트림이 정상 완료된 후 cancelStream이 호출될 경우 완성된 토큰·소스가 삭제되는 버그 수정
  - `cancelStream` useCallback의 deps에 `isStreaming`, `resetStreamingState` 추가

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1435#pullrequestreview-4330453405)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.5 Flash (high)
```

## Summary by Sourcery

스트리밍 채팅 취소의 견고성을 개선하여 이미 완료된 결과가 지워지는 것을 방지하고, 스트리밍 상태 초기화를 재사용 가능한 헬퍼로 중앙화합니다.

버그 수정:
- 스트림이 이미 종료된 이후에 `cancelStream` 이 호출되더라도, 완료된 토큰과 소스가 지워지지 않도록 방지합니다.

개선 사항:
- 스트리밍 상태 초기화를 중앙에서 관리하기 위해 `resetStreamingState` 헬퍼를 추출하고, 비정상적으로 스트리밍이 멈춘 상태에서만 이를 사용하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve robustness of streaming chat cancellation to avoid clearing completed results and centralize streaming state reset into a reusable helper.

Bug Fixes:
- Prevent cancelStream from clearing completed tokens and sources when called after a stream has already finished.

Enhancements:
- Extract a resetStreamingState helper to centralize streaming state initialization and use it only for abnormal stuck streaming states.

</details>