### PR TITLE
☘️ refactor [#12.3.1]: 4차 개선 - 마이그레이션 OR 논리, SSE 측정 기준, Registry 인터페이스 명세화

### DIFF
--- a/docs/P/v9.0/v9.4_knowledge_graph_tasks.md
+++ b/docs/P/v9.0/v9.4_knowledge_graph_tasks.md
@@ -52,9 +52,10 @@
   - 데이터 규모 임계값(Total Nodes < 5,000) 및 초기 배포 환경(단일 유저 중심의 로컬 개인화)을 고려하여 **일차적으로 `networkx`를 채택**.
   - `networkx` 사용 시, 파일 시스템 기반 저장 경로(`STORAGE_BASE_PATH`)에 해시된 사용자 ID를 적용하여 데이터 프라이버시 및 테넌트 격리를 보장함.
   - **`neo4j` 마이그레이션 트리거**: 하드코딩된 숫자가 아닌 `GraphConfig`의 임계값 상수를 명시적으로 참조하여 판단함.
-    - `GRAPH_MIGRATION_NODE_THRESHOLD` (단일 사용자 노드 10,000개 초과 시)
-    - `GRAPH_MIGRATION_CONCURRENCY_THRESHOLD` (활성 동시 접속자 10명 초과 시)
-    - 위 임계값 도달 시 인메모리 파일 락(Lock) 병목을 회피하기 위해 기 구축된 **Repository 추상화 패턴**을 통해 무중단 분산 환경(neo4j)으로 전환함.
+    - **발동 조건 (OR 로직)**: 데이터 규모 **또는(OR)** 동시 접속자 중 어느 하나라도 임계값을 초과할 경우 전환.
+    - `GRAPH_MIGRATION_NODE_THRESHOLD` (기준: 단일 사용자 노드 10,000개 초과 시)
+    - `GRAPH_MIGRATION_CONCURRENCY_THRESHOLD` (기준: FastAPI의 활성 SSE 스트리밍 세션 수가 10개 초과 시)
+    - 위 조건 도달 시 인메모리 파일 락(Lock) 병목을 회피하기 위해 기 구축된 **Repository 추상화 패턴**을 통해 무중단 분산 환경(neo4j)으로 전환함.
 - [ ] **엔티티/릴레이션 자동 추출 파이프라인**
   - 노트 내용 내의 위키링크(`[[노트명]]`)나 태그를 파싱하여 명시적 엣지(Explicit Edge) 생성.
   - LLM 또는 NLP 기법을 이용해 키워드 기반의 암묵적 엣지(Implicit Edge) 가중치 생성.
@@ -89,7 +90,7 @@
   - **[검증부] `backend/core/config_validator.py` (`GraphValidator`)**: `GraphConfig`의 상수를 참조하여 애플리케이션 시작(Startup) 시점에 OS 환경 변수 로드 수행.
     - 범위 이탈 시 즉각적인 **Clamping 보정 로직** 적용 및 `WARNING` 구조화 로그 출력.
     - 치명적인 로딩 실패 시 서브시스템(Subsystem) 단위를 `DEGRADED`로 격하하여 전체 부팅 중단 방지 (Subsystem Fail-fast 정책 적용). 하드코딩 절대 금지.
-      - **`DEGRADED` 런타임 폴백 연결(Wired) 명세**: `backend/agent/graph_router.py` 라우터 컴포넌트는 전역 상태 레지스트리의 `subsystem_ok[Subsystem.GRAPH_ENGINE]` 플래그를 쿼리 시점마다 확인합니다. 플래그가 `False`일 경우 서버 예외(500)를 발생시키지 않고 그래프 탐색을 스킵하며, 기존의 `Vector RAG` 모드로 조용히 다운그레이드(Silent Fallback)합니다. 프론트엔드는 이 상태를 전달받아 지식 맵 시각화 UI를 안전하게 비활성화합니다.
+      - **`DEGRADED` 런타임 폴백 연결(Wired) 명세**: `backend/agent/graph_router.py` 라우터 컴포넌트는 매 쿼리마다 `backend.core.health_registry` 모듈의 `HealthRegistry.is_ok(Subsystem.GRAPH_ENGINE)` 메서드 인터페이스를 통해 전역 상태를 검증합니다. 반환값이 `False`일 경우 서버 예외(500)를 발생시키지 않고 그래프 탐색을 스킵하며, 기존의 `Vector RAG` 모드로 조용히 다운그레이드(Silent Fallback)합니다. 프론트엔드는 이 상태를 전달받아 지식 맵 시각화 UI를 안전하게 비활성화합니다.
 
   | 환경 변수 | 타입 | 기본값 | 유효 범위 | 파싱 오류 시 동작 |
   |-----------|------|--------|-----------|------------------|


### PR DESCRIPTION
- **[ADR] 마이그레이션 트리거 논리 및 측정 기준 구체화**
  - `neo4j` 전환 발동 조건을 명확한 OR 로직(데이터 규모 또는 접속자 초과 시 발동)으로 확정.
  - 모호했던 동시 접속자 측정 기준을 `FastAPI 활성 SSE 스트리밍 세션 수`로 명시하여 명확한 메트릭 수집 포인트를 확립함.

- **[장애 복원력] DEGRADED 상태 검증 인터페이스 캡슐화**
  - GraphRAG 라우터가 전역 상태를 검증할 때, 전역 딕셔너리 직접 참조를 지양하고 `backend.core.health_registry` 모듈의 `HealthRegistry.is_ok`(Subsystem.GRAPH_ENGINE) 심볼을 거치도록 명세화하여 모듈 간 강결합을 원천 차단함.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1443#pullrequestreview-4348911677)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

아키텍처 문서에서 지식 그래프 서브시스템에 대한 마이그레이션 트리거와 디그레이드 모드 상태 점검(health check)을 더 명확히 합니다.

Documentation:
- neo4j 마이그레이션 트리거를 노드 개수 임계값과 동시 사용량 임계값 사이의 OR 조건으로 문서화하고, SSE 기반 동시성 측정 방식을 명시합니다.
- 표준화된 상태 점검을 위해 전역 플래그에 직접 접근하는 대신 `HealthRegistry.is_ok` 인터페이스를 통해 디그레이드된 `GRAPH_ENGINE` 동작을 설명합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify migration triggers and degraded-mode health checks for the knowledge graph subsystem in the architectural docs.

Documentation:
- Document the neo4j migration trigger as an OR condition between node count and concurrent usage thresholds, with explicit SSE-based concurrency measurement.
- Describe degraded GRAPH_ENGINE behavior via the HealthRegistry.is_ok interface instead of direct global flag access to standardize health checks.

</details>