### PR TITLE
☘️ refactor [#12.3.8]: 6차 개선 - load() 외부 예외 GraphLoadError 일관 캡슐화

### DIFF
--- a/backend/graph/networkx_repository.py
+++ b/backend/graph/networkx_repository.py
@@ -365,7 +365,12 @@ class NetworkXGraphRepository(AbstractGraphRepository):
         파일 시스템에서 GraphML을 읽어 인메모리 그래프를 복원한다.
 
         파일이 없는 경우: 빈 DiGraph 초기화 후 조용히 반환 (예외 없음).
-        파일이 손상된 경우: 예외를 상위로 전파하여 caller가 DEGRADED 처리를 결정한다.
+        파일이 손상된 경우: networkx/XML 파싱 예외를 GraphLoadError로 감싸
+            호출자가 스토리지 레이어의 구체적 예외에 노출되지 않도록 한다.
+            원본 예외는 __cause__ (from exc 체이닝)에 보존되어 디버깅 정보가 유지된다.
+
+        Raises:
+            GraphLoadError: 파일이 손상되어 GraphML 파싱에 실패한 경우
         """
         lock = self._get_user_lock(hashed_user_id)
         with lock:
@@ -381,7 +386,20 @@ class NetworkXGraphRepository(AbstractGraphRepository):
                 )
                 return
 
-            loaded = nx.read_graphml(str(target_path))
+            try:
+                loaded = nx.read_graphml(str(target_path))
+            except Exception as exc:
+                # networkx / XML 파싱 예외를 도메인 예외로 캡슐화하여
+                # 호출자가 스토리지 레이어의 구체적 예외에 노출되지 않도록 한다.
+                # `from exc` 체이닝으로 원본 예외는 __cause__에 보존된다.
+                logger.exception(
+                    "[GRAPH][NX] Failed to load graph from file system (subdir=%s).",
+                    "graph_data",
+                )
+                raise GraphLoadError(
+                    f"Failed to load graph for user (subdir=graph_data): {exc}"
+                ) from exc
+
             # read_graphml은 Graph를 반환할 수 있으므로 방향성 보장
             if not isinstance(loaded, nx.DiGraph):
                 loaded = nx.DiGraph(loaded)

--- a/backend/graph/networkx_repository.py
+++ b/backend/graph/networkx_repository.py
@@ -23,6 +23,7 @@ import logging
 import os
 import threading
 import uuid
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -368,9 +369,13 @@ class NetworkXGraphRepository(AbstractGraphRepository):
         파일이 손상된 경우: networkx/XML 파싱 예외를 GraphLoadError로 감싸
             호출자가 스토리지 레이어의 구체적 예외에 노출되지 않도록 한다.
             원본 예외는 __cause__ (from exc 체이닝)에 보존되어 디버깅 정보가 유지된다.
+            프로그래밍 버그(TypeError 등 파싱 무관 예외)는 의도적으로 통과시켜
+            근본 원인 파악을 방해하지 않는다.
 
         Raises:
-            GraphLoadError: 파일이 손상되어 GraphML 파싱에 실패한 경우
+            GraphLoadError: GraphML 파싱 실패 시 — 잘못된 XML 구문
+                (xml.etree.ElementTree.ParseError) 또는 GraphML 스키마 오류
+                (networkx.NetworkXError) 모두 포함.
         """
         lock = self._get_user_lock(hashed_user_id)
         with lock:
@@ -388,16 +393,17 @@ class NetworkXGraphRepository(AbstractGraphRepository):
 
             try:
                 loaded = nx.read_graphml(str(target_path))
-            except Exception as exc:
-                # networkx / XML 파싱 예외를 도메인 예외로 캡슐화하여
-                # 호출자가 스토리지 레이어의 구체적 예외에 노출되지 않도록 한다.
+            except (nx.NetworkXError, ET.ParseError) as exc:
+                # networkx/XML 파싱 관련 예외만 캡슐화한다.
+                # 프로그래밍 버그(TypeError 등)는 의도적으로 통과시켜
+                # GraphLoadError로 오해되지 않도록 한다.
                 # `from exc` 체이닝으로 원본 예외는 __cause__에 보존된다.
                 logger.exception(
-                    "[GRAPH][NX] Failed to load graph from file system (subdir=%s).",
-                    "graph_data",
+                    "[GRAPH][NX] Failed to load graph from file system (file=%s).",
+                    target_path.name,  # storage 내부 경로 비노출, 파일명만 기록
                 )
                 raise GraphLoadError(
-                    f"Failed to load graph for user (subdir=graph_data): {exc}"
+                    "Graph file could not be loaded from storage."
                 ) from exc
 
             # read_graphml은 Graph를 반환할 수 있으므로 방향성 보장


### PR DESCRIPTION
- [Refactor] `load()`에서 `nx.read_graphml()` 호출을 try/except로 감싸 networkx / XML 파싱 예외를 GraphLoadError로 래핑하여 재발생 → 호출자가 스토리지 레이어의 구체적 예외(NetworkXError, ParseError 등)에 직접 노출되지 않도록 외부 의존성 완전 캡슐화

- [Preserve] `raise GraphLoadError(...) from exc` 예외 체이닝 적용 → 원본 예외는 `__cause__`에 보존, 디버깅 정보 손실 없음

- [Docs] `load() docstring`에 `GraphLoadError Raises` 계약 명시

🔗 Related: 
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1499#pullrequestreview-4394952938)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

NetworkX 저장소 로드 경로에서, 저수준 그래프 로딩 오류를 도메인 특화 예외인 `GraphLoadError` 뒤로 캡슐화합니다.

Enhancements:
- `load()`에서 발생하는 NetworkX/XML 파싱 실패를 `GraphLoadError`로 감싸, 호출자에게는 스토리지 계층에 특화된 예외를 숨기면서도 예외 체이닝을 통해 원래 원인을 보존합니다.
- 파일 시스템에서 그래프를 로드하는 데 실패했을 때 구조화된 로깅을 추가하여 그래프 영속성(persistence) 관련 문제 디버깅을 돕습니다.

Documentation:
- `load()`의 계약(contract)을 문서화하여 GraphML 파싱이 실패할 때 `GraphLoadError`가 발생한다는 점을 명시적으로 밝히고, 손상된 파일에 대한 동작 방식도 명확히 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Encapsulate low-level graph loading errors behind a domain-specific GraphLoadError in the NetworkX repository load path.

Enhancements:
- Wrap networkx/XML parsing failures in load() into a GraphLoadError to hide storage-layer specific exceptions from callers while preserving the original cause via exception chaining.
- Add structured logging when graph loading from the filesystem fails to aid debugging of graph persistence issues.

Documentation:
- Document the load() contract to explicitly state that GraphLoadError is raised when GraphML parsing fails and clarify damaged-file behavior.

</details>