### PR TITLE
☘️ refactor [#12.3.3]: 6차 개선 - 브랜드 타입(Branded Type) 도입 및 런타임 가드 문서화

### DIFF
--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -192,10 +192,23 @@ export enum EdgeRelationshipType {
 
 /**
  * 백엔드에서 프론트엔드가 모르는 새로운 관계 타입 문자열을 보낼 경우를 대비한 Fallback 타입.
- * (string & {}) 기법을 사용하여 기존 Enum(EdgeRelationshipType)의 IDE 자동 완성 기능을 보존하면서도
- * 런타임 및 컴파일 타임에 임의의 문자열을 허용하는 유연성을 제공합니다.
+ * 브랜드 타입(Branded Type) 기법을 사용하여, 단순한 string과 엄격하게 구분합니다.
+ * 
+ * @example
+ * // 런타임 사용 권장 패턴 (Exhaustive Check 방지)
+ * function handleEdge(edge: GraphEdge) {
+ *   switch (edge.relationship_type) {
+ *     case EdgeRelationshipType.RELATED_TO:
+ *       // 알려진 타입 처리
+ *       break;
+ *     default:
+ *       // 알 수 없는 타입(UnknownRelationshipType)에 대한 안전한 폴백 처리
+ *       console.warn("Unknown relationship:", edge.relationship_type);
+ *       break;
+ *   }
+ * }
  */
-export type UnknownRelationshipType = string & {};
+export type UnknownRelationshipType = string & { readonly __brand: 'UnknownRelationshipType' };
 
 /**
  * 그래프 노드 데이터 타입 (백엔드 schemas/graph.py SSOT 연동)

--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -211,6 +211,17 @@ export enum EdgeRelationshipType {
 export type UnknownRelationshipType = string & { readonly __brand: 'UnknownRelationshipType' };
 
 /**
+ * 백엔드에서 전달된 알 수 없는 문자열을 UnknownRelationshipType 브랜드 타입으로 안전하게 변환하는 헬퍼 함수입니다.
+ * 코드베이스 전반에 불안전한 타입 단언(as)이 흩어지는 것을 방지하고 캐스팅 지점을 단일화(Centralize)합니다.
+ * 
+ * @param value 백엔드에서 전달된 임의의 문자열
+ * @returns 브랜딩이 적용된 UnknownRelationshipType
+ */
+export function asUnknownRelationshipType(value: string): UnknownRelationshipType {
+  return value as UnknownRelationshipType;
+}
+
+/**
  * 그래프 노드 데이터 타입 (백엔드 schemas/graph.py SSOT 연동)
  * @template TProps 속성(properties)의 구체적인 타입 (기본값: Record<string, unknown>)
  */


### PR DESCRIPTION
- **[타입 안전성 및 DX 향상] `web_ui/src/types/websocket.ts`**
  - 프론트엔드 내 하드코딩된 문자열 할당 원천 차단
    - `UnknownRelationshipType`에 `TypeScript`의 고급 기법인 브랜드 타입(Branded Type: `__brand`)을 적용.
    - 일반 문자열(Primitive String)과 컴파일 타임(Compile-time)에 엄격하게 구분.
  - JSDoc 주석을 통해 런타임에서 백엔드의 미지(Unknown) 엣지 타입을 다룰 때의 안전한 폴백(Fallback) 처리 패턴(switch default case)을 예제로 추가하여 동료 개발자들의 런타임 에러 방지 가이드라인 구축.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1459#pullrequestreview-4350999218)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

알 수 없는 엣지 관계 문자열에 대해 브랜드 타입(branded type)을 도입하고, 새로운 백엔드 관계 타입에 대해 런타임에서 안전하게 폴백(fallback) 처리하는 방법을 문서화합니다.

Enhancements:
- 단순 문자열 인터섹션 대신 브랜드 문자열 타입을 사용하여, 알 수 없는 엣지 관계 타입에 대한 타입 안정성을 강화합니다.

Documentation:
- 런타임에서 알 수 없는 엣지 관계 타입을 처리할 때 권장되는 `switch-case` 폴백 처리 방식을 보여주는 JSDoc 예제를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a branded type for unknown edge relationship strings and document safe runtime fallback handling for new backend relationship types.

Enhancements:
- Strengthen type safety for unknown edge relationship types by replacing a plain string intersection with a branded string type.

Documentation:
- Add JSDoc example illustrating recommended switch-case fallback handling for unknown edge relationship types at runtime.

</details>