### PR TITLE
☘️ refactor [#12.3.13]: 2차 개선 - 도구 호출 및 문서 리스트 런타임 타입 방어 강화

### DIFF
--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -198,6 +198,13 @@ async def _process_single_tool_call(
     source_documents: List[dict]
 ) -> None:
     """단일 도구 호출을 처리하고 결과를 컨텍스트 및 소스 문서 목록에 추가하는 헬퍼 함수."""
+    if not isinstance(tool_call, dict):
+        logger.warning(
+            "[Tool Dispatch] tool_call이 dict 타입이 아니므로 무시합니다.",
+            extra={"tool_call_type": type(tool_call).__name__}
+        )
+        return
+
     tool_name = tool_call.get("name")
     raw_args = tool_call.get("args")
 
@@ -498,11 +505,12 @@ async def standard_rag_node(state: AgentState) -> PlannerResult:
     )
 
     result = await _run_search_agent(plan_messages, base_context, search_documents_tool, "search_documents_tool")
+    docs = result.get("source_documents")
     return {
         "search_context": result["search_context"],
         "planner_failed": result["planner_failed"],
         "planner_error_message": result["planner_error_message"],
-        "source_documents": result.get("source_documents") or [],
+        "source_documents": docs if isinstance(docs, list) else [],
     }
 
 
@@ -535,11 +543,12 @@ async def fallback_search_node(state: AgentState) -> PlannerResult:
     )
 
     result = await _run_search_agent(plan_messages, base_context, deep_web_search_tool, "deep_web_search_tool")
+    docs = result.get("source_documents")
     return {
         "search_context": result["search_context"],
         "planner_failed": result["planner_failed"],
         "planner_error_message": result["planner_error_message"],
-        "source_documents": result.get("source_documents") or [],
+        "source_documents": docs if isinstance(docs, list) else [],
     }
 
 

--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -129,6 +129,21 @@ def _ensure_str(val: Any) -> str:
     return val if isinstance(val, str) else str(val)
 
 
+def _normalize_source_docs(raw: Any) -> List[dict]:
+    """
+    PlannerResult의 source_documents 필드를 안전하게 정규화하는 헬퍼.
+    - 값이 list이면 그대로 반환합니다.
+    - 그 외 모든 타입(None, str 등)은 빈 리스트로 정규화하여 하위 로직의 크래시를 방지합니다.
+    """
+    if isinstance(raw, list):
+        return raw
+    logger.debug(
+        "[Normalize] source_documents가 list 타입이 아니어서 빈 리스트로 정규화됩니다.",
+        extra={"actual_type": type(raw).__name__},
+    )
+    return []
+
+
 def _is_simple_greeting(cleaned_query: str) -> bool:
     """
     공백 기준으로 토큰화하여 단순 인사말인지 판별하는 헬퍼 함수.
@@ -201,7 +216,10 @@ async def _process_single_tool_call(
     if not isinstance(tool_call, dict):
         logger.warning(
             "[Tool Dispatch] tool_call이 dict 타입이 아니므로 무시합니다.",
-            extra={"tool_call_type": type(tool_call).__name__}
+            extra={
+                "tool_call_type": type(tool_call).__name__,
+                "tool_call_repr": repr(tool_call)[:80],  # 추적을 위한 제한적 식별자 (최대 80자)
+            }
         )
         return
 
@@ -505,12 +523,11 @@ async def standard_rag_node(state: AgentState) -> PlannerResult:
     )
 
     result = await _run_search_agent(plan_messages, base_context, search_documents_tool, "search_documents_tool")
-    docs = result.get("source_documents")
     return {
         "search_context": result["search_context"],
         "planner_failed": result["planner_failed"],
         "planner_error_message": result["planner_error_message"],
-        "source_documents": docs if isinstance(docs, list) else [],
+        "source_documents": _normalize_source_docs(result.get("source_documents")),
     }
 
 
@@ -543,12 +560,11 @@ async def fallback_search_node(state: AgentState) -> PlannerResult:
     )
 
     result = await _run_search_agent(plan_messages, base_context, deep_web_search_tool, "deep_web_search_tool")
-    docs = result.get("source_documents")
     return {
         "search_context": result["search_context"],
         "planner_failed": result["planner_failed"],
         "planner_error_message": result["planner_error_message"],
-        "source_documents": docs if isinstance(docs, list) else [],
+        "source_documents": _normalize_source_docs(result.get("source_documents")),
     }
 
 


### PR DESCRIPTION
- `_process_single_tool_call` 내에서 `tool_call`이 dict 타입이 아닐 경우 발생하는 AttributeError 방지를 위해 isinstance(tool_call, dict) 방어 로직 및 로깅 추가
- `source_documents` 조회 시 값이 list가 아닌 타입(예: 문자열 등)으로 전파되어 발생하는 하위 로직 크래시 방지를 위해 isinstance(docs, list) 기반 엄격한 정규화 적용

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1536#pullrequestreview-4424427433)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

채팅 에이전트 파이프라인에서 런타임 크래시를 방지하기 위해 도구 호출 처리와 소스 문서 정규화를 강화했습니다.

버그 수정:
- 도구 처리 중 `AttributeError`가 발생하지 않도록, 딕셔너리가 아닌 `tool_call` 항목들은 로깅 후 무시하도록 했습니다.
- 검색 에이전트의 `source_documents` 반환 값이 리스트가 아닐 경우, 후속 단계에서의 크래시를 방지하기 위해 빈 리스트로 정규화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden tool call handling and source document normalization to prevent runtime crashes in the chat agent pipeline.

Bug Fixes:
- Ignore non-dict tool_call entries with logging to avoid AttributeError during tool processing.
- Normalize search agent source_documents to an empty list when the returned value is not a list to prevent downstream crashes.

</details>