### PR TITLE
✨ feat [#12.3.3]: Phase 4-1 - ➁ 프론트엔드 그래프 타입 동기화 및 하드코딩 제거 (SSOT 준수)

### DIFF
--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -175,26 +175,40 @@ export interface WsConflict {
 }
 
 /**
- * 그래프 노드 데이터 타입
+ * 지식 그래프 노드 타입 (백엔드 SSOT 연동)
+ */
+export enum NodeType {
+  CATEGORY = "category",
+  NOTE = "note",
+}
+
+/**
+ * 그래프 노드 데이터 타입 (백엔드 schemas/graph.py SSOT 연동)
  */
 export interface GraphNode {
   id: string;
   label: string;
-  type: 'project' | 'area' | 'resource' | 'archive' | 'note';
-  val: number; // 크기
+  node_type: NodeType;
+  properties?: Record<string, unknown>;
+  position_x?: number | null;
+  position_y?: number | null;
+  user_id_hash?: string | null;
 }
 
 /**
- * 그래프 엣지 데이터 타입
+ * 그래프 엣지 데이터 타입 (백엔드 schemas/graph.py SSOT 연동)
  */
 export interface GraphEdge {
+  id: string;
   source: string;
   target: string;
-  value: number; // 가중치
+  relationship_type?: string;
+  weight?: number;
+  properties?: Record<string, unknown>;
 }
 
 /**
- * 그래프 전체 데이터 타입
+ * 그래프 전체 데이터 타입 (백엔드 GraphDataResponse 호환)
  */
 export interface GraphData {
   nodes: GraphNode[];

--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -189,10 +189,10 @@ export interface GraphNode {
   id: string;
   label: string;
   node_type: NodeType;
-  properties?: Record<string, unknown>;
-  position_x?: number | null;
-  position_y?: number | null;
-  user_id_hash?: string | null;
+  properties: Record<string, unknown>;
+  position_x: number | null;
+  position_y: number | null;
+  user_id_hash: string | null;
 }
 
 /**
@@ -202,9 +202,9 @@ export interface GraphEdge {
   id: string;
   source: string;
   target: string;
-  relationship_type?: string;
-  weight?: number;
-  properties?: Record<string, unknown>;
+  relationship_type: string;
+  weight: number;
+  properties: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
- **[프론트엔드] `web_ui/src/types/websocket.ts`**
  - 기존 프론트엔드에 하드코딩되어 있던 `GraphNode`, `GraphEdge` 더미 타입을 백엔드(`backend/schemas/graph.py`)의 SSOT(단일 진실 공급원) 스키마와 완벽하게 동기화.
  - PII 보안이 적용된 `user_id_hash` 필드 및 명시적 공간 좌표(position_x, position_y), Enum 타입(NodeType)을 TypeScript 인터페이스로 정확히 매핑하여 하드코딩 원천 차단.
  - properties 속성에 any 대신 unknown 타입을 사용하여 TypeScript 린트 룰(@typescript-eslint/no-explicit-any) 및 엄격한 타입 안정성 준수.
  - 향후 백엔드 스키마 변경 시 프론트엔드 파편화(Drift)가 발생하지 않도록 타입 안정성 확보.

🔗 Related: Issue [#1048]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro