### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -198,6 +198,13 @@ async def _process_single_tool_call(
     source_documents: List[dict]
 ) -> None:
     """단일 도구 호출을 처리하고 결과를 컨텍스트 및 소스 문서 목록에 추가하는 헬퍼 함수."""
+    if not isinstance(tool_call, dict):
+        logger.warning(
+            "[Tool Dispatch] tool_call이 dict 타입이 아니므로 무시합니다.",
+            extra={"tool_call_type": type(tool_call).__name__}
+        )
+        return
+
     tool_name = tool_call.get("name")
     raw_args = tool_call.get("args")
 
@@ -498,11 +505,12 @@ async def standard_rag_node(state: AgentState) -> PlannerResult:
     )
 
     result = await _run_search_agent(plan_messages, base_context, search_documents_tool, "search_documents_tool")
+    docs = result.get("source_documents")
     return {
         "search_context": result["search_context"],
         "planner_failed": result["planner_failed"],
         "planner_error_message": result["planner_error_message"],
-        "source_documents": result.get("source_documents") or [],
+        "source_documents": docs if isinstance(docs, list) else [],
     }
 
 
@@ -535,11 +543,12 @@ async def fallback_search_node(state: AgentState) -> PlannerResult:
     )
 
     result = await _run_search_agent(plan_messages, base_context, deep_web_search_tool, "deep_web_search_tool")
+    docs = result.get("source_documents")
     return {
         "search_context": result["search_context"],
         "planner_failed": result["planner_failed"],
         "planner_error_message": result["planner_error_message"],
-        "source_documents": result.get("source_documents") or [],
+        "source_documents": docs if isinstance(docs, list) else [],
     }
 
 

--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -129,6 +129,21 @@ def _ensure_str(val: Any) -> str:
     return val if isinstance(val, str) else str(val)
 
 
+def _normalize_source_docs(raw: Any) -> List[dict]:
+    """
+    PlannerResult의 source_documents 필드를 안전하게 정규화하는 헬퍼.
+    - 값이 list이면 그대로 반환합니다.
+    - 그 외 모든 타입(None, str 등)은 빈 리스트로 정규화하여 하위 로직의 크래시를 방지합니다.
+    """
+    if isinstance(raw, list):
+        return raw
+    logger.debug(
+        "[Normalize] source_documents가 list 타입이 아니어서 빈 리스트로 정규화됩니다.",
+        extra={"actual_type": type(raw).__name__},
+    )
+    return []
+
+
 def _is_simple_greeting(cleaned_query: str) -> bool:
     """
     공백 기준으로 토큰화하여 단순 인사말인지 판별하는 헬퍼 함수.
@@ -201,7 +216,10 @@ async def _process_single_tool_call(
     if not isinstance(tool_call, dict):
         logger.warning(
             "[Tool Dispatch] tool_call이 dict 타입이 아니므로 무시합니다.",
-            extra={"tool_call_type": type(tool_call).__name__}
+            extra={
+                "tool_call_type": type(tool_call).__name__,
+                "tool_call_repr": repr(tool_call)[:80],  # 추적을 위한 제한적 식별자 (최대 80자)
+            }
         )
         return
 
@@ -505,12 +523,11 @@ async def standard_rag_node(state: AgentState) -> PlannerResult:
     )
 
     result = await _run_search_agent(plan_messages, base_context, search_documents_tool, "search_documents_tool")
-    docs = result.get("source_documents")
     return {
         "search_context": result["search_context"],
         "planner_failed": result["planner_failed"],
         "planner_error_message": result["planner_error_message"],
-        "source_documents": docs if isinstance(docs, list) else [],
+        "source_documents": _normalize_source_docs(result.get("source_documents")),
     }
 
 
@@ -543,12 +560,11 @@ async def fallback_search_node(state: AgentState) -> PlannerResult:
     )
 
     result = await _run_search_agent(plan_messages, base_context, deep_web_search_tool, "deep_web_search_tool")
-    docs = result.get("source_documents")
     return {
         "search_context": result["search_context"],
         "planner_failed": result["planner_failed"],
         "planner_error_message": result["planner_error_message"],
-        "source_documents": docs if isinstance(docs, list) else [],
+        "source_documents": _normalize_source_docs(result.get("source_documents")),
     }
 
 


### PR DESCRIPTION
☘️ refactor [#12.3.13]: 2차 개선 - 도구 호출 및 문서 리스트 런타임 타입 방어 강화 
☘️ refactor [#12.3.13]: 3차 개선 - source_documents 정규화 헬퍼 추출 및 경고 로그 식별자 강화

## Summary by Sourcery

예상치 못한 런타임 타입으로 인한 크래시를 방지하기 위해 도구 호출 처리와 플래너 source document 정규화를 강화합니다.

버그 수정:
- 도구 디스패치 중 런타임 오류를 피하기 위해 dict가 아닌 `tool_call` 항목은 경고를 남기고 무시합니다.
- 이후 단계에서 발생하는 크래시를 방지하기 위해 list가 아닌 `planner source_documents` 값을 빈 리스트로 정규화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden tool call handling and planner source document normalization to prevent crashes from unexpected runtime types.

Bug Fixes:
- Ignore non-dict tool_call entries with a warning to avoid runtime errors during tool dispatch.
- Normalize non-list planner source_documents values to an empty list to prevent downstream crashes.

</details>