### PR TITLE
☘️ refactor [#12.3.9]: 4차 개선 - 추출 관측성(Observability) 극대화 및 하드코딩 제거

### DIFF
--- a/backend/graph/extractor.py
+++ b/backend/graph/extractor.py
@@ -1,7 +1,7 @@
 import re
 import logging
 from typing import List, Tuple, Dict, Any
-from collections import Counter
+from collections import Counter, defaultdict
 
 logger = logging.getLogger(__name__)
 
@@ -17,9 +17,13 @@ class EntityEdgeExtractor:
     # URL 파편화(예: http://example#section) 등에 매치되지 않도록 앞이 공백이거나 문자열의 시작점일 것 강제
     TAG_PATTERN = re.compile(r"(?:^|\s)#([a-zA-Z0-9_\uac00-\ud7a3]+)")
     
-    # LLM 토큰 초과(Context Window Overflow) 방지를 위한 최대 텍스트 길이 제한
-    # 문자 수 기준(약 1000~2000 토큰). LLM의 토큰 제한에 안전하도록 충분한 여유(Safety Margin)를 둡니다.
-    MAX_CONTENT_LENGTH = 4000
+    def __init__(self, max_content_length: int = 4000):
+        """
+        Args:
+            max_content_length: LLM 토큰 초과(Context Window Overflow) 방지를 위한 최대 텍스트 문자 수 제한.
+                                설정값에 따라 주입(Injection) 가능. (기본 4000자는 약 1000~2000 토큰 마진)
+        """
+        self.max_content_length = max_content_length
 
     def extract_explicit_edges(self, source_node_id: str, markdown_content: str) -> List[Tuple[str, str, Dict[str, Any]]]:
         """
@@ -40,7 +44,7 @@ class EntityEdgeExtractor:
         
         # 정규화된 canonical_target 리스트를 먼저 생성하여 동일한 타깃은 올바르게 집계되도록 함
         normalized_targets = []
-        aliases_map = {}
+        aliases_map = defaultdict(list)
         
         for raw_target in wikilink_matches:
             raw_target = raw_target.strip()
@@ -60,19 +64,20 @@ class EntityEdgeExtractor:
                 continue
             
             normalized_targets.append(canonical_target)
-            if alias:
-                # 가장 마지막에 발견된 별칭을 기록
-                aliases_map[canonical_target] = alias
+            if alias and alias not in aliases_map[canonical_target]:
+                # 결정론적이고 손실 없는 별칭 수집 (중복 방지 리스트 추가)
+                aliases_map[canonical_target].append(alias)
                 
         wikilink_counts = Counter(normalized_targets)
         for canonical_target, count in wikilink_counts.items():
-            attrs = {
+            attrs: Dict[str, Any] = {
                 "weight": float(count),
                 "edge_type": "explicit",
                 "relation": "wikilink"
             }
-            if canonical_target in aliases_map:
-                attrs["alias"] = aliases_map[canonical_target]
+            if canonical_target in aliases_map and aliases_map[canonical_target]:
+                # 여러 개의 별칭을 리스트 형태로 보존
+                attrs["aliases"] = aliases_map[canonical_target]
                 
             edges.append((source_node_id, canonical_target, attrs))
                 
@@ -118,12 +123,29 @@ class EntityEdgeExtractor:
             return edges
 
         # 긴 노트로 인한 LLM 토큰 초과 방어적 코딩 (Truncation)
-        if len(content) > self.MAX_CONTENT_LENGTH:
+        original_length = len(content)
+        is_truncated = original_length > self.max_content_length
+
+        if is_truncated:
+            truncated_length = self.max_content_length
             logger.warning(
-                f"[Graph Extraction] Note '{source_node_id}' exceeds MAX_CONTENT_LENGTH "
-                f"({self.MAX_CONTENT_LENGTH} chars). Truncating content for LLM safety."
+                "[Graph Extraction] Note '%s' exceeds max_content_length (%d chars). "
+                "Truncating content for LLM safety (original_length=%d, truncated_length=%d).",
+                source_node_id,
+                self.max_content_length,
+                original_length,
+                truncated_length,
             )
-        truncated_content = content[:self.MAX_CONTENT_LENGTH]
+            truncated_content = content[: self.max_content_length]
+        else:
+            truncated_content = content
+
+        # Downstream consumers(로그 및 트레이싱)를 위해 관측 가능한(Observable) 메타데이터 구성
+        truncation_metadata = {
+            "is_truncated": is_truncated,
+            "original_length": original_length,
+            "used_length": len(truncated_content),
+        }
 
         # LLM 프롬프트 구성 (System / User Message 형태로 확장을 고려)
         prompt_text = (
@@ -135,6 +157,12 @@ class EntityEdgeExtractor:
         try:
             # 의존성으로 주입받은 LLM 클라이언트를 통해 키워드 추출 (비동기 연동)
             from langchain_core.messages import HumanMessage
+            
+            # 구조화된 로깅(Structured Logging)에 메타데이터를 추가하여 디버깅 가시성 극대화
+            logger.info(
+                f"[Graph Extraction] Invoking LLM for implicit edges (Node: {source_node_id})",
+                extra={"truncation_metadata": truncation_metadata}
+            )
             
             response = await llm_client.ainvoke([HumanMessage(content=prompt_text)])
             response_text = str(response.content).strip()

--- a/backend/graph/extractor.py
+++ b/backend/graph/extractor.py
@@ -76,7 +76,9 @@ class EntityEdgeExtractor:
                 "relation": "wikilink"
             }
             if canonical_target in aliases_map and aliases_map[canonical_target]:
-                # 여러 개의 별칭을 리스트 형태로 보존
+                # 하위 호환성(Backwards Compatibility) 보장: 단일 스칼라 타입(가장 처음 발견된 별칭)
+                attrs["alias"] = aliases_map[canonical_target][0]
+                # 결정론적이고 손실 없는 전체 별칭 리스트 보존
                 attrs["aliases"] = aliases_map[canonical_target]
                 
             edges.append((source_node_id, canonical_target, attrs))


### PR DESCRIPTION
- 별칭(Alias) 병합 무손실 보장: `defaultdict(list)`를 도입하여 다중 별칭을 덮어쓰기 없이 리스트 배열로 완전하게 보존 (결정론적 추출 보장)

- Truncation 메타데이터 구조화: 암묵적 엣지 절삭 시 `truncation_metadata` 생성 후 `logger.info`의 `extra`로 전달하여 파이프라인의 관측성(Observability) 극대화

- 하드코딩 완전 제거: `MAX_CONTENT_LENGTH` 상수를 제거하고 생성자(`__init__`) 매개변수 기반의 의존성 주입 구조로 변경하여 LLM 모델 변경에 대한 유연성 확보

- 코드 안정성: Pyrefly 타입 추론 충돌 오류(`Dict[str, Any]`) 수정 완료

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1505#pullrequestreview-4396569463)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

LLM 기반 엣지 추출의 관찰 가능성(observability), 구성 가능성(configurability), 그리고 별칭(alias) 처리 방식을 개선하기 위해 그래프 엔티티 엣지 추출기를 리팩터링합니다.

버그 수정:
- 여러 위키링크가 동일한 정규화(canonical) 대상에 연결되는 경우, 이전에 탐지된 별칭이 덮어쓰이거나 손실되지 않도록 방지합니다.

개선 사항:
- 하드코딩된 상수 대신, `EntityEdgeExtractor` 생성자 파라미터를 통해 LLM 프롬프트의 최대 콘텐츠 길이를 설정 가능하도록 구성합니다.
- 리스트 기반 매핑(list-backed mapping)을 사용해 하나의 정규화 대상에 대해 여러 별칭을 유지하고, 추출된 엣지 속성에서 이를 `aliases` 필드로 노출합니다.
- LLM 트렁케이션(truncation) 동작에 대한 다운스트림 디버깅 및 추적 가시성을 높이기 위해, 구조화된 트렁케이션 메타데이터와 정보성 로깅을 추가합니다.
- 정적 타입 추론 도구와의 정합성을 위해 엣지 속성 딕셔너리의 타입 애너테이션을 정교하게 다듬습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the graph entity edge extractor to improve observability, configurability, and alias handling for LLM-based edge extraction.

Bug Fixes:
- Avoid overwriting or losing previously detected aliases when multiple wikilinks point to the same canonical target.

Enhancements:
- Make maximum content length for LLM prompts configurable via an EntityEdgeExtractor constructor parameter instead of a hardcoded constant.
- Preserve multiple aliases per canonical target using a list-backed mapping and expose them as an aliases field in extracted edge attributes.
- Add structured truncation metadata and informational logging around LLM truncation behavior to improve downstream debugging and tracing visibility.
- Refine type annotations on edge attribute dictionaries to align with static type inference tooling.

</details>