### PR TITLE
☘️ refactor [#12.3.2]: 4차 개선 - `user_id` 해싱 로직 `Falsy` 예외 처리 정밀 타겟팅

### DIFF
--- a/backend/api/endpoints/graph.py
+++ b/backend/api/endpoints/graph.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import random
+from typing import Any
 import logging
 
 from fastapi import APIRouter
@@ -34,6 +35,14 @@ from backend.utils.common import mask_pii_id
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/graph", tags=["Knowledge Graph (v1)"])
+
+def _is_valid_raw_user_id(raw_id: Any) -> bool:
+    """
+    원본 user_id가 해싱을 수행할 만큼 유효한 값인지 검증하는 헬퍼 함수입니다.
+    None, 빈 문자열(""), 공백 문자열("   ") 등은 결측치로 간주하여 False를 반환합니다.
+    숫자(예: 0) 등 그 외의 값은 유효한 Falsy/Truthy 값으로 간주하여 True를 반환합니다.
+    """
+    return raw_id is not None and (not isinstance(raw_id, str) or bool(raw_id.strip()))
 
 
 @router.get(
@@ -110,9 +119,9 @@ async def get_graph_data() -> GraphDataResponse:
         # 파일 노드 ID: 'file-{id}' 형식 (GraphEdge.id 규약과 동일)
         file_node_id = f"file-{file_id}"
 
-        # [PII 보안] user_id가 빈 문자열이 아닌 유효한 값인 경우에만 해싱 (Falsy 0 방어 및 "" 결측치 방어)
+        # [PII 보안] user_id가 유효한 값(공백 제외)인 경우에만 해싱
         raw_user_id = file.get("user_id")
-        hashed_uid = mask_pii_id(raw_user_id) if raw_user_id not in (None, "") else None
+        hashed_uid = mask_pii_id(raw_user_id) if _is_valid_raw_user_id(raw_user_id) else None
 
         # Deterministic position: 파일 ID 시드를 사용하여 리로드 시에도 레이아웃 안정 보장
         rng = random.Random(file_id)

--- a/backend/api/endpoints/graph.py
+++ b/backend/api/endpoints/graph.py
@@ -110,9 +110,9 @@ async def get_graph_data() -> GraphDataResponse:
         # 파일 노드 ID: 'file-{id}' 형식 (GraphEdge.id 규약과 동일)
         file_node_id = f"file-{file_id}"
 
-        # [PII 보안] user_id가 존재하는 경우 반드시 해시하여 저장
+        # [PII 보안] user_id가 빈 문자열이 아닌 유효한 값인 경우에만 해싱 (Falsy 0 방어 및 "" 결측치 방어)
         raw_user_id = file.get("user_id")
-        hashed_uid = mask_pii_id(raw_user_id) if raw_user_id is not None else None
+        hashed_uid = mask_pii_id(raw_user_id) if raw_user_id not in (None, "") else None
 
         # Deterministic position: 파일 ID 시드를 사용하여 리로드 시에도 레이아웃 안정 보장
         rng = random.Random(file_id)


### PR DESCRIPTION
- **[견고성/버그방지] `backend/api/endpoints/graph.py`**
  - `user_id_hash` 할당 전 결측치 체크 로직을 `is not None`에서 `not in (None, "")`으로 강화.
  - 숫자 0과 같은 유효한 Falsy 값은 보존하면서, '사용자 없음'을 의미할 수 있는 빈 문자열("")이 `mask_pii_id` 함수로 들어가 `<INVALID_PII>` 센티넬 값을 뱉어내는 엣지 케이스(Edge Case) 원천 방어.
  - 리뷰어 피드백 수용: 유효 ID 판별 정책 명문화

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1451#pullrequestreview-4349180209)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

버그 수정:
- 빈 문자열인 사용자 ID가 PII 마스킹 헬퍼에 전달되지 않도록 하여 잘못된 센티널 값 사용을 방지하면서, 여전히 `0`과 같은 falsy지만 유효한 ID는 허용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent empty-string user IDs from being passed to the PII masking helper, avoiding invalid sentinel values while still allowing falsy but valid IDs like 0.

</details>