### PR TITLE
☘️ refactor [#12.3.10]: 6차 개선 - 컨텍스트 매니저 인터페이스 고도화 및 예외 은닉(Swallowing) 방지

### DIFF
--- a/backend/api/endpoints/chat_stream.py
+++ b/backend/api/endpoints/chat_stream.py
@@ -211,9 +211,8 @@ async def stream_chat_endpoint(
         # [설계결정] node_count는 디스크 I/O를 유발하므로 이벤트 루프 블로킹을 방지하고, 
         # 스레드 안전성(Thread-safety) 확보 및 상태 공유 차단을 위해 스레드 내부에서 리포지토리 독립 인스턴스를 생성
         def _get_node_count() -> int:
-            local_repo = NetworkXGraphRepository(storage_base_path=_rag_cfg.storage_base_path)
             # 리포지토리 레벨에 캡슐화된 컨텍스트 매니저를 통해 안전하게 로드 후 해제
-            with local_repo.stateless_load(hashed_uid):
+            with NetworkXGraphRepository(storage_base_path=_rag_cfg.storage_base_path).stateless_load(hashed_uid) as local_repo:
                 return local_repo.node_count(hashed_uid)
             
         current_node_count = await anyio.to_thread.run_sync(_get_node_count)

--- a/backend/graph/networkx_repository.py
+++ b/backend/graph/networkx_repository.py
@@ -435,7 +435,7 @@ class NetworkXGraphRepository(AbstractGraphRepository):
             )
 
     @contextmanager
-    def stateless_load(self, hashed_user_id: str) -> Generator[None, None, None]:
+    def stateless_load(self, hashed_user_id: str) -> Generator["NetworkXGraphRepository", None, None]:
         """
         일회성 조회를 위해 그래프를 메모리에 로드하고, 블록 종료 시 안전하게 해제하는 컨텍스트 매니저.
         load() 실패 시(예: 파일 손상) 부작용이 발생하지 않도록 is_loaded 상태를 내부에서 관리한다.
@@ -444,7 +444,13 @@ class NetworkXGraphRepository(AbstractGraphRepository):
         try:
             self.load(hashed_user_id)
             is_loaded = True
-            yield
+            yield self
         finally:
             if is_loaded:
-                self.clear(hashed_user_id)
+                try:
+                    self.clear(hashed_user_id)
+                except Exception:
+                    logger.exception(
+                        "[GRAPH][NX] Failed to clear in-memory graph after stateless load (user_id_prefix=%s).",
+                        hashed_user_id[:8]
+                    )


### PR DESCRIPTION
- [Refactor] `stateless_load` 컨텍스트 매니저가 self를 yield 하도록 개선하여, 호출자 쪽에서 보다 직관적이고 유연하게(as local_repo) 저장소 인스턴스를 다룰 수 있도록 구조화.
- [Bugfix] finally 블록 내의 clear() 호출 과정에서 오류가 발생할 경우 원래 블록의 핵심 예외가 마스킹(Swallowing)되는 문제를 방지하기 위해, try-except 로 감싸고 로깅만 하도록 방어 로직 추가.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1515#pullrequestreview-4399839871)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

NetworkX 그래프 리포지토리의 `stateless_load` 컨텍스트 매니저 인터페이스를 다듬고, 정리(cleanup) 과정에서 발생하는 예외가 원래의 주요 에러를 가리지 않도록 합니다.

New Features:
- 호출 측에서 더 유연하고 로컬하게 사용할 수 있도록, `stateless_load` 컨텍스트 매니저가 리포지토리 인스턴스를 반환(yield)할 수 있게 합니다.

Bug Fixes:
- `stateless_load` 정리 과정에서 `clear()` 실행 실패가 발생했을 때, 관리되는 블록에서 발생한 원래 예외를 삼키지 않고, 해당 실패를 잡아 로깅하도록 합니다.

Enhancements:
- `stateless_load` 컨텍스트 매니저로 리포지토리를 인라인으로 생성하고, 반환된 인스턴스를 로컬 리포지토리로 사용함으로써 `chat_stream` 노드 수 조회 로직을 단순화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the NetworkX graph repository stateless_load context manager interface and prevent exceptions during cleanup from masking primary errors.

New Features:
- Allow the stateless_load context manager to yield the repository instance for more flexible, local usage in callers.

Bug Fixes:
- Ensure failures in clear() during stateless_load cleanup are caught and logged instead of swallowing the original exception from the managed block.

Enhancements:
- Simplify chat_stream node count retrieval by constructing the repository inline with the stateless_load context manager and using the yielded instance as a local repository.

</details>