### PR TITLE
☘️ refactor [#12.3.3]: 4차 개선 - 엣지 관계 타입 확장성(Resilience) 확보 및 제네릭 단순화

### DIFF
--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -212,22 +212,20 @@ export interface GraphEdge<TProps extends Record<string, unknown> = Record<strin
   id: string;
   source: string;
   target: string;
-  relationship_type: EdgeRelationshipType;
+  relationship_type: EdgeRelationshipType | (string & {});
   weight: number;
   properties: TProps;
 }
 
 /**
  * 그래프 전체 데이터 타입 (백엔드 GraphDataResponse 호환)
- * @template TNodeProps 노드 속성 타입
- * @template TEdgeProps 엣지 속성 타입
+ * @template TProps 노드와 엣지의 공통 확장 속성 타입
  */
 export interface GraphData<
-  TNodeProps extends Record<string, unknown> = Record<string, unknown>,
-  TEdgeProps extends Record<string, unknown> = Record<string, unknown>
+  TProps extends Record<string, unknown> = Record<string, unknown>
 > {
-  nodes: GraphNode<TNodeProps>[];
-  edges: GraphEdge<TEdgeProps>[];
+  nodes: GraphNode<TProps>[];
+  edges: GraphEdge<TProps>[];
 }
 
 /**

--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -191,6 +191,13 @@ export enum EdgeRelationshipType {
 }
 
 /**
+ * 백엔드에서 프론트엔드가 모르는 새로운 관계 타입 문자열을 보낼 경우를 대비한 Fallback 타입.
+ * (string & {}) 기법을 사용하여 기존 Enum(EdgeRelationshipType)의 IDE 자동 완성 기능을 보존하면서도
+ * 런타임 및 컴파일 타임에 임의의 문자열을 허용하는 유연성을 제공합니다.
+ */
+export type UnknownRelationshipType = string & {};
+
+/**
  * 그래프 노드 데이터 타입 (백엔드 schemas/graph.py SSOT 연동)
  * @template TProps 속성(properties)의 구체적인 타입 (기본값: Record<string, unknown>)
  */
@@ -212,20 +219,22 @@ export interface GraphEdge<TProps extends Record<string, unknown> = Record<strin
   id: string;
   source: string;
   target: string;
-  relationship_type: EdgeRelationshipType | (string & {});
+  relationship_type: EdgeRelationshipType | UnknownRelationshipType;
   weight: number;
   properties: TProps;
 }
 
 /**
  * 그래프 전체 데이터 타입 (백엔드 GraphDataResponse 호환)
- * @template TProps 노드와 엣지의 공통 확장 속성 타입
+ * @template TNodeProps 노드 속성의 확장 타입
+ * @template TEdgeProps 엣지 속성의 확장 타입
  */
 export interface GraphData<
-  TProps extends Record<string, unknown> = Record<string, unknown>
+  TNodeProps extends Record<string, unknown> = Record<string, unknown>,
+  TEdgeProps extends Record<string, unknown> = Record<string, unknown>
 > {
-  nodes: GraphNode<TProps>[];
-  edges: GraphEdge<TProps>[];
+  nodes: GraphNode<TNodeProps>[];
+  edges: GraphEdge<TEdgeProps>[];
 }
 
 /**


### PR DESCRIPTION
- **[타입 확장성] `web_ui/src/types/websocket.ts`**
  - `GraphEdge`의 `relationship_type` 속성에 `(string & {})` Fallback 패턴을 적용.
    - IDE 상에서 `EdgeRelationshipType Enum`의 리터럴 자동 완성(Type Hint)을 유지
    - 향후 백엔드에서 프론트엔드가 알지 못하는 새로운 문자열 관계 타입을 내려주더라도 타입 에러가 발생하지 않도록 유연성(Resilience) 확보. (타입 안정성과 백엔드 확장성의 조화)
  - GraphData의 분리되어 있던 TNodeProps, TEdgeProps 제네릭 매개변수를 단일 TProps로 통합하여, 프론트엔드 개발자의 실무 사용성(DX) 극대화.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1457#pullrequestreview-4350981163)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

엣지(Edge) 관계 타입을 완화하고 그래프 데이터 제네릭을 단순화하여 확장성과 개발자 경험을 개선합니다.

Enhancements:
- 향후 백엔드와의 호환성을 위해 `GraphEdge`의 `relationship_type`이 기존에 정의된 enum 값뿐만 아니라 임의의 문자열 기반 관계 타입도 허용하도록 합니다.
- 사용 편의를 위해 `GraphData`의 노드 및 엣지 속성 제네릭을 하나의 공통 `TProps` 타입으로 통합합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax edge relationship typing and simplify graph data generics for better extensibility and developer ergonomics.

Enhancements:
- Allow GraphEdge relationship_type to accept both known enum values and arbitrary string relationship types for future backend compatibility.
- Unify GraphData node and edge property generics into a single shared TProps type to simplify usage.

</details>