### PR TITLE
✨ feat [#12.3.4]: Phase 4-1 - ➂ GraphConfig SSOT 뼈대 구축 (지식 그래프 설정 선언부)

### DIFF
--- a/backend/core/config/graph.py
+++ b/backend/core/config/graph.py
@@ -1,0 +1,167 @@
+# backend/core/config/graph.py
+
+"""
+GraphConfig — Phase 4 (Knowledge Graph) 설정 스키마 및 기본값 정의
+==================================================================
+
+역할 (4-0 SSOT 정책에 따른 책임 분리):
+  이 모듈은 지식 그래프 관련 환경 변수의 '스키마, 환경 변수 키, 기본값, 유효 범위'만 정의합니다.
+  실제 OS 환경 변수 로딩, Clamping, Subsystem(DEGRADED) 등록은
+  4-5 정책에 따라 `backend/core/config_validator.py`의 GraphValidator에 위임됩니다.
+
+하드코딩 금지:
+  모든 수치 상수·환경 변수 키 문자열은 이 모듈에만 중앙 정의합니다.
+  개별 모듈에서 값을 복사하거나 재정의하는 것을 금지합니다.
+
+민감 정보 보호:
+  `GRAPH_DB_URL` 등 연결 문자열은 로그에 원문을 남기지 않으며,
+  사용자 식별은 hashed_user_id 기반 테넌트 격리 정책을 따릅니다.
+"""
+
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+from backend.config import ConfigRange
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 환경 변수 키 상수 (문자열 하드코딩 방지)
+# ─────────────────────────────────────────────────────────────────────────────
+
+_ENV_MAX_TRAVERSAL_DEPTH: str = "GRAPH_MAX_TRAVERSAL_DEPTH"
+_ENV_MAX_GRAPH_NODES: str = "NEXT_PUBLIC_MAX_GRAPH_NODES"
+_ENV_DB_URL: str = "GRAPH_DB_URL"
+_ENV_MIGRATION_NODE_THRESHOLD: str = "GRAPH_MIGRATION_NODE_THRESHOLD"
+_ENV_MIGRATION_CONCURRENCY_THRESHOLD: str = "GRAPH_MIGRATION_CONCURRENCY_THRESHOLD"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 유효 범위 상수 (Clamping 규칙 중앙 정의 — v9.4_knowledge_graph_tasks.md SSOT)
+# ─────────────────────────────────────────────────────────────────────────────
+
+_MAX_TRAVERSAL_DEPTH_RANGE: ConfigRange = ConfigRange(min=1, max=5)
+_MAX_GRAPH_NODES_RANGE: ConfigRange = ConfigRange(min=50, max=2000)
+_MIGRATION_NODE_THRESHOLD_RANGE: ConfigRange = ConfigRange(min=5000, max=50000)
+_MIGRATION_CONCURRENCY_THRESHOLD_RANGE: ConfigRange = ConfigRange(min=5, max=100)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 기본값 상수 (Magic Numbers 제거)
+# ─────────────────────────────────────────────────────────────────────────────
+
+_DEFAULT_MAX_TRAVERSAL_DEPTH: int = 3
+_DEFAULT_MAX_GRAPH_NODES: int = 500
+_DEFAULT_DB_URL: str = ""
+_DEFAULT_MIGRATION_NODE_THRESHOLD: int = 10000
+_DEFAULT_MIGRATION_CONCURRENCY_THRESHOLD: int = 10
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 공개 상수 별칭 (외부·Validator 참조용)
+# ─────────────────────────────────────────────────────────────────────────────
+
+GRAPH_ENV_MAX_TRAVERSAL_DEPTH: str = _ENV_MAX_TRAVERSAL_DEPTH
+GRAPH_ENV_MAX_GRAPH_NODES: str = _ENV_MAX_GRAPH_NODES
+GRAPH_ENV_DB_URL: str = _ENV_DB_URL
+GRAPH_ENV_MIGRATION_NODE_THRESHOLD: str = _ENV_MIGRATION_NODE_THRESHOLD
+GRAPH_ENV_MIGRATION_CONCURRENCY_THRESHOLD: str = _ENV_MIGRATION_CONCURRENCY_THRESHOLD
+
+GRAPH_DEFAULT_MAX_TRAVERSAL_DEPTH: int = _DEFAULT_MAX_TRAVERSAL_DEPTH
+GRAPH_DEFAULT_MAX_GRAPH_NODES: int = _DEFAULT_MAX_GRAPH_NODES
+GRAPH_DEFAULT_DB_URL: str = _DEFAULT_DB_URL
+GRAPH_DEFAULT_MIGRATION_NODE_THRESHOLD: int = _DEFAULT_MIGRATION_NODE_THRESHOLD
+GRAPH_DEFAULT_MIGRATION_CONCURRENCY_THRESHOLD: int = (
+    _DEFAULT_MIGRATION_CONCURRENCY_THRESHOLD
+)
+
+GRAPH_MAX_TRAVERSAL_DEPTH_RANGE: ConfigRange = _MAX_TRAVERSAL_DEPTH_RANGE
+GRAPH_MAX_GRAPH_NODES_RANGE: ConfigRange = _MAX_GRAPH_NODES_RANGE
+GRAPH_MIGRATION_NODE_THRESHOLD_RANGE: ConfigRange = _MIGRATION_NODE_THRESHOLD_RANGE
+GRAPH_MIGRATION_CONCURRENCY_THRESHOLD_RANGE: ConfigRange = (
+    _MIGRATION_CONCURRENCY_THRESHOLD_RANGE
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GraphConfig 데이터 클래스 (명시적 타입 스키마 — 로딩 로직 없음)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class GraphConfig:
+    """
+    지식 그래프 파이프라인 런타임 설정 스키마.
+
+    이 클래스는 필드·기본값·환경 변수 키·유효 범위의 SSOT입니다.
+    `load()` 등 OS 환경 변수 읽기는 GraphValidator(config_validator.py)에서만 수행합니다.
+
+    사용 예시 (Validator 구현 후):
+        config: GraphConfig = graph_validator.load_graph_config()
+        depth = config.max_traversal_depth
+    """
+
+    max_traversal_depth: int = field(
+        default_factory=lambda: _DEFAULT_MAX_TRAVERSAL_DEPTH
+    )
+    max_graph_nodes: int = field(default_factory=lambda: _DEFAULT_MAX_GRAPH_NODES)
+    db_url: str = field(default_factory=lambda: _DEFAULT_DB_URL)
+    migration_node_threshold: int = field(
+        default_factory=lambda: _DEFAULT_MIGRATION_NODE_THRESHOLD
+    )
+    migration_concurrency_threshold: int = field(
+        default_factory=lambda: _DEFAULT_MIGRATION_CONCURRENCY_THRESHOLD
+    )
+
+    ENV_MAX_TRAVERSAL_DEPTH: ClassVar[str] = _ENV_MAX_TRAVERSAL_DEPTH
+    ENV_MAX_GRAPH_NODES: ClassVar[str] = _ENV_MAX_GRAPH_NODES
+    ENV_DB_URL: ClassVar[str] = _ENV_DB_URL
+    ENV_MIGRATION_NODE_THRESHOLD: ClassVar[str] = _ENV_MIGRATION_NODE_THRESHOLD
+    ENV_MIGRATION_CONCURRENCY_THRESHOLD: ClassVar[str] = (
+        _ENV_MIGRATION_CONCURRENCY_THRESHOLD
+    )
+
+    DEFAULT_MAX_TRAVERSAL_DEPTH: ClassVar[int] = _DEFAULT_MAX_TRAVERSAL_DEPTH
+    DEFAULT_MAX_GRAPH_NODES: ClassVar[int] = _DEFAULT_MAX_GRAPH_NODES
+    DEFAULT_DB_URL: ClassVar[str] = _DEFAULT_DB_URL
+    DEFAULT_MIGRATION_NODE_THRESHOLD: ClassVar[int] = _DEFAULT_MIGRATION_NODE_THRESHOLD
+    DEFAULT_MIGRATION_CONCURRENCY_THRESHOLD: ClassVar[int] = (
+        _DEFAULT_MIGRATION_CONCURRENCY_THRESHOLD
+    )
+
+    MAX_TRAVERSAL_DEPTH_RANGE: ClassVar[ConfigRange] = _MAX_TRAVERSAL_DEPTH_RANGE
+    MAX_GRAPH_NODES_RANGE: ClassVar[ConfigRange] = _MAX_GRAPH_NODES_RANGE
+    MIGRATION_NODE_THRESHOLD_RANGE: ClassVar[ConfigRange] = (
+        _MIGRATION_NODE_THRESHOLD_RANGE
+    )
+    MIGRATION_CONCURRENCY_THRESHOLD_RANGE: ClassVar[ConfigRange] = (
+        _MIGRATION_CONCURRENCY_THRESHOLD_RANGE
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 모듈 로드 시점 기본값 정합성 검사 (Fail-fast — Python -O에서도 보장)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _ensure_default_in_range(name: str, val: int, r: ConfigRange) -> None:
+    if not (r.min <= val <= r.max):
+        raise RuntimeError(
+            f"[GRAPH][CONFIG][INVARIANT ERROR] Default {name}={val} is outside "
+            f"allowed range [{r.min}, {r.max}]. Check graph.py constants."
+        )
+
+
+_ensure_default_in_range(
+    "MAX_TRAVERSAL_DEPTH",
+    _DEFAULT_MAX_TRAVERSAL_DEPTH,
+    _MAX_TRAVERSAL_DEPTH_RANGE,
+)
+_ensure_default_in_range(
+    "MAX_GRAPH_NODES", _DEFAULT_MAX_GRAPH_NODES, _MAX_GRAPH_NODES_RANGE
+)
+_ensure_default_in_range(
+    "MIGRATION_NODE_THRESHOLD",
+    _DEFAULT_MIGRATION_NODE_THRESHOLD,
+    _MIGRATION_NODE_THRESHOLD_RANGE,
+)
+_ensure_default_in_range(
+    "MIGRATION_CONCURRENCY_THRESHOLD",
+    _DEFAULT_MIGRATION_CONCURRENCY_THRESHOLD,
+    _MIGRATION_CONCURRENCY_THRESHOLD_RANGE,
+)

--- a/backend/core/config/graph.py
+++ b/backend/core/config/graph.py
@@ -1,142 +1,51 @@
 # backend/core/config/graph.py
 
 """
-GraphConfig — Phase 4 (Knowledge Graph) 설정 스키마 및 기본값 정의
-==================================================================
+지식 그래프 설정 SSOT (Phase 4-0).
 
-역할 (4-0 SSOT 정책에 따른 책임 분리):
-  이 모듈은 지식 그래프 관련 환경 변수의 '스키마, 환경 변수 키, 기본값, 유효 범위'만 정의합니다.
-  실제 OS 환경 변수 로딩, Clamping, Subsystem(DEGRADED) 등록은
-  4-5 정책에 따라 `backend/core/config_validator.py`의 GraphValidator에 위임됩니다.
-
-하드코딩 금지:
-  모든 수치 상수·환경 변수 키 문자열은 이 모듈에만 중앙 정의합니다.
-  개별 모듈에서 값을 복사하거나 재정의하는 것을 금지합니다.
-
-민감 정보 보호:
-  `GRAPH_DB_URL` 등 연결 문자열은 로그에 원문을 남기지 않으며,
-  사용자 식별은 hashed_user_id 기반 테넌트 격리 정책을 따릅니다.
+환경 변수 키, 기본값, 유효 범위만 정의합니다.
+로딩·Clamping·Subsystem 등록은 GraphValidator(config_validator.py) 책임입니다.
 """
 
-from dataclasses import dataclass, field
-from typing import ClassVar
+from dataclasses import dataclass
 
 from backend.config import ConfigRange
 
-# ─────────────────────────────────────────────────────────────────────────────
-# 환경 변수 키 상수 (문자열 하드코딩 방지)
-# ─────────────────────────────────────────────────────────────────────────────
+# 환경 변수 키 (문자열 하드코딩 금지 — 모듈 SSOT)
+ENV_MAX_TRAVERSAL_DEPTH = "GRAPH_MAX_TRAVERSAL_DEPTH"
+ENV_MAX_GRAPH_NODES = "NEXT_PUBLIC_MAX_GRAPH_NODES"
+ENV_DB_URL = "GRAPH_DB_URL"
+ENV_MIGRATION_NODE_THRESHOLD = "GRAPH_MIGRATION_NODE_THRESHOLD"
+ENV_MIGRATION_CONCURRENCY_THRESHOLD = "GRAPH_MIGRATION_CONCURRENCY_THRESHOLD"
 
-_ENV_MAX_TRAVERSAL_DEPTH: str = "GRAPH_MAX_TRAVERSAL_DEPTH"
-_ENV_MAX_GRAPH_NODES: str = "NEXT_PUBLIC_MAX_GRAPH_NODES"
-_ENV_DB_URL: str = "GRAPH_DB_URL"
-_ENV_MIGRATION_NODE_THRESHOLD: str = "GRAPH_MIGRATION_NODE_THRESHOLD"
-_ENV_MIGRATION_CONCURRENCY_THRESHOLD: str = "GRAPH_MIGRATION_CONCURRENCY_THRESHOLD"
+# 기본값 (v9.4_knowledge_graph_tasks.md)
+DEFAULT_MAX_TRAVERSAL_DEPTH = 3
+DEFAULT_MAX_GRAPH_NODES = 500
+DEFAULT_DB_URL = ""
+DEFAULT_MIGRATION_NODE_THRESHOLD = 10000
+DEFAULT_MIGRATION_CONCURRENCY_THRESHOLD = 10
 
-# ─────────────────────────────────────────────────────────────────────────────
-# 유효 범위 상수 (Clamping 규칙 중앙 정의 — v9.4_knowledge_graph_tasks.md SSOT)
-# ─────────────────────────────────────────────────────────────────────────────
-
-_MAX_TRAVERSAL_DEPTH_RANGE: ConfigRange = ConfigRange(min=1, max=5)
-_MAX_GRAPH_NODES_RANGE: ConfigRange = ConfigRange(min=50, max=2000)
-_MIGRATION_NODE_THRESHOLD_RANGE: ConfigRange = ConfigRange(min=5000, max=50000)
-_MIGRATION_CONCURRENCY_THRESHOLD_RANGE: ConfigRange = ConfigRange(min=5, max=100)
-
-# ─────────────────────────────────────────────────────────────────────────────
-# 기본값 상수 (Magic Numbers 제거)
-# ─────────────────────────────────────────────────────────────────────────────
-
-_DEFAULT_MAX_TRAVERSAL_DEPTH: int = 3
-_DEFAULT_MAX_GRAPH_NODES: int = 500
-_DEFAULT_DB_URL: str = ""
-_DEFAULT_MIGRATION_NODE_THRESHOLD: int = 10000
-_DEFAULT_MIGRATION_CONCURRENCY_THRESHOLD: int = 10
-
-# ─────────────────────────────────────────────────────────────────────────────
-# 공개 상수 별칭 (외부·Validator 참조용)
-# ─────────────────────────────────────────────────────────────────────────────
-
-GRAPH_ENV_MAX_TRAVERSAL_DEPTH: str = _ENV_MAX_TRAVERSAL_DEPTH
-GRAPH_ENV_MAX_GRAPH_NODES: str = _ENV_MAX_GRAPH_NODES
-GRAPH_ENV_DB_URL: str = _ENV_DB_URL
-GRAPH_ENV_MIGRATION_NODE_THRESHOLD: str = _ENV_MIGRATION_NODE_THRESHOLD
-GRAPH_ENV_MIGRATION_CONCURRENCY_THRESHOLD: str = _ENV_MIGRATION_CONCURRENCY_THRESHOLD
-
-GRAPH_DEFAULT_MAX_TRAVERSAL_DEPTH: int = _DEFAULT_MAX_TRAVERSAL_DEPTH
-GRAPH_DEFAULT_MAX_GRAPH_NODES: int = _DEFAULT_MAX_GRAPH_NODES
-GRAPH_DEFAULT_DB_URL: str = _DEFAULT_DB_URL
-GRAPH_DEFAULT_MIGRATION_NODE_THRESHOLD: int = _DEFAULT_MIGRATION_NODE_THRESHOLD
-GRAPH_DEFAULT_MIGRATION_CONCURRENCY_THRESHOLD: int = (
-    _DEFAULT_MIGRATION_CONCURRENCY_THRESHOLD
-)
-
-GRAPH_MAX_TRAVERSAL_DEPTH_RANGE: ConfigRange = _MAX_TRAVERSAL_DEPTH_RANGE
-GRAPH_MAX_GRAPH_NODES_RANGE: ConfigRange = _MAX_GRAPH_NODES_RANGE
-GRAPH_MIGRATION_NODE_THRESHOLD_RANGE: ConfigRange = _MIGRATION_NODE_THRESHOLD_RANGE
-GRAPH_MIGRATION_CONCURRENCY_THRESHOLD_RANGE: ConfigRange = (
-    _MIGRATION_CONCURRENCY_THRESHOLD_RANGE
-)
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# GraphConfig 데이터 클래스 (명시적 타입 스키마 — 로딩 로직 없음)
-# ─────────────────────────────────────────────────────────────────────────────
+# Clamping 범위
+MAX_TRAVERSAL_DEPTH_RANGE = ConfigRange(min=1, max=5)
+MAX_GRAPH_NODES_RANGE = ConfigRange(min=50, max=2000)
+MIGRATION_NODE_THRESHOLD_RANGE = ConfigRange(min=5000, max=50000)
+MIGRATION_CONCURRENCY_THRESHOLD_RANGE = ConfigRange(min=5, max=100)
 
 
 @dataclass
 class GraphConfig:
     """
-    지식 그래프 파이프라인 런타임 설정 스키마.
+    지식 그래프 런타임 설정 스키마 (인스턴스 필드만).
 
-    이 클래스는 필드·기본값·환경 변수 키·유효 범위의 SSOT입니다.
-    `load()` 등 OS 환경 변수 읽기는 GraphValidator(config_validator.py)에서만 수행합니다.
-
-    사용 예시 (Validator 구현 후):
-        config: GraphConfig = graph_validator.load_graph_config()
-        depth = config.max_traversal_depth
+    상수(키·기본값·범위)는 이 모듈의 모듈 레벨 이름을 import하여 사용합니다.
+    OS 환경 변수 읽기는 GraphValidator에서만 수행합니다.
     """
 
-    max_traversal_depth: int = field(
-        default_factory=lambda: _DEFAULT_MAX_TRAVERSAL_DEPTH
-    )
-    max_graph_nodes: int = field(default_factory=lambda: _DEFAULT_MAX_GRAPH_NODES)
-    db_url: str = field(default_factory=lambda: _DEFAULT_DB_URL)
-    migration_node_threshold: int = field(
-        default_factory=lambda: _DEFAULT_MIGRATION_NODE_THRESHOLD
-    )
-    migration_concurrency_threshold: int = field(
-        default_factory=lambda: _DEFAULT_MIGRATION_CONCURRENCY_THRESHOLD
-    )
-
-    ENV_MAX_TRAVERSAL_DEPTH: ClassVar[str] = _ENV_MAX_TRAVERSAL_DEPTH
-    ENV_MAX_GRAPH_NODES: ClassVar[str] = _ENV_MAX_GRAPH_NODES
-    ENV_DB_URL: ClassVar[str] = _ENV_DB_URL
-    ENV_MIGRATION_NODE_THRESHOLD: ClassVar[str] = _ENV_MIGRATION_NODE_THRESHOLD
-    ENV_MIGRATION_CONCURRENCY_THRESHOLD: ClassVar[str] = (
-        _ENV_MIGRATION_CONCURRENCY_THRESHOLD
-    )
-
-    DEFAULT_MAX_TRAVERSAL_DEPTH: ClassVar[int] = _DEFAULT_MAX_TRAVERSAL_DEPTH
-    DEFAULT_MAX_GRAPH_NODES: ClassVar[int] = _DEFAULT_MAX_GRAPH_NODES
-    DEFAULT_DB_URL: ClassVar[str] = _DEFAULT_DB_URL
-    DEFAULT_MIGRATION_NODE_THRESHOLD: ClassVar[int] = _DEFAULT_MIGRATION_NODE_THRESHOLD
-    DEFAULT_MIGRATION_CONCURRENCY_THRESHOLD: ClassVar[int] = (
-        _DEFAULT_MIGRATION_CONCURRENCY_THRESHOLD
-    )
-
-    MAX_TRAVERSAL_DEPTH_RANGE: ClassVar[ConfigRange] = _MAX_TRAVERSAL_DEPTH_RANGE
-    MAX_GRAPH_NODES_RANGE: ClassVar[ConfigRange] = _MAX_GRAPH_NODES_RANGE
-    MIGRATION_NODE_THRESHOLD_RANGE: ClassVar[ConfigRange] = (
-        _MIGRATION_NODE_THRESHOLD_RANGE
-    )
-    MIGRATION_CONCURRENCY_THRESHOLD_RANGE: ClassVar[ConfigRange] = (
-        _MIGRATION_CONCURRENCY_THRESHOLD_RANGE
-    )
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# 모듈 로드 시점 기본값 정합성 검사 (Fail-fast — Python -O에서도 보장)
-# ─────────────────────────────────────────────────────────────────────────────
+    max_traversal_depth: int = DEFAULT_MAX_TRAVERSAL_DEPTH
+    max_graph_nodes: int = DEFAULT_MAX_GRAPH_NODES
+    db_url: str = DEFAULT_DB_URL
+    migration_node_threshold: int = DEFAULT_MIGRATION_NODE_THRESHOLD
+    migration_concurrency_threshold: int = DEFAULT_MIGRATION_CONCURRENCY_THRESHOLD
 
 
 def _ensure_default_in_range(name: str, val: int, r: ConfigRange) -> None:
@@ -147,21 +56,20 @@ def _ensure_default_in_range(name: str, val: int, r: ConfigRange) -> None:
         )
 
 
-_ensure_default_in_range(
-    "MAX_TRAVERSAL_DEPTH",
-    _DEFAULT_MAX_TRAVERSAL_DEPTH,
-    _MAX_TRAVERSAL_DEPTH_RANGE,
+_DEFAULT_INVARIANTS: tuple[tuple[str, int, ConfigRange], ...] = (
+    ("MAX_TRAVERSAL_DEPTH", DEFAULT_MAX_TRAVERSAL_DEPTH, MAX_TRAVERSAL_DEPTH_RANGE),
+    ("MAX_GRAPH_NODES", DEFAULT_MAX_GRAPH_NODES, MAX_GRAPH_NODES_RANGE),
+    (
+        "MIGRATION_NODE_THRESHOLD",
+        DEFAULT_MIGRATION_NODE_THRESHOLD,
+        MIGRATION_NODE_THRESHOLD_RANGE,
+    ),
+    (
+        "MIGRATION_CONCURRENCY_THRESHOLD",
+        DEFAULT_MIGRATION_CONCURRENCY_THRESHOLD,
+        MIGRATION_CONCURRENCY_THRESHOLD_RANGE,
+    ),
 )
-_ensure_default_in_range(
-    "MAX_GRAPH_NODES", _DEFAULT_MAX_GRAPH_NODES, _MAX_GRAPH_NODES_RANGE
-)
-_ensure_default_in_range(
-    "MIGRATION_NODE_THRESHOLD",
-    _DEFAULT_MIGRATION_NODE_THRESHOLD,
-    _MIGRATION_NODE_THRESHOLD_RANGE,
-)
-_ensure_default_in_range(
-    "MIGRATION_CONCURRENCY_THRESHOLD",
-    _DEFAULT_MIGRATION_CONCURRENCY_THRESHOLD,
-    _MIGRATION_CONCURRENCY_THRESHOLD_RANGE,
-)
+
+for _name, _val, _range in _DEFAULT_INVARIANTS:
+    _ensure_default_in_range(_name, _val, _range)


### PR DESCRIPTION
- **[백엔드] `backend/core/config/graph.py`**
  - `Phase 4-0` 정책에 따라 GraphConfig 데이터 클래스 신설 (로딩/검증 로직 없이 선언만 담당).
  - 환경 변수 키 SSOT 캡슐화: GRAPH_MAX_TRAVERSAL_DEPTH, NEXT_PUBLIC_MAX_GRAPH_NODES, GRAPH_DB_URL, GRAPH_MIGRATION_NODE_THRESHOLD, GRAPH_MIGRATION_CONCURRENCY_THRESHOLD.
  - v9.4 스펙 기준 기본값(3, 500, "", 10000, 10) 및 ConfigRange(Clamping 범위) 중앙 정의로 하드코딩 분산 방지.
  - 모듈 로드 시 기본값 정합성 검사(Fail-fast)로 잘못된 상수 조기 탐지.

🔗 Related: Issue [#1048]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

지식 그래프 런타임 설정을 위한 전용 설정 스키마 모듈을 도입합니다.

새 기능:
- 지식 그래프 관련 설정 필드, 해당 기본값, 환경 변수 키, 유효 범위를 위한 단일 신뢰 소스로서 `GraphConfig` 데이터클래스를 추가합니다.

개선 사항:
- 여기저기 흩어져 있던 매직 넘버와 문자열 키를 제거하기 위해, 지식 그래프 설정 상수, 기본값, 클램핑 범위를 새로운 `backend/core/config/graph.py` 모듈로 중앙 집중화합니다.
- 모듈 임포트 시점에 그래프 설정 기본값이 정의된 범위 내에 있는지 보장하기 위해 fail-fast 검증을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated configuration schema module for knowledge graph runtime settings.

New Features:
- Add a GraphConfig dataclass as the single source of truth for knowledge graph-related configuration fields, their defaults, environment variable keys, and valid ranges.

Enhancements:
- Centralize knowledge graph configuration constants, default values, and clamping ranges in a new backend/core/config/graph.py module to eliminate scattered magic numbers and string keys.
- Add fail-fast validation to ensure graph configuration default values stay within their defined ranges at module import time.

</details>