### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/docs/P/v9.0/v9.4_knowledge_graph_tasks.md
+++ b/docs/P/v9.0/v9.4_knowledge_graph_tasks.md
@@ -54,7 +54,7 @@
   - **`neo4j` 마이그레이션 트리거**: 하드코딩된 숫자가 아닌 `GraphConfig`의 임계값 상수를 명시적으로 참조하여 판단함.
     - **발동 조건 (OR 로직)**: 데이터 규모 **또는(OR)** 동시 접속자 중 어느 하나라도 임계값을 초과할 경우 전환.
     - `GRAPH_MIGRATION_NODE_THRESHOLD` (기준: 단일 사용자 노드 10,000개 초과 시)
-    - `GRAPH_MIGRATION_CONCURRENCY_THRESHOLD` (기준: FastAPI의 활성 SSE 스트리밍 세션 수가 10개 초과 시)
+    - `GRAPH_MIGRATION_CONCURRENCY_THRESHOLD` (기준: FastAPI **단일 워커 인스턴스(Per-worker) 내부**의 활성 SSE 스트리밍 세션 수가 10개 초과 시. 다중 워커 간 합산이 아님을 명시)
     - 위 조건 도달 시 인메모리 파일 락(Lock) 병목을 회피하기 위해 기 구축된 **Repository 추상화 패턴**을 통해 무중단 분산 환경(neo4j)으로 전환함.
 - [ ] **엔티티/릴레이션 자동 추출 파이프라인**
   - 노트 내용 내의 위키링크(`[[노트명]]`)나 태그를 파싱하여 명시적 엣지(Explicit Edge) 생성.
@@ -90,7 +90,7 @@
   - **[검증부] `backend/core/config_validator.py` (`GraphValidator`)**: `GraphConfig`의 상수를 참조하여 애플리케이션 시작(Startup) 시점에 OS 환경 변수 로드 수행.
     - 범위 이탈 시 즉각적인 **Clamping 보정 로직** 적용 및 `WARNING` 구조화 로그 출력.
     - 치명적인 로딩 실패 시 서브시스템(Subsystem) 단위를 `DEGRADED`로 격하하여 전체 부팅 중단 방지 (Subsystem Fail-fast 정책 적용). 하드코딩 절대 금지.
-      - **`DEGRADED` 런타임 폴백 연결(Wired) 명세**: `backend/agent/graph_router.py` 라우터 컴포넌트는 매 쿼리마다 `backend.core.health_registry` 모듈의 `HealthRegistry.is_ok(Subsystem.GRAPH_ENGINE)` 메서드 인터페이스를 통해 전역 상태를 검증합니다. 반환값이 `False`일 경우 서버 예외(500)를 발생시키지 않고 그래프 탐색을 스킵하며, 기존의 `Vector RAG` 모드로 조용히 다운그레이드(Silent Fallback)합니다. 프론트엔드는 이 상태를 전달받아 지식 맵 시각화 UI를 안전하게 비활성화합니다.
+      - **`DEGRADED` 런타임 폴백 연결(Wired) 명세**: `backend/agent/graph_router.py` 라우터 컴포넌트는 매 쿼리마다 `backend.core.health_registry` 모듈의 `HealthRegistry.is_ok(Subsystem.GRAPH_ENGINE)` 메서드 인터페이스를 통해 전역 상태를 검증합니다. 반환값이 `False`일 경우 서버 예외(500)를 발생시키지 않고 그래프 탐색을 스킵하며, 기존의 `Vector RAG` 모드로 조용히 다운그레이드(Silent Fallback)합니다. 프론트엔드는 이 상태를 전달받아 지식 맵 시각화 UI를 안전하게 비활성화합니다. **(⚠️ 계약 사항: 이 API 인터페이스만이 서브시스템 상태에 대한 유일한 단일 진실 공급원(SSOT)이며, 향후 어떠한 경우에도 전역 플래그에 직접 접근하는 안티패턴을 엄격히 금지함.)**
 
   | 환경 변수 | 타입 | 기본값 | 유효 범위 | 파싱 오류 시 동작 |
   |-----------|------|--------|-----------|------------------|


### PR DESCRIPTION
☘️ refactor [#12.3.1]: 5차 개선 - 워커 당 측정 기준 확립 및 SSOT 규약 강제화

## Summary by Sourcery

지식 그래프 엔진을 위한 동시성 임계값과 서브시스템 상태 SSOT(single source of truth) 계약을 명확히 합니다.

Documentation:
- 그래프 마이그레이션 동시성 임계값이 모든 워커 전체가 아닌, FastAPI 워커 인스턴스당 기준으로 측정된다는 점을 명확히 합니다.
- HealthRegistry API가 서브시스템 상태에 대한 단일 진실 소스(SSOT)임을 문서화하고, 전역 플래그에 직접 접근하는 것을 금지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify concurrency thresholds and subsystem health SSOT contracts for the knowledge graph engine.

Documentation:
- Clarify that the graph migration concurrency threshold is measured per FastAPI worker instance rather than across all workers.
- Document that the HealthRegistry API is the single source of truth for subsystem health state and forbid direct access to global flags.

</details>