### PR TITLE
♻️ refactor [#12.2.30]: 6차 개선 - `isStreamingRef` 도입 및 `cancelStream stable` 참조 달성

### DIFF
--- a/web_ui/src/hooks/useStreamingChat.ts
+++ b/web_ui/src/hooks/useStreamingChat.ts
@@ -90,6 +90,11 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
   // 상태 업데이트를 트리거하지 않고 안전하게 접근 가능
   const abortControllerRef = useRef<AbortController | null>(null);
 
+  // isStreaming 최신값을 ref로 추적하여, stable 콜백(cancelStream 등)에서
+  // deps 없이 현재 스트리밍 상태를 안전하게 읽을 수 있도록 합니다.
+  const isStreamingRef = useRef(false);
+  isStreamingRef.current = isStreaming; // 렌더마다 동기 업데이트
+
   // 콜백들을 ref로 보관하여 콜백이 바뀌어도 startStream 재생성을 방지
   const onErrorRef = useRef(options.onError);
   const onFinishRef = useRef(options.onFinish);
@@ -108,33 +113,23 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
   }, []);
 
   /**
-   * isStreaming, tokens, sources, error를 초기값으로 일괄 초기화합니다.
-   * 컨트롤러 없이 isStreaming이 true인 비정상 교착 상태에서만 호출해야 합니다.
-   * (setIsStreaming 등 안정적인 상태 setter만 사용하므로 useCallback 불필요)
-   */
-  const resetStreamingState = () => {
-    setIsStreaming(false);
-    setTokens('');
-    setSources([]);
-    setError(null);
-  };
-
-  /**
    * 진행 중인 스트림을 안전하게 중단합니다.
    * - 컨트롤러가 있으면: abort()를 통해 스트림 취소 (finally 블록이 isStreaming을 정리)
-   * - 컨트롤러가 없고 isStreaming이 true면: 비정상 교착 상태로 전체 상태를 강제 초기화
-   * - 컨트롤러도 없고 isStreaming도 false면: 이미 완료된 상태이므로 무시 (결과 보존)
+   * - 컨트롤러가 없고 isStreamingRef가 true면: 비정상 교착 상태로 전체 상태를 강제 초기화
+   * - 컨트롤러도 없고 isStreamingRef도 false면: 이미 완료된 상태이므로 무시 (결과 보존)
    */
   const cancelStream = useCallback(() => {
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
-    } else if (isStreaming) {
-      // isStreaming=true이지만 컨트롤러가 없는 비정상 교착 상태에서만 전체 리셋
-      // (정상 완료 후 cancelStream 호출 시 완료된 tokens/sources를 지우지 않도록 보호)
-      resetStreamingState();
+    } else if (isStreamingRef.current) {
+      // 컨트롤러가 없는데 isStreaming=true인 비정상 교착 상태에서만 전체 리셋
+      // (정상 완료 후 호출 시 isStreamingRef.current === false이므로 이 블록에 진입하지 않아 결과를 보존)
+      setIsStreaming(false);
+      setTokens('');
+      setSources([]);
+      setError(null);
     }
-  }, [isStreaming]); // resetStreamingState는 안정적인 setter만 참조하므로 deps 불필요
-
+  }, []); // isStreaming은 isStreamingRef로 읽으므로 deps 없이 stable 참조 보장
 
   /**
    * 스트리밍을 시작합니다.


### PR DESCRIPTION
- **[web_ui/src/hooks/useStreamingChat.ts]**:
  - `isStreamingRef = useRef(false)` 추가 및 렌더마다 동기 업데이트(`isStreamingRef.current = isStreaming`)로 `stable` 콜백에서 최신 `isStreaming` 상태를 `deps` 없이 안전하게 읽는 구조 도입
  - `resetStreamingState` 별도 함수를 `cancelStream` 내부에 인라인하여 비정상 교착 상태 복구 로직의 의도치 않은 재사용 위험 원천 제거
  - `cancelStream` useCallback deps를 `[isStreaming]`에서 `[]`로 단순화하여 완전한 stable 참조 보장

🔗 Related:
- Issue [#1047]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1437#pullrequestreview-4337594367)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

스트리밍 취소 로직을 개선하여, 안정적인 콜백이 불필요한 재생성 없이 최신 스트리밍 상태를 안전하게 읽을 수 있도록 합니다.

개선 사항:
- `ref`를 통해 최신 스트리밍 상태를 추적하여, `cancelStream`과 같은 안정적인 콜백이 의존성 없이 해당 상태를 읽을 수 있도록 합니다.
- 비정상적인 데드락 복구 경로에서 의도치 않은 재사용을 방지하기 위해 스트리밍 상태 초기화 로직을 `cancelStream` 내부에 바로 인라인합니다.
- 반응형 상태 대신 새로운 `ref`에서 스트리밍 상태를 읽도록 변경하여, `cancelStream`을 의존성 없는 안정적인 콜백으로 단순화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine streaming cancellation logic to ensure stable callbacks can safely read the latest streaming state without unnecessary re-creations.

Enhancements:
- Track the latest streaming state via a ref to allow stable callbacks like cancelStream to read it without dependencies.
- Inline the streaming state reset logic directly into cancelStream to avoid unintended reuse in abnormal deadlock recovery paths.
- Simplify cancelStream to a dependency-free stable callback by reading streaming state from the new ref instead of from reactive state.

</details>