### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/hooks/useStreamingChat.ts
+++ b/web_ui/src/hooks/useStreamingChat.ts
@@ -110,13 +110,14 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
   /**
    * isStreaming, tokens, sources, error를 초기값으로 일괄 초기화합니다.
    * 컨트롤러 없이 isStreaming이 true인 비정상 교착 상태에서만 호출해야 합니다.
+   * (setIsStreaming 등 안정적인 상태 setter만 사용하므로 useCallback 불필요)
    */
-  const resetStreamingState = useCallback(() => {
+  const resetStreamingState = () => {
     setIsStreaming(false);
     setTokens('');
     setSources([]);
     setError(null);
-  }, []);
+  };
 
   /**
    * 진행 중인 스트림을 안전하게 중단합니다.
@@ -132,7 +133,8 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
       // (정상 완료 후 cancelStream 호출 시 완료된 tokens/sources를 지우지 않도록 보호)
       resetStreamingState();
     }
-  }, [isStreaming, resetStreamingState]);
+  }, [isStreaming]); // resetStreamingState는 안정적인 setter만 참조하므로 deps 불필요
+
 
   /**
    * 스트리밍을 시작합니다.

--- a/web_ui/src/hooks/useStreamingChat.ts
+++ b/web_ui/src/hooks/useStreamingChat.ts
@@ -108,20 +108,31 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
   }, []);
 
   /**
+   * isStreaming, tokens, sources, error를 초기값으로 일괄 초기화합니다.
+   * 컨트롤러 없이 isStreaming이 true인 비정상 교착 상태에서만 호출해야 합니다.
+   */
+  const resetStreamingState = useCallback(() => {
+    setIsStreaming(false);
+    setTokens('');
+    setSources([]);
+    setError(null);
+  }, []);
+
+  /**
    * 진행 중인 스트림을 안전하게 중단합니다.
-   * 이미 완료되었거나 없는 경우 무시합니다.
+   * - 컨트롤러가 있으면: abort()를 통해 스트림 취소 (finally 블록이 isStreaming을 정리)
+   * - 컨트롤러가 없고 isStreaming이 true면: 비정상 교착 상태로 전체 상태를 강제 초기화
+   * - 컨트롤러도 없고 isStreaming도 false면: 이미 완료된 상태이므로 무시 (결과 보존)
    */
   const cancelStream = useCallback(() => {
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
-    } else {
-      // abortController가 없더라도 UI 상태 교착 방지 및 데이터 오염 방지를 위해 전체 스트리밍 상태 초기화
-      setIsStreaming(false);
-      setTokens('');
-      setSources([]);
-      setError(null);
+    } else if (isStreaming) {
+      // isStreaming=true이지만 컨트롤러가 없는 비정상 교착 상태에서만 전체 리셋
+      // (정상 완료 후 cancelStream 호출 시 완료된 tokens/sources를 지우지 않도록 보호)
+      resetStreamingState();
     }
-  }, []);
+  }, [isStreaming, resetStreamingState]);
 
   /**
    * 스트리밍을 시작합니다.


### PR DESCRIPTION
🛡️ fix [#12.2.30]: 4차 개선 - cancelStream 완료 상태 보호 및 resetStreamingState 헬퍼 추출
☘️ refactor [#12.2.30]: 5차 개선 - `resetStreamingState useCallback` 제거 및 deps 단순화

## Summary by Sourcery

완료된 결과를 지우지 않도록 스트리밍 채팅 취소 동작을 다듬고, 스트리밍 상태 초기화를 중앙에서 관리하도록 개선합니다.

Bug Fixes:
- 스트림이 이미 완료된 이후에 호출되었을 때 `cancelStream` 이 토큰과 소스를 제거하지 않도록 방지합니다.

Enhancements:
- 비정상적인 데드락 상황에서 스트리밍 관련 상태를 일관되게 초기화하기 위해 `resetStreamingState` 헬퍼를 추출했습니다.
- `cancelStream` 이 `isStreaming` 상태에 의존하도록 변경하고, 콜백 의존성을 단순화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine streaming chat cancellation to avoid wiping completed results and centralize streaming state resets.

Bug Fixes:
- Prevent cancelStream from clearing tokens and sources when called after a stream has already completed.

Enhancements:
- Extract a resetStreamingState helper to consistently reset streaming-related state in abnormal deadlock scenarios.
- Update cancelStream to rely on isStreaming state and simplify its callback dependencies.

</details>