### PR TITLE
☘️ refactor [#12.3.3]: 2차 개선 - 그래프 인터페이스 제네릭(Generic) 도입 및 엣지 타입 Enum화

### DIFF
--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -194,7 +194,7 @@ export enum EdgeRelationshipType {
  * 그래프 노드 데이터 타입 (백엔드 schemas/graph.py SSOT 연동)
  * @template TProps 속성(properties)의 구체적인 타입 (기본값: Record<string, unknown>)
  */
-export interface GraphNode<TProps = Record<string, unknown>> {
+export interface GraphNode<TProps extends Record<string, unknown> = Record<string, unknown>> {
   id: string;
   label: string;
   node_type: NodeType;
@@ -208,7 +208,7 @@ export interface GraphNode<TProps = Record<string, unknown>> {
  * 그래프 엣지 데이터 타입 (백엔드 schemas/graph.py SSOT 연동)
  * @template TProps 속성(properties)의 구체적인 타입 (기본값: Record<string, unknown>)
  */
-export interface GraphEdge<TProps = Record<string, unknown>> {
+export interface GraphEdge<TProps extends Record<string, unknown> = Record<string, unknown>> {
   id: string;
   source: string;
   target: string;
@@ -223,8 +223,8 @@ export interface GraphEdge<TProps = Record<string, unknown>> {
  * @template TEdgeProps 엣지 속성 타입
  */
 export interface GraphData<
-  TNodeProps = Record<string, unknown>,
-  TEdgeProps = Record<string, unknown>
+  TNodeProps extends Record<string, unknown> = Record<string, unknown>,
+  TEdgeProps extends Record<string, unknown> = Record<string, unknown>
 > {
   nodes: GraphNode<TNodeProps>[];
   edges: GraphEdge<TEdgeProps>[];

--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -183,13 +183,22 @@ export enum NodeType {
 }
 
 /**
- * 그래프 노드 데이터 타입 (백엔드 schemas/graph.py SSOT 연동)
+ * 지식 그래프 엣지 관계 타입 (백엔드 SSOT 연동)
  */
-export interface GraphNode {
+export enum EdgeRelationshipType {
+  RELATED_TO = "related_to",
+  // 백엔드 확장에 따라 추가 가능
+}
+
+/**
+ * 그래프 노드 데이터 타입 (백엔드 schemas/graph.py SSOT 연동)
+ * @template TProps 속성(properties)의 구체적인 타입 (기본값: Record<string, unknown>)
+ */
+export interface GraphNode<TProps = Record<string, unknown>> {
   id: string;
   label: string;
   node_type: NodeType;
-  properties: Record<string, unknown>;
+  properties: TProps;
   position_x: number | null;
   position_y: number | null;
   user_id_hash: string | null;
@@ -197,22 +206,28 @@ export interface GraphNode {
 
 /**
  * 그래프 엣지 데이터 타입 (백엔드 schemas/graph.py SSOT 연동)
+ * @template TProps 속성(properties)의 구체적인 타입 (기본값: Record<string, unknown>)
  */
-export interface GraphEdge {
+export interface GraphEdge<TProps = Record<string, unknown>> {
   id: string;
   source: string;
   target: string;
-  relationship_type: string;
+  relationship_type: EdgeRelationshipType;
   weight: number;
-  properties: Record<string, unknown>;
+  properties: TProps;
 }
 
 /**
  * 그래프 전체 데이터 타입 (백엔드 GraphDataResponse 호환)
+ * @template TNodeProps 노드 속성 타입
+ * @template TEdgeProps 엣지 속성 타입
  */
-export interface GraphData {
-  nodes: GraphNode[];
-  edges: GraphEdge[];
+export interface GraphData<
+  TNodeProps = Record<string, unknown>,
+  TEdgeProps = Record<string, unknown>
+> {
+  nodes: GraphNode<TNodeProps>[];
+  edges: GraphEdge<TEdgeProps>[];
 }
 
 /**


### PR DESCRIPTION
- **[타입 확장성 및 안전성] `web_ui/src/types/websocket.ts`**
  - `GraphEdge`의 `relationship_type` 속성을 단순 문자열(string)에서 `EdgeRelationshipType Enum`으로 엄격하게 격상하여, 백엔드 규약 위반 및 오타로 인한 런타임 버그 원천 차단.
  - GraphNode, GraphEdge, GraphData 인터페이스에 제네릭(Generic: <TProps>)을 도입
    - 기본 타입(Record<string, unknown>)의 안전성을 유지
    - 필요 시 프론트엔드 개발자가 속성(properties)의 구체적인 형태를 타입 캐스팅(as) 없이 유연하게 확장하여 사용할 수 있도록 아키텍처 수준의 타입 개선 적용.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1455#pullrequestreview-4350962644)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

노드, 엣지, 그래프 데이터에 대한 그래프 WebSocket 타입에 더 강력한 타이핑과 제네릭을 도입합니다.

새로운 기능:
- 백엔드 정의와 정렬되는 그래프 엣지 관계 타입을 나타내기 위해 `EdgeRelationshipType` enum을 추가합니다.
- 사용자 정의 가능하고 타입 안정성이 보장되는 페이로드를 지원하기 위해 `GraphNode`, `GraphEdge`, `GraphData` 인터페이스를 그 프로퍼티에 대해 제네릭으로 만듭니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce stronger typing and generics to the graph WebSocket types for nodes, edges, and graph data.

New Features:
- Add an EdgeRelationshipType enum to represent graph edge relationship types aligned with backend definitions.
- Make GraphNode, GraphEdge, and GraphData interfaces generic over their properties to support customizable, type-safe payloads.

</details>