### PR TITLE
☘️ refactor [#12.3.3]: 10차 개선 - 브랜드 심볼 캡슐화(Encapsulation) 및 네이밍 일관성 확보

### DIFF
--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -192,14 +192,15 @@ export enum EdgeRelationshipType {
 
 /**
  * 향후 다른 브랜드 타입이 추가될 때 우연한 이름 충돌이나 전역 스코프 오염을 방지하기 위한
- * 모듈 레벨의 고유 식별자(Symbol)입니다. (ES2015 Module 스코프 활용)
+ * 모듈 내부 전용 고유 식별자(Symbol)입니다. 
+ * 외부 모듈과의 결합도(Coupling)를 낮추고 정보 은닉(Encapsulation)을 강제하기 위해 export 하지 않습니다.
  * 런타임 코드에서는 삭제되며 오직 컴파일 타임의 타입 구분에만 사용됩니다.
  */
-export declare const GraphUnknownRelationshipBrand: unique symbol;
+declare const UnknownRelationshipBrand: unique symbol;
 
 /**
  * 백엔드에서 프론트엔드가 모르는 새로운 관계 타입 문자열을 보낼 경우를 대비한 Fallback 타입.
- * 모듈 스코프의 Unique Symbol을 사용하여 외부와의 충돌을 막고, 
+ * 모듈 스코프 내에 캡슐화된 Unique Symbol을 사용하여 외부와의 충돌을 막고, 
  * 브랜드 값을 명시적 리터럴 문자열('UnknownRelationshipType')로 지정하여 IDE의 에러 툴팁 가독성을 극대화합니다.
  * 
  * @example
@@ -217,7 +218,7 @@ export declare const GraphUnknownRelationshipBrand: unique symbol;
  * }
  */
 export type UnknownRelationshipType = string & { 
-  readonly [GraphUnknownRelationshipBrand]: 'UnknownRelationshipType' 
+  readonly [UnknownRelationshipBrand]: 'UnknownRelationshipType' 
 };
 
 /**


### PR DESCRIPTION
- **[클린 아키텍처 및 은닉화] `web_ui/src/types/websocket.ts`**
  - 브랜드 타입의 내부 구현체인 고유 심볼(unique symbol)에서 `export` 키워드를 제거하여 모듈 외부로의 노출(Surface Area)을 최소화.
  - 이를 통해 외부 모듈이 프론트엔드의 내부 브랜딩 메커니즘에 의존하는 결합도(Coupling)를 낮추고 완벽한 정보 은닉(Information Hiding) 달성.
  - `GraphUnknownRelationshipBrand`로 불일치했던 식별자 네이밍을 `UnknownRelationshipBrand`로 일치시켜 타입 이름(`UnknownRelationshipType`)과의 일관성 및 가독성(DX) 극대화.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1465#pullrequestreview-4351043057)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

알 수 없는 그래프 엣지 관계를 나타내는 내부 브랜드 심볼을 캡슐화하고, 해당 타입과의 명명 규칙을 일치시켜 일관성과 정보 은닉을 개선합니다.

개선 사항:
- 알 수 없는 관계 타입을 표시하는 고유 심볼을 외부 모듈에서 숨겨 결합도를 낮추고 캡슐화를 강화합니다.
- 내부 브랜드 심볼의 이름을 `UnknownRelationshipType` 명명 규칙에 맞게 변경하여 일관성과 가독성을 높입니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Encapsulate the internal brand symbol for unknown graph edge relationships and align its naming with the corresponding type for improved consistency and information hiding.

Enhancements:
- Hide the unique symbol used to brand unknown relationship types from external modules to reduce coupling and enforce encapsulation.
- Rename the internal brand symbol to match the UnknownRelationshipType naming for clearer consistency and readability.

</details>