### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/api/endpoints/graph.py
+++ b/backend/api/endpoints/graph.py
@@ -1,112 +1,132 @@
 # backend/api/endpoints/graph.py
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Phase 4: 지식 그래프 API 엔드포인트 - v1
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#
+# [SSOT 정책]
+# 이 라우터의 모든 응답은 반드시 `backend.schemas.graph`의 모델을 response_model로 선언해야 합니다.
+# raw dict 반환은 OpenAPI 스키마 동기화를 깨뜨리므로 절대 허용되지 않습니다.
+#
+# [버저닝 정책]
+# 현재 라우터 prefix: /api/graph (= v1)
+# Breaking Change 발생 시 /api/v2/graph 라우터를 신규 생성하고,
+# 이 v1 라우터는 Deprecation 헤더를 추가하여 일정 기간 유지합니다.
+#
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+from __future__ import annotations
+
+import random
+import logging
 
 from fastapi import APIRouter
+
 from backend.database.connection import DatabaseConnection
-import random
+from backend.schemas.graph import (
+    EdgeRelationshipType,
+    GraphDataResponse,
+    GraphEdge,
+    GraphNode,
+    NodeType,
+)
+from backend.utils.common import mask_pii_id
 
-router = APIRouter(prefix="/graph", tags=["visualization"])
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/graph", tags=["Knowledge Graph (v1)"])
 
 
-@router.get("/data")
-async def get_graph_data():
+@router.get(
+    "/data",
+    response_model=GraphDataResponse,
+    summary="PARA 기반 지식 그래프 데이터 조회",
+    description=(
+        "PARA 방법론(Projects/Areas/Resources/Archive) 기반으로 구성된 "
+        "노트 간의 노드-엣지 데이터를 반환합니다. "
+        "프론트엔드 react-force-graph 시각화에 사용됩니다.\n\n"
+        "[SSOT] 응답 스키마는 `backend.schemas.graph.GraphDataResponse`를 단일 진실 공급원으로 합니다."
+    ),
+)
+async def get_graph_data() -> GraphDataResponse:
     """
-    PARA Graph View를 위한 노드와 엣지 데이터 반환 using React Flow format
+    PARA Graph View를 위한 노드와 엣지 데이터를 SSOT 스키마 형식으로 반환합니다.
+
+    [v1] 현재는 PARA 카테고리 계층 관계(EdgeRelationshipType.PARA_CATEGORY)만 표현합니다.
+    Phase 4-1에서 명시적/암묵적 관계 추출 파이프라인이 연동되면 확장됩니다.
     """
-    nodes = []
-    edges = []
+    # ─── PARA 카테고리 노드 (고정 시드 노드) ───────────────────────────────
+    para_categories = ["Projects", "Areas", "Resources", "Archive"]
 
