### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -194,7 +194,7 @@ export enum EdgeRelationshipType {
  * 그래프 노드 데이터 타입 (백엔드 schemas/graph.py SSOT 연동)
  * @template TProps 속성(properties)의 구체적인 타입 (기본값: Record<string, unknown>)
  */
-export interface GraphNode<TProps = Record<string, unknown>> {
+export interface GraphNode<TProps extends Record<string, unknown> = Record<string, unknown>> {
   id: string;
   label: string;
   node_type: NodeType;
@@ -208,7 +208,7 @@ export interface GraphNode<TProps = Record<string, unknown>> {
  * 그래프 엣지 데이터 타입 (백엔드 schemas/graph.py SSOT 연동)
  * @template TProps 속성(properties)의 구체적인 타입 (기본값: Record<string, unknown>)
  */
-export interface GraphEdge<TProps = Record<string, unknown>> {
+export interface GraphEdge<TProps extends Record<string, unknown> = Record<string, unknown>> {
   id: string;
   source: string;
   target: string;
@@ -223,8 +223,8 @@ export interface GraphEdge<TProps = Record<string, unknown>> {
  * @template TEdgeProps 엣지 속성 타입
  */
 export interface GraphData<
-  TNodeProps = Record<string, unknown>,
-  TEdgeProps = Record<string, unknown>
+  TNodeProps extends Record<string, unknown> = Record<string, unknown>,
+  TEdgeProps extends Record<string, unknown> = Record<string, unknown>
 > {
   nodes: GraphNode<TNodeProps>[];
   edges: GraphEdge<TEdgeProps>[];

--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -183,13 +183,22 @@ export enum NodeType {
 }
 
 /**
- * 그래프 노드 데이터 타입 (백엔드 schemas/graph.py SSOT 연동)
+ * 지식 그래프 엣지 관계 타입 (백엔드 SSOT 연동)
  */
-export interface GraphNode {
+export enum EdgeRelationshipType {
+  RELATED_TO = "related_to",
+  // 백엔드 확장에 따라 추가 가능
+}
+
+/**
+ * 그래프 노드 데이터 타입 (백엔드 schemas/graph.py SSOT 연동)
+ * @template TProps 속성(properties)의 구체적인 타입 (기본값: Record<string, unknown>)
+ */
+export interface GraphNode<TProps = Record<string, unknown>> {
   id: string;
   label: string;
   node_type: NodeType;
-  properties: Record<string, unknown>;
+  properties: TProps;
   position_x: number | null;
   position_y: number | null;
   user_id_hash: string | null;
@@ -197,22 +206,28 @@ export interface GraphNode {
 
 /**
  * 그래프 엣지 데이터 타입 (백엔드 schemas/graph.py SSOT 연동)
+ * @template TProps 속성(properties)의 구체적인 타입 (기본값: Record<string, unknown>)
  */
-export interface GraphEdge {
+export interface GraphEdge<TProps = Record<string, unknown>> {
   id: string;
   source: string;
   target: string;
-  relationship_type: string;
+  relationship_type: EdgeRelationshipType;
   weight: number;
-  properties: Record<string, unknown>;
+  properties: TProps;
 }
 
 /**
  * 그래프 전체 데이터 타입 (백엔드 GraphDataResponse 호환)
+ * @template TNodeProps 노드 속성 타입
+ * @template TEdgeProps 엣지 속성 타입
  */
-export interface GraphData {
-  nodes: GraphNode[];
-  edges: GraphEdge[];
+export interface GraphData<
+  TNodeProps = Record<string, unknown>,
+  TEdgeProps = Record<string, unknown>
+> {
+  nodes: GraphNode<TNodeProps>[];
+  edges: GraphEdge<TEdgeProps>[];
 }
 
 /**


### PR DESCRIPTION
☘️ refactor [#12.3.3]: 2차 개선 - 그래프 인터페이스 제네릭(Generic) 도입 및 엣지 타입 Enum화 
☘️ refactor [#12.3.3]: 3차 개선 - 그래프 인터페이스 제네릭(Generic) 타입 제약(Constraints) 강화

## Summary by Sourcery

제네릭과 enum 기반의 엣지 관계를 통해 그래프 웹소켓 페이로드에 더 강력한 타입을 도입합니다.

새 기능:
- 백엔드 SSOT와 정렬되도록 그래프 엣지 관계 타입용 enum을 추가합니다.

개선 사항:
- 그래프 노드, 엣지 및 그래프 데이터 인터페이스를 각 속성에 대해 제네릭으로 만들어, 다양한 사용 사례에서 더 엄격하고 재사용 가능한 타이핑이 가능하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce stronger typing for graph websocket payloads via generics and enum-based edge relationships.

New Features:
- Add an enum for graph edge relationship types to align with backend SSOT.

Enhancements:
- Make graph node, edge, and graph data interfaces generic over their properties to allow stricter, reusable typing across use cases.

</details>