### PR TITLE
☘️ refactor [#12.3.6]: 6차 개선 - `is_ok` 오용 방지를 위한 명시적 `TypeError` 도입

### DIFF
--- a/backend/core/health_registry.py
+++ b/backend/core/health_registry.py
@@ -404,8 +404,10 @@ class HealthRegistry:
         elif isinstance(subsystem, str):
             key = subsystem
         else:
-            # 런타임 방어적 코딩: 타입 힌트와 다른 타입이 예기치 않게 들어온 경우 문자열로 안전하게 강제 변환
-            key = str(subsystem)
+            raise TypeError(
+                f"[HEALTH_REGISTRY] Unsupported subsystem type: {type(subsystem).__name__}. "
+                "subsystem must be a string or Enum."
+            )
             
         summary = precomputed_summary if precomputed_summary is not None else self.get_summary()
         status = summary.get(key)


### PR DESCRIPTION
- API 오용을 방지하기 위해 str 또는 Enum이 아닌 예기치 않은 타입 유입 시 조용히 캐스팅하는 대신 명시적인 TypeError를 raise하도록 개선 (Fail-fast 원칙 적용)
- 허용되는 타입 분기를 명확히 하여 정적 린터 호환성을 유지하고, 런타임 방어 로직의 단순함과 엄격함 확보

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1489#pullrequestreview-4378151657)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

헬스 체크 서브시스템 식별자에 대해 엄격한 타입 검증을 적용하여, 잘못된 입력 타입이 들어올 경우 즉시 실패하도록 합니다.

버그 수정:
- 식별자가 문자열도 아니고 Enum도 아닐 때 `TypeError`를 발생시켜, 예기치 않은 서브시스템 타입이 조용히 캐스팅되는 문제를 방지합니다.

개선 사항:
- 헬스 레지스트리의 `is_ok` 체크에서 런타임 타입 처리를 더 명확하고 견고하게 만들어, API 오용을 보다 잘 방지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce strict type validation for health check subsystem identifiers to fail fast on invalid input types.

Bug Fixes:
- Prevent silent casting of unexpected subsystem types by raising a TypeError when the identifier is neither a string nor an Enum.

Enhancements:
- Clarify and harden runtime type handling in health registry is_ok checks to better guard against API misuse.

</details>