### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -97,29 +97,79 @@ def _extract_seed_node_ids(vector_results: List[Dict[str, Any]]) -> List[str]:
     순서로 탐색하여 Seed Node를 식별한다. 원래 스코어 순서(내림차순)를 보존하며
     중복을 제거한다.
 
+    ID는 다음 우선순위로 추출되며, 문자열이 아닌 ID는 str()로 정규화된다.
+    - result['id']
+    - result['metadata']['id']
+    - result['metadata']['source']
+
+    비문자열 ID를 발견하면 경고 로그를 남기고, str() 변환에 실패하는 경우에만
+    해당 항목을 건너뛴다.
+
     Args:
-        vector_results: 벡터 검색 결과 리스트. 각 항목은 {'content': ..., 'metadata': ..., 'score': ...} 형식.
+        vector_results: 벡터 검색 결과 리스트. 각 항목은
+            {'content': ..., 'metadata': ..., 'score': ...} 형식.
 
     Returns:
-        중복 없는 Seed Node ID 목록 (스코어 순서 보존)
+        스코어 순서를 보존한 고유 Seed Node ID 문자열 리스트.
     """
-    seen: set[str] = set()
-    seed_ids: List[str] = []
+    seed_node_ids: List[str] = []
+    seen_ids: set[str] = set()
 
-    for result in vector_results:
-        # 1순위: 최상위 'id' 필드
-        node_id = result.get("id")
+    for idx, result in enumerate(vector_results):
+        node_id = None
+        source_field = None
 
-        # 2순위: metadata 내의 'id' 또는 'source' 필드
-        if not node_id:
-            metadata = result.get("metadata") or {}
-            node_id = metadata.get("id") or metadata.get("source")
+        # 1) result['id']
+        if "id" in result and result["id"] is not None:
+            node_id = result["id"]
+            source_field = "id"
+        else:
+            metadata = result.get("metadata")
+            if isinstance(metadata, dict):
+                # 2) result['metadata']['id']
+                if metadata.get("id") is not None:
+                    node_id = metadata["id"]
+                    source_field = "metadata.id"
+                # 3) result['metadata']['source']
+                elif metadata.get("source") is not None:
+                    node_id = metadata["source"]
+                    source_field = "metadata.source"
 
-        if node_id and isinstance(node_id, str) and node_id not in seen:
-            seen.add(node_id)
-            seed_ids.append(node_id)
+        if node_id is None:
+            # No usable ID for this result; silently skip to preserve previous behavior.
+            continue
 
-    return seed_ids
+        # Normalize non-string IDs and log for observability.
+        if not isinstance(node_id, str):
+            logger.warning(
+                "[GRAPH_ROUTER] Non-string seed node id from %s at index %d: %r (type=%s); coercing to str.",
+                source_field or "<unknown>",
+                idx,
+                node_id,
+                type(node_id).__name__,
+            )
+            try:
+                node_id_str = str(node_id)
+            except Exception:
+                logger.error(
+                    "[GRAPH_ROUTER] Failed to coerce seed node id from %s at index %d to str; skipping.",
+                    source_field or "<unknown>",
+                    idx,
+                    exc_info=True,
+                )
+                continue
+        else:
+            node_id_str = node_id
+
+        # Skip empty strings after normalization
+        if not node_id_str:
+            continue
+
+        if node_id_str not in seen_ids:
+            seen_ids.add(node_id_str)
+            seed_node_ids.append(node_id_str)
+
+    return seed_node_ids
 
 
 def _serialize_neighbor_node(
@@ -148,9 +198,13 @@ def _serialize_neighbor_node(
     return {
         "content": str(content),
         "metadata": {
+            **{
+                k: v
+                for k, v in attrs.items()
+                if k not in ("content", "text", "source", "id")
+            },
             "id": node_id,
             "source": attrs.get("source", node_id),
-            **{k: v for k, v in attrs.items() if k not in ("content", "text", "source")},
         },
         "score": graph_score,
     }
@@ -193,7 +247,6 @@ class GraphHybridRouter:
         query: str,
         vector_results: List[Dict[str, Any]],
         hashed_user_id: Optional[str] = None,
-        graph_repository: Optional[AbstractGraphRepository] = None,
     ) -> List[Dict[str, Any]]:
         """
         벡터 검색 결과(vector_results)를 입력받아 그래프 탐색과 결합하여 하이브리드 결과를 반환한다.
@@ -209,7 +262,6 @@ class GraphHybridRouter:
             query           : 사용자 쿼리 (로깅 목적, 현재 탐색 로직에는 미사용)
             vector_results  : 벡터 검색 결과 리스트
             hashed_user_id  : 테넌트 식별자 (SHA-256 hex, PII 미포함). None이면 탐색 스킵.
-            graph_repository: 이 호출에서만 사용할 Repository (생성자 주입보다 우선).
 
         Returns:
             vector_results + 그래프 이웃 노드 결과가 결합된 리스트.
@@ -231,16 +283,13 @@ class GraphHybridRouter:
             return vector_results
 
         # ── 2단계: 탐색 가능 여부 사전 검사 ────────────────────────────────
-        # 인자로 전달된 repository를 우선 사용, 없으면 생성자 주입 repository 사용
-        effective_repo = graph_repository if graph_repository is not None else self.graph_repository
-
-        if not hashed_user_id or effective_repo is None:
+        if not hashed_user_id or self.graph_repository is None:
             logger.debug(
                 "[GRAPH_ROUTER] Graph traversal skipped: "
                 "hashed_user_id=%s, repository_available=%s. "
                 "Returning vector_results as-is.",
                 "provided" if hashed_user_id else "missing",
-                effective_repo is not None,
+                self.graph_repository is not None,
             )
             return vector_results
 
@@ -258,11 +307,23 @@ class GraphHybridRouter:
         max_depth = _load_traversal_depth()
 
         # ── 5단계: BFS 탐색 및 결과 수집 ─────────────────────────────────────
+        return self._traverse_and_enrich(
+            seed_ids, vector_results, hashed_user_id, max_depth
+        )
+
+    def _traverse_and_enrich(
+        self,
+        seed_ids: List[str],
+        vector_results: List[Dict[str, Any]],
+        hashed_user_id: str,
+        max_depth: int,
+    ) -> List[Dict[str, Any]]:
         graph_enriched: List[Dict[str, Any]] = list(vector_results)
-        visited_neighbor_ids: set[str] = set(seed_ids)  # Seed 자체는 중복 추가 방지
+        visited_neighbor_ids: set[str] = set(seed_ids)
 
         try:
-            with effective_repo.stateless_load(hashed_user_id) as repo:
+            assert self.graph_repository is not None  # guarded earlier
+            with self.graph_repository.stateless_load(hashed_user_id) as repo:
                 for seed_id in seed_ids:
                     neighbors = repo.neighbors(
                         hashed_user_id,
@@ -278,9 +339,7 @@ class GraphHybridRouter:
                         graph_enriched.append(
                             _serialize_neighbor_node(neighbor_id, attrs)
                         )
-
         except Exception:
-            # 그래프 탐색 중 예기치 못한 오류 발생 시 원본 결과로 Silent Fallback
             logger.exception(
                 "[GRAPH_ROUTER] Unexpected error during graph traversal. "
                 "Falling back to vector_results only."
@@ -329,5 +388,4 @@ def run_hybrid_search(
         query,
         vector_results,
         hashed_user_id=hashed_user_id,
-        graph_repository=graph_repository,
     )

--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -1,29 +1,221 @@
 # backend/agent/graph_router.py
 
+"""
+Phase 4-2: GraphRAG 하이브리드 라우터
+
+책임:
+  - 매 쿼리마다 HealthRegistry.is_ok(Subsystem.GRAPH_ENGINE)를 최우선 검사.
+    False 반환 시 그래프 탐색을 스킵하고 즉시 Vector RAG로 Silent Fallback.
+  - 벡터 검색 결과의 Top-K 노드를 Seed Node로 삼아 지식 그래프 BFS 탐색 수행.
+  - GRAPH_MAX_TRAVERSAL_DEPTH 환경 변수를 [1, 5] 범위로 Clamping하여 무한 루프 방지.
+  - 그래프 탐색 결과를 Vector RAG 결과에 결합하여 반환.
+
+보안 원칙:
+  - hashed_user_id 단위로 테넌트를 격리하여 타 사용자 그래프가 섞이지 않는다.
+  - PII(user_id 원문)는 절대 이 모듈 어디에도 전달되지 않는다.
+  - stateless_load 컨텍스트 매니저를 사용하여 조회 후 인메모리 데이터를 즉시 정리.
+"""
+
 import logging
 from typing import Any, Dict, List, Optional
 
 from backend.core.health_registry import HealthRegistry
 from backend.core.config_validator import Subsystem
+from backend.core.config.graph import (
+    MAX_TRAVERSAL_DEPTH_RANGE,
+    DEFAULT_MAX_TRAVERSAL_DEPTH,
+    ENV_MAX_TRAVERSAL_DEPTH,
+)
+from backend.graph.base import AbstractGraphRepository
 
 logger = logging.getLogger(__name__)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 내부 헬퍼
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _clamp_depth(depth: int) -> int:
+    """
+    탐색 깊이를 [1, 5] 범위로 강제(Clamping).
+
+    GRAPH_MAX_TRAVERSAL_DEPTH 환경 변수가 범위를 벗어나거나 파싱에 실패한 경우에도
+    이 함수가 최후 방어선으로 작동하여 무한 루프를 예방한다.
+
+    Args:
+        depth: 적용 예정 탐색 깊이
+
+    Returns:
+        [1, 5] 범위로 보정된 탐색 깊이
+    """
+    min_depth = MAX_TRAVERSAL_DEPTH_RANGE.min
+    max_depth = MAX_TRAVERSAL_DEPTH_RANGE.max
+    clamped = max(min_depth, min(depth, max_depth))
+    if clamped != depth:
+        logger.warning(
+            "[GRAPH_ROUTER] GRAPH_MAX_TRAVERSAL_DEPTH=%d is out of range [%d, %d]. "
+            "Clamped to %d.",
+            depth,
+            min_depth,
+            max_depth,
+            clamped,
+        )
+    return clamped
+
+
+def _load_traversal_depth() -> int:
+    """
+    환경 변수에서 GRAPH_MAX_TRAVERSAL_DEPTH를 읽어 Clamping 후 반환한다.
+
+    GraphEngineConfig.from_env()를 재호출하지 않고 경량으로 처리하기 위해
+    os.environ을 직접 참조하며, 파싱 실패 시 기본값을 사용한다.
+    최종 Clamping은 _clamp_depth()에 위임하여 중복 로직을 방지한다.
+
+    Returns:
+        보정된 탐색 깊이 (int)
+    """
+    import os
+    raw = os.environ.get(ENV_MAX_TRAVERSAL_DEPTH, "")
+    if raw.strip():
+        try:
+            return _clamp_depth(int(raw.strip()))
+        except ValueError:
+            logger.warning(
+                "[GRAPH_ROUTER] Cannot parse %s='%s' as int; "
+                "falling back to default=%d.",
+                ENV_MAX_TRAVERSAL_DEPTH,
+                raw,
+                DEFAULT_MAX_TRAVERSAL_DEPTH,
+            )
+    return _clamp_depth(DEFAULT_MAX_TRAVERSAL_DEPTH)
+
+
+def _extract_seed_node_ids(vector_results: List[Dict[str, Any]]) -> List[str]:
+    """
+    vector_results에서 고유한 Seed Node ID 목록을 추출한다.
+
+    각 결과 딕셔너리의 'id' 또는 'metadata.id', 'metadata.source' 필드를 우선순위
+    순서로 탐색하여 Seed Node를 식별한다. 원래 스코어 순서(내림차순)를 보존하며
+    중복을 제거한다.
+
+    Args:
+        vector_results: 벡터 검색 결과 리스트. 각 항목은 {'content': ..., 'metadata': ..., 'score': ...} 형식.
+
+    Returns:
+        중복 없는 Seed Node ID 목록 (스코어 순서 보존)
+    """
+    seen: set[str] = set()
+    seed_ids: List[str] = []
+
+    for result in vector_results:
+        # 1순위: 최상위 'id' 필드
+        node_id = result.get("id")
+
+        # 2순위: metadata 내의 'id' 또는 'source' 필드
+        if not node_id:
+            metadata = result.get("metadata") or {}
+            node_id = metadata.get("id") or metadata.get("source")
+
+        if node_id and isinstance(node_id, str) and node_id not in seen:
+            seen.add(node_id)
+            seed_ids.append(node_id)
+
+    return seed_ids
+
+
+def _serialize_neighbor_node(
+    node_id: str,
+    attrs: Dict[str, Any],
+    graph_score: float = 0.5,
+) -> Dict[str, Any]:
+    """
+    그래프 이웃 노드를 RAG 결과 표준 포맷으로 직렬화한다.
+
+    Args:
+        node_id     : 이웃 노드 ID
+        attrs       : get_node_attrs()로 조회한 노드 속성 딕셔너리
+        graph_score : 그래프 탐색으로 발견된 노드의 기본 점수 (기본값: 0.5)
+
+    Returns:
+        {'content': str, 'metadata': dict, 'score': float} 형식의 딕셔너리
+    """
+    # content: 노드 속성에서 텍스트 필드를 우선 탐색
+    content = (
+        attrs.get("content")
+        or attrs.get("text")
+        or attrs.get("title")
+        or node_id
+    )
+    return {
+        "content": str(content),
+        "metadata": {
+            "id": node_id,
+            "source": attrs.get("source", node_id),
+            **{k: v for k, v in attrs.items() if k not in ("content", "text", "source")},
+        },
+        "score": graph_score,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GraphHybridRouter
+# ─────────────────────────────────────────────────────────────────────────────
 
 class GraphHybridRouter:
     """
     기존 벡터 검색(Vector RAG) 결과와 지식 그래프 탐색 결과를 결합하는 하이브리드 쿼리 라우터.
+
+    DI(의존성 주입) 계약:
+        - health_registry: 명시적 None 체크로 주입 여부를 판단한다. falsy한 유사
+          인스턴스가 단락 평가(or)로 누락되는 버그를 원천 방지.
+        - graph_repository: 선택적 주입. None이면 route_query 호출 시 그래프 탐색을
+          스킵하지 않으나, hashed_user_id와 함께 전달해야 실제 탐색이 수행된다.
+
+    테스트 격리:
+        생성자 주입을 통해 Mock HealthRegistry / Mock Repository를 손쉽게 주입할 수 있다.
     """
-    
-    def __init__(self, health_registry: Optional[HealthRegistry] = None) -> None:
+
+    def __init__(
+        self,
+        health_registry: Optional[HealthRegistry] = None,
+        graph_repository: Optional[AbstractGraphRepository] = None,
+    ) -> None:
+        # 명시적 None 체크 — falsy한 유효 인스턴스가 or 단락으로 버려지는 버그 방지
         if health_registry is None:
             self.health_registry = HealthRegistry.get_instance()
         else:
             self.health_registry = health_registry
 
-    def route_query(self, query: str, vector_results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        # graph_repository는 None도 유효 상태 (route_query에서 개별 처리)
+        self.graph_repository: Optional[AbstractGraphRepository] = graph_repository
+
+    def route_query(
+        self,
+        query: str,
+        vector_results: List[Dict[str, Any]],
+        hashed_user_id: Optional[str] = None,
+        graph_repository: Optional[AbstractGraphRepository] = None,
+    ) -> List[Dict[str, Any]]:
         """
         벡터 검색 결과(vector_results)를 입력받아 그래프 탐색과 결합하여 하이브리드 결과를 반환한다.
+
+        동작 순서:
+            1. HealthRegistry.is_ok(GRAPH_ENGINE) 체크 → False면 즉시 Silent Fallback.
+            2. hashed_user_id 또는 graph_repository 없으면 그래프 탐색 스킵.
+            3. vector_results에서 Seed Node ID 추출.
+            4. GRAPH_MAX_TRAVERSAL_DEPTH Clamping 후 BFS 이웃 탐색.
+            5. 이웃 노드를 RAG 포맷으로 직렬화하여 vector_results에 결합 반환.
+
+        Args:
+            query           : 사용자 쿼리 (로깅 목적, 현재 탐색 로직에는 미사용)
+            vector_results  : 벡터 검색 결과 리스트
+            hashed_user_id  : 테넌트 식별자 (SHA-256 hex, PII 미포함). None이면 탐색 스킵.
+            graph_repository: 이 호출에서만 사용할 Repository (생성자 주입보다 우선).
+
+        Returns:
+            vector_results + 그래프 이웃 노드 결과가 결합된 리스트.
+            탐색 실패 또는 헬스 이상 시 원본 vector_results 반환.
         """
-        # [핵심] 매 쿼리마다 HealthRegistry.is_ok(Subsystem.GRAPH_ENGINE)를 최우선 검사
+        # ── 1단계: SSOT 상태 검사 (최우선 가드레일) ─────────────────────────
         if not self.health_registry.is_ok(Subsystem.GRAPH_ENGINE):
             summary = self.health_registry.get_summary()
             current_status = summary.get(Subsystem.GRAPH_ENGINE.value, "UNKNOWN")
@@ -34,26 +226,108 @@ class GraphHybridRouter:
                 extra={
                     "subsystem": Subsystem.GRAPH_ENGINE.value,
                     "status": current_status,
-                }
+                },
             )
-            # 그래프 로직 스킵하고 조용히(Silent Fallback) Vector RAG 결과 반환
             return vector_results
-            
-        # TODO: Phase 4-2 / 2단계: 하이브리드 탐색 알고리즘 결합 로직
-        # FAISS 등 벡터 검색 결과의 Top-K 노드들을 그래프의 진입점(Seed Node)으로 설정하고,
-        # GRAPH_MAX_TRAVERSAL_DEPTH를 넘지 않도록 무한 루프 방지용 Clamping 순회 로직 구현 예정.
-        
-        # 임시로 기존 vector_results 반환 (뼈대 단계)
-        return vector_results
+
+        # ── 2단계: 탐색 가능 여부 사전 검사 ────────────────────────────────
+        # 인자로 전달된 repository를 우선 사용, 없으면 생성자 주입 repository 사용
+        effective_repo = graph_repository if graph_repository is not None else self.graph_repository
+
+        if not hashed_user_id or effective_repo is None:
+            logger.debug(
+                "[GRAPH_ROUTER] Graph traversal skipped: "
+                "hashed_user_id=%s, repository_available=%s. "
+                "Returning vector_results as-is.",
+                "provided" if hashed_user_id else "missing",
+                effective_repo is not None,
+            )
+            return vector_results
+
+        # ── 3단계: Seed Node 추출 ────────────────────────────────────────────
+        seed_ids = _extract_seed_node_ids(vector_results)
+
+        if not seed_ids:
+            logger.debug(
+                "[GRAPH_ROUTER] No valid seed node IDs found in vector_results. "
+                "Returning vector_results as-is."
+            )
+            return vector_results
+
+        # ── 4단계: GRAPH_MAX_TRAVERSAL_DEPTH Clamping ────────────────────────
+        max_depth = _load_traversal_depth()
+
+        # ── 5단계: BFS 탐색 및 결과 수집 ─────────────────────────────────────
+        graph_enriched: List[Dict[str, Any]] = list(vector_results)
+        visited_neighbor_ids: set[str] = set(seed_ids)  # Seed 자체는 중복 추가 방지
+
+        try:
+            with effective_repo.stateless_load(hashed_user_id) as repo:
+                for seed_id in seed_ids:
+                    neighbors = repo.neighbors(
+                        hashed_user_id,
+                        seed_id,
+                        max_depth=max_depth,
+                    )
+                    for neighbor_id in neighbors:
+                        if neighbor_id in visited_neighbor_ids:
+                            continue
+                        visited_neighbor_ids.add(neighbor_id)
+
+                        attrs = repo.get_node_attrs(hashed_user_id, neighbor_id) or {}
+                        graph_enriched.append(
+                            _serialize_neighbor_node(neighbor_id, attrs)
+                        )
+
+        except Exception:
+            # 그래프 탐색 중 예기치 못한 오류 발생 시 원본 결과로 Silent Fallback
+            logger.exception(
+                "[GRAPH_ROUTER] Unexpected error during graph traversal. "
+                "Falling back to vector_results only."
+            )
+            return vector_results
+
+        logger.debug(
+            "[GRAPH_ROUTER] Graph traversal complete. "
+            "seeds=%d, neighbors_added=%d, total_results=%d, depth=%d.",
+            len(seed_ids),
+            len(graph_enriched) - len(vector_results),
+            len(graph_enriched),
+            max_depth,
+        )
+        return graph_enriched
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 헬퍼 함수
+# ─────────────────────────────────────────────────────────────────────────────
 
 def run_hybrid_search(
-    query: str, 
-    vector_results: List[Dict[str, Any]], 
-    router: Optional[GraphHybridRouter] = None
+    query: str,
+    vector_results: List[Dict[str, Any]],
+    router: Optional[GraphHybridRouter] = None,
+    hashed_user_id: Optional[str] = None,
+    graph_repository: Optional[AbstractGraphRepository] = None,
 ) -> List[Dict[str, Any]]:
     """
-    하이브리드 검색을 실행하는 헬퍼 함수
+    하이브리드 검색을 실행하는 헬퍼 함수.
+
+    Args:
+        query           : 사용자 쿼리
+        vector_results  : 벡터 검색 결과 리스트
+        router          : GraphHybridRouter 인스턴스 (None이면 기본 생성).
+                          테스트 또는 IoC 컨테이너에서 주입할 수 있다.
+        hashed_user_id  : 테넌트 식별자 (PII 미포함). None이면 그래프 탐색 스킵.
+        graph_repository: Repository 인스턴스 (None이면 router 생성자 주입 사용).
+
+    Returns:
+        vector_results + 그래프 탐색 결과가 결합된 리스트.
     """
     if router is None:
-        router = GraphHybridRouter()
-    return router.route_query(query, vector_results)
+        router = GraphHybridRouter(graph_repository=graph_repository)
+    return router.route_query(
+        query,
+        vector_results,
+        hashed_user_id=hashed_user_id,
+        graph_repository=graph_repository,
+    )

--- a/backend/graph/base.py
+++ b/backend/graph/base.py
@@ -18,7 +18,8 @@
 from __future__ import annotations
 
 import abc
-from typing import Any, Iterator
+from contextlib import contextmanager
+from typing import Any, Generator, Iterator
 
 
 class GraphError(Exception):
@@ -274,4 +275,30 @@ class AbstractGraphRepository(abc.ABC):
 
         Args:
             hashed_user_id: 테넌트 식별자
+        """
+
+    # ─────────────────────────────────────────────────────────────────────
+    # 유틸리티 (Utility)
+    # ─────────────────────────────────────────────────────────────────────
+
+    @contextmanager
+    @abc.abstractmethod
+    def stateless_load(
+        self,
+        hashed_user_id: str,
+    ) -> Generator["AbstractGraphRepository", None, None]:
+        """
+        일회성 조회를 위해 그래프를 메모리에 로드하고, 블록 종료 시 안전하게 해제하는 컨텍스트 매니저.
+
+        계약:
+            - `with repo.stateless_load(hashed_user_id) as r:` 블록 진입 시
+              load()를 호출하여 그래프를 인메모리로 복원한다.
+            - 블록 정상 종료 및 예외 발생 시 모두 clear()를 호출하여 메모리를 해제한다.
+            - load() 실패 시(예: 파일 손상) 부작용 없이 예외를 상위로 전파한다.
+
+        Args:
+            hashed_user_id: 테넌트 식별자 (PII 미포함)
+
+        Yields:
+            self — 로드 완료된 Repository 인스턴스
         """

--- a/tests/unit/test_graph_router.py
+++ b/tests/unit/test_graph_router.py
@@ -1,0 +1,656 @@
+# tests/unit/test_graph_router.py
+
+"""
+Phase 4-2 Step 2: GraphHybridRouter 단위 테스트
+================================================
+
+테스트 범위:
+  - Silent Fallback: GRAPH_ENGINE이 DEGRADED/비정상 시 vector_results 원본 반환.
+  - Seed Node 파싱: vector_results에서 id/metadata 필드 정확히 추출.
+  - Clamping 경계: GRAPH_MAX_TRAVERSAL_DEPTH [1, 5] 강제.
+  - BFS 탐색: 체인/다이아몬드/사이클 그래프에서 무한 루프 없이 이웃 수집.
+  - stateless_load 라이프사이클: 조회 후 인메모리 자원 해제 검증.
+  - 반환 결과 스키마: content/metadata/score 필드 포함 여부.
+  - 의존성 주입(DI): 생성자 및 route_query 인자로 repository 주입 가능.
+  - 예외 격리: 탐색 중 예외 발생 시 vector_results 원본으로 Silent Fallback.
+
+보안 원칙:
+  - 테스트 더미 hashed_user_id는 실제 PII를 포함하지 않는 64자 hex 고정값 사용.
+  - storage_base_path는 tmp_path(pytest fixture)만 사용.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from backend.agent.graph_router import (
+    GraphHybridRouter,
+    _clamp_depth,
+    _extract_seed_node_ids,
+    _load_traversal_depth,
+    _serialize_neighbor_node,
+    run_hybrid_search,
+)
+from backend.core.config.graph import (
+    DEFAULT_MAX_TRAVERSAL_DEPTH,
+    ENV_MAX_TRAVERSAL_DEPTH,
+    MAX_TRAVERSAL_DEPTH_RANGE,
+)
+from backend.core.config_validator import Subsystem
+from backend.graph.networkx_repository import NetworkXGraphRepository
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 테스트 더미 상수 — PII 미포함, 64자 hex
+# ─────────────────────────────────────────────────────────────────────────────
+
+_DUMMY_HASH = "a" * 64
+_DUMMY_HASH_B = "b" * 64  # 테넌트 격리 검증용
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def healthy_registry() -> MagicMock:
+    """GRAPH_ENGINE이 정상(HEALTHY) 상태인 Mock HealthRegistry."""
+    registry = MagicMock()
+    registry.is_ok.return_value = True
+    return registry
+
+
+@pytest.fixture()
+def degraded_registry() -> MagicMock:
+    """GRAPH_ENGINE이 DEGRADED 상태인 Mock HealthRegistry."""
+    registry = MagicMock()
+    registry.is_ok.return_value = False
+    registry.get_summary.return_value = {Subsystem.GRAPH_ENGINE.value: "DEGRADED"}
+    return registry
+
+
+@pytest.fixture()
+def storage_path(tmp_path: Path) -> str:
+    """각 테스트마다 격리된 임시 storage_base_path."""
+    return str(tmp_path)
+
+
+@pytest.fixture()
+def repo(storage_path: str) -> NetworkXGraphRepository:
+    """테스트용 NetworkXGraphRepository 인스턴스."""
+    return NetworkXGraphRepository(storage_base_path=storage_path)
+
+
+@pytest.fixture()
+def simple_vector_results() -> List[Dict[str, Any]]:
+    """단순 벡터 검색 결과 픽스처 (id 필드 포함)."""
+    return [
+        {"id": "note-001", "content": "Python basics", "metadata": {}, "score": 0.9},
+        {"id": "note-002", "content": "Machine learning", "metadata": {}, "score": 0.8},
+    ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _clamp_depth 단위 테스트
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestClampDepth:
+    def test_value_within_range_is_unchanged(self) -> None:
+        assert _clamp_depth(3) == 3
+
+    def test_min_boundary_is_preserved(self) -> None:
+        assert _clamp_depth(MAX_TRAVERSAL_DEPTH_RANGE.min) == MAX_TRAVERSAL_DEPTH_RANGE.min
+
+    def test_max_boundary_is_preserved(self) -> None:
+        assert _clamp_depth(MAX_TRAVERSAL_DEPTH_RANGE.max) == MAX_TRAVERSAL_DEPTH_RANGE.max
+
+    def test_below_min_is_clamped_to_min(self) -> None:
+        assert _clamp_depth(0) == MAX_TRAVERSAL_DEPTH_RANGE.min
+        assert _clamp_depth(-5) == MAX_TRAVERSAL_DEPTH_RANGE.min
+
+    def test_above_max_is_clamped_to_max(self) -> None:
+        assert _clamp_depth(10) == MAX_TRAVERSAL_DEPTH_RANGE.max
+        assert _clamp_depth(999) == MAX_TRAVERSAL_DEPTH_RANGE.max
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _load_traversal_depth 단위 테스트
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestLoadTraversalDepth:
+    def test_returns_default_when_env_not_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ENV_MAX_TRAVERSAL_DEPTH, raising=False)
+        assert _load_traversal_depth() == _clamp_depth(DEFAULT_MAX_TRAVERSAL_DEPTH)
+
+    def test_reads_valid_env_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_MAX_TRAVERSAL_DEPTH, "2")
+        assert _load_traversal_depth() == 2
+
+    def test_clamps_env_value_above_max(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_MAX_TRAVERSAL_DEPTH, "99")
+        assert _load_traversal_depth() == MAX_TRAVERSAL_DEPTH_RANGE.max
+
+    def test_clamps_env_value_below_min(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_MAX_TRAVERSAL_DEPTH, "0")
+        assert _load_traversal_depth() == MAX_TRAVERSAL_DEPTH_RANGE.min
+
+    def test_returns_default_on_non_integer_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_MAX_TRAVERSAL_DEPTH, "not_a_number")
+        assert _load_traversal_depth() == _clamp_depth(DEFAULT_MAX_TRAVERSAL_DEPTH)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _extract_seed_node_ids 단위 테스트
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestExtractSeedNodeIds:
+    def test_extracts_top_level_id_field(self) -> None:
+        results = [
+            {"id": "note-A", "content": "...", "score": 0.9},
+            {"id": "note-B", "content": "...", "score": 0.8},
+        ]
+        assert _extract_seed_node_ids(results) == ["note-A", "note-B"]
+
+    def test_falls_back_to_metadata_id(self) -> None:
+        results = [
+            {"content": "...", "metadata": {"id": "note-C"}, "score": 0.7},
+        ]
+        assert _extract_seed_node_ids(results) == ["note-C"]
+
+    def test_falls_back_to_metadata_source(self) -> None:
+        results = [
+            {"content": "...", "metadata": {"source": "note-D"}, "score": 0.6},
+        ]
+        assert _extract_seed_node_ids(results) == ["note-D"]
+
+    def test_top_level_id_takes_priority_over_metadata(self) -> None:
+        results = [
+            {"id": "note-E", "metadata": {"id": "note-F", "source": "note-G"}, "score": 0.5},
+        ]
+        assert _extract_seed_node_ids(results) == ["note-E"]
+
+    def test_deduplicates_ids(self) -> None:
+        results = [
+            {"id": "note-A", "content": "...", "score": 0.9},
+            {"id": "note-A", "content": "...", "score": 0.85},
+            {"id": "note-B", "content": "...", "score": 0.8},
+        ]
+        ids = _extract_seed_node_ids(results)
+        assert ids == ["note-A", "note-B"]
+
+    def test_skips_results_without_id(self) -> None:
+        results = [
+            {"content": "no id here", "metadata": {}, "score": 0.5},
+        ]
+        assert _extract_seed_node_ids(results) == []
+
+    def test_preserves_score_order(self) -> None:
+        results = [
+            {"id": "note-Z", "content": "...", "score": 0.95},
+            {"id": "note-A", "content": "...", "score": 0.7},
+        ]
+        assert _extract_seed_node_ids(results) == ["note-Z", "note-A"]
+
+    def test_empty_input_returns_empty_list(self) -> None:
+        assert _extract_seed_node_ids([]) == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _serialize_neighbor_node 단위 테스트
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSerializeNeighborNode:
+    def test_returns_required_schema_fields(self) -> None:
+        result = _serialize_neighbor_node("node-X", {"title": "Test Note"})
+        assert "content" in result
+        assert "metadata" in result
+        assert "score" in result
+
+    def test_uses_content_field_if_available(self) -> None:
+        result = _serialize_neighbor_node("node-X", {"content": "Hello World"})
+        assert result["content"] == "Hello World"
+
+    def test_falls_back_to_text_then_title(self) -> None:
+        result_text = _serialize_neighbor_node("node-X", {"text": "Via Text"})
+        assert result_text["content"] == "Via Text"
+
+        result_title = _serialize_neighbor_node("node-X", {"title": "Via Title"})
+        assert result_title["content"] == "Via Title"
+
+    def test_falls_back_to_node_id_when_no_text(self) -> None:
+        result = _serialize_neighbor_node("node-X", {})
+        assert result["content"] == "node-X"
+
+    def test_metadata_contains_id(self) -> None:
+        result = _serialize_neighbor_node("node-X", {"title": "Test"})
+        assert result["metadata"]["id"] == "node-X"
+
+    def test_custom_score_is_applied(self) -> None:
+        result = _serialize_neighbor_node("node-X", {}, graph_score=0.75)
+        assert result["score"] == 0.75
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# GraphHybridRouter.route_query 동작 테스트
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestRouteQuerySilentFallback:
+    """GRAPH_ENGINE 비정상 시 Silent Fallback 검증."""
+
+    def test_returns_vector_results_when_degraded(
+        self,
+        degraded_registry: MagicMock,
+        simple_vector_results: List[Dict[str, Any]],
+    ) -> None:
+        router = GraphHybridRouter(health_registry=degraded_registry)
+        result = router.route_query("query", simple_vector_results)
+        assert result is simple_vector_results
+
+    def test_does_not_raise_when_degraded(
+        self,
+        degraded_registry: MagicMock,
+        simple_vector_results: List[Dict[str, Any]],
+    ) -> None:
+        router = GraphHybridRouter(health_registry=degraded_registry)
+        # 예외 없이 정상 반환되어야 함
+        router.route_query("query", simple_vector_results)
+
+    def test_is_ok_called_with_graph_engine_subsystem(
+        self,
+        degraded_registry: MagicMock,
+        simple_vector_results: List[Dict[str, Any]],
+    ) -> None:
+        router = GraphHybridRouter(health_registry=degraded_registry)
+        router.route_query("query", simple_vector_results)
+        degraded_registry.is_ok.assert_called_once_with(Subsystem.GRAPH_ENGINE)
+
+
+class TestRouteQuerySkipConditions:
+    """hashed_user_id 또는 repository 누락 시 탐색 스킵 검증."""
+
+    def test_skips_traversal_without_hashed_user_id(
+        self,
+        healthy_registry: MagicMock,
+        simple_vector_results: List[Dict[str, Any]],
+        repo: NetworkXGraphRepository,
+    ) -> None:
+        router = GraphHybridRouter(health_registry=healthy_registry, graph_repository=repo)
+        result = router.route_query("query", simple_vector_results, hashed_user_id=None)
+        assert result is simple_vector_results
+
+    def test_skips_traversal_without_repository(
+        self,
+        healthy_registry: MagicMock,
+        simple_vector_results: List[Dict[str, Any]],
+    ) -> None:
+        router = GraphHybridRouter(health_registry=healthy_registry, graph_repository=None)
+        result = router.route_query(
+            "query",
+            simple_vector_results,
+            hashed_user_id=_DUMMY_HASH,
+            graph_repository=None,
+        )
+        assert result is simple_vector_results
+
+    def test_skips_traversal_when_seed_nodes_empty(
+        self,
+        healthy_registry: MagicMock,
+        repo: NetworkXGraphRepository,
+    ) -> None:
+        # id 필드 없는 vector_results → Seed Node 없음 → 탐색 스킵
+        no_id_results = [{"content": "text", "score": 0.5}]
+        router = GraphHybridRouter(health_registry=healthy_registry, graph_repository=repo)
+        result = router.route_query(
+            "query",
+            no_id_results,
+            hashed_user_id=_DUMMY_HASH,
+        )
+        assert result is no_id_results
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BFS 탐색 그래프 구조 테스트
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestRouteQueryBFSTraversal:
+    """다양한 그래프 구조에서 BFS 탐색 정확도 및 안전성 검증."""
+
+    def _make_vector_results(self, node_id: str) -> List[Dict[str, Any]]:
+        return [{"id": node_id, "content": "Seed", "metadata": {}, "score": 0.9}]
+
+    def test_chain_graph_traversal(
+        self,
+        healthy_registry: MagicMock,
+        repo: NetworkXGraphRepository,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """체인 A → B → C 그래프에서 depth=2 탐색 시 B, C 모두 수집."""
+        monkeypatch.setenv(ENV_MAX_TRAVERSAL_DEPTH, "2")
+        repo.add_node(_DUMMY_HASH, "A", title="Node A")
+        repo.add_node(_DUMMY_HASH, "B", title="Node B")
+        repo.add_node(_DUMMY_HASH, "C", title="Node C")
+        repo.add_edge(_DUMMY_HASH, "A", "B")
+        repo.add_edge(_DUMMY_HASH, "B", "C")
+        repo.persist(_DUMMY_HASH)
+
+        router = GraphHybridRouter(health_registry=healthy_registry)
+        results = router.route_query(
+            "query",
+            self._make_vector_results("A"),
+            hashed_user_id=_DUMMY_HASH,
+            graph_repository=repo,
+        )
+        result_ids = {r.get("metadata", {}).get("id") or r.get("id") for r in results}
+        assert "B" in result_ids
+        assert "C" in result_ids
+
+    def test_diamond_graph_no_duplicate(
+        self,
+        healthy_registry: MagicMock,
+        repo: NetworkXGraphRepository,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """다이아몬드 A→B, A→C, B→D, C→D에서 D가 중복 없이 1회만 수집."""
+        monkeypatch.setenv(ENV_MAX_TRAVERSAL_DEPTH, "3")
+        for nid in ["A", "B", "C", "D"]:
+            repo.add_node(_DUMMY_HASH, nid, title=f"Node {nid}")
+        repo.add_edge(_DUMMY_HASH, "A", "B")
+        repo.add_edge(_DUMMY_HASH, "A", "C")
+        repo.add_edge(_DUMMY_HASH, "B", "D")
+        repo.add_edge(_DUMMY_HASH, "C", "D")
+        repo.persist(_DUMMY_HASH)
+
+        router = GraphHybridRouter(health_registry=healthy_registry)
+        results = router.route_query(
+            "query",
+            self._make_vector_results("A"),
+            hashed_user_id=_DUMMY_HASH,
+            graph_repository=repo,
+        )
+        neighbor_ids = [
+            r.get("metadata", {}).get("id")
+            for r in results
+            if r.get("metadata", {}).get("id") != "A"
+        ]
+        assert neighbor_ids.count("D") == 1, "D should appear exactly once (no duplicates)"
+
+    def test_cycle_graph_no_infinite_loop(
+        self,
+        healthy_registry: MagicMock,
+        repo: NetworkXGraphRepository,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """사이클 A→B→C→A 그래프에서 무한 루프 없이 탐색 완료."""
+        monkeypatch.setenv(ENV_MAX_TRAVERSAL_DEPTH, "5")
+        for nid in ["A", "B", "C"]:
+            repo.add_node(_DUMMY_HASH, nid, title=f"Node {nid}")
+        repo.add_edge(_DUMMY_HASH, "A", "B")
+        repo.add_edge(_DUMMY_HASH, "B", "C")
+        repo.add_edge(_DUMMY_HASH, "C", "A")
+        repo.persist(_DUMMY_HASH)
+
+        router = GraphHybridRouter(health_registry=healthy_registry)
+        # 무한 루프라면 여기서 타임아웃 발생 — 통과하면 안전함
+        results = router.route_query(
+            "query",
+            self._make_vector_results("A"),
+            hashed_user_id=_DUMMY_HASH,
+            graph_repository=repo,
+        )
+        assert len(results) > 0
+
+    def test_isolated_node_returns_only_vector_results(
+        self,
+        healthy_registry: MagicMock,
+        repo: NetworkXGraphRepository,
+    ) -> None:
+        """고립 노드(이웃 없음) Seed의 경우 vector_results만 반환."""
+        repo.add_node(_DUMMY_HASH, "isolated", title="Lonely Node")
+        repo.persist(_DUMMY_HASH)
+
+        router = GraphHybridRouter(health_registry=healthy_registry)
+        vector_in = self._make_vector_results("isolated")
+        results = router.route_query(
+            "query",
+            vector_in,
+            hashed_user_id=_DUMMY_HASH,
+            graph_repository=repo,
+        )
+        assert results == vector_in
+
+    def test_result_items_have_required_schema(
+        self,
+        healthy_registry: MagicMock,
+        repo: NetworkXGraphRepository,
+    ) -> None:
+        """반환된 그래프 이웃 노드 결과가 content/metadata/score 스키마를 갖는지 검증."""
+        repo.add_node(_DUMMY_HASH, "A", title="Node A", content="A content")
+        repo.add_node(_DUMMY_HASH, "B", title="Node B", content="B content")
+        repo.add_edge(_DUMMY_HASH, "A", "B")
+        repo.persist(_DUMMY_HASH)
+
+        router = GraphHybridRouter(health_registry=healthy_registry)
+        results = router.route_query(
+            "query",
+            self._make_vector_results("A"),
+            hashed_user_id=_DUMMY_HASH,
+            graph_repository=repo,
+        )
+        graph_nodes = [r for r in results if r.get("metadata", {}).get("id") == "B"]
+        assert len(graph_nodes) == 1
+        node = graph_nodes[0]
+        assert "content" in node
+        assert "metadata" in node
+        assert "score" in node
+        assert isinstance(node["score"], float)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# stateless_load 라이프사이클 검증
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestStatelessLoadLifecycle:
+    def test_graph_cleared_after_traversal(
+        self,
+        healthy_registry: MagicMock,
+        repo: NetworkXGraphRepository,
+    ) -> None:
+        """stateless_load 컨텍스트 종료 후 인메모리 그래프가 비어 있어야 한다."""
+        repo.add_node(_DUMMY_HASH, "A", title="Node A")
+        repo.add_node(_DUMMY_HASH, "B", title="Node B")
+        repo.add_edge(_DUMMY_HASH, "A", "B")
+        repo.persist(_DUMMY_HASH)
+
+        router = GraphHybridRouter(health_registry=healthy_registry)
+        vector_in = [{"id": "A", "content": "Seed", "metadata": {}, "score": 0.9}]
+        router.route_query(
+            "query",
+            vector_in,
+            hashed_user_id=_DUMMY_HASH,
+            graph_repository=repo,
+        )
+        # 탐색 완료 후 node_count()는 0이어야 한다 (clear 호출됨)
+        assert repo.node_count(_DUMMY_HASH) == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 예외 격리 (Exception Isolation)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestExceptionIsolation:
+    def test_exception_in_traversal_falls_back_to_vector_results(
+        self,
+        healthy_registry: MagicMock,
+        simple_vector_results: List[Dict[str, Any]],
+    ) -> None:
+        """탐색 중 예외 발생 시 vector_results 원본 반환, 예외 전파 없음."""
+        broken_repo = MagicMock()
+        # stateless_load를 컨텍스트 매니저처럼 동작하되 내부에서 예외 발생
+        broken_repo.stateless_load.side_effect = RuntimeError("Simulated IO failure")
+
+        router = GraphHybridRouter(health_registry=healthy_registry)
+        result = router.route_query(
+            "query",
+            simple_vector_results,
+            hashed_user_id=_DUMMY_HASH,
+            graph_repository=broken_repo,
+        )
+        assert result is simple_vector_results
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 의존성 주입 (DI) 검증
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDependencyInjection:
+    def test_constructor_injected_registry_is_used(
+        self,
+        degraded_registry: MagicMock,
+        simple_vector_results: List[Dict[str, Any]],
+    ) -> None:
+        """생성자로 주입한 registry가 실제로 사용되는지 검증."""
+        router = GraphHybridRouter(health_registry=degraded_registry)
+        router.route_query("q", simple_vector_results)
+        degraded_registry.is_ok.assert_called()
+
+    def test_route_query_repo_overrides_constructor_repo(
+        self,
+        healthy_registry: MagicMock,
+        repo: NetworkXGraphRepository,
+    ) -> None:
+        """route_query의 graph_repository 인자가 생성자 주입보다 우선한다."""
+        fallback_repo = MagicMock()
+        fallback_repo.stateless_load.return_value.__enter__ = MagicMock(return_value=fallback_repo)
+        fallback_repo.stateless_load.return_value.__exit__ = MagicMock(return_value=False)
+        fallback_repo.neighbors.return_value = []
+
+        router = GraphHybridRouter(
+            health_registry=healthy_registry,
+            graph_repository=fallback_repo,  # 생성자 주입
+        )
+        # route_query에서 다른 repo를 전달하면 이쪽이 사용되어야 함
+        # (repo는 실제 NetworkXGraphRepository — 데이터 없어 이웃도 없음)
+        vector_in = [{"id": "A", "content": "seed", "metadata": {}, "score": 0.9}]
+        router.route_query(
+            "q",
+            vector_in,
+            hashed_user_id=_DUMMY_HASH,
+            graph_repository=repo,  # 인자 우선
+        )
+        # fallback_repo.stateless_load은 호출되지 않아야 함
+        fallback_repo.stateless_load.assert_not_called()
+
+    def test_none_registry_uses_global_singleton(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """health_registry=None이면 HealthRegistry.get_instance()를 호출한다."""
+        mock_instance = MagicMock()
+        mock_instance.is_ok.return_value = False
+        mock_instance.get_summary.return_value = {}
+
+        with patch(
+            "backend.agent.graph_router.HealthRegistry.get_instance",
+            return_value=mock_instance,
+        ):
+            router = GraphHybridRouter(health_registry=None)
+            router.route_query("q", [])
+            mock_instance.is_ok.assert_called_once_with(Subsystem.GRAPH_ENGINE)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# run_hybrid_search 헬퍼 함수 테스트
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestRunHybridSearch:
+    def test_creates_default_router_when_none(
+        self,
+        degraded_registry: MagicMock,
+        simple_vector_results: List[Dict[str, Any]],
+    ) -> None:
+        """router=None이면 내부에서 GraphHybridRouter()를 생성한다."""
+        # 글로벌 싱글톤을 degraded로 교체하여 실제 router 생성 경로 검증
+        with patch(
+            "backend.agent.graph_router.HealthRegistry.get_instance",
+            return_value=degraded_registry,
+        ):
+            result = run_hybrid_search("q", simple_vector_results, router=None)
+        assert result == simple_vector_results
+
+    def test_uses_provided_router(
+        self,
+        simple_vector_results: List[Dict[str, Any]],
+    ) -> None:
+        """router가 제공되면 해당 router의 route_query를 사용한다."""
+        mock_router = MagicMock()
+        mock_router.route_query.return_value = simple_vector_results
+
+        run_hybrid_search("q", simple_vector_results, router=mock_router)
+        mock_router.route_query.assert_called_once()
+
+    def test_passes_hashed_user_id_and_repo_to_route_query(
+        self,
+        simple_vector_results: List[Dict[str, Any]],
+        repo: NetworkXGraphRepository,
+    ) -> None:
+        """hashed_user_id와 graph_repository가 route_query에 전달된다."""
+        mock_router = MagicMock()
+        mock_router.route_query.return_value = simple_vector_results
+
+        run_hybrid_search(
+            "q",
+            simple_vector_results,
+            router=mock_router,
+            hashed_user_id=_DUMMY_HASH,
+            graph_repository=repo,
+        )
+        call_kwargs = mock_router.route_query.call_args
+        assert call_kwargs.kwargs.get("hashed_user_id") == _DUMMY_HASH
+        assert call_kwargs.kwargs.get("graph_repository") is repo
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 테넌트 격리 검증
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestTenantIsolation:
+    def test_user_a_graph_does_not_leak_to_user_b(
+        self,
+        healthy_registry: MagicMock,
+        repo: NetworkXGraphRepository,
+    ) -> None:
+        """사용자 A의 그래프 이웃이 사용자 B 조회에서 나타나지 않는다."""
+        # 사용자 A: A → B 엣지
+        repo.add_node(_DUMMY_HASH, "A", title="User A Node A")
+        repo.add_node(_DUMMY_HASH, "B", title="User A Node B")
+        repo.add_edge(_DUMMY_HASH, "A", "B")
+        repo.persist(_DUMMY_HASH)
+
+        # 사용자 B: 그래프 없음 (빈 그래프)
+        router = GraphHybridRouter(health_registry=healthy_registry)
+        vector_in_b = [{"id": "A", "content": "B's query", "metadata": {}, "score": 0.9}]
+        result_b = router.route_query(
+            "query",
+            vector_in_b,
+            hashed_user_id=_DUMMY_HASH_B,  # 사용자 B
+            graph_repository=repo,
+        )
+        # 사용자 B의 결과에 사용자 A의 "B" 노드가 포함되어선 안 됨
+        neighbor_ids = [
+            r.get("metadata", {}).get("id")
+            for r in result_b
+            if r.get("metadata", {}).get("id") not in (None, "A")
+        ]
+        assert "B" not in neighbor_ids

--- a/tests/unit/test_graph_router.py
+++ b/tests/unit/test_graph_router.py
@@ -201,6 +201,13 @@ class TestExtractSeedNodeIds:
     def test_empty_input_returns_empty_list(self) -> None:
         assert _extract_seed_node_ids([]) == []
 
+    def test_coerces_non_string_ids_to_string(self) -> None:
+        results = [
+            {"id": 123, "content": "...", "score": 0.9},
+            {"id": None, "metadata": {"id": 456}, "score": 0.8},
+        ]
+        assert _extract_seed_node_ids(results) == ["123", "456"]
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # _serialize_neighbor_node 단위 테스트
@@ -297,7 +304,6 @@ class TestRouteQuerySkipConditions:
             "query",
             simple_vector_results,
             hashed_user_id=_DUMMY_HASH,
-            graph_repository=None,
         )
         assert result is simple_vector_results
 
@@ -343,12 +349,11 @@ class TestRouteQueryBFSTraversal:
         repo.add_edge(_DUMMY_HASH, "B", "C")
         repo.persist(_DUMMY_HASH)
 
-        router = GraphHybridRouter(health_registry=healthy_registry)
+        router = GraphHybridRouter(health_registry=healthy_registry, graph_repository=repo)
         results = router.route_query(
             "query",
             self._make_vector_results("A"),
             hashed_user_id=_DUMMY_HASH,
-            graph_repository=repo,
         )
         result_ids = {r.get("metadata", {}).get("id") or r.get("id") for r in results}
         assert "B" in result_ids
@@ -370,12 +375,11 @@ class TestRouteQueryBFSTraversal:
         repo.add_edge(_DUMMY_HASH, "C", "D")
         repo.persist(_DUMMY_HASH)
 
-        router = GraphHybridRouter(health_registry=healthy_registry)
+        router = GraphHybridRouter(health_registry=healthy_registry, graph_repository=repo)
         results = router.route_query(
             "query",
             self._make_vector_results("A"),
             hashed_user_id=_DUMMY_HASH,
-            graph_repository=repo,
         )
         neighbor_ids = [
             r.get("metadata", {}).get("id")
@@ -399,13 +403,12 @@ class TestRouteQueryBFSTraversal:
         repo.add_edge(_DUMMY_HASH, "C", "A")
         repo.persist(_DUMMY_HASH)
 
-        router = GraphHybridRouter(health_registry=healthy_registry)
+        router = GraphHybridRouter(health_registry=healthy_registry, graph_repository=repo)
         # 무한 루프라면 여기서 타임아웃 발생 — 통과하면 안전함
         results = router.route_query(
             "query",
             self._make_vector_results("A"),
             hashed_user_id=_DUMMY_HASH,
-            graph_repository=repo,
         )
         assert len(results) > 0
 
@@ -418,13 +421,12 @@ class TestRouteQueryBFSTraversal:
         repo.add_node(_DUMMY_HASH, "isolated", title="Lonely Node")
         repo.persist(_DUMMY_HASH)
 
-        router = GraphHybridRouter(health_registry=healthy_registry)
+        router = GraphHybridRouter(health_registry=healthy_registry, graph_repository=repo)
         vector_in = self._make_vector_results("isolated")
         results = router.route_query(
             "query",
             vector_in,
             hashed_user_id=_DUMMY_HASH,
-            graph_repository=repo,
         )
         assert results == vector_in
 
@@ -439,12 +441,11 @@ class TestRouteQueryBFSTraversal:
         repo.add_edge(_DUMMY_HASH, "A", "B")
         repo.persist(_DUMMY_HASH)
 
-        router = GraphHybridRouter(health_registry=healthy_registry)
+        router = GraphHybridRouter(health_registry=healthy_registry, graph_repository=repo)
         results = router.route_query(
             "query",
             self._make_vector_results("A"),
             hashed_user_id=_DUMMY_HASH,
-            graph_repository=repo,
         )
         graph_nodes = [r for r in results if r.get("metadata", {}).get("id") == "B"]
         assert len(graph_nodes) == 1
@@ -472,13 +473,12 @@ class TestStatelessLoadLifecycle:
         repo.add_edge(_DUMMY_HASH, "A", "B")
         repo.persist(_DUMMY_HASH)
 
-        router = GraphHybridRouter(health_registry=healthy_registry)
+        router = GraphHybridRouter(health_registry=healthy_registry, graph_repository=repo)
         vector_in = [{"id": "A", "content": "Seed", "metadata": {}, "score": 0.9}]
         router.route_query(
             "query",
             vector_in,
             hashed_user_id=_DUMMY_HASH,
-            graph_repository=repo,
         )
         # 탐색 완료 후 node_count()는 0이어야 한다 (clear 호출됨)
         assert repo.node_count(_DUMMY_HASH) == 0
@@ -500,12 +500,11 @@ class TestExceptionIsolation:
         # stateless_load를 컨텍스트 매니저처럼 동작하되 내부에서 예외 발생
         broken_repo.stateless_load.side_effect = RuntimeError("Simulated IO failure")
 
-        router = GraphHybridRouter(health_registry=healthy_registry)
+        router = GraphHybridRouter(health_registry=healthy_registry, graph_repository=broken_repo)
         result = router.route_query(
             "query",
             simple_vector_results,
             hashed_user_id=_DUMMY_HASH,
-            graph_repository=broken_repo,
         )
         assert result is simple_vector_results
 
@@ -526,12 +525,12 @@ class TestDependencyInjection:
         router.route_query("q", simple_vector_results)
         degraded_registry.is_ok.assert_called()
 
-    def test_route_query_repo_overrides_constructor_repo(
+    def test_constructor_repo_is_used(
         self,
         healthy_registry: MagicMock,
         repo: NetworkXGraphRepository,
     ) -> None:
-        """route_query의 graph_repository 인자가 생성자 주입보다 우선한다."""
+        """생성자로 주입한 graph_repository가 사용된다."""
         fallback_repo = MagicMock()
         fallback_repo.stateless_load.return_value.__enter__ = MagicMock(return_value=fallback_repo)
         fallback_repo.stateless_load.return_value.__exit__ = MagicMock(return_value=False)
@@ -541,17 +540,13 @@ class TestDependencyInjection:
             health_registry=healthy_registry,
             graph_repository=fallback_repo,  # 생성자 주입
         )
-        # route_query에서 다른 repo를 전달하면 이쪽이 사용되어야 함
-        # (repo는 실제 NetworkXGraphRepository — 데이터 없어 이웃도 없음)
         vector_in = [{"id": "A", "content": "seed", "metadata": {}, "score": 0.9}]
         router.route_query(
             "q",
             vector_in,
             hashed_user_id=_DUMMY_HASH,
-            graph_repository=repo,  # 인자 우선
         )
-        # fallback_repo.stateless_load은 호출되지 않아야 함
-        fallback_repo.stateless_load.assert_not_called()
+        fallback_repo.stateless_load.assert_called_once_with(_DUMMY_HASH)
 
     def test_none_registry_uses_global_singleton(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """health_registry=None이면 HealthRegistry.get_instance()를 호출한다."""
@@ -599,12 +594,12 @@ class TestRunHybridSearch:
         run_hybrid_search("q", simple_vector_results, router=mock_router)
         mock_router.route_query.assert_called_once()
 
-    def test_passes_hashed_user_id_and_repo_to_route_query(
+    def test_passes_hashed_user_id_to_route_query(
         self,
         simple_vector_results: List[Dict[str, Any]],
         repo: NetworkXGraphRepository,
     ) -> None:
-        """hashed_user_id와 graph_repository가 route_query에 전달된다."""
+        """hashed_user_id가 route_query에 전달된다."""
         mock_router = MagicMock()
         mock_router.route_query.return_value = simple_vector_results
 
@@ -617,7 +612,23 @@ class TestRunHybridSearch:
         )
         call_kwargs = mock_router.route_query.call_args
         assert call_kwargs.kwargs.get("hashed_user_id") == _DUMMY_HASH
-        assert call_kwargs.kwargs.get("graph_repository") is repo
+
+    @patch("backend.agent.graph_router.GraphHybridRouter")
+    def test_run_hybrid_search_passes_repo_to_constructor(
+        self,
+        mock_router_cls: MagicMock,
+        simple_vector_results: List[Dict[str, Any]],
+        repo: NetworkXGraphRepository,
+    ) -> None:
+        mock_instance = mock_router_cls.return_value
+        run_hybrid_search(
+            "q",
+            simple_vector_results,
+            router=None,
+            graph_repository=repo,
+        )
+        mock_router_cls.assert_called_once_with(graph_repository=repo)
+        mock_instance.route_query.assert_called_once()
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -639,13 +650,12 @@ class TestTenantIsolation:
         repo.persist(_DUMMY_HASH)
 
         # 사용자 B: 그래프 없음 (빈 그래프)
-        router = GraphHybridRouter(health_registry=healthy_registry)
+        router = GraphHybridRouter(health_registry=healthy_registry, graph_repository=repo)
         vector_in_b = [{"id": "A", "content": "B's query", "metadata": {}, "score": 0.9}]
         result_b = router.route_query(
             "query",
             vector_in_b,
             hashed_user_id=_DUMMY_HASH_B,  # 사용자 B
-            graph_repository=repo,
         )
         # 사용자 B의 결과에 사용자 A의 "B" 노드가 포함되어선 안 됨
         neighbor_ids = [


### PR DESCRIPTION
✨ feat [#12.3.12]: Phase 4-2 - ➁ `stateless_load ABC` 계약 정의 및 코드 간결화 
☘️ refactor [#12.3.12]: 1차 개선 - `GraphHybridRouter` 리뷰 반영 및 인터페이스 안정화

## Summary by Sourcery

상태를 저장하지 않는 레포지토리 컨텍스트를 사용하여 그래프 탐색을 통해 벡터 검색 결과를 보강하는, 헬스 인식(health-aware) GraphRAG 하이브리드 라우터를 도입하고, 이를 지원하는 추상화와 포괄적인 단위 테스트를 추가합니다.

Enhancements:
- `GraphHybridRouter`를 구현하여 제한된(traversal depth를 clamp한) 그래프 탐색 깊이와 안전한 폴백(safe fallbacks)을 사용해, 조건부로 벡터 검색 결과를 그래프 기반 이웃들과 결합합니다.
- 요청 단위의 인메모리 그래프 라이프사이클 관리를 보장하기 위해, `AbstractGraphRepository`를 확장하여 `stateless_load` 컨텍스트 매니저 계약을 추가합니다.
- `run_hybrid_search` 헬퍼를 개선하여 그래프 레포지토리 의존성 주입을 지원하고, `hashed_user_id`를 통한 테넌트 인식(tenant-aware) 라우팅을 가능하게 합니다.

Tests:
- `GraphHybridRouter` 헬퍼, 탐색 동작(traversal behavior), 에러 처리, 의존성 주입, `stateless_load` 라이프사이클, 테넌트 격리(tenant isolation)에 대한 폭넓은 단위 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a health-aware GraphRAG hybrid router that enriches vector search results with graph traversal using a stateless repository context, along with supporting abstractions and comprehensive unit tests.

Enhancements:
- Implement GraphHybridRouter to conditionally combine vector search results with graph-based neighbors using clamped traversal depth and safe fallbacks.
- Extend AbstractGraphRepository with a stateless_load context manager contract to ensure per-request in-memory graph lifecycle management.
- Enhance the run_hybrid_search helper to support dependency injection of the graph repository and tenant-aware routing via hashed_user_id.

Tests:
- Add extensive unit tests for GraphHybridRouter helpers, traversal behavior, error handling, dependency injection, stateless_load lifecycle, and tenant isolation.

</details>