### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -173,7 +173,9 @@ def _extract_seed_node_ids(vector_results: List[Dict[str, Any]]) -> List[str]:
 
     if coerced_count > 0:
         logger.info(
-            "[GRAPH_ROUTER] Coerced %d non-string seed node IDs to str.", coerced_count
+            "[GRAPH_ROUTER] Coerced %d out of %d seed node IDs to str.",
+            coerced_count,
+            len(vector_results),
         )
 
     return seed_node_ids

--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -114,6 +114,7 @@ def _extract_seed_node_ids(vector_results: List[Dict[str, Any]]) -> List[str]:
     """
     seed_node_ids: List[str] = []
     seen_ids: set[str] = set()
+    coerced_count = 0
 
     for idx, result in enumerate(vector_results):
         node_id = None
@@ -141,7 +142,7 @@ def _extract_seed_node_ids(vector_results: List[Dict[str, Any]]) -> List[str]:
 
         # Normalize non-string IDs and log for observability.
         if not isinstance(node_id, str):
-            logger.warning(
+            logger.debug(
                 "[GRAPH_ROUTER] Non-string seed node id from %s at index %d: %r (type=%s); coercing to str.",
                 source_field or "<unknown>",
                 idx,
@@ -150,6 +151,7 @@ def _extract_seed_node_ids(vector_results: List[Dict[str, Any]]) -> List[str]:
             )
             try:
                 node_id_str = str(node_id)
+                coerced_count += 1
             except Exception:
                 logger.error(
                     "[GRAPH_ROUTER] Failed to coerce seed node id from %s at index %d to str; skipping.",
@@ -168,6 +170,11 @@ def _extract_seed_node_ids(vector_results: List[Dict[str, Any]]) -> List[str]:
         if node_id_str not in seen_ids:
             seen_ids.add(node_id_str)
             seed_node_ids.append(node_id_str)
+
+    if coerced_count > 0:
+        logger.info(
+            "[GRAPH_ROUTER] Coerced %d non-string seed node IDs to str.", coerced_count
+        )
 
     return seed_node_ids
 
@@ -265,7 +272,7 @@ class GraphHybridRouter:
 
         Returns:
             vector_results + 그래프 이웃 노드 결과가 결합된 리스트.
-            탐색 실패 또는 헬스 이상 시 원본 vector_results 반환.
+            탐색 실패 또는 헬스 이상 시 원본 vector_results(또는 예외 발생 직전까지 수집된 부분 결과) 반환.
         """
         # ── 1단계: SSOT 상태 검사 (최우선 가드레일) ─────────────────────────
         if not self.health_registry.is_ok(Subsystem.GRAPH_ENGINE):
@@ -342,9 +349,9 @@ class GraphHybridRouter:
         except Exception:
             logger.exception(
                 "[GRAPH_ROUTER] Unexpected error during graph traversal. "
-                "Falling back to vector_results only."
+                "Returning partially enriched results (or original vector_results)."
             )
-            return vector_results
+            return graph_enriched
 
         logger.debug(
             "[GRAPH_ROUTER] Graph traversal complete. "
@@ -382,6 +389,12 @@ def run_hybrid_search(
     Returns:
         vector_results + 그래프 탐색 결과가 결합된 리스트.
     """
+    if router is not None and graph_repository is not None:
+        logger.warning(
+            "[GRAPH_ROUTER] Custom router provided along with graph_repository to run_hybrid_search. "
+            "The graph_repository argument will be ignored."
+        )
+
     if router is None:
         router = GraphHybridRouter(graph_repository=graph_repository)
     return router.route_query(

--- a/tests/unit/test_graph_router.py
+++ b/tests/unit/test_graph_router.py
@@ -490,12 +490,12 @@ class TestStatelessLoadLifecycle:
 
 
 class TestExceptionIsolation:
-    def test_exception_in_traversal_falls_back_to_vector_results(
+    def test_exception_in_traversal_returns_partial_results(
         self,
         healthy_registry: MagicMock,
         simple_vector_results: List[Dict[str, Any]],
     ) -> None:
-        """탐색 중 예외 발생 시 vector_results 원본 반환, 예외 전파 없음."""
+        """탐색 중 예외 발생 시 예외 전파 없이 수집된 부분 결과(또는 vector_results 원본)를 반환."""
         broken_repo = MagicMock()
         # stateless_load를 컨텍스트 매니저처럼 동작하되 내부에서 예외 발생
         broken_repo.stateless_load.side_effect = RuntimeError("Simulated IO failure")


### PR DESCRIPTION
☘️ refactor [#12.3.12]: 2차 개선 - GraphHybridRouter 성능 및 로깅 최적화, 예외 부분 복구 지원
☘️ refactor [#12.3.12]: 3차 개선 - Seed Node ID 강제 변환 로그 문맥 강화

## Summary by Sourcery

시드 노드 처리, 오류 폴백 동작, 하이브리드 검색 구성과 관련하여 GraphHybridRouter의 동작과 관측 가능성을 개선합니다.

Enhancements:
- 항목별 로깅 수준은 debug로 낮추는 대신, 문자열이 아닌 시드 노드 ID가 문자열로 강제 변환(coerce)된 경우 그 총 개수를 집계하여 추적 및 로그로 남깁니다.
- 예외가 발생했을 때 항상 원래의 벡터 결과로 되돌리는 대신, 그래프 탐색 폴백 동작을 명확히 하고 조정하여 부분적으로만 보강된(partially enriched) 결과를 반환하도록 합니다.
- `run_hybrid_search`가 커스텀 라우터와 `graph_repository` 둘 다와 함께 호출될 때, `graph_repository`가 무시된다는 점을 문서화하고 경고를 출력합니다.

Tests:
- 그래프 탐색 예외 격리 테스트를 업데이트하여, 항상 기존 `vector_results`만을 기대하는 대신 새로운 부분 결과 폴백 동작을 검증하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine GraphHybridRouter behavior and observability for seed node handling, error fallback behavior, and hybrid search configuration.

Enhancements:
- Track and log aggregate counts of non-string seed node IDs coerced to strings while downgrading per-item logging to debug level.
- Clarify and adjust graph traversal fallback to return partially enriched results when exceptions occur instead of always reverting to original vector results.
- Warn when run_hybrid_search is called with both a custom router and graph_repository, documenting that graph_repository is ignored.

Tests:
- Update traversal exception isolation test to assert the new partial-results fallback behavior instead of always expecting original vector_results.

</details>