-    # helper for positions
-    # PARA Categories layout (fixed)
-    category_positions = {
-        "Projects": {"x": 0, "y": 0},
-        "Areas": {"x": 600, "y": 0},
-        "Resources": {"x": 0, "y": 600},
-        "Archive": {"x": 600, "y": 600},
-    }
-
-    # 1. Add Category Nodes
-    for cat, pos in category_positions.items():
-        nodes.append(
-            {
-                "id": cat,
-                "type": "input",
-                "data": {"label": cat},
-                "position": pos,
-                "style": {
-                    "width": 120,
-                    "height": 120,
-                    "borderRadius": "50%",
-                    "display": "flex",
-                    "justifyContent": "center",
-                    "alignItems": "center",
-                    "backgroundColor": "#e0e7ff",
-                    "border": "2px solid #6366f1",
-                    "fontWeight": "bold",
-                    "fontSize": "14px",
-                    "color": "#3730a3",
-                },
-            }
+    nodes: list[GraphNode] = [
+        GraphNode(
+            id=cat,
+            label=cat,
+            node_type=NodeType.CATEGORY,
+            properties={"para_category": cat},
         )
+        for cat in para_categories
+    ]
+    edges: list[GraphEdge] = []
 
-    with DatabaseConnection() as db:
-        files = db.get_files_with_para()
+    # ─── 파일 노드 및 카테고리→파일 엣지 생성 ────────────────────────────────
+    try:
+        with DatabaseConnection() as db:
+            files = db.get_files_with_para()
+    except Exception:
+        logger.exception("그래프 데이터 조회 중 DB 연결 실패. 빈 그래프를 반환합니다.")
+        return GraphDataResponse(nodes=nodes, edges=edges)
 
-    # 2. Add File Nodes and Edges
+    valid_category_ids = set(para_categories)
+
+    file_nodes: list[GraphNode] = []
+    file_edges: list[GraphEdge] = []
+
     for file in files:
         file_id = str(file["id"])
-        filename = file["filename"]
-        category = file["para_category"]
+        filename = file.get("filename", "")
+        category = file.get("para_category", "")
 
-        # Skip if category is not in our main PARA (unless we want to show uncategorized)
-        if not category or category not in category_positions:
+        if not category or category not in valid_category_ids:
             continue
 
-        # Deterministic offset around the category based on file id
-        # This ensures the graph layout is stable across reloads
-        base_pos = category_positions[category]
+        # 파일 노드 ID: 'file-{id}' 형식 (GraphEdge.id 규약과 동일)
+        file_node_id = f"file-{file_id}"
 
-        # Seed random with file_id for consistent positioning
+        # [PII 보안] user_id가 존재하는 경우 반드시 해시하여 저장
+        raw_user_id = file.get("user_id")
+        hashed_uid = mask_pii_id(raw_user_id) if raw_user_id else None
+
+        # Deterministic position: 파일 ID 시드를 사용하여 리로드 시에도 레이아웃 안정 보장
         rng = random.Random(file_id)
-
         offset_x = rng.randint(-200, 200)
         offset_y = rng.randint(-200, 200)
-
-        # Avoid placing too close to center (simple rejection logic)
         if abs(offset_x) < 80 and abs(offset_y) < 80:
             offset_x += 100 if offset_x >= 0 else -100
 
-        file_node_id = f"file-{file_id}"
-
-        nodes.append(
-            {
-                "id": file_node_id,
-                "data": {"label": filename},
-                "position": {
-                    "x": base_pos["x"] + offset_x,
-                    "y": base_pos["y"] + offset_y,
+        file_nodes.append(
+            GraphNode(
+                id=file_node_id,
+                label=filename,
+                node_type=NodeType.NOTE,
+                properties={
+                    "para_category": category,
+                    "offset_x": offset_x,
+                    "offset_y": offset_y,
                 },
-                "style": {
-                    "width": 100,
-                    "height": 40,
-                    "borderRadius": "20px",
-                    "fontSize": "12px",
-                    "display": "flex",
-                    "justifyContent": "center",
-                    "alignItems": "center",
-                    "backgroundColor": "white",
-                    "border": "1px solid #cbd5e1",
-                },
-            }
+                user_id_hash=hashed_uid,
+            )
+        )
+        file_edges.append(
+            GraphEdge(
+                id=f"e-{category}-{file_node_id}",
+                source=category,
+                target=file_node_id,
+                relationship_type=EdgeRelationshipType.PARA_CATEGORY,
+                weight=1.0,
+            )
         )
 
-        # Edge from Category to File
-        edges.append(
-            {
-                "id": f"e-{category}-{file_node_id}",
-                "source": category,
-                "target": file_node_id,
-                "animated": True,
-            }
-        )
+    nodes.extend(file_nodes)
+    edges.extend(file_edges)
 
-    return {"nodes": nodes, "edges": edges}
+    return GraphDataResponse(nodes=nodes, edges=edges)

--- a/backend/api/endpoints/graph.py
+++ b/backend/api/endpoints/graph.py
@@ -55,7 +55,13 @@ async def get_graph_data() -> GraphDataResponse:
     Phase 4-1에서 명시적/암묵적 관계 추출 파이프라인이 연동되면 확장됩니다.
     """
     # ─── PARA 카테고리 노드 (고정 시드 노드) ───────────────────────────────
-    para_categories = ["Projects", "Areas", "Resources", "Archive"]
+    # 기존 graph.py의 하드코딩 레이아웃을 기반으로 고정 좌표 부여
+    category_positions = {
+        "Projects": {"x": 0.0, "y": 0.0},
+        "Areas": {"x": 600.0, "y": 0.0},
+        "Resources": {"x": 0.0, "y": 600.0},
+        "Archive": {"x": 600.0, "y": 600.0},
+    }
 
     nodes: list[GraphNode] = [
         GraphNode(
@@ -63,8 +69,10 @@ async def get_graph_data() -> GraphDataResponse:
             label=cat,
             node_type=NodeType.CATEGORY,
             properties={"para_category": cat},
+            position_x=category_positions.get(cat, {}).get("x"),
+            position_y=category_positions.get(cat, {}).get("y"),
         )
-        for cat in para_categories
+        for cat in category_positions
     ]
     edges: list[GraphEdge] = []
 
@@ -76,7 +84,7 @@ async def get_graph_data() -> GraphDataResponse:
         logger.exception("그래프 데이터 조회 중 DB 연결 실패. 빈 그래프를 반환합니다.")
         return GraphDataResponse(nodes=nodes, edges=edges)
 
-    valid_category_ids = set(para_categories)
+    valid_category_ids = set(category_positions)
 
     file_nodes: list[GraphNode] = []
     file_edges: list[GraphEdge] = []
@@ -103,6 +111,13 @@ async def get_graph_data() -> GraphDataResponse:
         if abs(offset_x) < 80 and abs(offset_y) < 80:
             offset_x += 100 if offset_x >= 0 else -100
 
+        # 중심 카테고리 좌표를 기준으로 난수 오프셋 연산
+        base_x = category_positions.get(category, {}).get("x", 0.0)
+        base_y = category_positions.get(category, {}).get("y", 0.0)
+        
+        pos_x = base_x + offset_x
+        pos_y = base_y + offset_y
+
         file_nodes.append(
             GraphNode(
                 id=file_node_id,
@@ -110,9 +125,9 @@ async def get_graph_data() -> GraphDataResponse:
                 node_type=NodeType.NOTE,
                 properties={
                     "para_category": category,
-                    "offset_x": offset_x,
-                    "offset_y": offset_y,
                 },
+                position_x=pos_x,
+                position_y=pos_y,
                 user_id_hash=hashed_uid,
             )
         )

--- a/backend/schemas/graph.py
+++ b/backend/schemas/graph.py
@@ -1,0 +1,208 @@
+# backend/schemas/graph.py
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Phase 4: 지식 그래프 스키마 - 단일 진실 공급원 (SSOT)
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#
+# [SSOT 정책] 이 파일은 지식 그래프의 모든 데이터 타입에 대한 단일 진실 공급원입니다.
+# - 백엔드: 이 모델만을 응답 타입으로 사용해야 합니다 (raw dict 반환 금지).
+# - 프론트엔드: OpenAPI 스키마를 통해 자동 생성된 타입만 사용해야 합니다.
+#   (frontend 내 Node, Link 타입 수동 하드코딩 절대 금지)
+#
+# [버저닝 정책]
+# Breaking Change 발생 시 API v2 네임스페이스를 새로 생성하고,
+# 이 v1 모델은 하위 호환성 유지를 위해 Deprecation 기간 동안 보존합니다.
+# 직접 삭제하지 마세요.
+#
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+from backend.utils.common import mask_pii_id
+
+
+# ─────────────────────────────────────────
+# Enums (확장 가능한 관계 유형)
+# ─────────────────────────────────────────
+
+
+class EdgeRelationshipType(str, Enum):
+    """
+    노트 간 관계의 유형.
+
+    - EXPLICIT_LINK: 사용자가 위키링크([[노트명]]) 또는 태그로 직접 명시한 관계.
+    - IMPLICIT_SEMANTIC: LLM/NLP 분석을 통해 자동으로 발견된 의미론적 관계.
+    - PARA_CATEGORY: PARA 방법론(Projects/Areas/Resources/Archive)에 따른 계층 관계.
+    """
+
+    EXPLICIT_LINK = "explicit_link"
+    IMPLICIT_SEMANTIC = "implicit_semantic"
+    PARA_CATEGORY = "para_category"
+
+
+class NodeType(str, Enum):
+    """
+    그래프 노드의 종류.
+
+    - NOTE: 실제 마크다운 노트 문서.
+    - KEYWORD: LLM/NLP 분석으로 추출된 핵심 키워드.
+    - TAG: 사용자가 직접 부여한 태그.
+    - CATEGORY: PARA 카테고리 (Projects, Areas, Resources, Archive).
+    """
+
+    NOTE = "note"
+    KEYWORD = "keyword"
+    TAG = "tag"
+    CATEGORY = "category"
+
+
+# ─────────────────────────────────────────
+# Core Graph Models (v1)
+# ─────────────────────────────────────────
+
+
+class GraphNode(BaseModel):
+    """
+    지식 그래프의 노드(정점) 모델. [SSOT - v1]
+
+    각 노드는 노트, 키워드, 태그, 또는 PARA 카테고리 중 하나를 나타냅니다.
+
+    [PII 보안 정책]
+    user_id는 원본 값을 절대 직렬화하지 않습니다.
+    user_id_hash 필드만 외부에 노출되며, mask_pii_id()를 통해 자동 마스킹됩니다.
+    """
+
+    id: str = Field(
+        ...,
+        description="노드의 고유 식별자. 노트의 경우 파일 경로 기반 해시값을 권장.",
+    )
+    label: str = Field(
+        ...,
+        description="시각화 UI에 표시될 노드의 이름. (예: 노트 제목, 키워드)",
+    )
+    node_type: NodeType = Field(
+        default=NodeType.NOTE,
+        description="노드의 종류. NodeType enum 참조.",
+    )
+    properties: dict[str, Any] = Field(
+        default_factory=dict,
+        description="노드에 연결된 추가 메타데이터. (예: {'para_category': 'Projects', 'tags': ['AI']})",
+    )
+    user_id_hash: Optional[str] = Field(
+        default=None,
+        description=(
+            "이 노드의 소유자를 나타내는 해시된 사용자 ID. "
+            "원본 user_id는 절대 저장/직렬화되지 않습니다 (PII 보호)."
+        ),
+    )
+
+    @field_validator("user_id_hash")
+    @classmethod
+    def ensure_user_id_is_hashed(cls, v: Optional[str]) -> Optional[str]:
+        """
+        user_id_hash 필드에 비해시 원본값이 실수로 주입되는 것을 방어합니다.
+        이 validator가 호출될 시점에 이미 hash된 값이 들어와야 합니다.
+        원본 user_id를 직접 이 필드에 넣지 마세요.
+        """
+        if v is None:
+            return None
+        # 길이 체크: SHA-256 hex는 64자. mask_pii_id 기본 truncate는 12자.
+        # 원본 user_id처럼 보이는 값이 들어오면 한 번 더 마스킹하여 방어.
+        return mask_pii_id(v) if len(v) > 64 else v
+
+
+class GraphEdge(BaseModel):
+    """
+    지식 그래프의 엣지(간선) 모델. [SSOT - v1]
+
+    두 노드(source → target) 간의 방향 있는 관계를 표현합니다.
+    """
+
+    id: str = Field(
+        ...,
+        description="엣지의 고유 식별자. 충돌 방지를 위해 'e-{source_id}-{target_id}' 형식 권장.",
+    )
+    source: str = Field(
+        ...,
+        description="출발 노드의 id. GraphNode.id를 참조해야 합니다.",
+    )
+    target: str = Field(
+        ...,
+        description="도착 노드의 id. GraphNode.id를 참조해야 합니다.",
+    )
+    relationship_type: EdgeRelationshipType = Field(
+        default=EdgeRelationshipType.EXPLICIT_LINK,
+        description="두 노드 간의 관계 유형. EdgeRelationshipType enum 참조.",
+    )
+    weight: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "엣지의 강도(유사도/중요도). 0.0(약한 연결) ~ 1.0(강한 연결). "
+            "IMPLICIT_SEMANTIC 관계의 경우 LLM이 산출한 코사인 유사도를 사용."
+        ),
+    )
+
+
+# ─────────────────────────────────────────
+# API Response Models (v1)
+# ─────────────────────────────────────────
+
+
+class GraphDataResponse(BaseModel):
+    """
+    그래프 데이터 API 엔드포인트의 표준 응답 모델. [SSOT - v1]
+
+    [OpenAPI 동기화]
+    이 모델은 FastAPI의 response_model에 반드시 지정되어야 합니다.
+    프론트엔드 타입 자동 생성의 근거가 되는 SSOT입니다.
+    """
+
+    nodes: list[GraphNode] = Field(
+        default_factory=list,
+        description="그래프를 구성하는 전체 노드 목록.",
+    )
+    edges: list[GraphEdge] = Field(
+        default_factory=list,
+        description="그래프를 구성하는 전체 엣지 목록.",
+    )
+
+
+# ─────────────────────────────────────────
+# v1 Versioning Namespace (Breaking Change 대비)
+# ─────────────────────────────────────────
+#
+# [버저닝 가이드]
+# 향후 스키마에 Breaking Change가 발생할 경우 (예: 엣지 타입 다각화):
+#
+#   1. `backend/schemas/graph_v2.py` 파일을 신규 생성합니다.
+#   2. 변경된 모델을 v2에 정의합니다 (이 파일의 v1 모델은 건드리지 않습니다).
+#   3. 새 API 라우터를 `/api/v2/graph` 경로에 등록합니다.
+#   4. `/api/v1/graph` 라우터는 Deprecation 헤더를 추가하여 일정 기간 유지합니다.
+#   5. 프론트엔드 타입 자동 생성기를 v2 기준으로 재실행합니다.
+#
+# 이 네임스페이스 앨리어스는 현재 코드베이스에서
+# "이 모델이 v1 계약임"을 명시적으로 드러내기 위한 임포트 편의 목적입니다.
+#
+GraphNodeV1 = GraphNode
+GraphEdgeV1 = GraphEdge
+GraphDataResponseV1 = GraphDataResponse
+
+__all__ = [
+    # Enums
+    "NodeType",
+    "EdgeRelationshipType",
+    # v1 Core Models (SSOT)
+    "GraphNode",
+    "GraphEdge",
+    "GraphDataResponse",
+    # v1 Versioning Aliases
+    "GraphNodeV1",
+    "GraphEdgeV1",
+    "GraphDataResponseV1",
+]

--- a/backend/schemas/graph.py
+++ b/backend/schemas/graph.py
@@ -21,8 +21,9 @@ from enum import Enum
 from typing import Any, Optional
 
 from pydantic import BaseModel, Field, field_validator
+import re
 
-from backend.utils.common import mask_pii_id
+from backend.utils.common import mask_pii_id, INVALID_PII_SENTINEL
 
 
 # ─────────────────────────────────────────
@@ -92,6 +93,14 @@ class GraphNode(BaseModel):
         default_factory=dict,
         description="노드에 연결된 추가 메타데이터. (예: {'para_category': 'Projects', 'tags': ['AI']})",
     )
+    position_x: Optional[float] = Field(
+        default=None,
+        description="시각화 화면에서의 X 좌표 (명시적 레이아웃 정보)",
+    )
+    position_y: Optional[float] = Field(
+        default=None,
+        description="시각화 화면에서의 Y 좌표 (명시적 레이아웃 정보)",
+    )
     user_id_hash: Optional[str] = Field(
         default=None,
         description=(
@@ -104,15 +113,22 @@ class GraphNode(BaseModel):
     @classmethod
     def ensure_user_id_is_hashed(cls, v: Optional[str]) -> Optional[str]:
         """
-        user_id_hash 필드에 비해시 원본값이 실수로 주입되는 것을 방어합니다.
-        이 validator가 호출될 시점에 이미 hash된 값이 들어와야 합니다.
-        원본 user_id를 직접 이 필드에 넣지 마세요.
+        [보안 강화] user_id_hash 필드에 원본 ID가 실수로 주입되는 것을 차단합니다.
+        오직 mask_pii_id()를 통과한 해시 문자열(12자리/64자리 Hex) 또는 INVALID_PII_SENTINEL만 허용합니다.
         """
         if v is None:
             return None
-        # 길이 체크: SHA-256 hex는 64자. mask_pii_id 기본 truncate는 12자.
-        # 원본 user_id처럼 보이는 값이 들어오면 한 번 더 마스킹하여 방어.
-        return mask_pii_id(v) if len(v) > 64 else v
+        
+        if v == INVALID_PII_SENTINEL:
+            return v
+            
+        # 정확히 소문자 a-f, 0-9 로 구성된 12자리(truncate) 또는 64자리(full sha256)만 허용
+        if not re.match(r"^[a-f0-9]{12}$|^[a-f0-9]{64}$", v):
+            raise ValueError(
+                "PII 보안 경고: user_id_hash 필드에 안전하지 않은 값이 입력되었습니다. "
+                "반드시 mask_pii_id(raw_user_id)를 통해 해싱된 값을 전달해야 합니다."
+            )
+        return v
 
 
 class GraphEdge(BaseModel):


### PR DESCRIPTION
✨ feat [#12.3.2]: Phase 4-1 - ➀ 그래프 스키마 SSOT(GraphNode, GraphEdge) 정의 및 엔드포인트 연동
☘️ refactor [#12.3.2]: 1차 개선 - 그래프 스키마 PII 보안 강화 및 레이아웃 명시화

## Summary by Sourcery

지식 그래프에 대한 단일 진실 공급원(SSOT) 스키마를 정의하고, 그래프 API 엔드포인트가 PARA 인지 레이아웃과 PII 안전한 사용자 식별자를 사용하는 새로운 타입 기반 모델을 사용하도록 마이그레이션합니다.

New Features:
- 그래프 노드, 엣지 및 응답을 위한 SSOT Pydantic 모델을 도입하고, 노드 및 관계 유형에 대한 확장 가능한 enum과 명시적 레이아웃 좌표 지원을 포함합니다.

Enhancements:
- `/graph/data` 엔드포인트를 리팩터링하여, PARA 카테고리 레이아웃을 유지하면서도 결정적 위치 지정(deterministic positioning)과 PII 보호를 위한 `user_id` 해싱을 추가한 타입 기반 `GraphNode` 및 `GraphEdge` 인스턴스를 통해 `GraphDataResponse`를 반환하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Define a single-source-of-truth schema for the knowledge graph and migrate the graph API endpoint to use the new typed models with PARA-aware layout and PII-safe user identifiers.

New Features:
- Introduce SSOT Pydantic models for graph nodes, edges, and responses, including extensible enums for node and relationship types and support for explicit layout coordinates.

Enhancements:
- Refactor the /graph/data endpoint to return GraphDataResponse via typed GraphNode and GraphEdge instances, preserving PARA category layout while adding deterministic positioning and user_id hashing for PII protection.

</details>