### PR TITLE
☘️ refactor [#12.3.12]: 6차 개선 - 매직 넘버 상수화 및 로깅 문맥(Tenant) 강화

### DIFF
--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -92,7 +92,7 @@ def _load_traversal_depth() -> int:
 COERCION_WARNING_THRESHOLD = 0.5
 
 
-def _get_node_id_and_source(result: Dict[str, Any]) -> tuple[Any, Optional[str]]:
+def _get_node_id_and_source(result: Dict[str, Any]) -> tuple[Optional[Any], Optional[str]]:
     """결과 딕셔너리에서 node_id와 출처(source_field)를 추출한다."""
     if "id" in result and result["id"] is not None:
         return result["id"], "id"

--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -89,7 +89,28 @@ def _load_traversal_depth() -> int:
     return _clamp_depth(DEFAULT_MAX_TRAVERSAL_DEPTH)
 
 
-def _extract_seed_node_ids(vector_results: List[Dict[str, Any]]) -> List[str]:
+COERCION_WARNING_THRESHOLD = 0.5
+
+
+def _get_node_id_and_source(result: Dict[str, Any]) -> tuple[Any, Optional[str]]:
+    """결과 딕셔너리에서 node_id와 출처(source_field)를 추출한다."""
+    if "id" in result and result["id"] is not None:
+        return result["id"], "id"
+    
+    metadata = result.get("metadata")
+    if isinstance(metadata, dict):
+        if metadata.get("id") is not None:
+            return metadata["id"], "metadata.id"
+        if metadata.get("source") is not None:
+            return metadata["source"], "metadata.source"
+            
+    return None, None
+
+
+def _extract_seed_node_ids(
+    vector_results: List[Dict[str, Any]],
+    hashed_user_id: Optional[str] = None,
+) -> List[str]:
     """
     vector_results에서 고유한 Seed Node ID 목록을 추출한다.
 
@@ -117,24 +138,7 @@ def _extract_seed_node_ids(vector_results: List[Dict[str, Any]]) -> List[str]:
     coerced_count = 0
 
     for idx, result in enumerate(vector_results):
-        node_id = None
-        source_field = None
-
-        # 1) result['id']
-        if "id" in result and result["id"] is not None:
-            node_id = result["id"]
-            source_field = "id"
-        else:
-            metadata = result.get("metadata")
-            if isinstance(metadata, dict):
-                # 2) result['metadata']['id']
-                if metadata.get("id") is not None:
-                    node_id = metadata["id"]
-                    source_field = "metadata.id"
-                # 3) result['metadata']['source']
-                elif metadata.get("source") is not None:
-                    node_id = metadata["source"]
-                    source_field = "metadata.source"
+        node_id, source_field = _get_node_id_and_source(result)
 
         if node_id is None:
             # No usable ID for this result; silently skip to preserve previous behavior.
@@ -178,12 +182,13 @@ def _extract_seed_node_ids(vector_results: List[Dict[str, Any]]) -> List[str]:
             coerced_count,
             total,
         )
-        if total > 0 and (coerced_count / total) >= 0.5:
+        if total > 0 and (coerced_count / total) >= COERCION_WARNING_THRESHOLD:
             logger.warning(
                 "[GRAPH_ROUTER] High coercion rate: %d out of %d seed node IDs were non-string. "
-                "Check upstream vector store data quality.",
+                "Check upstream vector store data quality. (tenant=%s)",
                 coerced_count,
                 total,
+                hashed_user_id or "unknown",
             )
 
     return seed_node_ids
@@ -311,7 +316,7 @@ class GraphHybridRouter:
             return vector_results
 
         # ── 3단계: Seed Node 추출 ────────────────────────────────────────────
-        seed_ids = _extract_seed_node_ids(vector_results)
+        seed_ids = _extract_seed_node_ids(vector_results, hashed_user_id=hashed_user_id)
 
         if not seed_ids:
             logger.debug(


### PR DESCRIPTION
- [backend/agent/graph_router.py]
  - `COERCION_WARNING_THRESHOLD` 상수를 도입하여 `0.5` 매직 넘버를 제거하고 의도 명확화.
  - `_extract_seed_node_ids`에 `hashed_user_id`를 전달하여, 강제 변환 비율 이상(WARNING) 발생 시 어느 테넌트의 데이터 오염인지 즉시 추적할 수 있도록 로깅 Context 강화.
  - `_extract_seed_node_ids` 내부의 ID 탐색 로직을 헬퍼 함수(`_get_node_id_and_source`)로 분리하여 인지 복잡도(Cognitive Complexity) 완화.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1529#pullrequestreview-4411773909)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

그래프 라우터 시드 노드 ID 추출 로직을 리팩터링하여 매직 넘버를 줄이고, 로깅 컨텍스트를 개선하며, ID 조회 로직을 단순화했습니다.

개선 사항:
- 인라인 매직 넘버 대신, 시드 노드 ID 강제 변환(coercion) 비율을 위한 명명된 임계값 상수를 도입했습니다.
- 추출 함수를 단순화하고 인지적 복잡성을 줄이기 위해, 시드 노드 ID 및 소스 해석 로직을 전담하는 헬퍼를 별도로 추출했습니다.
- 벡터 스토어의 데이터 품질 문제에 대한 추적 가능성을 높이기 위해, 고비율 강제 변환 로그에 테넌트 식별자를 포함했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor graph router seed node ID extraction to reduce magic numbers, improve logging context, and simplify ID lookup logic.

Enhancements:
- Introduce a named threshold constant for seed node ID coercion rate instead of using an inline magic number.
- Extract seed node ID and source resolution into a dedicated helper to simplify the extraction function and reduce cognitive complexity.
- Include tenant identifier in high-coercion logging to improve traceability of data quality issues in the vector store.

</details>