### PR TITLE
☘️ refactor [#12.3.10]: 2차 개선 - `Double-checked caching` 및 크로스 스레드 상태 공유 차단

### DIFF
--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -83,20 +83,20 @@ async def sse_session_tracker() -> AsyncGenerator[int, None]:
 # ─────────────────────────────────────────────────────────────────────────────
 _pepper_cache: TTLCache = TTLCache(maxsize=1, ttl=300)  # 5분 단위 갱신
 _pepper_lock = asyncio.Lock()
-_graph_repo = NetworkXGraphRepository(storage_base_path=_rag_cfg.storage_base_path)
 
 async def get_cached_global_pepper() -> str:
     """KMS 지연시간 감소를 위한 global_pepper 메모리 캐싱"""
+    # Fast path: lock-free read
+    if "pepper" in _pepper_cache:
+        return _pepper_cache["pepper"]
+
+    # Slow path: 잠금 기반 double-checked 패턴으로 KMS 호출
     async with _pepper_lock:
         if "pepper" in _pepper_cache:
             return _pepper_cache["pepper"]
         pepper = await fetch_global_pepper()
         _pepper_cache["pepper"] = pepper
         return pepper
-
-def get_graph_repository() -> NetworkXGraphRepository:
-    """그래프 리포지토리 재사용 의존성 주입"""
-    return _graph_repo
 
 # SSE 이벤트 이름 상수 (클라이언트 API 계약 — 하드코딩 방지)
 # 프론트엔드와 동기화된 표준 이벤트 이름이므로, 변경 시 이 상수만 수정하면 됩니다.
@@ -181,7 +181,6 @@ async def stream_chat_endpoint(
     request: Request,
     body: ChatQueryRequest,
     current_sse_count: int = Depends(sse_session_tracker),
-    repo: NetworkXGraphRepository = Depends(get_graph_repository),
 ) -> EventSourceResponse:
     """
     SSE 기반 스트리밍 엔드포인트 (2단계: 어댑터 연결).
@@ -207,8 +206,14 @@ async def stream_chat_endpoint(
         
         hashed_uid = compute_hashed_user_id(body.user_id, per_user_salt, global_pepper)
         
-        # [설계결정] node_count는 디스크 I/O를 유발하므로 이벤트 루프 블로킹을 피하기 위해 스레드 풀에서 실행
-        current_node_count = await anyio.to_thread.run_sync(repo.node_count, hashed_uid)
+        # [설계결정] node_count는 디스크 I/O를 유발하므로 이벤트 루프 블로킹을 방지하고, 
+        # 스레드 안전성(Thread-safety) 확보 및 상태 공유 차단을 위해 스레드 내부에서 리포지토리 독립 인스턴스를 생성
+        def _get_node_count() -> int:
+            local_repo = NetworkXGraphRepository(storage_base_path=_rag_cfg.storage_base_path)
+            local_repo.load(hashed_uid)
+            return local_repo.node_count(hashed_uid)
+            
+        current_node_count = await anyio.to_thread.run_sync(_get_node_count)
     except Exception as exc:
         logger.warning(
             "%s[MIGRATION] Failed to fetch node count for trigger: %s",

--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -86,14 +86,16 @@ _pepper_lock = asyncio.Lock()
 
 async def get_cached_global_pepper() -> str:
     """KMS 지연시간 감소를 위한 global_pepper 메모리 캐싱"""
-    # Fast path: lock-free read
-    if "pepper" in _pepper_cache:
-        return _pepper_cache["pepper"]
+    # Fast path: lock-free atomic read (TOCTOU 방지)
+    cached_pepper = _pepper_cache.get("pepper")
+    if cached_pepper is not None:
+        return cached_pepper
 
     # Slow path: 잠금 기반 double-checked 패턴으로 KMS 호출
     async with _pepper_lock:
-        if "pepper" in _pepper_cache:
-            return _pepper_cache["pepper"]
+        cached_pepper = _pepper_cache.get("pepper")
+        if cached_pepper is not None:
+            return cached_pepper
         pepper = await fetch_global_pepper()
         _pepper_cache["pepper"] = pepper
         return pepper
@@ -210,8 +212,12 @@ async def stream_chat_endpoint(
         # 스레드 안전성(Thread-safety) 확보 및 상태 공유 차단을 위해 스레드 내부에서 리포지토리 독립 인스턴스를 생성
         def _get_node_count() -> int:
             local_repo = NetworkXGraphRepository(storage_base_path=_rag_cfg.storage_base_path)
-            local_repo.load(hashed_uid)
-            return local_repo.node_count(hashed_uid)
+            try:
+                local_repo.load(hashed_uid)
+                return local_repo.node_count(hashed_uid)
+            finally:
+                # 명시적 메모리 해제를 통해 인스턴스 소멸 전 GC 부담 경감
+                local_repo.clear(hashed_uid)
             
         current_node_count = await anyio.to_thread.run_sync(_get_node_count)
     except Exception as exc:


### PR DESCRIPTION
- [Performance]
  - `get_cached_global_pepper` 내부에 `Double-checked locking` 패턴 적용.
  - 이미 캐시된 값에 대한 불필요한 Lock 획득/대기(Contention) 방지.
- [Concurrency]
  - `NetworkXGraphRepository`를 전역/의존성 주입으로 공유하지 않고, `anyio.to_thread` 내부에서 독립 인스턴스로 생성 후 폐기하도록 변경.
  - 이를 통해 크로스 스레드 환경에서의 의도치 않은 상태 공유 및 Thread-safety 이슈 원천 차단.
- [Bugfix] `node_count` 호출 전 디스크로부터 `load()`를 명시적으로 수행하여 정확한 노드 수 조회 보장.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1511#pullrequestreview-4399678674)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

더 나은 성능과 스레드 안전성을 위해 채팅 스트리밍 엔드포인트 캐싱과 그래프 리포지토리 사용 방식을 개선합니다.

버그 수정:
- 쿼리 전에 디스크에서 그래프 데이터를 명시적으로 로드하여 정확한 노드 수를 보장합니다.

개선 사항:
- 캐시 적중 시 불필요한 락 획득을 피하기 위해 double-checked locking 패턴으로 전역 pepper 캐싱을 최적화합니다.
- 스레드 간 상태 공유를 피하기 위해, 더 이상 전역 `NetworkXGraphRepository` 인스턴스를 공유하지 않고 노드 수를 계산할 때 스레드별 리포지토리 인스턴스를 생성합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine chat streaming endpoint caching and graph repository usage for better performance and thread safety.

Bug Fixes:
- Ensure accurate node counts by explicitly loading graph data from disk before querying.

Enhancements:
- Optimize global pepper caching with a double-checked locking pattern to avoid unnecessary locking on cache hits.
- Stop sharing a global NetworkXGraphRepository instance and instead create per-thread repository instances when computing node counts to avoid cross-thread state sharing.

</details>