### PR TITLE
☘️ refactor [#12.3.8]: 2차 개선 - 동시성 병목(Lock contention) 최적화 및 하드코딩/테스트 보강

### DIFF
--- a/backend/graph/networkx_repository.py
+++ b/backend/graph/networkx_repository.py
@@ -46,10 +46,8 @@ class NetworkXGraphRepository(AbstractGraphRepository):
         repo.persist(hashed_user_id)       # 파일시스템 영속화
 
     스레드 안전성:
-        뮤테이션(add_node/remove_node/add_edge/remove_edge/persist/load/clear) 호출은
-        사용자별 threading.Lock으로 직렬화된다.
-        읽기 전용 쿼리(has_node/has_edge/neighbors/node_count/iter_nodes)는
-        Lock 없이 호출 가능하지만, 동시 뮤테이션 중에는 일관성이 보장되지 않는다.
+        모든 뮤테이션 및 읽기 쿼리는 사용자별 threading.Lock으로 직렬화되어
+        동시 변이 중 일관성을 보장한다. (사용자 간에는 완전 병렬 처리 가능)
     """
 
     def __init__(self, storage_base_path: str) -> None:
@@ -86,14 +84,23 @@ class NetworkXGraphRepository(AbstractGraphRepository):
         """
         사용자 DiGraph를 반환한다. 없으면 빈 DiGraph를 생성하여 등록한다.
 
-        _meta_lock 없이 호출 가능 (이미 획득된 컨텍스트에서 호출).
+        _graphs 딕셔너리 변경은 _meta_lock으로 보호하여 스레드 안전성을 보장한다.
         """
-        if hashed_user_id not in self._graphs:
-            self._graphs[hashed_user_id] = nx.DiGraph()
-        return self._graphs[hashed_user_id]
+        g = self._graphs.get(hashed_user_id)
+        if g is not None:
+            return g
+        
+        with self._meta_lock:
+            if hashed_user_id not in self._graphs:
+                self._graphs[hashed_user_id] = nx.DiGraph()
+            return self._graphs[hashed_user_id]
 
     def _get_user_lock(self, hashed_user_id: str) -> threading.Lock:
-        """사용자별 Lock을 반환하고, 없으면 생성한다."""
+        """사용자별 Lock을 반환하고, 없으면 생성한다 (Double-checked locking)."""
+        lock = self._locks.get(hashed_user_id)
+        if lock is not None:
+            return lock
+            
         with self._meta_lock:
             if hashed_user_id not in self._locks:
                 self._locks[hashed_user_id] = threading.Lock()
@@ -327,9 +334,10 @@ class NetworkXGraphRepository(AbstractGraphRepository):
             # 디렉토리 보장 — 부모가 없으면 생성
             target_path.parent.mkdir(parents=True, exist_ok=True)
 
-            # 원자적 쓰기: 임시 파일 → rename
-            tmp_suffix = f".graphml.{uuid.uuid4().hex}.tmp"
-            tmp_path = target_path.with_suffix(tmp_suffix)
+            # 원자적 쓰기: 임시 파일 → rename (확장자 로직과 독립적으로 이름 구성)
+            tmp_path = target_path.with_name(
+                f"{target_path.name}.{uuid.uuid4().hex}.tmp"
+            )
 
             try:
                 nx.write_graphml(g, str(tmp_path))

--- a/tests/unit/test_graph_repository.py
+++ b/tests/unit/test_graph_repository.py
@@ -208,6 +208,27 @@ class TestEdgeCRUD:
         assert repo.has_edge(_DUMMY_HASH_A, "a", "b") is True
         assert repo.has_edge(_DUMMY_HASH_A, "b", "a") is False
 
+    def test_get_edge_attrs_returns_none_for_absent(
+        self, repo: NetworkXGraphRepository
+    ) -> None:
+        assert repo.get_edge_attrs(_DUMMY_HASH_A, "ghost-src", "ghost-tgt") is None
+
+    def test_get_edge_attrs_returns_defensive_copy(
+        self, repo: NetworkXGraphRepository
+    ) -> None:
+        """반환된 dict 변경이 내부 상태에 영향을 주지 않아야 한다."""
+        repo.add_node(_DUMMY_HASH_A, "src")
+        repo.add_node(_DUMMY_HASH_A, "tgt")
+        repo.add_edge(_DUMMY_HASH_A, "src", "tgt", weight=1.0)
+        
+        attrs = repo.get_edge_attrs(_DUMMY_HASH_A, "src", "tgt")
+        assert attrs is not None
+        attrs["weight"] = 2.0
+        
+        attrs_again = repo.get_edge_attrs(_DUMMY_HASH_A, "src", "tgt")
+        assert attrs_again is not None
+        assert attrs_again["weight"] == 1.0
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # BFS 탐색 (neighbors)
@@ -223,9 +244,8 @@ class TestNeighbors:
     def _build_chain(self, repo: NetworkXGraphRepository) -> None:
         """A → B → C → D 체인 그래프."""
         self._add_abcd_nodes(repo)
-        repo.add_edge(_DUMMY_HASH_A, "A", "B")
-        repo.add_edge(_DUMMY_HASH_A, "B", "C")
-        repo.add_edge(_DUMMY_HASH_A, "C", "D")
+        for src, tgt in [("A", "B"), ("B", "C"), ("C", "D")]:
+            repo.add_edge(_DUMMY_HASH_A, src, tgt)
 
     def test_depth_1_returns_direct_successor(
         self, repo: NetworkXGraphRepository
@@ -255,10 +275,8 @@ class TestNeighbors:
     ) -> None:
         """A → B, A → C, B → D, C → D 다이아몬드 — D 중복 없음."""
         self._add_abcd_nodes(repo)
-        repo.add_edge(_DUMMY_HASH_A, "A", "B")
-        repo.add_edge(_DUMMY_HASH_A, "A", "C")
-        repo.add_edge(_DUMMY_HASH_A, "B", "D")
-        repo.add_edge(_DUMMY_HASH_A, "C", "D")
+        for src, tgt in [("A", "B"), ("A", "C"), ("B", "D"), ("C", "D")]:
+            repo.add_edge(_DUMMY_HASH_A, src, tgt)
         result = repo.neighbors(_DUMMY_HASH_A, "A", max_depth=2)
         assert result.count("D") == 1
 
@@ -308,6 +326,18 @@ class TestStatistics:
 
 
 class TestPersistence:
+    def test_load_raises_on_invalid_graphml(
+        self, repo: NetworkXGraphRepository, storage_path: str
+    ) -> None:
+        invalid_path = build_graph_path(_DUMMY_HASH_A, storage_path)
+        invalid_path.parent.mkdir(parents=True, exist_ok=True)
+        invalid_path.write_text("this is not valid GraphML", encoding="utf-8")
+
+        # When the persisted GraphML is corrupted/invalid, load should propagate
+        # the underlying failure rather than silently succeeding.
+        with pytest.raises(Exception):
+            repo.load(_DUMMY_HASH_A)
+
     def test_persist_creates_file(
         self, repo: NetworkXGraphRepository, storage_path: str
     ) -> None:

--- a/tests/unit/test_graph_repository.py
+++ b/tests/unit/test_graph_repository.py
@@ -335,7 +335,9 @@ class TestPersistence:
 
         # When the persisted GraphML is corrupted/invalid, load should propagate
         # the underlying failure rather than silently succeeding.
-        with pytest.raises(Exception):
+        import xml.etree.ElementTree as ET
+        import networkx as nx
+        with pytest.raises((ET.ParseError, nx.NetworkXError)):
             repo.load(_DUMMY_HASH_A)
 
     def test_persist_creates_file(


### PR DESCRIPTION
- **동시성 병목 해소**: `_get_user_lock`에 Double-checked locking 패턴을 적용하여, 읽기 쿼리 시 불필요한 `_meta_lock` 경합을 제거하고 높은 병렬 처리 성능 확보.

- **안전한 딕셔너리 접근**: `_get_or_create_graph` 내 `_graphs` 맵 쓰기 연산 시 `_meta_lock`을 강제하여 미세한 레이스 컨디션 차단.

- **하드코딩 제거**: 임시 파일 생성 시 `.graphml` 확장자를 하드코딩하지 않고, `target_path.name`을 활용하여 경로 유틸리티와의 결합도(Coupling) 제거.

- **계약 및 예외 테스트 강화**:
  - 읽기 연산도 락으로 직렬화된다는 최신 동기화 모델에 맞게 Docstring 수정.
  - 엣지 속성의 Defensive copy 검증 및 손상된 GraphML 파일 로드 시 Fail-fast(예외 전파) 작동 여부 검증 테스트 추가.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1495#pullrequestreview-4394897535)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

그래프 저장소의 동시성 처리와 영속성을 최적화하고, 계약(Contract) 및 에러 동작 테스트를 강화합니다.

Enhancements:
- 사용자별 그래프 딕셔너리 변경이 메타 락(meta lock)에 의해 보호되도록 하고, 그래프 및 락 조회 시 이중 확인(double-checked) 방식을 사용해 락 경합(lock contention)을 줄입니다.
- GraphML 영속성에서 임시 파일 이름을 파일 확장자와 독립적으로 생성하도록 조정하여, 특정 접미사에 대한 결합도를 낮춥니다.
- 저장소의 스레드 안정성(thread-safety) 문서를 명확히 하여, 사용자별 읽기와 쓰기가 모두 직렬화된 접근(serialized access)을 따른다는 점을 반영합니다.

Tests:
- `get_edge_attrs`가 존재하지 않는 엣지에 대해 `None`을 반환하는지, 그리고 내부 상태를 변경하지 않는 방어적 복사(defensive copy)를 제공하는지 검증하는 테스트를 추가합니다.
- 손상된 GraphML 파일을 로드할 때 조용히 실패하지 않고 예외를 발생시키는지 확인하는 회귀(regression) 테스트를 추가합니다.
- 그래프 생성 헬퍼 테스트를 리팩터링하여, source/target 쌍에 대한 간결한 반복(iteration)을 통해 엣지를 구성하도록 변경합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize graph repository concurrency handling and persistence while strengthening contract and error behavior tests.

Enhancements:
- Ensure per-user graph dictionary mutations are protected by a meta lock and reduce lock contention via double-checked retrieval for graphs and locks.
- Adjust GraphML persistence to build temporary filenames independent of the file extension, reducing coupling to specific suffixes.
- Clarify repository thread-safety documentation to reflect serialized access for both reads and writes per user.

Tests:
- Add tests verifying get_edge_attrs returns None for missing edges and provides a defensive copy that does not mutate internal state.
- Add a regression test ensuring loading a corrupted GraphML file raises an exception instead of failing silently.
- Refactor graph-building helper tests to construct edges via compact iteration over source/target pairs.

</details>