### PR TITLE
✨ feat [#12.3.6]: Phase 4-5 - ➁ `HealthRegistry is_ok` 인터페이스 신설 및 SSOT 캡슐화 보장

### DIFF
--- a/backend/core/health_registry.py
+++ b/backend/core/health_registry.py
@@ -378,7 +378,11 @@ class HealthRegistry:
 
     # ── 개별/전체 상태 판정 (SSOT 연동용) ────────────────────────────────
 
-    def is_ok(self, subsystem: str | Enum) -> bool:
+    def is_ok(
+        self,
+        subsystem: str | Enum,
+        precomputed_summary: Optional[Dict[str, str]] = None,
+    ) -> bool:
         """
         특정 서브시스템의 상태가 정상(HEALTHY)인지 단일 진실 공급원(SSOT)을 통해 확인한다.
         
@@ -388,14 +392,16 @@ class HealthRegistry:
 
         Args:
             subsystem: 확인할 서브시스템 식별자 (문자열 또는 Enum)
+            precomputed_summary: (선택) 최적화를 위한 사전 조회된 상태 요약 딕셔너리.
+                                 루프 내 등에서 반복 호출 시 Redis I/O를 최소화하기 위해 사용.
         """
         if isinstance(subsystem, Enum):
-            key = subsystem.value
+            # Enum의 값이 문자열이 아닐 경우(예: 정수형 Enum)를 대비하여 명시적으로 문자열 변환
+            key = str(subsystem.value)
         else:
-            # subsystem은 이미 str 또는 str로 취급 가능한 타입
-            key = subsystem
+            key = str(subsystem)
             
-        summary = self.get_summary()
+        summary = precomputed_summary if precomputed_summary is not None else self.get_summary()
         status = summary.get(key)
         
         return status is None or status == SubsystemStatus.HEALTHY.value

--- a/backend/core/health_registry.py
+++ b/backend/core/health_registry.py
@@ -376,7 +376,29 @@ class HealthRegistry:
         remaining = self._redis_fallback_ttl_secs - elapsed
         return max(0.0, remaining)
 
-    # ── 전체 상태 판정 (/health 응답용) ──────────────────────────────────
+    # ── 개별/전체 상태 판정 (SSOT 연동용) ────────────────────────────────
+
+    def is_ok(self, subsystem: str | Enum) -> bool:
+        """
+        특정 서브시스템의 상태가 정상(HEALTHY)인지 단일 진실 공급원(SSOT)을 통해 확인한다.
+        
+        - 라우터 및 애플리케이션 계층에서 서브시스템 가동 여부 판별에 사용 (Fail-fast 연결).
+        - 상태가 아직 보고되지 않은(None) 서브시스템은 기본적으로 정상(HEALTHY)으로 간주한다.
+        - 명시적인 DEGRADED 또는 FAILED 상태일 경우 False를 반환한다.
+
+        Args:
+            subsystem: 확인할 서브시스템 식별자 (문자열 또는 Enum)
+        """
+        if isinstance(subsystem, Enum):
+            key = subsystem.value
+        else:
+            # subsystem은 이미 str 또는 str로 취급 가능한 타입
+            key = subsystem
+            
+        summary = self.get_summary()
+        status = summary.get(key)
+        
+        return status is None or status == SubsystemStatus.HEALTHY.value
 
     def is_healthy(self) -> bool:
         """


### PR DESCRIPTION
- 라우터 및 애플리케이션 계층에서 서브시스템 상태(DEGRADED/FAILED)를 안전하게 판별할 수 있도록 `is_ok` 메서드 추가
- 미보고된 서브시스템은 기본적으로 정상(HEALTHY)으로 간주하여 하위 호환성 유지
- 문자열 및 Enum 타입 식별자를 모두 지원하여 호출부의 유연성 확보
- 서브시스템 상태 검증의 단일 진실 공급원(SSOT)으로 작동하도록 설계 구조 강제화

🔗 Related: Issue [#1048]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

새로운 기능:
- 특정 하위 시스템이 정상(healthy) 상태로 간주되는지를 판단하기 위한 `HealthRegistry.is_ok` 인터페이스를 도입했습니다. 이전 버전과의 호환성을 위해 보고되지 않은 하위 시스템은 기본적으로 정상 상태로 처리됩니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce a HealthRegistry.is_ok interface to determine whether a given subsystem is considered healthy, defaulting unreported subsystems to healthy for backward compatibility.

</details>