### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -175,26 +175,40 @@ export interface WsConflict {
 }
 
 /**
- * 그래프 노드 데이터 타입
+ * 지식 그래프 노드 타입 (백엔드 SSOT 연동)
+ */
+export enum NodeType {
+  CATEGORY = "category",
+  NOTE = "note",
+}
+
+/**
+ * 그래프 노드 데이터 타입 (백엔드 schemas/graph.py SSOT 연동)
  */
 export interface GraphNode {
   id: string;
   label: string;
-  type: 'project' | 'area' | 'resource' | 'archive' | 'note';
-  val: number; // 크기
+  node_type: NodeType;
+  properties?: Record<string, unknown>;
+  position_x?: number | null;
+  position_y?: number | null;
+  user_id_hash?: string | null;
 }
 
 /**
- * 그래프 엣지 데이터 타입
+ * 그래프 엣지 데이터 타입 (백엔드 schemas/graph.py SSOT 연동)
  */
 export interface GraphEdge {
+  id: string;
   source: string;
   target: string;
-  value: number; // 가중치
+  relationship_type?: string;
+  weight?: number;
+  properties?: Record<string, unknown>;
 }
 
 /**
- * 그래프 전체 데이터 타입
+ * 그래프 전체 데이터 타입 (백엔드 GraphDataResponse 호환)
  */
 export interface GraphData {
   nodes: GraphNode[];

--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -189,10 +189,10 @@ export interface GraphNode {
   id: string;
   label: string;
   node_type: NodeType;
-  properties?: Record<string, unknown>;
-  position_x?: number | null;
-  position_y?: number | null;
-  user_id_hash?: string | null;
+  properties: Record<string, unknown>;
+  position_x: number | null;
+  position_y: number | null;
+  user_id_hash: string | null;
 }
 
 /**
@@ -202,9 +202,9 @@ export interface GraphEdge {
   id: string;
   source: string;
   target: string;
-  relationship_type?: string;
-  weight?: number;
-  properties?: Record<string, unknown>;
+  relationship_type: string;
+  weight: number;
+  properties: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
✨ feat [#12.3.3]: Phase 4-1 - ➁ 프론트엔드 그래프 타입 동기화 및 하드코딩 제거 (SSOT 준수) 
☘️ refactor [#12.3.3]: 1차 개선 - 프론트엔드 타입 엄격화(Tightening) 및 컴파일 안전성 극대화

## Summary by Sourcery

프론트엔드 그래프 웹소켓 타입을 백엔드 SSOT 스키마와 정렬하여 지식 그래프의 노드와 엣지 타입을 일치시킵니다.

새 기능:
- 백엔드 지식 그래프 노드 카테고리를 표현하기 위한 전용 `NodeType` enum을 도입합니다.

개선 사항:
- 스키마 일관성을 위해 `GraphNode`와 `GraphEdge` 인터페이스를 확장하여 `node_type`, `properties`, `positions`, `relationship_type`, `weight`와 같은 백엔드와 정렬된 필드를 포함하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align frontend graph websocket types with backend SSOT schema for knowledge graph nodes and edges.

New Features:
- Introduce a dedicated NodeType enum to represent backend knowledge graph node categories.

Enhancements:
- Extend GraphNode and GraphEdge interfaces to include backend-aligned fields such as node_type, properties, positions, relationship_type, and weight for schema consistency.

</details>