### PR TITLE
☘️ refactor [#12.3.11]: 2차 개선 - 하이브리드 라우터 구조화된 로깅 적용 및 인터페이스 클린업

### DIFF
--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -16,7 +16,7 @@ class GraphHybridRouter:
     def __init__(self, health_registry: Optional[HealthRegistry] = None) -> None:
         self.health_registry = health_registry or HealthRegistry.get_instance()
 
-    def route_query(self, query: str, vector_results: List[Dict[str, Any]], **kwargs: Any) -> List[Dict[str, Any]]:
+    def route_query(self, query: str, vector_results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
         벡터 검색 결과(vector_results)를 입력받아 그래프 탐색과 결합하여 하이브리드 결과를 반환한다.
         """
@@ -24,10 +24,14 @@ class GraphHybridRouter:
         if not self.health_registry.is_ok(Subsystem.GRAPH_ENGINE):
             summary = self.health_registry.get_summary()
             current_status = summary.get(Subsystem.GRAPH_ENGINE.value, "UNKNOWN")
-            logger.info(
+            logger.warning(
                 "[GRAPH_ROUTER] GRAPH_ENGINE subsystem is %s. "
                 "Skipping graph traversal and silently falling back to Vector RAG.",
-                current_status
+                current_status,
+                extra={
+                    "subsystem": Subsystem.GRAPH_ENGINE.value,
+                    "status": current_status,
+                }
             )
             # 그래프 로직 스킵하고 조용히(Silent Fallback) Vector RAG 결과 반환
             return vector_results
@@ -39,9 +43,13 @@ class GraphHybridRouter:
         # 임시로 기존 vector_results 반환 (뼈대 단계)
         return vector_results
 
-def run_hybrid_search(query: str, vector_results: List[Dict[str, Any]], **kwargs: Any) -> List[Dict[str, Any]]:
+def run_hybrid_search(
+    query: str, 
+    vector_results: List[Dict[str, Any]], 
+    router: Optional[GraphHybridRouter] = None
+) -> List[Dict[str, Any]]:
     """
     하이브리드 검색을 실행하는 헬퍼 함수
     """
-    router = GraphHybridRouter()
-    return router.route_query(query, vector_results, **kwargs)
+    router = router or GraphHybridRouter()
+    return router.route_query(query, vector_results)

--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -51,5 +51,6 @@ def run_hybrid_search(
     """
     하이브리드 검색을 실행하는 헬퍼 함수
     """
-    router = router or GraphHybridRouter()
+    if router is None:
+        router = GraphHybridRouter()
     return router.route_query(query, vector_results)


### PR DESCRIPTION
- [Observability] `GRAPH_ENGINE` 서브시스템의 우회(Fallback)는 성능 저하를 의미하므로 로깅 레벨을 `warning`으로 상향하고, 외부 모니터링 도구가 즉각 감지할 수 있도록 `extra` 기반의 구조화된 로깅(Structured Logging) 필드 추가.
- [Clean Code] 목적이 불분명하고 사용되지 않는 `**kwargs` 인자를 선제적으로 제거하여 인터페이스 시그니처의 의도를 명확히 함.
- [Architecture] 헬퍼 함수(`run_hybrid_search`)에 `router` 인스턴스 주입 옵션을 추가하여 제어 역전(IoC) 및 완전한 외부 테스트 용이성 달성.
- [Security] 하드코딩을 방지하고 `Subsystem` Enum의 value를 로그에 활용함으로써 PII 누출 없는 안전한 상태 참조를 보장함.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1519#pullrequestreview-4406544951)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

하이브리드 그래프 라우터의 인터페이스를 더 엄격하게 다듬고, graph-engine 폴백(fallback)의 관측 가능성을 향상시켰습니다.

Enhancements:
- GRAPH_ENGINE 폴백 로그의 레벨을 경고(warning)로 상향하고, 서브시스템 상태에 대한 구조화된 로그 필드를 추가했습니다.
- 의도를 명확히 하기 위해 그래프 라우팅 및 하이브리드 검색 헬퍼 인터페이스에서 사용되지 않는 `kwargs`를 제거했습니다.
- 테스트 용이성과 제어력을 높이기 위해 하이브리드 검색 헬퍼에 `GraphHybridRouter` 인스턴스를 주입할 수 있도록 허용했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten the hybrid graph router’s interface while improving observability of graph-engine fallbacks.

Enhancements:
- Raise GRAPH_ENGINE fallback logs to warning level and add structured log fields for subsystem status.
- Remove unused kwargs from the graph routing and hybrid search helper interfaces to clarify intent.
- Allow injecting a GraphHybridRouter instance into the hybrid search helper to improve testability and control.

</details>