### PR TITLE
✨ feat [#12.3.9]: Phase 4-1 - ➁ 엔티티 및 관계(Edge) 추출 파이프라인 구축

### DIFF
--- a/backend/graph/__init__.py
+++ b/backend/graph/__init__.py
@@ -1,20 +1,23 @@
 # backend/graph/__init__.py
 
 """
-지식 그래프 Repository 추상화 계층 (Phase 4-1).
+지식 그래프 Repository 추상화 계층 (Phase 4-1) 및 파이프라인.
 
 공개 API:
     AbstractGraphRepository   — 엔진 불가지론적 인터페이스
     NetworkXGraphRepository   — networkx 기반 인메모리/파일시스템 구현체
     build_graph_path          — 테넌트 격리 경로 빌더 (공유 헬퍼)
+    EntityEdgeExtractor       — 마크다운 및 LLM 기반 명시/암묵적 엣지 추출기
 """
 
 from backend.graph.base import AbstractGraphRepository
 from backend.graph.networkx_repository import NetworkXGraphRepository
 from backend.graph.path_utils import build_graph_path
+from backend.graph.extractor import EntityEdgeExtractor
 
 __all__ = [
     "AbstractGraphRepository",
     "NetworkXGraphRepository",
     "build_graph_path",
+    "EntityEdgeExtractor",
 ]

--- a/backend/graph/extractor.py
+++ b/backend/graph/extractor.py
@@ -1,5 +1,8 @@
 import re
+import logging
 from typing import List, Tuple, Dict, Any
+
+logger = logging.getLogger(__name__)
 
 class EntityEdgeExtractor:
     """
@@ -9,9 +12,9 @@ class EntityEdgeExtractor:
     # 위키링크 정규식 (예: [[Note Title]])
     WIKILINK_PATTERN = re.compile(r"\[\[(.*?)\]\]")
     
-    # 해시태그 정규식 (예: #tag_name, 공백이나 구두점으로 끝남)
-    # 영문, 숫자, 한글, 언더바 등 지원
-    TAG_PATTERN = re.compile(r"#([a-zA-Z0-9_\uac00-\ud7a3]+)")
+    # 해시태그 정규식 (예: #tag_name)
+    # URL 파편화(예: http://example#section) 등에 매치되지 않도록 앞이 공백이거나 문자열의 시작점일 것 강제
+    TAG_PATTERN = re.compile(r"(?:^|\s)#([a-zA-Z0-9_\uac00-\ud7a3]+)")
 
     def extract_explicit_edges(self, source_node_id: str, markdown_content: str) -> List[Tuple[str, str, Dict[str, Any]]]:
         """
@@ -28,13 +31,32 @@ class EntityEdgeExtractor:
         
         # 1. 위키링크 추출
         wikilinks = set(self.WIKILINK_PATTERN.findall(markdown_content))
-        for target in wikilinks:
-            if target := target.strip():
-                edges.append((
-                    source_node_id, 
-                    target, 
-                    {"weight": 1.0, "edge_type": "explicit", "relation": "wikilink"}
-                ))
+        for raw_target in wikilinks:
+            raw_target = raw_target.strip()
+            if not raw_target:
+                continue
+                
+            # [[Title|Alias]] 형태 지원: 좌측을 canonical ID로 사용
+            if "|" in raw_target:
+                canonical_target, alias = raw_target.split("|", 1)
+                canonical_target = canonical_target.strip()
+                alias = alias.strip()
+            else:
+                canonical_target = raw_target
+                alias = None
+                
+            if not canonical_target:
+                continue
+                
+            attrs = {
+                "weight": 1.0,
+                "edge_type": "explicit",
+                "relation": "wikilink"
+            }
+            if alias:
+                attrs["alias"] = alias
+                
+            edges.append((source_node_id, canonical_target, attrs))
                 
         # 2. 태그 추출
         tags = set(self.TAG_PATTERN.findall(markdown_content))
@@ -76,17 +98,18 @@ class EntityEdgeExtractor:
         
         try:
             # 의존성으로 주입받은 LLM 클라이언트를 통해 키워드 추출 (비동기 연동)
-            # Langchain BaseChatModel의 ainvoke 지원 가정 (프로젝트의 ChatOpenAI 등)
             from langchain_core.messages import HumanMessage
             
             response = await llm_client.ainvoke([HumanMessage(content=prompt_text)])
             response_text = str(response.content).strip()
             
-            # 파싱 로직 (쉼표 분리)
-            extracted_keywords = [kw.strip() for kw in response_text.split(",") if kw.strip()]
+            # 파싱 로직 (쉼표 분리) 및 중복 제거
+            raw_keywords = [kw.strip() for kw in response_text.split(",") if kw.strip()]
+            
+            # 프롬프트 제약 보장: 최대 3개 키워드만 제한 및 순서 유지 중복 제거 방어 로직
+            extracted_keywords = list(dict.fromkeys(raw_keywords))[:3]
             
             # 암묵적 엣지에는 명시적 엣지보다 낮은 기본 가중치 부여 (예: 0.5)
-            # 추후 LLM 응답에 weight까지 포함시키도록 프롬프트 고도화 가능
             edges.extend(
                 (
                     source_node_id,
@@ -98,8 +121,8 @@ class EntityEdgeExtractor:
                 
         except Exception as exc:
             # LLM 연동 실패 시 애플리케이션의 중단을 막기 위해 예외 캡처 및 로깅
-            # 프로젝트 컨벤션에 따라 GraphLoadError 등으로 래핑할 수 있음
-            import logging
-            logging.error(f"[Graph Extraction] Failed to extract implicit edges for node {source_node_id}: {exc}")
+            # ai_bot_review_summary 체크리스트에 따라 logger.exception()을 사용하여 Stack Trace 기록
+            logger.exception(f"[Graph Extraction] Failed to extract implicit edges for node {source_node_id}")
             
         return edges
+

--- a/backend/graph/extractor.py
+++ b/backend/graph/extractor.py
@@ -1,0 +1,105 @@
+import re
+from typing import List, Tuple, Dict, Any
+
+class EntityEdgeExtractor:
+    """
+    마크다운 텍스트에서 엔티티 및 관계(Edge)를 추출하는 파이프라인 클래스입니다.
+    """
+
+    # 위키링크 정규식 (예: [[Note Title]])
+    WIKILINK_PATTERN = re.compile(r"\[\[(.*?)\]\]")
+    
+    # 해시태그 정규식 (예: #tag_name, 공백이나 구두점으로 끝남)
+    # 영문, 숫자, 한글, 언더바 등 지원
+    TAG_PATTERN = re.compile(r"#([a-zA-Z0-9_\uac00-\ud7a3]+)")
+
+    def extract_explicit_edges(self, source_node_id: str, markdown_content: str) -> List[Tuple[str, str, Dict[str, Any]]]:
+        """
+        마크다운 본문에서 위키링크와 태그를 파싱하여 명시적 엣지를 생성합니다.
+        
+        Args:
+            source_node_id: 출발 노드 ID (현재 노트 등)
+            markdown_content: 파싱할 마크다운 텍스트
+            
+        Returns:
+            생성된 명시적 엣지 목록: List of (source_node_id, target_node_id, attrs)
+        """
+        edges = []
+        
+        # 1. 위키링크 추출
+        wikilinks = set(self.WIKILINK_PATTERN.findall(markdown_content))
+        for target in wikilinks:
+            if target := target.strip():
+                edges.append((
+                    source_node_id, 
+                    target, 
+                    {"weight": 1.0, "edge_type": "explicit", "relation": "wikilink"}
+                ))
+                
+        # 2. 태그 추출
+        tags = set(self.TAG_PATTERN.findall(markdown_content))
+        for tag in tags:
+            if tag := tag.strip():
+                # 태그 노드 식별을 위해 '#' 접두사 유지
+                edges.append((
+                    source_node_id, 
+                    f"#{tag}", 
+                    {"weight": 1.0, "edge_type": "explicit", "relation": "tag"}
+                ))
+                
+        return edges
+
+    async def extract_implicit_edges(self, source_node_id: str, content: str, llm_client: Any) -> List[Tuple[str, str, Dict[str, Any]]]:
+        """
+        LLM 또는 NLP 모듈을 연동하여 텍스트의 키워드 및 문맥 유사도 기반의 
+        암묵적 엣지(Implicit Edge)를 추출하고 가중치를 부여합니다.
+        
+        Args:
+            source_node_id: 출발 노드 ID
+            content: 분석할 텍스트 내용
+            llm_client: LangChain 호환 LLM 인터페이스 또는 OpenAI 클라이언트 인스턴스 (의존성 주입)
+            
+        Returns:
+            생성된 암묵적 엣지 목록: List of (source_node_id, target_node_id, attrs)
+        """
+        edges = []
+        
+        if not content.strip() or not llm_client:
+            return edges
+
+        # LLM 프롬프트 구성 (System / User Message 형태로 확장을 고려)
+        prompt_text = (
+            "Analyze the following text and extract up to 3 core related keywords or entities. "
+            "Return ONLY a comma-separated list of keywords, without any extra text.\n\n"
+            f"Text: {content}"
+        )
+        
+        try:
+            # 의존성으로 주입받은 LLM 클라이언트를 통해 키워드 추출 (비동기 연동)
+            # Langchain BaseChatModel의 ainvoke 지원 가정 (프로젝트의 ChatOpenAI 등)
+            from langchain_core.messages import HumanMessage
+            
+            response = await llm_client.ainvoke([HumanMessage(content=prompt_text)])
+            response_text = str(response.content).strip()
+            
+            # 파싱 로직 (쉼표 분리)
+            extracted_keywords = [kw.strip() for kw in response_text.split(",") if kw.strip()]
+            
+            # 암묵적 엣지에는 명시적 엣지보다 낮은 기본 가중치 부여 (예: 0.5)
+            # 추후 LLM 응답에 weight까지 포함시키도록 프롬프트 고도화 가능
+            edges.extend(
+                (
+                    source_node_id,
+                    keyword,
+                    {"weight": 0.5, "edge_type": "implicit", "relation": "semantic_keyword"}
+                )
+                for keyword in extracted_keywords
+            )
+                
+        except Exception as exc:
+            # LLM 연동 실패 시 애플리케이션의 중단을 막기 위해 예외 캡처 및 로깅
+            # 프로젝트 컨벤션에 따라 GraphLoadError 등으로 래핑할 수 있음
+            import logging
+            logging.error(f"[Graph Extraction] Failed to extract implicit edges for node {source_node_id}: {exc}")
+            
+        return edges


### PR DESCRIPTION
- 마크다운 파서를 통해 명시적 위키링크(`[[노트명]]`) 및 태그 추출을 통한 명시적 엣지(Explicit Edge) 자동 생성 로직 구현 (`EntityEdgeExtractor`)
- LLM/NLP 모듈 비동기 연동(`ainvoke`)을 통해 텍스트 컨텍스트 및 키워드 기반의 암묵적 엣지(Implicit Edge) 생성 및 가중치 부여 인터페이스 구축
- 정규식 최적화 처리 및 하드코딩 배제로 유연성 확보 (`__init__.py` 익스포트 반영)

🔗 Related: Issue [#1048]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

마크다운 콘텐츠에서 명시적 및 암시적 그래프 엣지를 추출하기 위한 파이프라인 클래스를 도입하고, 이를 그래프 모듈의 public API를 통해 노출합니다.

New Features:
- 마크다운 텍스트의 위키 링크와 태그로부터 명시적 엣지를 도출하는 `EntityEdgeExtractor`를 추가합니다.
- 기본 가중치 메타데이터를 포함한 비동기 방식의 LLM 기반 의미론적(semantic) 암시적 엣지 추출을 지원합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a pipeline class for extracting explicit and implicit graph edges from markdown content and expose it via the graph module public API.

New Features:
- Add EntityEdgeExtractor to derive explicit edges from wiki links and tags in markdown text.
- Support asynchronous extraction of implicit, LLM-based semantic edges with basic weighting metadata.

</details>