### PR TITLE
☘️ refactor [#12.3.12]: 8차 개선 - `Seed Node ID` 타입 힌트 강화 및 방어 로직 추가

### DIFF
--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -17,7 +17,7 @@ Phase 4-2: GraphRAG 하이브리드 라우터
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from backend.core.health_registry import HealthRegistry
 from backend.core.config_validator import Subsystem
@@ -92,17 +92,24 @@ def _load_traversal_depth() -> int:
 COERCION_WARNING_THRESHOLD = 0.5
 
 
-def _get_node_id_and_source(result: Dict[str, Any]) -> tuple[Optional[Any], Optional[str]]:
-    """결과 딕셔너리에서 node_id와 출처(source_field)를 추출한다."""
-    if "id" in result and result["id"] is not None:
-        return result["id"], "id"
+def _get_node_id_and_source(result: Dict[str, Any]) -> tuple[Optional[Union[str, int]], Optional[str]]:
+    """결과 딕셔너리에서 node_id와 출처(source_field)를 추출한다.
+    
+    유효한 ID는 문자열(str) 또는 정수(int) 형태이며, 빈 문자열은 허용하지 않는다.
+    """
+    val_id = result.get("id")
+    if isinstance(val_id, (str, int)) and str(val_id).strip():
+        return val_id, "id"
     
     metadata = result.get("metadata")
     if isinstance(metadata, dict):
-        if metadata.get("id") is not None:
-            return metadata["id"], "metadata.id"
-        if metadata.get("source") is not None:
-            return metadata["source"], "metadata.source"
+        val_meta_id = metadata.get("id")
+        if isinstance(val_meta_id, (str, int)) and str(val_meta_id).strip():
+            return val_meta_id, "metadata.id"
+            
+        val_meta_source = metadata.get("source")
+        if isinstance(val_meta_source, (str, int)) and str(val_meta_source).strip():
+            return val_meta_source, "metadata.source"
             
     return None, None
 


### PR DESCRIPTION
- [backend/agent/graph_router.py]
  - `_get_node_id_and_source`의 반환 타입을 `Optional[Union[str, int]]`로 제한하여 식별자의 예상 데이터 형태를 명시.
  - `is not None` 검사를 `isinstance(val, (str, int)) and str(val).strip()` 기반의 엄격한 유효성 검사로 강화하여, 빈 문자열이나 부적절한 스칼라 타입이 유효한 ID로 평가되는 장애(Surprising coercion behavior) 원천 차단.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1531#pullrequestreview-4411878010)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개선 사항:
- 노드 ID 추출 시 결과(result) 및 메타데이터(metadata) 필드에서 **빈 문자열이 아닌 문자열** 또는 **정수 식별자**만 허용하도록 제한하여, 타입 안정성을 높이고 잘못된 ID를 방지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Constrain node ID extraction to only accept non-empty string or integer identifiers from result and metadata fields, improving type safety and guarding against invalid IDs.

</details>