### PR TITLE
☘️ refactor [#12.3.5]: 3차 개선 - 서브시스템 도메인 상태(DISABLED vs DEGRADED) 분리 및 동적 로깅 지원

### DIFF
--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -54,6 +54,14 @@ class Subsystem(str, Enum):
     GRAPH_ENGINE = "graph_engine"  # Phase 4: 지식 그래프 엔진 서브시스템
 
 
+class SubsystemHealthState(str, Enum):
+    """서브시스템 상태 식별자 (로깅 및 가시성 목적)."""
+
+    DISABLED = "DISABLED"
+    DEGRADED = "DEGRADED"
+    UNHEALTHY = "UNHEALTHY"
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # 내부 파서 헬퍼 (모듈 내부 전용)
 # ─────────────────────────────────────────────────────────────────────────────
@@ -289,28 +297,34 @@ def _parse_float_clamped(
     return clamped
 
 
-def _log_disabled_subsystems(
+def _log_subsystem_state(
     subsystem_ok: Mapping[Subsystem, bool],
     *,
-    state_label: Literal["DISABLED", "DEGRADED", "UNHEALTHY"] = "DISABLED",
+    state_label: SubsystemHealthState = SubsystemHealthState.DISABLED,
 ) -> None:
-    """비활성화된/저하된 서브시스템 운영 가시성 로깅 헬퍼.
+    """서브시스템 상태(비활성/저하/비정상) 운영 가시성 로깅 헬퍼.
 
     Args:
         subsystem_ok: 서브시스템별 상태 플래그 (True: 정상, False: 비정상/비활성/저하).
-        state_label: 서브시스템 상태 레이블. 예: "DISABLED", "DEGRADED", "UNHEALTHY".
-                     각 설정 클래스의 도메인 의미(비활성/저하 등)에 맞게 호출부에서 지정.
+        state_label: 서브시스템 상태 레이블. 각 설정 클래스의 도메인 의미(비활성/저하 등)에 맞게 호출부에서 지정.
     """
     for sub, ok in subsystem_ok.items():
         if not ok:
             # sub는 Subsystem 타입임이 보장되므로, 명시적으로 .value를 호출하여 str로 변환
             sub_name: str = sub.value
-            logger.error(
+            
+            # 상태에 따른 동적 로그 레벨 할당
+            # DEGRADED, UNHEALTHY는 서비스가 유지되므로 WARNING, 
+            # DISABLED는 일부 기능이 정지되므로 ERROR 레벨 할당
+            log_level = logging.WARNING if state_label in (SubsystemHealthState.DEGRADED, SubsystemHealthState.UNHEALTHY) else logging.ERROR
+            
+            logger.log(
+                log_level,
                 "[CONFIG][SUBSYSTEM %s] '%s' subsystem is %s due to invalid "
                 "configuration. Register via HealthRegistry for /health exposure.",
-                state_label,
+                state_label.value,
                 sub_name,
-                state_label,
+                state_label.value,
             )
 
 
@@ -469,8 +483,8 @@ class PersonalizedRAGConfig:
             range_=cls._AWS_WORKERS_RANGE,
         )
 
-        # ── 4. 비활성화된 서브시스템 운영 가시성 로깅 ────────────────────
-        _log_disabled_subsystems(subsystem_ok)
+        # ── 4. 서브시스템 상태(비활성/저하/비정상) 운영 가시성 로깅 ──────────
+        _log_subsystem_state(subsystem_ok)
 
         return cls(
             storage_base_path=storage_base_path,
@@ -608,8 +622,8 @@ class RealtimeStreamingConfig:
             ok_ka and ok_buf and ok_to and ok_ver
         )
 
-        # ── 비활성화된 서브시스템 운영 가시성 로깅 (경계에서 .value 변환) ──
-        _log_disabled_subsystems(subsystem_ok, state_label="DEGRADED")
+        # ── 서브시스템 상태(비활성/저하/비정상) 운영 가시성 로깅 (경계에서 .value 변환) ──
+        _log_subsystem_state(subsystem_ok, state_label=SubsystemHealthState.DEGRADED)
 
         return cls(
             keepalive_interval_secs=keepalive,
@@ -745,8 +759,8 @@ class GraphEngineConfig:
             ok_depth and ok_nodes and ok_mn and ok_mc
         )
 
-        # ── 비활성화된 서브시스템 운영 가시성 로깅 ───────────────────────
-        _log_disabled_subsystems(subsystem_ok, state_label="DEGRADED")
+        # ── 서브시스템 상태(비활성/저하/비정상) 운영 가시성 로깅 ───────────────────────
+        _log_subsystem_state(subsystem_ok, state_label=SubsystemHealthState.DEGRADED)
 
         return cls(
             max_traversal_depth=max_depth,

--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import logging
 import os
 from enum import Enum
-from typing import Callable, ClassVar, Dict, Mapping
+from typing import Callable, ClassVar, Dict, Literal, Mapping
 
 # 프로젝트 공통 유틸 재사용 — 중복 구현 금지
 from backend.config import ConfigRange, _clamp
@@ -289,16 +289,28 @@ def _parse_float_clamped(
     return clamped
 
 
-def _log_disabled_subsystems(subsystem_ok: Mapping[Subsystem, bool]) -> None:
-    """비활성화된 서브시스템 운영 가시성 로깅 헬퍼."""
+def _log_disabled_subsystems(
+    subsystem_ok: Mapping[Subsystem, bool],
+    *,
+    state_label: Literal["DISABLED", "DEGRADED", "UNHEALTHY"] = "DISABLED",
+) -> None:
+    """비활성화된/저하된 서브시스템 운영 가시성 로깅 헬퍼.
+
+    Args:
+        subsystem_ok: 서브시스템별 상태 플래그 (True: 정상, False: 비정상/비활성/저하).
+        state_label: 서브시스템 상태 레이블. 예: "DISABLED", "DEGRADED", "UNHEALTHY".
+                     각 설정 클래스의 도메인 의미(비활성/저하 등)에 맞게 호출부에서 지정.
+    """
     for sub, ok in subsystem_ok.items():
         if not ok:
             # sub는 Subsystem 타입임이 보장되므로, 명시적으로 .value를 호출하여 str로 변환
             sub_name: str = sub.value
             logger.error(
-                "[CONFIG][SUBSYSTEM DISABLED] '%s' subsystem is DISABLED due to "
-                "invalid configuration. Register via HealthRegistry for /health exposure.",
+                "[CONFIG][SUBSYSTEM %s] '%s' subsystem is %s due to invalid "
+                "configuration. Register via HealthRegistry for /health exposure.",
+                state_label,
                 sub_name,
+                state_label,
             )
 
 
@@ -597,7 +609,7 @@ class RealtimeStreamingConfig:
         )
 
         # ── 비활성화된 서브시스템 운영 가시성 로깅 (경계에서 .value 변환) ──
-        _log_disabled_subsystems(subsystem_ok)
+        _log_disabled_subsystems(subsystem_ok, state_label="DEGRADED")
 
         return cls(
             keepalive_interval_secs=keepalive,
@@ -734,7 +746,7 @@ class GraphEngineConfig:
         )
 
         # ── 비활성화된 서브시스템 운영 가시성 로깅 ───────────────────────
-        _log_disabled_subsystems(subsystem_ok)
+        _log_disabled_subsystems(subsystem_ok, state_label="DEGRADED")
 
         return cls(
             max_traversal_depth=max_depth,


### PR DESCRIPTION
- **[가시성 개선] 공통 로깅 헬퍼(`_log_disabled_subsystems`) 고도화**
  - 고정된 `DISABLED` 하드코딩 문구를 제거하고 `state_label` 주입 파라미터 추가 (`Literal["DISABLED", "DEGRADED", "UNHEALTHY"]`).
  - 로그 메시지의 Prefix와 Body에 주입된 상태를 동적으로 렌더링하여 운영(Ops) 모니터링 시 정확한 장애 레벨 구분이 가능하도록 개선.

- **[의미론적(Semantic) 정합성 반영] 각 서브시스템별 상태 매핑**
  - `GraphEngineConfig`: 파싱 실패 시 NetworkX 우회 모드로 동작하므로 `state_label="DEGRADED"` 적용.
  - `RealtimeStreamingConfig`: 파싱 실패 시 비스트리밍 모드로 우회하므로 `state_label="DEGRADED"` 적용.
  - `PersonalizedRAGConfig`: 인덱스 접근 불가 시 즉시 비활성화되므로 기본값인 `DISABLED` 유지.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1473#pullrequestreview-4362057738)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

차별화된 서브시스템 상태 로깅을 지원하고, 특정 구성에 대해 Degraded 상태 매핑을 적용합니다.

개선 사항:
- 비활성화된 서브시스템 로깅 헬퍼를 일반화하여 동적 상태 레이블을 받을 수 있도록 하고, 운영 가시성을 위해 로그 메시지에 이를 렌더링합니다.
- 다른 서브시스템의 기존 동작은 유지하면서, `RealtimeStreamingConfig` 및 `GraphEngineConfig` 실패를 서브시스템 상태 `DEGRADED`로 매핑합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support differentiated subsystem state logging and apply degraded state mapping for specific configs.

Enhancements:
- Generalize the disabled subsystem logging helper to accept a dynamic state label and render it in log messages for operational visibility.
- Map RealtimeStreamingConfig and GraphEngineConfig failures to a DEGRADED subsystem state while retaining existing semantics for other subsystems.

</details>