### PR TITLE
☘️ refactor [#12.3.12]: 9차 개선 - Seed Node ID 검증 로직 모듈화 및 bool 엣지 케이스 방어

### DIFF
--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -92,23 +92,30 @@ def _load_traversal_depth() -> int:
 COERCION_WARNING_THRESHOLD = 0.5
 
 
+def _is_valid_identifier(val: Any) -> bool:
+    """ID가 유효한 문자열 또는 정수인지 검증하며, bool 타입이나 빈 문자열은 제외한다."""
+    if isinstance(val, bool):
+        return False
+    return isinstance(val, (str, int)) and bool(str(val).strip())
+
+
 def _get_node_id_and_source(result: Dict[str, Any]) -> tuple[Optional[Union[str, int]], Optional[str]]:
     """결과 딕셔너리에서 node_id와 출처(source_field)를 추출한다.
     
     유효한 ID는 문자열(str) 또는 정수(int) 형태이며, 빈 문자열은 허용하지 않는다.
     """
     val_id = result.get("id")
-    if isinstance(val_id, (str, int)) and str(val_id).strip():
+    if _is_valid_identifier(val_id):
         return val_id, "id"
     
     metadata = result.get("metadata")
     if isinstance(metadata, dict):
         val_meta_id = metadata.get("id")
-        if isinstance(val_meta_id, (str, int)) and str(val_meta_id).strip():
+        if _is_valid_identifier(val_meta_id):
             return val_meta_id, "metadata.id"
             
         val_meta_source = metadata.get("source")
-        if isinstance(val_meta_source, (str, int)) and str(val_meta_source).strip():
+        if _is_valid_identifier(val_meta_source):
             return val_meta_source, "metadata.source"
             
     return None, None


### PR DESCRIPTION
- [backend/agent/graph_router.py]
  - `isinstance(..., (str, int))` 검증 패턴의 중복을 제거하기 위해 `_is_valid_identifier` 헬퍼 함수로 추출(DRY 원칙 적용).
  - 파이썬에서 `bool`이 `int`의 서브클래스인 언어적 특성으로 인해 `True`/`False`가 유효한 ID로 잘못 평가되는 잠재적 버그를 원천 차단하기 위해 `isinstance(val, bool)` 명시적 제외 로직 추가.

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1532#pullrequestreview-4411923558)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

그래프 라우터에서 노드 식별자 검증을 모듈화하고, 불리언 엣지 케이스가 유효한 ID로 처리되는 문제에 대비해 검증을 강화합니다.

개선 사항:
- 결과 및 메타데이터 필드에서 ID를 도출할 때 사용되는 노드 식별자 검증 로직을 재사용 가능한 헬퍼로 분리합니다.
- 이전에 유효한 ID로 오해될 수 있었던 불리언 값 및 빈 문자열을 거부하도록 식별자 검증을 강화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modularize node identifier validation in the graph router and harden it against boolean edge cases being treated as valid IDs.

Enhancements:
- Extract a reusable helper for validating node identifiers used when deriving IDs from result and metadata fields.
- Tighten identifier validation to reject boolean values and empty strings that could previously be misinterpreted as valid IDs.

</details>