### PR TITLE
☘️ refactor [#12.3.3]: 9차 개선 - 명시적 브랜드 값(Recognizable Brand) 적용 및 ESLint 준수

### DIFF
--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -191,14 +191,16 @@ export enum EdgeRelationshipType {
 }
 
 /**
- * 브랜드 타입을 위한 우주 유일의 고유 식별자(Symbol).
+ * 향후 다른 브랜드 타입이 추가될 때 우연한 이름 충돌이나 전역 스코프 오염을 방지하기 위한
+ * 모듈 레벨의 고유 식별자(Symbol)입니다. (ES2015 Module 스코프 활용)
  * 런타임 코드에서는 삭제되며 오직 컴파일 타임의 타입 구분에만 사용됩니다.
  */
-declare const UnknownRelationshipBrand: unique symbol;
+export declare const GraphUnknownRelationshipBrand: unique symbol;
 
 /**
  * 백엔드에서 프론트엔드가 모르는 새로운 관계 타입 문자열을 보낼 경우를 대비한 Fallback 타입.
- * Unique Symbol 기반의 브랜드 타입(Branded Type) 기법을 사용하여, 단순한 string과 외부 라이브러리 간의 타입 충돌을 완벽히 방지합니다.
+ * 모듈 스코프의 Unique Symbol을 사용하여 외부와의 충돌을 막고, 
+ * 브랜드 값을 명시적 리터럴 문자열('UnknownRelationshipType')로 지정하여 IDE의 에러 툴팁 가독성을 극대화합니다.
  * 
  * @example
  * // 런타임 사용 권장 패턴 (Exhaustive Check 방지)
@@ -214,7 +216,9 @@ declare const UnknownRelationshipBrand: unique symbol;
  *   }
  * }
  */
-export type UnknownRelationshipType = string & { readonly [UnknownRelationshipBrand]: true };
+export type UnknownRelationshipType = string & { 
+  readonly [GraphUnknownRelationshipBrand]: 'UnknownRelationshipType' 
+};
 
 /**
  * 백엔드에서 전달된 알 수 없는 문자열을 UnknownRelationshipType 브랜드 타입으로 안전하게 변환하는 헬퍼 함수입니다.


### PR DESCRIPTION
- **[디버깅/DX 및 린트 최적화] `web_ui/src/types/websocket.ts`**
  - `UnknownRelationshipType`의 브랜드 속성 값을 단순 `true`에서 `'UnknownRelationshipType'`라는 리터럴 문자열로 명시적으로 지정(Recognizable Brand Pattern).
  - 이를 통해 프론트엔드 개발자가 잘못된 엣지 타입을 다룰 때 IDE(VSCode 등) 에러 툴팁과 컴파일 메시지에서 어떤 브랜드 타입이 누락되었는지 즉각적으로 인지할 수 있도록 디버깅 경험(DX) 극대화.
  - 최신 ESLint 룰(@typescript-eslint/no-namespace)을 준수하기 위해 namespace를 제거하고 모듈 레벨의 명시적 심볼명(`GraphUnknownRelationshipBrand`)을 활용하여 전역 스코프 오염 방지 및 타입 격리 달성.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1463#pullrequestreview-4351029907)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

웹소켓 타입에서 알 수 없는 엣지 관계(unknown edge relationships)에 대한 브랜드 타입을 정교하게 다듬어, IDE 피드백을 개선하고 모듈 범위 심볼 사용 방식과 일치시키도록 합니다.

Enhancements:
- 알 수 없는 관계 브랜딩을 위한 모듈 범위의 고유 심볼을 export하여 전역 네임스페이스 충돌을 피하고, 향후 추가될 브랜디드 타입들을 지원합니다.
- `UnknownRelationshipType` 브랜드 페이로드를 불리언 플래그에서 설명적인 리터럴 문자열로 변경하여, 브랜딩 누락 문제를 툴링에서 더 잘 식별할 수 있도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the branded type for unknown edge relationships in the websocket types to improve IDE feedback and align with module-scoped symbol usage.

Enhancements:
- Export a module-scoped unique symbol for unknown relationship branding to avoid global namespace collisions and support future branded types.
- Change the UnknownRelationshipType brand payload from a boolean flag to a descriptive literal string to make missing-brand issues more recognizable in tooling.

</details>