### PR TITLE
✨ feat [#12.3.10]: Phase 4-1 - ➂ 지식 그래프 마이그레이션 트리거 및 SSE 동시성 모니터링 구현

### DIFF
--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -30,6 +30,9 @@ import uuid
 from itertools import islice
 from typing import Any, AsyncGenerator
 
+import anyio
+import anyio.to_thread
+from cachetools import TTLCache  # type: ignore[import, import-untyped]
 from fastapi import APIRouter, Request, Depends
 from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
@@ -43,7 +46,6 @@ from backend.core.config_validator import GraphEngineConfig, PersonalizedRAGConf
 from backend.graph import NetworkXGraphRepository
 from backend.services.personalized_index_service import compute_hashed_user_id
 from backend.core.aws_client_wrapper import fetch_global_pepper
-import threading
 
 logger = logging.getLogger(__name__)
 
@@ -60,21 +62,41 @@ _rag_cfg = PersonalizedRAGConfig.from_env()
 # SSE 동시성 모니터링 상태 (Per-worker)
 # ─────────────────────────────────────────────────────────────────────────────
 _active_sse_sessions: int = 0
-_sse_sessions_lock = threading.Lock()
+_sse_sessions_lock = asyncio.Lock()
 
 async def sse_session_tracker() -> AsyncGenerator[int, None]:
     """
     FastAPI Depends: 워커 인스턴스(Per-worker) 내부 SSE 세션 수를 추적합니다.
     """
     global _active_sse_sessions
-    with _sse_sessions_lock:
+    async with _sse_sessions_lock:
         _active_sse_sessions += 1
     
     try:
         yield _active_sse_sessions
     finally:
-        with _sse_sessions_lock:
+        async with _sse_sessions_lock:
             _active_sse_sessions -= 1
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 전역 의존성 캐싱 (Per-worker)
+# ─────────────────────────────────────────────────────────────────────────────
+_pepper_cache: TTLCache = TTLCache(maxsize=1, ttl=300)  # 5분 단위 갱신
+_pepper_lock = asyncio.Lock()
+_graph_repo = NetworkXGraphRepository(storage_base_path=_rag_cfg.storage_base_path)
+
+async def get_cached_global_pepper() -> str:
+    """KMS 지연시간 감소를 위한 global_pepper 메모리 캐싱"""
+    async with _pepper_lock:
+        if "pepper" in _pepper_cache:
+            return _pepper_cache["pepper"]
+        pepper = await fetch_global_pepper()
+        _pepper_cache["pepper"] = pepper
+        return pepper
+
+def get_graph_repository() -> NetworkXGraphRepository:
+    """그래프 리포지토리 재사용 의존성 주입"""
+    return _graph_repo
 
 # SSE 이벤트 이름 상수 (클라이언트 API 계약 — 하드코딩 방지)
 # 프론트엔드와 동기화된 표준 이벤트 이름이므로, 변경 시 이 상수만 수정하면 됩니다.
@@ -159,6 +181,7 @@ async def stream_chat_endpoint(
     request: Request,
     body: ChatQueryRequest,
     current_sse_count: int = Depends(sse_session_tracker),
+    repo: NetworkXGraphRepository = Depends(get_graph_repository),
 ) -> EventSourceResponse:
     """
     SSE 기반 스트리밍 엔드포인트 (2단계: 어댑터 연결).
@@ -180,11 +203,12 @@ async def stream_chat_endpoint(
     try:
         # [설계결정] DB 연동 전까지 user_id를 이용해 임시 salt 구성
         per_user_salt = f"mock_salt_{body.user_id}"
-        global_pepper = await fetch_global_pepper()
+        global_pepper = await get_cached_global_pepper()
         
         hashed_uid = compute_hashed_user_id(body.user_id, per_user_salt, global_pepper)
-        repo = NetworkXGraphRepository(storage_base_path=_rag_cfg.storage_base_path)
-        current_node_count = repo.node_count(hashed_uid)
+        
+        # [설계결정] node_count는 디스크 I/O를 유발하므로 이벤트 루프 블로킹을 피하기 위해 스레드 풀에서 실행
+        current_node_count = await anyio.to_thread.run_sync(repo.node_count, hashed_uid)
     except Exception as exc:
         logger.warning(
             "%s[MIGRATION] Failed to fetch node count for trigger: %s",

--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -30,7 +30,7 @@ import uuid
 from itertools import islice
 from typing import Any, AsyncGenerator
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, Depends
 from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
 
@@ -39,6 +39,11 @@ from backend.api.models import ChatQueryRequest
 from backend.core.config.streaming import StreamingConfig
 from backend.schemas.streaming import DoneChunk, ErrorChunk, StreamChunk, TokenChunk
 from backend.utils import get_chat_log_extra
+from backend.core.config_validator import GraphEngineConfig, PersonalizedRAGConfig
+from backend.graph import NetworkXGraphRepository
+from backend.services.personalized_index_service import compute_hashed_user_id
+from backend.core.aws_client_wrapper import fetch_global_pepper
+import threading
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +53,28 @@ router = APIRouter(prefix="/chat", tags=["chat-stream"])
 # 모듈 로드 시점 설정 로드 (환경 변수 반영 + Clamp 보장)
 # ─────────────────────────────────────────────────────────────────────────────
 _cfg = StreamingConfig.load()
+_graph_cfg = GraphEngineConfig.from_env()
+_rag_cfg = PersonalizedRAGConfig.from_env()
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SSE 동시성 모니터링 상태 (Per-worker)
+# ─────────────────────────────────────────────────────────────────────────────
+_active_sse_sessions: int = 0
+_sse_sessions_lock = threading.Lock()
+
+async def sse_session_tracker() -> AsyncGenerator[int, None]:
+    """
+    FastAPI Depends: 워커 인스턴스(Per-worker) 내부 SSE 세션 수를 추적합니다.
+    """
+    global _active_sse_sessions
+    with _sse_sessions_lock:
+        _active_sse_sessions += 1
+    
+    try:
+        yield _active_sse_sessions
+    finally:
+        with _sse_sessions_lock:
+            _active_sse_sessions -= 1
 
 # SSE 이벤트 이름 상수 (클라이언트 API 계약 — 하드코딩 방지)
 # 프론트엔드와 동기화된 표준 이벤트 이름이므로, 변경 시 이 상수만 수정하면 됩니다.
@@ -131,6 +158,7 @@ def _safe_repr(obj: Any, _depth: int = 0) -> str:
 async def stream_chat_endpoint(
     request: Request,
     body: ChatQueryRequest,
+    current_sse_count: int = Depends(sse_session_tracker),
 ) -> EventSourceResponse:
     """
     SSE 기반 스트리밍 엔드포인트 (2단계: 어댑터 연결).
@@ -147,6 +175,37 @@ async def stream_chat_endpoint(
         _LOG_TAG,
         extra=get_chat_log_extra(body),
     )
+
+    # ── 마이그레이션 트리거 모니터링 (3단계) ──────────────────────────────────────────
+    try:
+        # [설계결정] DB 연동 전까지 user_id를 이용해 임시 salt 구성
+        per_user_salt = f"mock_salt_{body.user_id}"
+        global_pepper = await fetch_global_pepper()
+        
+        hashed_uid = compute_hashed_user_id(body.user_id, per_user_salt, global_pepper)
+        repo = NetworkXGraphRepository(storage_base_path=_rag_cfg.storage_base_path)
+        current_node_count = repo.node_count(hashed_uid)
+    except Exception as exc:
+        logger.warning(
+            "%s[MIGRATION] Failed to fetch node count for trigger: %s",
+            _LOG_TAG,
+            exc,
+        )
+        current_node_count = 0
+
+    if (
+        current_node_count > _graph_cfg.migration_node_threshold
+        or current_sse_count > _graph_cfg.migration_concurrency_threshold
+    ):
+        logger.warning(
+            "%s[MIGRATION_TRIGGER] Neo4j migration recommended. "
+            "node_count=%d (threshold=%d), sse_sessions=%d (threshold=%d)",
+            _LOG_TAG,
+            current_node_count,
+            _graph_cfg.migration_node_threshold,
+            current_sse_count,
+            _graph_cfg.migration_concurrency_threshold,
+        )
 
     async def event_generator() -> AsyncGenerator[dict, None]:
         # ── 설정값 로컬 바인딩 ────────────────────────────────────────────────


### PR DESCRIPTION
- FastAPI Depends를 활용하여 워커 인스턴스(Per-worker) 내부 활성 SSE 세션 수를 안전하게 추적하는 제너레이터(sse_session_tracker) 도입.
- 스트리밍 엔드포인트(stream_chat_endpoint)에 진입 시 사용자 그래프 노드 수와 현재 세션 수를 조회하여 설정된 임계값 초과 시 Neo4j 전환 권장 경고(Warning) 발생 기능 추가.
- GraphEngineConfig 및 PersonalizedRAGConfig를 통한 임계값(Thresholds) 동적 주입으로 코드 내 하드코딩 원천 차단.
- DB 연동 전까지 데이터 프라이버시 보호를 위해 AWS KMS 기반 global_pepper 연동 및 결정론적 단방향 해싱(compute_hashed_user_id) 적용.

🔗 Related: Issue [#1048]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

스트리밍 채팅 엔드포인트에서 워커별 SSE 동시성 추적과 그래프 사용량 모니터링을 도입하여, 런타임 임계값을 기반으로 한 Neo4j 마이그레이션 권장 사항을 제공하도록 합니다.

새 기능:
- 스트리밍 채팅 엔드포인트에서 FastAPI 의존성을 통해 워커별 활성 SSE 세션을 추적하여, 동시성 인지(concurrency-aware) 동작을 지원합니다.
- 사용자별 그래프 노드 수나 활성 SSE 세션 수가 설정 가능한 임계값을 초과할 경우 Neo4j 마이그레이션 권장 경고를 로그로 남깁니다.
- 개인화된 그래프 스토리지를 조회할 때 KMS 기반의 결정론적으로 해시된 사용자 ID를 적용하여, DB 통합 이전에 사용자 프라이버시를 보호합니다.

개선 사항:
- 스트리밍 파이프라인에 하드코딩된 마이그레이션 한계값을 피하기 위해, 환경 변수 기반 설정에서 그래프 엔진 및 개인화 RAG 임계값을 로드합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce per-worker SSE concurrency tracking and graph usage monitoring in the streaming chat endpoint to drive Neo4j migration recommendations based on runtime thresholds.

New Features:
- Track active SSE sessions per worker in the streaming chat endpoint via a FastAPI dependency to support concurrency-aware behavior.
- Log Neo4j migration recommendation warnings when per-user graph node counts or active SSE sessions exceed configurable thresholds.
- Apply KMS-backed, deterministically hashed user IDs when querying personalized graph storage to protect user privacy before DB integration.

Enhancements:
- Load graph engine and personalized RAG thresholds from environment-driven configs to avoid hardcoded migration limits in the streaming pipeline.

</details>