### PR TITLE
☘️ refactor [#12.3.8]: 4차 개선 - Repository 외부 의존성(Exception) 캡슐화

### DIFF
--- a/backend/graph/base.py
+++ b/backend/graph/base.py
@@ -21,6 +21,11 @@ import abc
 from typing import Any, Iterator
 
 
+class GraphLoadError(Exception):
+    """그래프 데이터를 스토리지에서 불러오는 중 발생하는 예외"""
+    pass
+
+
 class AbstractGraphRepository(abc.ABC):
     """
     엔진 불가지론적 그래프 Repository 추상 기반 클래스.

--- a/backend/graph/base.py
+++ b/backend/graph/base.py
@@ -21,7 +21,12 @@ import abc
 from typing import Any, Iterator
 
 
-class GraphLoadError(Exception):
+class GraphError(Exception):
+    """그래프 도메인 관련 최상위 예외"""
+    pass
+
+
+class GraphLoadError(GraphError):
     """그래프 데이터를 스토리지에서 불러오는 중 발생하는 예외"""
     pass
 

--- a/backend/graph/networkx_repository.py
+++ b/backend/graph/networkx_repository.py
@@ -28,7 +28,7 @@ from typing import Any, Iterator
 
 import networkx as nx
 
-from backend.graph.base import AbstractGraphRepository
+from backend.graph.base import AbstractGraphRepository, GraphLoadError
 from backend.graph.path_utils import build_graph_path
 
 logger = logging.getLogger(__name__)

--- a/tests/unit/test_graph_repository.py
+++ b/tests/unit/test_graph_repository.py
@@ -27,7 +27,7 @@ from typing import Any
 import networkx as nx
 import pytest
 
-from backend.graph.base import AbstractGraphRepository
+from backend.graph.base import GraphLoadError, AbstractGraphRepository
 from backend.graph.networkx_repository import NetworkXGraphRepository
 from backend.graph.path_utils import build_graph_path
 
@@ -334,10 +334,8 @@ class TestPersistence:
         invalid_path.write_text("this is not valid GraphML", encoding="utf-8")
 
         # When the persisted GraphML is corrupted/invalid, load should propagate
-        # the underlying failure rather than silently succeeding.
-        import xml.etree.ElementTree as ET
-        import networkx as nx
-        with pytest.raises((ET.ParseError, nx.NetworkXError)):
+        # the underlying failure wrapped in a GraphLoadError, masking external details.
+        with pytest.raises(GraphLoadError):
             repo.load(_DUMMY_HASH_A)
 
     def test_persist_creates_file(


### PR DESCRIPTION
- **사용자 정의 예외 적용**: `GraphLoadError`를 `base.py`에 신설하여, 외부 라이브러리(NetworkX, xml 등)의 구체적인 예외가 도메인 밖으로 새어나가지(Leak) 않도록 캡슐화.

- **테스트 결합도 완화**: 손상된 GraphML 파일 로드 테스트가 외부 구현 세부 사항에 의존하지 않도록, `GraphLoadError` 발생 여부만 검증하도록 리팩토링.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1497#pullrequestreview-4394922753)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

그래프 저장소 레이어에서 도메인 전용 예외를 통해 외부 그래프 로딩 오류를 캡슐화합니다.

개선 사항:
- 저장소에서 그래프 데이터를 로딩할 때 실패하는 경우를 위해 `GraphLoadError` 도메인 예외를 도입합니다.
- NetworkX 기반 그래프 저장소가 외부 라이브러리 예외 대신 `GraphLoadError`를 발생시키도록 준비합니다.

테스트:
- 잘못된 GraphML 로딩 테스트를 정교화하여, NetworkX 또는 XML 관련 예외가 아니라 `GraphLoadError`가 발생하는지를 검증하도록 수정합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Encapsulate external graph loading errors behind a domain-specific exception in the graph repository layer.

Enhancements:
- Introduce a GraphLoadError domain exception for failures when loading graph data from storage.
- Prepare the NetworkX-based graph repository to surface GraphLoadError instead of external library exceptions.

Tests:
- Refine the invalid GraphML loading test to assert GraphLoadError is raised rather than NetworkX or XML-specific exceptions.

</details>