### PR TITLE
☘️ refactor [#12.3.3]: 8차 개선 - `Unique Symbol   브랜드 적용 및 팩토리 경계(Boundary) 확립

### DIFF
--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -191,8 +191,14 @@ export enum EdgeRelationshipType {
 }
 
 /**
+ * 브랜드 타입을 위한 우주 유일의 고유 식별자(Symbol).
+ * 런타임 코드에서는 삭제되며 오직 컴파일 타임의 타입 구분에만 사용됩니다.
+ */
+declare const UnknownRelationshipBrand: unique symbol;
+
+/**
  * 백엔드에서 프론트엔드가 모르는 새로운 관계 타입 문자열을 보낼 경우를 대비한 Fallback 타입.
- * 브랜드 타입(Branded Type) 기법을 사용하여, 단순한 string과 엄격하게 구분합니다.
+ * Unique Symbol 기반의 브랜드 타입(Branded Type) 기법을 사용하여, 단순한 string과 외부 라이브러리 간의 타입 충돌을 완벽히 방지합니다.
  * 
  * @example
  * // 런타임 사용 권장 패턴 (Exhaustive Check 방지)
@@ -208,11 +214,14 @@ export enum EdgeRelationshipType {
  *   }
  * }
  */
-export type UnknownRelationshipType = string & { readonly __brand: 'UnknownRelationshipType' };
+export type UnknownRelationshipType = string & { readonly [UnknownRelationshipBrand]: true };
 
 /**
  * 백엔드에서 전달된 알 수 없는 문자열을 UnknownRelationshipType 브랜드 타입으로 안전하게 변환하는 헬퍼 함수입니다.
  * 코드베이스 전반에 불안전한 타입 단언(as)이 흩어지는 것을 방지하고 캐스팅 지점을 단일화(Centralize)합니다.
+ * 
+ * @internal 이 함수는 오직 백엔드 API 응답(WebSocket, Fetch 등)을 파싱하는 최전방 경계(Boundary Layer)에서만 사용되어야 합니다.
+ * 비즈니스 로직 내부에서 임의로 호출하여 캐스팅하는 것을 엄격히 금지합니다.
  * 
  * @param value 백엔드에서 전달된 임의의 문자열
  * @returns 브랜딩이 적용된 UnknownRelationshipType


### PR DESCRIPTION
- **[엔터프라이즈급 타입 안전성] `web_ui/src/types/websocket.ts`**
  - `UnknownRelationshipType`의 브랜드 키를 단순 문자열 속성(`__brand`)에서 타입스크립트 고유 심볼(`unique symbol`)로 승격. 이를 통해 서드파티 라이브러리 등 외부 환경과의 예기치 않은 타입 충돌(Collision) 가능성을 수학적으로 완벽히 차단.
  - `asUnknownRelationshipType` 팩토리 함수에 `@internal` JSDoc 어노테이션 및 경고 문구를 추가.
    - 이 함수가 프론트엔드의 비즈니스 로직 내부로 침투하는 것을 막음.
    - 오직 백엔드 API와의 경계선(Boundary Layer)에서만 사용되도록 아키텍처 규칙 확립.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1461#pullrequestreview-4351016229)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

웹소켓 타입에서 `UnknownRelationshipType` 브랜딩을 강화하여 고유 심볼을 사용하고, 이를 경계 계층에서만 사용하는 팩토리로 공식화합니다.

향상 사항:
- 외부 라이브러리와의 잠재적인 타입 충돌을 피하기 위해 `UnknownRelationshipType` 브랜딩을 문자열 프로퍼티에서 고유 심볼로 전환합니다.
- `asUnknownRelationshipType` 헬퍼를 백엔드 API 파싱을 위한 내부용, 경계 계층 전용 팩토리로 문서화하고 사용을 제한합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen the UnknownRelationshipType branding in websocket types to use a unique symbol and formalize its use as a boundary-layer-only factory.

Enhancements:
- Switch UnknownRelationshipType branding from a string property to a unique symbol to avoid potential type collisions with external libraries.
- Document and restrict the asUnknownRelationshipType helper as an internal, boundary-layer-only factory for backend API parsing.

</details>