### PR TITLE
☘️ refactor [#12.3.12]: 4차 개선 - `High QPS` 환경 대비 로깅 최적화

### DIFF
--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -172,11 +172,19 @@ def _extract_seed_node_ids(vector_results: List[Dict[str, Any]]) -> List[str]:
             seed_node_ids.append(node_id_str)
 
     if coerced_count > 0:
+        total = len(vector_results)
         logger.debug(
             "[GRAPH_ROUTER] Coerced %d out of %d seed node IDs to str.",
             coerced_count,
-            len(vector_results),
+            total,
         )
+        if total > 0 and (coerced_count / total) >= 0.5:
+            logger.warning(
+                "[GRAPH_ROUTER] High coercion rate: %d out of %d seed node IDs were non-string. "
+                "Check upstream vector store data quality.",
+                coerced_count,
+                total,
+            )
 
     return seed_node_ids
 

--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -172,7 +172,7 @@ def _extract_seed_node_ids(vector_results: List[Dict[str, Any]]) -> List[str]:
             seed_node_ids.append(node_id_str)
 
     if coerced_count > 0:
-        logger.info(
+        logger.debug(
             "[GRAPH_ROUTER] Coerced %d out of %d seed node IDs to str.",
             coerced_count,
             len(vector_results),


### PR DESCRIPTION
- [backend/agent/graph_router.py]
  - `_extract_seed_node_ids`: Seed Node ID 강제 변환 요약 로그의 레벨을 `INFO`에서 `DEBUG`로 강등하여, 초당 요청 수(QPS)가 높은 프로덕션 환경에서의 I/O 병목 및 로그 스팸(Noise) 발생을 원천 차단.
  - `_traverse_and_enrich`: `try` 블록 이전의 초기화 로직 유지 확인 (UnboundLocalError 원천 차단 보장).

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1527#pullrequestreview-4411674274)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Enhancements:
- 높은 요청률 환경에서 로그 소음과 I/O 오버헤드를 최소화하기 위해, 시드 노드 ID 강제 변환 요약 로그의 로그 레벨을 INFO에서 DEBUG로 낮쌉니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Downgrade seed node ID coercion summary logging from INFO to DEBUG to minimize log noise and I/O overhead under high request rates.

</details>