### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -54,58 +54,46 @@ class Subsystem(str, Enum):
     GRAPH_ENGINE = "graph_engine"  # Phase 4: 지식 그래프 엔진 서브시스템
 
 
-# SubsystemHealthState 전용 — 표준 logging 모듈 상수만 허용 (임의 정수 하드코딩 금지)
-_SUBSYSTEM_HEALTH_KNOWN_LOG_LEVELS: frozenset[int] = frozenset(
-    {
-        logging.NOTSET,
-        logging.DEBUG,
-        logging.INFO,
-        logging.WARNING,
-        logging.ERROR,
-        logging.CRITICAL,
-    }
-)
-
-
 class SubsystemHealthState(str, Enum):
     """서브시스템 상태 식별자 및 로그 레벨 SSOT (로깅·가시성).
 
     각 멤버는 (label, log_level)을 함께 정의한다.
     신규 상태 추가 시 __new__에 표준 logging 레벨 상수를 반드시 지정한다.
     log_level은 읽기 전용 property로만 노출된다.
-    허용 log_level 집합: _SUBSYSTEM_HEALTH_KNOWN_LOG_LEVELS (이 enum 전용).
     """
+
+    # 이 enum 전용 — 표준 logging 모듈 상수만 허용 (임의 정수 하드코딩 금지)
+    # dunder(__) 이름을 사용하여 Enum 멤버로 취급되는 것을 완전히 차단하고, 일반 ClassVar로 동작하게 한다.
+    __ALLOWED_LOG_LEVELS__: ClassVar[frozenset[int]] = frozenset(
+        {
+            logging.NOTSET,
+            logging.DEBUG,
+            logging.INFO,
+            logging.WARNING,
+            logging.ERROR,
+            logging.CRITICAL,
+        }
+    )
 
     DISABLED = ("DISABLED", logging.ERROR)
     DEGRADED = ("DEGRADED", logging.WARNING)
 
     _log_level: int
 
-    @classmethod
-    def _ensure_valid_log_level(
-        cls,
-        label: str,
-        log_level: int,
-        exc_type: type[Exception],
-    ) -> int:
-        """log_level 타입·허용 값 검증 SSOT (__new__에서만 호출)."""
+    def __new__(cls, label: str, log_level: int) -> "SubsystemHealthState":
         if not isinstance(log_level, int):
-            raise exc_type(
+            raise ValueError(
                 f"[CONFIG][SUBSYSTEM] SubsystemHealthState.{label!r} requires "
                 f"log_level to be int, got {type(log_level).__name__}."
             )
-        if log_level not in _SUBSYSTEM_HEALTH_KNOWN_LOG_LEVELS:
-            raise exc_type(
+        if log_level not in cls.__ALLOWED_LOG_LEVELS__:
+            raise ValueError(
                 f"[CONFIG][SUBSYSTEM] SubsystemHealthState.{label!r} has invalid "
                 f"log_level={log_level}. Use a standard logging.* constant."
             )
-        return log_level
-
-    def __new__(cls, label: str, log_level: int) -> "SubsystemHealthState":
-        validated_level = cls._ensure_valid_log_level(label, log_level, ValueError)
         obj = str.__new__(cls, label)
         obj._value_ = label
-        obj._log_level = validated_level
+        obj._log_level = log_level
         return obj
 
     @property


### PR DESCRIPTION
☘️ refactor [#12.3.5]: 10차 개선 - `SubsystemHealthState` 과잉 설계 제거 및 `__new__` 인라인 단순화

## Summary by Sourcery

엄격한 허용 로그 레벨 검증을 유지하면서 `SubsystemHealthState` enum을 단순화합니다.

개선 사항:
- 보조 검증 헬퍼를 제거하고, 로그 레벨 검증 로직을 `SubsystemHealthState.__new__` 내부에 직접 인라인합니다.
- 별도의 모듈 수준 상수에 의존하지 않고, 허용되는 로그 레벨을 저장하기 위한 내부 `ClassVar`를 도입합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the SubsystemHealthState enum while preserving strict validation of allowed logging levels.

Enhancements:
- Inline log-level validation logic directly in SubsystemHealthState.__new__ and remove the auxiliary validation helper.
- Introduce an internal ClassVar to hold the allowed logging levels instead of relying on a separate module-level constant.

</details>