### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -212,22 +212,20 @@ export interface GraphEdge<TProps extends Record<string, unknown> = Record<strin
   id: string;
   source: string;
   target: string;
-  relationship_type: EdgeRelationshipType;
+  relationship_type: EdgeRelationshipType | (string & {});
   weight: number;
   properties: TProps;
 }
 
 /**
  * 그래프 전체 데이터 타입 (백엔드 GraphDataResponse 호환)
- * @template TNodeProps 노드 속성 타입
- * @template TEdgeProps 엣지 속성 타입
+ * @template TProps 노드와 엣지의 공통 확장 속성 타입
  */
 export interface GraphData<
-  TNodeProps extends Record<string, unknown> = Record<string, unknown>,
-  TEdgeProps extends Record<string, unknown> = Record<string, unknown>
+  TProps extends Record<string, unknown> = Record<string, unknown>
 > {
-  nodes: GraphNode<TNodeProps>[];
-  edges: GraphEdge<TEdgeProps>[];
+  nodes: GraphNode<TProps>[];
+  edges: GraphEdge<TProps>[];
 }
 
 /**

--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -191,6 +191,13 @@ export enum EdgeRelationshipType {
 }
 
 /**
+ * 백엔드에서 프론트엔드가 모르는 새로운 관계 타입 문자열을 보낼 경우를 대비한 Fallback 타입.
+ * (string & {}) 기법을 사용하여 기존 Enum(EdgeRelationshipType)의 IDE 자동 완성 기능을 보존하면서도
+ * 런타임 및 컴파일 타임에 임의의 문자열을 허용하는 유연성을 제공합니다.
+ */
+export type UnknownRelationshipType = string & {};
+
+/**
  * 그래프 노드 데이터 타입 (백엔드 schemas/graph.py SSOT 연동)
  * @template TProps 속성(properties)의 구체적인 타입 (기본값: Record<string, unknown>)
  */
@@ -212,20 +219,22 @@ export interface GraphEdge<TProps extends Record<string, unknown> = Record<strin
   id: string;
   source: string;
   target: string;
-  relationship_type: EdgeRelationshipType | (string & {});
+  relationship_type: EdgeRelationshipType | UnknownRelationshipType;
   weight: number;
   properties: TProps;
 }
 
 /**
  * 그래프 전체 데이터 타입 (백엔드 GraphDataResponse 호환)
- * @template TProps 노드와 엣지의 공통 확장 속성 타입
+ * @template TNodeProps 노드 속성의 확장 타입
+ * @template TEdgeProps 엣지 속성의 확장 타입
  */
 export interface GraphData<
-  TProps extends Record<string, unknown> = Record<string, unknown>
+  TNodeProps extends Record<string, unknown> = Record<string, unknown>,
+  TEdgeProps extends Record<string, unknown> = Record<string, unknown>
 > {
-  nodes: GraphNode<TProps>[];
-  edges: GraphEdge<TProps>[];
+  nodes: GraphNode<TNodeProps>[];
+  edges: GraphEdge<TEdgeProps>[];
 }
 
 /**


### PR DESCRIPTION
☘️ refactor [#12.3.3]: 4차 개선 - 엣지 관계 타입 확장성(Resilience) 확보 및 제네릭 단순화 
☘️ refactor [#12.3.3]: 5차 개선 - 그래프 제네릭 유연성 복구 및 불투명 타입 명시적 문서화

## Summary by Sourcery

그래프 엣지가 알려진 enum 기반과 백엔드에서 정의된 알 수 없는 관계 타입을 모두 처리할 수 있도록 허용하고, 그래프 제네릭에 대한 문서를 약간 명확히 합니다.

New Features:
- 백엔드에서 넘어오는, 기존에 알 수 없었던 엣지 관계에 대해 문자열 기반의 폴백(fallback) 관계 타입을 지원합니다.

Enhancements:
- 그래프 엣지의 `relationship_type` 타입 정의를 완화하여, 기존 enum과 새로운 폴백 타입 둘 다 허용하도록 합니다.
- `GraphData` 제네릭 매개변수 문서를 명확히 하여, 이것들이 노드와 엣지 속성의 확장 타입을 나타낸다는 점을 강조합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow graph edges to carry both known enum-based and unknown backend-defined relationship types while slightly clarifying graph generics documentation.

New Features:
- Support a fallback string-based relationship type for previously unknown edge relationships from the backend.

Enhancements:
- Relax graph edge relationship_type typing to accept either the existing enum or the new fallback type.
- Clarify GraphData generic parameter documentation to highlight they represent extension types for node and edge properties.

</details>