### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/graph/extractor.py
+++ b/backend/graph/extractor.py
@@ -1,7 +1,7 @@
 import re
 import logging
 from typing import List, Tuple, Dict, Any
-from collections import Counter
+from collections import Counter, defaultdict
 
 logger = logging.getLogger(__name__)
 
@@ -17,9 +17,13 @@ class EntityEdgeExtractor:
     # URL 파편화(예: http://example#section) 등에 매치되지 않도록 앞이 공백이거나 문자열의 시작점일 것 강제
     TAG_PATTERN = re.compile(r"(?:^|\s)#([a-zA-Z0-9_\uac00-\ud7a3]+)")
     
-    # LLM 토큰 초과(Context Window Overflow) 방지를 위한 최대 텍스트 길이 제한
-    # 문자 수 기준(약 1000~2000 토큰). LLM의 토큰 제한에 안전하도록 충분한 여유(Safety Margin)를 둡니다.
-    MAX_CONTENT_LENGTH = 4000
+    def __init__(self, max_content_length: int = 4000):
+        """
+        Args:
+            max_content_length: LLM 토큰 초과(Context Window Overflow) 방지를 위한 최대 텍스트 문자 수 제한.
+                                설정값에 따라 주입(Injection) 가능. (기본 4000자는 약 1000~2000 토큰 마진)
+        """
+        self.max_content_length = max_content_length
 
     def extract_explicit_edges(self, source_node_id: str, markdown_content: str) -> List[Tuple[str, str, Dict[str, Any]]]:
         """
@@ -40,7 +44,7 @@ class EntityEdgeExtractor:
         
         # 정규화된 canonical_target 리스트를 먼저 생성하여 동일한 타깃은 올바르게 집계되도록 함
         normalized_targets = []
-        aliases_map = {}
+        aliases_map = defaultdict(list)
         
         for raw_target in wikilink_matches:
             raw_target = raw_target.strip()
@@ -60,19 +64,20 @@ class EntityEdgeExtractor:
                 continue
             
             normalized_targets.append(canonical_target)
-            if alias:
-                # 가장 마지막에 발견된 별칭을 기록
-                aliases_map[canonical_target] = alias
+            if alias and alias not in aliases_map[canonical_target]:
+                # 결정론적이고 손실 없는 별칭 수집 (중복 방지 리스트 추가)
+                aliases_map[canonical_target].append(alias)
                 
         wikilink_counts = Counter(normalized_targets)
         for canonical_target, count in wikilink_counts.items():
-            attrs = {
+            attrs: Dict[str, Any] = {
                 "weight": float(count),
                 "edge_type": "explicit",
                 "relation": "wikilink"
             }
-            if canonical_target in aliases_map:
-                attrs["alias"] = aliases_map[canonical_target]
+            if canonical_target in aliases_map and aliases_map[canonical_target]:
+                # 여러 개의 별칭을 리스트 형태로 보존
+                attrs["aliases"] = aliases_map[canonical_target]
                 
             edges.append((source_node_id, canonical_target, attrs))
                 
@@ -118,12 +123,29 @@ class EntityEdgeExtractor:
             return edges
 
         # 긴 노트로 인한 LLM 토큰 초과 방어적 코딩 (Truncation)
-        if len(content) > self.MAX_CONTENT_LENGTH:
+        original_length = len(content)
+        is_truncated = original_length > self.max_content_length
+
+        if is_truncated:
+            truncated_length = self.max_content_length
             logger.warning(
-                f"[Graph Extraction] Note '{source_node_id}' exceeds MAX_CONTENT_LENGTH "
-                f"({self.MAX_CONTENT_LENGTH} chars). Truncating content for LLM safety."
+                "[Graph Extraction] Note '%s' exceeds max_content_length (%d chars). "
+                "Truncating content for LLM safety (original_length=%d, truncated_length=%d).",
+                source_node_id,
+                self.max_content_length,
+                original_length,
+                truncated_length,
             )
-        truncated_content = content[:self.MAX_CONTENT_LENGTH]
+            truncated_content = content[: self.max_content_length]
+        else:
+            truncated_content = content
+
+        # Downstream consumers(로그 및 트레이싱)를 위해 관측 가능한(Observable) 메타데이터 구성
+        truncation_metadata = {
+            "is_truncated": is_truncated,
+            "original_length": original_length,
+            "used_length": len(truncated_content),
+        }
 
         # LLM 프롬프트 구성 (System / User Message 형태로 확장을 고려)
         prompt_text = (
@@ -135,6 +157,12 @@ class EntityEdgeExtractor:
         try:
             # 의존성으로 주입받은 LLM 클라이언트를 통해 키워드 추출 (비동기 연동)
             from langchain_core.messages import HumanMessage
+            
+            # 구조화된 로깅(Structured Logging)에 메타데이터를 추가하여 디버깅 가시성 극대화
+            logger.info(
+                f"[Graph Extraction] Invoking LLM for implicit edges (Node: {source_node_id})",
+                extra={"truncation_metadata": truncation_metadata}
+            )
             
             response = await llm_client.ainvoke([HumanMessage(content=prompt_text)])
             response_text = str(response.content).strip()

--- a/backend/graph/extractor.py
+++ b/backend/graph/extractor.py
@@ -76,7 +76,9 @@ class EntityEdgeExtractor:
                 "relation": "wikilink"
             }
             if canonical_target in aliases_map and aliases_map[canonical_target]:
-                # 여러 개의 별칭을 리스트 형태로 보존
+                # 하위 호환성(Backwards Compatibility) 보장: 단일 스칼라 타입(가장 처음 발견된 별칭)
+                attrs["alias"] = aliases_map[canonical_target][0]
+                # 결정론적이고 손실 없는 전체 별칭 리스트 보존
                 attrs["aliases"] = aliases_map[canonical_target]
                 
             edges.append((source_node_id, canonical_target, attrs))


### PR DESCRIPTION
☘️ refactor [#12.3.9]: 4차 개선 - 추출 관측성(Observability) 극대화 및 하드코딩 제거 
☘️ refactor [#12.3.9]: 5차 개선 - 엔티티 추출 파이프라인 하위 호환성(Backwards Compatibility) 보장

## Summary by Sourcery

그래프 엔터티 엣지 추출을 정교화하여, 암시적(implicit) 및 명시적(explicit) 엣지 처리의 관측 가능성(observability), 구성 가능성(configurability), 그리고 하위 호환성(backwards compatibility)을 개선합니다.

신규 기능:
- 생성자 주입(constructor injection)을 통해 암시적 엣지 추출 시 사용할 최대 콘텐츠 길이를 설정할 수 있는 기능을 지원합니다.
- 암시적 엣지 추출을 위한 LLM 호출에 대해 구조화된 트렁케이션(truncation) 메타데이터와 구조화된 로깅을 노출합니다.
- 기존(alias) 동작을 유지하면서도 위키링크(wikilink) 타깃에 대해 기본(primary) 별칭과 전체 별칭 목록을 모두 보존합니다.

개선 사항:
- `defaultdict` 기반 리스트를 사용해 손실 없이(deterministic, non-lossy) 별칭을 수집하면서, 중복을 방지합니다.
- 메타데이터 및 로그에서 트렁케이션 상태와 길이를 명시적으로 추적함으로써, 긴 노트 처리에 대한 방어적 로직을 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine graph entity edge extraction to improve observability, configurability, and backwards compatibility of implicit and explicit edge handling.

New Features:
- Support configurable maximum content length for implicit edge extraction via constructor injection.
- Expose structured truncation metadata and structured logging around LLM invocations for implicit edge extraction.
- Preserve both a primary alias and a full alias list for wikilink targets while maintaining legacy alias behavior.

Enhancements:
- Ensure deterministic, non-lossy alias collection using a defaultdict-backed list while avoiding duplicates.
- Improve defensive handling of long notes by explicitly tracking truncation state and lengths in metadata and logs.

</details>