### PR TITLE
☘️ refactor [#12.3.5]: 10차 개선 - `SubsystemHealthState` 과잉 설계 제거 및 `__new__` 인라인 단순화

### DIFF
--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -54,58 +54,46 @@ class Subsystem(str, Enum):
     GRAPH_ENGINE = "graph_engine"  # Phase 4: 지식 그래프 엔진 서브시스템
 
 
-# SubsystemHealthState 전용 — 표준 logging 모듈 상수만 허용 (임의 정수 하드코딩 금지)
-_SUBSYSTEM_HEALTH_KNOWN_LOG_LEVELS: frozenset[int] = frozenset(
-    {
-        logging.NOTSET,
-        logging.DEBUG,
-        logging.INFO,
-        logging.WARNING,
-        logging.ERROR,
-        logging.CRITICAL,
-    }
-)
-
-
 class SubsystemHealthState(str, Enum):
     """서브시스템 상태 식별자 및 로그 레벨 SSOT (로깅·가시성).
 
     각 멤버는 (label, log_level)을 함께 정의한다.
     신규 상태 추가 시 __new__에 표준 logging 레벨 상수를 반드시 지정한다.
     log_level은 읽기 전용 property로만 노출된다.
-    허용 log_level 집합: _SUBSYSTEM_HEALTH_KNOWN_LOG_LEVELS (이 enum 전용).
     """
+
+    # 이 enum 전용 — 표준 logging 모듈 상수만 허용 (임의 정수 하드코딩 금지)
+    # dunder(__) 이름을 사용하여 Enum 멤버로 취급되는 것을 완전히 차단하고, 일반 ClassVar로 동작하게 한다.
+    __ALLOWED_LOG_LEVELS__: ClassVar[frozenset[int]] = frozenset(
+        {
+            logging.NOTSET,
+            logging.DEBUG,
+            logging.INFO,
+            logging.WARNING,
+            logging.ERROR,
+            logging.CRITICAL,
+        }
+    )
 
     DISABLED = ("DISABLED", logging.ERROR)
     DEGRADED = ("DEGRADED", logging.WARNING)
 
     _log_level: int
 
-    @classmethod
-    def _ensure_valid_log_level(
-        cls,
-        label: str,
-        log_level: int,
-        exc_type: type[Exception],
-    ) -> int:
-        """log_level 타입·허용 값 검증 SSOT (__new__에서만 호출)."""
+    def __new__(cls, label: str, log_level: int) -> "SubsystemHealthState":
         if not isinstance(log_level, int):
-            raise exc_type(
+            raise ValueError(
                 f"[CONFIG][SUBSYSTEM] SubsystemHealthState.{label!r} requires "
                 f"log_level to be int, got {type(log_level).__name__}."
             )
-        if log_level not in _SUBSYSTEM_HEALTH_KNOWN_LOG_LEVELS:
-            raise exc_type(
+        if log_level not in cls.__ALLOWED_LOG_LEVELS__:
+            raise ValueError(
                 f"[CONFIG][SUBSYSTEM] SubsystemHealthState.{label!r} has invalid "
                 f"log_level={log_level}. Use a standard logging.* constant."
             )
-        return log_level
-
-    def __new__(cls, label: str, log_level: int) -> "SubsystemHealthState":
-        validated_level = cls._ensure_valid_log_level(label, log_level, ValueError)
         obj = str.__new__(cls, label)
         obj._value_ = label
-        obj._log_level = validated_level
+        obj._log_level = log_level
         return obj
 
     @property


### PR DESCRIPTION
- **[응집성 강화] 검증 집합(_ALLOWED_LOG_LEVELS)을 Enum 내부 ClassVar로 이동**
  - 모듈 전역 `_SUBSYSTEM_HEALTH_KNOWN_LOG_LEVELS` frozenset 제거 → 모듈 네임스페이스 오염 방지.
  - `ClassVar[frozenset[int]]`로 Enum 내부에 선언하여 "이 Enum 전용"임을 구조로 표현.
- **[단순화] `_ensure_valid_log_level` 헬퍼 classmethod 제거**
  - `exc_type: type[Exception]` 파라미터는 실제로 항상 `ValueError`만 사용 → 불필요한 범용성 제거.
  - 검증 로직을 `__new__` 내부에 직접 인라인하여 빠른 실패(Fail-Fast) 명확화.
  - `log_level` 읽기 전용 property 및 3개 호출부 동작 무변경 확인.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1481#pullrequestreview-4362944167)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

`SubsystemHealthState`를 리팩터링하여 로그 레벨 검증을 enum 내부에 캡슐화하고, enum 생성 방식을 단순화합니다.

개선 사항:
- 허용되는 로그 레벨 집합을 클래스 수준 상수로 `SubsystemHealthState` 내부로 옮겨, 그 범위를 enum으로 제한합니다.
- 로그 레벨 검증을 `SubsystemHealthState.__new__` 안으로 직접 인라인하고, 사용되지 않는 도우미 classmethod를 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor SubsystemHealthState to encapsulate log-level validation within the enum and simplify enum construction.

Enhancements:
- Move the allowed log-level set into SubsystemHealthState as a class-level constant to limit its scope to the enum.
- Inline log-level validation directly into SubsystemHealthState.__new__ and remove the unused helper classmethod.

</details>