### PR TITLE
☘️ refactor [#12.3.11]: 4차 개선 - 생성자 DI 파라미터 Falsy 버그 리스크 차단 및 일관성 확보

### DIFF
--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -14,7 +14,10 @@ class GraphHybridRouter:
     """
     
     def __init__(self, health_registry: Optional[HealthRegistry] = None) -> None:
-        self.health_registry = health_registry or HealthRegistry.get_instance()
+        if health_registry is None:
+            self.health_registry = HealthRegistry.get_instance()
+        else:
+            self.health_registry = health_registry
 
     def route_query(self, query: str, vector_results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """


### PR DESCRIPTION
- [Bugfix] `GraphHybridRouter.__init__`에서 의존성 주입(DI)된 `health_registry` 파라미터를 평가할 때, 파이썬 단축 평가(`or`) 안티패턴을 제거하고 명시적인 `is None` 체크 로직으로 개선함.
- [Consistency] 이전 차수에서 수정한 헬퍼 함수의 로직과 동일하게 내부 생성자의 방어 로직을 통일하여 코드베이스의 무결성을 확보함.
- [Testability] 이를 통해 유효하지만 Falsy하게 평가될 수 있는 Mock 레지스트리나 유사 인스턴스를 주입할 경우 강제로 전역 싱글톤으로 덮어써지는 런타임 엣지 케이스를 원천 차단하여 완전한 단위 테스트 제어 역전(IoC)을 보장함.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1521#pullrequestreview-4406593552)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

버그 수정:
- `GraphHybridRouter`에 주입된, 유효하지만 falsy한 `health_registry` 인스턴스가 전역 `HealthRegistry` 싱글톤으로 조용히 대체되지 않도록 방지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent valid but falsy health_registry instances injected into GraphHybridRouter from being silently replaced by the global HealthRegistry singleton.

</details>