### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/core/health_registry.py
+++ b/backend/core/health_registry.py
@@ -404,8 +404,10 @@ class HealthRegistry:
         elif isinstance(subsystem, str):
             key = subsystem
         else:
-            # 런타임 방어적 코딩: 타입 힌트와 다른 타입이 예기치 않게 들어온 경우 문자열로 안전하게 강제 변환
-            key = str(subsystem)
+            raise TypeError(
+                f"[HEALTH_REGISTRY] Unsupported subsystem type: {type(subsystem).__name__}. "
+                "subsystem must be a string or Enum."
+            )
             
         summary = precomputed_summary if precomputed_summary is not None else self.get_summary()
         status = summary.get(key)


### PR DESCRIPTION
☘️ refactor [#12.3.6]: 6차 개선 - `is_ok` 오용 방지를 위한 명시적 TypeError 도입

## Summary by Sourcery

버그 수정:
- 지원되지 않는 입력에 대해 `TypeError`를 발생시켜, `health_registry.is_ok`에서 잘못된 서브시스템 타입이 조용히 허용되는 문제를 방지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent silent acceptance of invalid subsystem types in health_registry.is_ok by raising a TypeError for unsupported inputs.

</details>