### PR TITLE
☘️ refactor [#12.3.10]: 4차 개선 - load 실패 시 clear 부작용 방지 플래그 적용

### DIFF
--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -212,12 +212,15 @@ async def stream_chat_endpoint(
         # 스레드 안전성(Thread-safety) 확보 및 상태 공유 차단을 위해 스레드 내부에서 리포지토리 독립 인스턴스를 생성
         def _get_node_count() -> int:
             local_repo = NetworkXGraphRepository(storage_base_path=_rag_cfg.storage_base_path)
+            is_loaded = False
             try:
                 local_repo.load(hashed_uid)
+                is_loaded = True
                 return local_repo.node_count(hashed_uid)
             finally:
-                # 명시적 메모리 해제를 통해 인스턴스 소멸 전 GC 부담 경감
-                local_repo.clear(hashed_uid)
+                # [설계결정] load 성공 시에만 명시적 메모리 해제 수행 (오류 시 부작용 방지)
+                if is_loaded:
+                    local_repo.clear(hashed_uid)
             
         current_node_count = await anyio.to_thread.run_sync(_get_node_count)
     except Exception as exc:

--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -212,15 +212,9 @@ async def stream_chat_endpoint(
         # 스레드 안전성(Thread-safety) 확보 및 상태 공유 차단을 위해 스레드 내부에서 리포지토리 독립 인스턴스를 생성
         def _get_node_count() -> int:
             local_repo = NetworkXGraphRepository(storage_base_path=_rag_cfg.storage_base_path)
-            is_loaded = False
-            try:
-                local_repo.load(hashed_uid)
-                is_loaded = True
+            # 리포지토리 레벨에 캡슐화된 컨텍스트 매니저를 통해 안전하게 로드 후 해제
+            with local_repo.stateless_load(hashed_uid):
                 return local_repo.node_count(hashed_uid)
-            finally:
-                # [설계결정] load 성공 시에만 명시적 메모리 해제 수행 (오류 시 부작용 방지)
-                if is_loaded:
-                    local_repo.clear(hashed_uid)
             
         current_node_count = await anyio.to_thread.run_sync(_get_node_count)
     except Exception as exc:

--- a/backend/graph/networkx_repository.py
+++ b/backend/graph/networkx_repository.py
@@ -25,7 +25,8 @@ import threading
 import uuid
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, Iterator, Generator
+from contextlib import contextmanager
 
 import networkx as nx
 
@@ -432,3 +433,18 @@ class NetworkXGraphRepository(AbstractGraphRepository):
             logger.debug(
                 "[GRAPH][NX] In-memory graph cleared (user isolated).",
             )
+
+    @contextmanager
+    def stateless_load(self, hashed_user_id: str) -> Generator[None, None, None]:
+        """
+        일회성 조회를 위해 그래프를 메모리에 로드하고, 블록 종료 시 안전하게 해제하는 컨텍스트 매니저.
+        load() 실패 시(예: 파일 손상) 부작용이 발생하지 않도록 is_loaded 상태를 내부에서 관리한다.
+        """
+        is_loaded = False
+        try:
+            self.load(hashed_user_id)
+            is_loaded = True
+            yield
+        finally:
+            if is_loaded:
+                self.clear(hashed_user_id)


### PR DESCRIPTION
- [Bugfix] `NetworkXGraphRepository`의 load() 메서드가 실패(Corrupt file 등)했을 때 finally 블록에서 무조건적으로 clear()가 호출되어 발생할 수 있는 부작용을 막기 위해 `is_loaded` 플래그 방어 로직 추가.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1513#pullrequestreview-4399759606)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

버그 수정:
- 저장소 로드가 완료되기 전에 실패하는 경우, 채팅 스트리밍 노드 수를 세는 헬퍼에서 의도치 않게 그래프가 초기화되지 않도록 방지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent unintended graph clearing in the chat streaming node-count helper when repository load fails before completion.

</details>