### PR TITLE
☘️ refactor [#12.3.12]: 2차 개선 - `GraphHybridRouter` 성능 및 로깅 최적화, 예외 부분 복구 지원

### DIFF
--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -173,7 +173,9 @@ def _extract_seed_node_ids(vector_results: List[Dict[str, Any]]) -> List[str]:
 
     if coerced_count > 0:
         logger.info(
-            "[GRAPH_ROUTER] Coerced %d non-string seed node IDs to str.", coerced_count
+            "[GRAPH_ROUTER] Coerced %d out of %d seed node IDs to str.",
+            coerced_count,
+            len(vector_results),
         )
 
     return seed_node_ids

--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -114,6 +114,7 @@ def _extract_seed_node_ids(vector_results: List[Dict[str, Any]]) -> List[str]:
     """
     seed_node_ids: List[str] = []
     seen_ids: set[str] = set()
+    coerced_count = 0
 
     for idx, result in enumerate(vector_results):
         node_id = None
@@ -141,7 +142,7 @@ def _extract_seed_node_ids(vector_results: List[Dict[str, Any]]) -> List[str]:
 
         # Normalize non-string IDs and log for observability.
         if not isinstance(node_id, str):
-            logger.warning(
+            logger.debug(
                 "[GRAPH_ROUTER] Non-string seed node id from %s at index %d: %r (type=%s); coercing to str.",
                 source_field or "<unknown>",
                 idx,
@@ -150,6 +151,7 @@ def _extract_seed_node_ids(vector_results: List[Dict[str, Any]]) -> List[str]:
             )
             try:
                 node_id_str = str(node_id)
+                coerced_count += 1
             except Exception:
                 logger.error(
                     "[GRAPH_ROUTER] Failed to coerce seed node id from %s at index %d to str; skipping.",
@@ -168,6 +170,11 @@ def _extract_seed_node_ids(vector_results: List[Dict[str, Any]]) -> List[str]:
         if node_id_str not in seen_ids:
             seen_ids.add(node_id_str)
             seed_node_ids.append(node_id_str)
+
+    if coerced_count > 0:
+        logger.info(
+            "[GRAPH_ROUTER] Coerced %d non-string seed node IDs to str.", coerced_count
+        )
 
     return seed_node_ids
 
@@ -265,7 +272,7 @@ class GraphHybridRouter:
 
         Returns:
             vector_results + 그래프 이웃 노드 결과가 결합된 리스트.
-            탐색 실패 또는 헬스 이상 시 원본 vector_results 반환.
+            탐색 실패 또는 헬스 이상 시 원본 vector_results(또는 예외 발생 직전까지 수집된 부분 결과) 반환.
         """
         # ── 1단계: SSOT 상태 검사 (최우선 가드레일) ─────────────────────────
         if not self.health_registry.is_ok(Subsystem.GRAPH_ENGINE):
@@ -342,9 +349,9 @@ class GraphHybridRouter:
         except Exception:
             logger.exception(
                 "[GRAPH_ROUTER] Unexpected error during graph traversal. "
-                "Falling back to vector_results only."
+                "Returning partially enriched results (or original vector_results)."
             )
-            return vector_results
+            return graph_enriched
 
         logger.debug(
             "[GRAPH_ROUTER] Graph traversal complete. "
@@ -382,6 +389,12 @@ def run_hybrid_search(
     Returns:
         vector_results + 그래프 탐색 결과가 결합된 리스트.
     """
+    if router is not None and graph_repository is not None:
+        logger.warning(
+            "[GRAPH_ROUTER] Custom router provided along with graph_repository to run_hybrid_search. "
+            "The graph_repository argument will be ignored."
+        )
+
     if router is None:
         router = GraphHybridRouter(graph_repository=graph_repository)
     return router.route_query(

--- a/tests/unit/test_graph_router.py
+++ b/tests/unit/test_graph_router.py
@@ -490,12 +490,12 @@ class TestStatelessLoadLifecycle:
 
 
 class TestExceptionIsolation:
-    def test_exception_in_traversal_falls_back_to_vector_results(
+    def test_exception_in_traversal_returns_partial_results(
         self,
         healthy_registry: MagicMock,
         simple_vector_results: List[Dict[str, Any]],
     ) -> None:
-        """탐색 중 예외 발생 시 vector_results 원본 반환, 예외 전파 없음."""
+        """탐색 중 예외 발생 시 예외 전파 없이 수집된 부분 결과(또는 vector_results 원본)를 반환."""
         broken_repo = MagicMock()
         # stateless_load를 컨텍스트 매니저처럼 동작하되 내부에서 예외 발생
         broken_repo.stateless_load.side_effect = RuntimeError("Simulated IO failure")


### PR DESCRIPTION
- [backend/agent/graph_router.py]
  - `_extract_seed_node_ids`: 비문자열 ID 변환 시 개별 로깅 레벨을 `DEBUG`로 낮추고, 전체 변환 횟수를 루프 종료 후 한 번만 `INFO`로 집계하여 대규모 트래픽 시의 로그 스팸(Noise) 문제 해결.
  - `_traverse_and_enrich`: 예외 발생 시 수집된 데이터를 전부 버리지 않고, 예외 발생 직전까지 수집된 부분 결과를 반환하도록(Partial Fallback) 수정하여 탐색 효율 향상.
  - `run_hybrid_search`: `router`와 `graph_repository`가 동시에 주입될 경우 발생하는 인자 무시 문제에 대해 명시적 경고(Warning) 로그 추가 및 의도 문서화.
- [tests/unit/test_graph_router.py]
  - `test_exception_in_traversal_returns_partial_results`: 예외 발생 시 부분 결과(또는 원본 vector_results)가 반환되는지 확인하도록 테스트 이름 및 docstring 최적화.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1525#pullrequestreview-4411565503)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

GraphHybridRouter 로깅 및 폴백(fallback) 동작을 최적화하고, 하이브리드 검색 라우팅의 의미를 명확히 합니다.

버그 수정:
- 그래프 탐색 중 예외가 발생하여 폴백할 때, 수집된 데이터를 버리는 대신 부분적으로 보강된(partially enriched) 결과를 반환하도록 보장합니다.

개선 사항:
- 문자열이 아닌 시드 노드 ID 강제 변환(coercion)에 대한 로그를 하나의 info 로그로 집계하고, 개별 항목에 대한 상세 정보는 debug 레벨로 낮춰 로그 소음을 줄입니다.
- 탐색 실패 시 부분 결과(partial result)로 폴백하는 동작을 반영하도록 `route_query`의 문서화된 동작을 명확히 합니다.
- `run_hybrid_search`가 커스텀 라우터와 `graph_repository` 둘 다와 함께 호출되는 경우, 이 상황에서 `graph_repository`가 무시된다는 점을 문서화하고 경고를 추가합니다.

테스트:
- 탐색 예외 격리 테스트를 조정하여, 부분 결과 또는 원본 결과로의 폴백 동작을 단언(assert)하고, 설명을 더 명확하게 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize GraphHybridRouter logging and fallback behavior while clarifying hybrid search routing semantics.

Bug Fixes:
- Ensure graph traversal exceptions return partially enriched results instead of discarding collected data when falling back.

Enhancements:
- Reduce log noise by aggregating non-string seed node ID coercion into a single info log with per-item details downgraded to debug level.
- Clarify the documented behavior of route_query to reflect partial-result fallbacks on traversal failure.
- Add a warning when run_hybrid_search is invoked with both a custom router and graph_repository, documenting that graph_repository is ignored in this case.

Tests:
- Adjust the traversal exception isolation test to assert partial-result or original-result fallback behavior and update its description for clarity.

</details>