### PR TITLE
✨ feat [#12.3.11]: Phase 4-2 - ➀ GraphRAG 하이브리드 라우터 뼈대 구축 및 SSOT 가드레일 적용

### DIFF
--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -1,7 +1,7 @@
 # backend/agent/graph_router.py
 
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from backend.core.health_registry import HealthRegistry
 from backend.core.config_validator import Subsystem
@@ -13,8 +13,8 @@ class GraphHybridRouter:
     기존 벡터 검색(Vector RAG) 결과와 지식 그래프 탐색 결과를 결합하는 하이브리드 쿼리 라우터.
     """
     
-    def __init__(self) -> None:
-        self.health_registry = HealthRegistry.get_instance()
+    def __init__(self, health_registry: Optional[HealthRegistry] = None) -> None:
+        self.health_registry = health_registry or HealthRegistry.get_instance()
 
     def route_query(self, query: str, vector_results: List[Dict[str, Any]], **kwargs: Any) -> List[Dict[str, Any]]:
         """
@@ -22,9 +22,12 @@ class GraphHybridRouter:
         """
         # [핵심] 매 쿼리마다 HealthRegistry.is_ok(Subsystem.GRAPH_ENGINE)를 최우선 검사
         if not self.health_registry.is_ok(Subsystem.GRAPH_ENGINE):
+            summary = self.health_registry.get_summary()
+            current_status = summary.get(Subsystem.GRAPH_ENGINE.value, "UNKNOWN")
             logger.info(
-                "[GRAPH_ROUTER] GRAPH_ENGINE subsystem is DEGRADED. "
-                "Skipping graph traversal and silently falling back to Vector RAG."
+                "[GRAPH_ROUTER] GRAPH_ENGINE subsystem is %s. "
+                "Skipping graph traversal and silently falling back to Vector RAG.",
+                current_status
             )
             # 그래프 로직 스킵하고 조용히(Silent Fallback) Vector RAG 결과 반환
             return vector_results

--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -1,0 +1,44 @@
+# backend/agent/graph_router.py
+
+import logging
+from typing import Any, Dict, List
+
+from backend.core.health_registry import HealthRegistry
+from backend.core.config_validator import Subsystem
+
+logger = logging.getLogger(__name__)
+
+class GraphHybridRouter:
+    """
+    기존 벡터 검색(Vector RAG) 결과와 지식 그래프 탐색 결과를 결합하는 하이브리드 쿼리 라우터.
+    """
+    
+    def __init__(self) -> None:
+        self.health_registry = HealthRegistry.get_instance()
+
+    def route_query(self, query: str, vector_results: List[Dict[str, Any]], **kwargs: Any) -> List[Dict[str, Any]]:
+        """
+        벡터 검색 결과(vector_results)를 입력받아 그래프 탐색과 결합하여 하이브리드 결과를 반환한다.
+        """
+        # [핵심] 매 쿼리마다 HealthRegistry.is_ok(Subsystem.GRAPH_ENGINE)를 최우선 검사
+        if not self.health_registry.is_ok(Subsystem.GRAPH_ENGINE):
+            logger.info(
+                "[GRAPH_ROUTER] GRAPH_ENGINE subsystem is DEGRADED. "
+                "Skipping graph traversal and silently falling back to Vector RAG."
+            )
+            # 그래프 로직 스킵하고 조용히(Silent Fallback) Vector RAG 결과 반환
+            return vector_results
+            
+        # TODO: Phase 4-2 / 2단계: 하이브리드 탐색 알고리즘 결합 로직
+        # FAISS 등 벡터 검색 결과의 Top-K 노드들을 그래프의 진입점(Seed Node)으로 설정하고,
+        # GRAPH_MAX_TRAVERSAL_DEPTH를 넘지 않도록 무한 루프 방지용 Clamping 순회 로직 구현 예정.
+        
+        # 임시로 기존 vector_results 반환 (뼈대 단계)
+        return vector_results
+
+def run_hybrid_search(query: str, vector_results: List[Dict[str, Any]], **kwargs: Any) -> List[Dict[str, Any]]:
+    """
+    하이브리드 검색을 실행하는 헬퍼 함수
+    """
+    router = GraphHybridRouter()
+    return router.route_query(query, vector_results, **kwargs)


### PR DESCRIPTION
- `backend/agent/graph_router.py` 신규 모듈 생성
  - 하이브리드 쿼리 라우터(`GraphHybridRouter`)의 초기 뼈대 구축.
  - 매 쿼리마다 단일 진실 공급원(SSOT)인 `HealthRegistry.is_ok(Subsystem.GRAPH_ENGINE)`를 최우선으로 검사하도록 방어적 로직 구현.
  - `GRAPH_ENGINE` 서브시스템이 DEGRADED 상태이거나 비정상일 경우, 쿼리를 실패시키지 않고 즉시 기존 Vector RAG 모드로 조용히 폴백(Silent Fallback)하여 서비스 가용성을 보장함.

🔗 Related: Issue [#1048]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

서브시스템 상태 점검에 의해 보호되는 초기 Graph RAG–Vector RAG 하이브리드 쿼리 라우터를 도입합니다.

New Features:
- 향후 벡터 검색과 그래프 탐색의 하이브리드를 사용해 쿼리를 라우팅하면서, 현재는 벡터 검색 결과를 반환하는 `GraphHybridRouter` 컴포넌트를 추가합니다.
- 외부 호출자가 하이브리드 라우터를 호출할 수 있도록 `run_hybrid_search` 헬퍼 함수를 노출합니다.

Enhancements:
- 그래프 탐색을 수행할지, 아니면 순수 Vector RAG로 폴백할지를 결정하기 위해 `GRAPH_ENGINE` 서브시스템에 대해 `HealthRegistry`를 사용하는 방어적인 SSOT 상태 점검을 통합합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an initial Graph RAG–Vector RAG hybrid query router guarded by subsystem health checks.

New Features:
- Add a GraphHybridRouter component that routes queries using a future hybrid of vector search and graph traversal while currently returning vector search results.
- Expose a run_hybrid_search helper function to invoke the hybrid router from external callers.

Enhancements:
- Integrate a defensive SSOT health check using HealthRegistry for the GRAPH_ENGINE subsystem to decide whether to execute graph traversal or fall back to pure Vector RAG.

</details>