### PR TITLE
☘️ refactor [#12.3.5]: 7차 개선 - `SubsystemHealthState`에 `log_level` SSOT 내장

### DIFF
--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -55,43 +55,23 @@ class Subsystem(str, Enum):
 
 
 class SubsystemHealthState(str, Enum):
-    """서브시스템 상태 식별자 (로깅 및 가시성 목적)."""
+    """서브시스템 상태 식별자 및 로그 레벨 SSOT (로깅·가시성).
 
-    DISABLED = "DISABLED"
-    DEGRADED = "DEGRADED"
-
-
-# OCP(Open-Closed Principle): 상태별 로그 레벨 SSOT — Enum 멤버 추가 시 매핑 필수
-_LEVEL_BY_STATE: Dict[SubsystemHealthState, int] = {
-    SubsystemHealthState.DISABLED: logging.ERROR,
-    SubsystemHealthState.DEGRADED: logging.WARNING,
-}
-
-
-def _resolve_subsystem_log_level(state_label: SubsystemHealthState) -> int:
+    각 멤버는 (label, log_level)을 함께 정의한다.
+    신규 상태 추가 시 __new__에 log_level을 반드시 지정해야 하며,
+    별도 전역 매핑 dict 없이 enum 정의만으로 Fail-fast·OCP를 만족한다.
     """
-    SubsystemHealthState에 대응하는 로그 레벨을 반환한다.
 
-    매핑 누락 시 조용히 ERROR로 폴백하지 않고 즉시 실패(Fail-fast)하여,
-    경미한 신규 상태가 과도한 심각도로 로깅되는 운영 사고를 방지한다.
-    """
-    try:
-        return _LEVEL_BY_STATE[state_label]
-    except KeyError as exc:
-        mapped = ", ".join(s.value for s in _LEVEL_BY_STATE)
-        raise RuntimeError(
-            f"[CONFIG][SUBSYSTEM] No log level mapping for state {state_label.value!r}. "
-            f"Add an entry to _LEVEL_BY_STATE. Currently mapped: {mapped}"
-        ) from exc
+    DISABLED = ("DISABLED", logging.ERROR)
+    DEGRADED = ("DEGRADED", logging.WARNING)
 
+    log_level: int
 
-for _state in SubsystemHealthState:
-    if _state not in _LEVEL_BY_STATE:
-        raise RuntimeError(
-            f"[CONFIG][SUBSYSTEM][INVARIANT ERROR] SubsystemHealthState."
-            f"{_state.name} is not mapped in _LEVEL_BY_STATE. "
-            "Every enum member must have an explicit log level."
-        )
+    def __new__(cls, label: str, log_level: int) -> "SubsystemHealthState":
+        obj = str.__new__(cls, label)
+        obj._value_ = label
+        obj.log_level = log_level
+        return obj
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -344,7 +324,7 @@ def _log_subsystem_state(
         subsystem_ok: 서브시스템별 상태 플래그 (True: 정상, False: state_label 해당).
         state_label: 비정상 서브시스템에 부여할 상태 레이블 (호출부에서 DISABLED 또는 DEGRADED).
     """
-    log_level = _resolve_subsystem_log_level(state_label)
+    log_level = state_label.log_level
 
     for sub, ok in subsystem_ok.items():
         if not ok:


### PR DESCRIPTION
- **[백엔드] `backend/core/config_validator.py`**
  - `SubsystemHealthState` 멤버별 (label, log_level)을 `__new__`로 정의하여 로그 레벨 SSOT를 enum 단일 위치로 통합.
  - _LEVEL_BY_STATE, _resolve_subsystem_log_level, import 시 invariant 루프 제거로 간접층·import 실패 리스크 감소.
  - _log_subsystem_state는 state_label.log_level을 직접 사용 (DISABLED→ERROR, DEGRADED→WARNING 동작 유지).
  - 신규 상태 추가 시 log_level 미지정은 정의 시점에서 드러나 OCP·Fail-fast 목표 유지.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1477#pullrequestreview-4362773021)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

SubsystemHealthState 열거형(enum)에 로그 레벨 설정을 인라인(inline)하여 서브시스템 헬스 로그 레벨의 단일 진실 소스(single source of truth)로 만들었습니다.

개선 사항:
- 로그 레벨 메타데이터를 SubsystemHealthState 열거형 각 멤버에 직접 연결하고, 별도로 존재하던 전역 매핑과 resolver 함수를 제거했습니다.
- 서브시스템 상태 로깅에서 간접 조회와 불변성(invariant) 검사를 사용하는 대신, 열거형의 `log_level` 속성을 바로 참조하도록 단순화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Inline log level configuration into SubsystemHealthState enum to make it the single source of truth for subsystem health log levels.

Enhancements:
- Attach log level metadata directly to SubsystemHealthState enum members and remove the separate global mapping and resolver function.
- Simplify subsystem state logging to consume the enum’s log_level attribute instead of using an indirect lookup and invariant checks.

</details>