### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/graph/networkx_repository.py
+++ b/backend/graph/networkx_repository.py
@@ -46,10 +46,8 @@ class NetworkXGraphRepository(AbstractGraphRepository):
         repo.persist(hashed_user_id)       # 파일시스템 영속화
 
     스레드 안전성:
-        뮤테이션(add_node/remove_node/add_edge/remove_edge/persist/load/clear) 호출은
-        사용자별 threading.Lock으로 직렬화된다.
-        읽기 전용 쿼리(has_node/has_edge/neighbors/node_count/iter_nodes)는
-        Lock 없이 호출 가능하지만, 동시 뮤테이션 중에는 일관성이 보장되지 않는다.
+        모든 뮤테이션 및 읽기 쿼리는 사용자별 threading.Lock으로 직렬화되어
+        동시 변이 중 일관성을 보장한다. (사용자 간에는 완전 병렬 처리 가능)
     """
 
     def __init__(self, storage_base_path: str) -> None:
@@ -86,14 +84,23 @@ class NetworkXGraphRepository(AbstractGraphRepository):
         """
         사용자 DiGraph를 반환한다. 없으면 빈 DiGraph를 생성하여 등록한다.
 
-        _meta_lock 없이 호출 가능 (이미 획득된 컨텍스트에서 호출).
+        _graphs 딕셔너리 변경은 _meta_lock으로 보호하여 스레드 안전성을 보장한다.
         """
-        if hashed_user_id not in self._graphs:
-            self._graphs[hashed_user_id] = nx.DiGraph()
-        return self._graphs[hashed_user_id]
+        g = self._graphs.get(hashed_user_id)
+        if g is not None:
+            return g
+        
+        with self._meta_lock:
+            if hashed_user_id not in self._graphs:
+                self._graphs[hashed_user_id] = nx.DiGraph()
+            return self._graphs[hashed_user_id]
 
     def _get_user_lock(self, hashed_user_id: str) -> threading.Lock:
-        """사용자별 Lock을 반환하고, 없으면 생성한다."""
+        """사용자별 Lock을 반환하고, 없으면 생성한다 (Double-checked locking)."""
+        lock = self._locks.get(hashed_user_id)
+        if lock is not None:
+            return lock
+            
         with self._meta_lock:
             if hashed_user_id not in self._locks:
                 self._locks[hashed_user_id] = threading.Lock()
@@ -327,9 +334,10 @@ class NetworkXGraphRepository(AbstractGraphRepository):
             # 디렉토리 보장 — 부모가 없으면 생성
             target_path.parent.mkdir(parents=True, exist_ok=True)
 
-            # 원자적 쓰기: 임시 파일 → rename
-            tmp_suffix = f".graphml.{uuid.uuid4().hex}.tmp"
-            tmp_path = target_path.with_suffix(tmp_suffix)
+            # 원자적 쓰기: 임시 파일 → rename (확장자 로직과 독립적으로 이름 구성)
+            tmp_path = target_path.with_name(
+                f"{target_path.name}.{uuid.uuid4().hex}.tmp"
+            )
 
             try:
                 nx.write_graphml(g, str(tmp_path))

--- a/tests/unit/test_graph_repository.py
+++ b/tests/unit/test_graph_repository.py
@@ -208,6 +208,27 @@ class TestEdgeCRUD:
         assert repo.has_edge(_DUMMY_HASH_A, "a", "b") is True
         assert repo.has_edge(_DUMMY_HASH_A, "b", "a") is False
 
+    def test_get_edge_attrs_returns_none_for_absent(
+        self, repo: NetworkXGraphRepository
+    ) -> None:
+        assert repo.get_edge_attrs(_DUMMY_HASH_A, "ghost-src", "ghost-tgt") is None
+
+    def test_get_edge_attrs_returns_defensive_copy(
+        self, repo: NetworkXGraphRepository
+    ) -> None:
+        """반환된 dict 변경이 내부 상태에 영향을 주지 않아야 한다."""
+        repo.add_node(_DUMMY_HASH_A, "src")
+        repo.add_node(_DUMMY_HASH_A, "tgt")
+        repo.add_edge(_DUMMY_HASH_A, "src", "tgt", weight=1.0)
+        
+        attrs = repo.get_edge_attrs(_DUMMY_HASH_A, "src", "tgt")
+        assert attrs is not None
+        attrs["weight"] = 2.0
+        
+        attrs_again = repo.get_edge_attrs(_DUMMY_HASH_A, "src", "tgt")
+        assert attrs_again is not None
+        assert attrs_again["weight"] == 1.0
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # BFS 탐색 (neighbors)
@@ -223,9 +244,8 @@ class TestNeighbors:
     def _build_chain(self, repo: NetworkXGraphRepository) -> None:
         """A → B → C → D 체인 그래프."""
         self._add_abcd_nodes(repo)
-        repo.add_edge(_DUMMY_HASH_A, "A", "B")
-        repo.add_edge(_DUMMY_HASH_A, "B", "C")
-        repo.add_edge(_DUMMY_HASH_A, "C", "D")
+        for src, tgt in [("A", "B"), ("B", "C"), ("C", "D")]:
+            repo.add_edge(_DUMMY_HASH_A, src, tgt)
 
     def test_depth_1_returns_direct_successor(
         self, repo: NetworkXGraphRepository
@@ -255,10 +275,8 @@ class TestNeighbors:
     ) -> None:
         """A → B, A → C, B → D, C → D 다이아몬드 — D 중복 없음."""
         self._add_abcd_nodes(repo)
-        repo.add_edge(_DUMMY_HASH_A, "A", "B")
-        repo.add_edge(_DUMMY_HASH_A, "A", "C")
-        repo.add_edge(_DUMMY_HASH_A, "B", "D")
-        repo.add_edge(_DUMMY_HASH_A, "C", "D")
+        for src, tgt in [("A", "B"), ("A", "C"), ("B", "D"), ("C", "D")]:
+            repo.add_edge(_DUMMY_HASH_A, src, tgt)
         result = repo.neighbors(_DUMMY_HASH_A, "A", max_depth=2)
         assert result.count("D") == 1
 
@@ -308,6 +326,18 @@ class TestStatistics:
 
 
 class TestPersistence:
+    def test_load_raises_on_invalid_graphml(
+        self, repo: NetworkXGraphRepository, storage_path: str
+    ) -> None:
+        invalid_path = build_graph_path(_DUMMY_HASH_A, storage_path)
+        invalid_path.parent.mkdir(parents=True, exist_ok=True)
+        invalid_path.write_text("this is not valid GraphML", encoding="utf-8")
+
+        # When the persisted GraphML is corrupted/invalid, load should propagate
+        # the underlying failure rather than silently succeeding.
+        with pytest.raises(Exception):
+            repo.load(_DUMMY_HASH_A)
+
     def test_persist_creates_file(
         self, repo: NetworkXGraphRepository, storage_path: str
     ) -> None:

--- a/tests/unit/test_graph_repository.py
+++ b/tests/unit/test_graph_repository.py
@@ -335,7 +335,9 @@ class TestPersistence:
 
         # When the persisted GraphML is corrupted/invalid, load should propagate
         # the underlying failure rather than silently succeeding.
-        with pytest.raises(Exception):
+        import xml.etree.ElementTree as ET
+        import networkx as nx
+        with pytest.raises((ET.ParseError, nx.NetworkXError)):
             repo.load(_DUMMY_HASH_A)
 
     def test_persist_creates_file(


### PR DESCRIPTION
☘️ refactor [#12.3.8]: 2차 개선 - 동시성 병목(Lock contention) 최적화 및 하드코딩/테스트 보강 
☘️ refactor [#12.3.8]: 3차 개선 - 예외 처리 명확화 (Fail-fast 원칙 적용)

## Summary by Sourcery

동시성 보장과 영속성 동작을 강화하고, 엣지 속성과 영속성 실패에 대한 테스트를 확장합니다.

버그 수정:
- 동시 접근 시 레이스 컨디션을 피하기 위해, 사용자 그래프 맵 변화가 메타 락(meta lock)에 의해 보호되도록 합니다.
- 동시 변경 중에도 일관성을 보장하기 위해, 읽기를 포함한 모든 그래프 연산을 사용자 단위 락을 통해 직렬화합니다.
- 임시 GraphML 파일 이름이 대상 파일 확장자와 무관하게 생성되도록 수정하여, 확장자가 바뀌더라도 원자적 쓰기가 보장되도록 합니다.

개선 사항:
- 사용자별 락에 대해 double-checked locking을 사용하여 동시 접근 시 락 경합을 줄입니다.
- 사용자 단위로 읽기/쓰기 전체가 직렬화된다는 내용을 리포지토리 동시성 문서에 명확히 기술합니다.
- 엣지 정의를 순회하는 방식으로 테스트용 그래프 생성 헬퍼를 약간 단순화합니다.

테스트:
- `get_edge_attrs`가 존재하지 않는 엣지에 대해 `None`을 반환하고, 내부 상태가 외부로 새어나가지 않는 방어적 복사본을 반환하는지 검증하는 테스트를 추가합니다.
- GraphML 스토리지가 손상되었거나 잘못된 경우, `load`가 적절한 예외와 함께 빠르게 실패하는지 확인하는 영속성 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen graph repository concurrency guarantees and persistence behavior while extending tests for edge attributes and persistence failures.

Bug Fixes:
- Ensure user graph map mutations are protected by a meta lock to avoid race conditions under concurrent access.
- Make all graph operations, including reads, serialized per user via user-level locks to ensure consistency during concurrent mutations.
- Fix temporary GraphML file naming to be independent of the target file extension, preserving atomic writes across extension changes.

Enhancements:
- Use double-checked locking for per-user locks to reduce lock contention under concurrent access.
- Clarify repository concurrency documentation to describe full serialization of reads and writes per user.
- Slightly simplify test graph construction helpers by iterating over edge definitions.

Tests:
- Add tests verifying get_edge_attrs returns None for missing edges and returns a defensive copy that does not leak internal state.
- Add a persistence test that load fails fast with appropriate exceptions when GraphML storage is corrupted or invalid.

</details>