### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -28,6 +28,7 @@
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "react-force-graph-2d": "^1.29.1",
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.1",
         "reactflow": "^11.11.4",
@@ -5233,6 +5234,12 @@
         }
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -5664,7 +5671,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -5678,14 +5685,6 @@
       "dependencies": {
         "@types/react": "*"
       }
-    },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -6384,6 +6383,15 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -6756,6 +6764,16 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bezier-js": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
+      "integrity": "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -6903,6 +6921,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-color-tracker": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/canvas-color-tracker/-/canvas-color-tracker-1.3.2.tgz",
+      "integrity": "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -7131,6 +7161,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
+      "license": "MIT"
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
@@ -7171,6 +7207,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-format": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
@@ -7192,10 +7244,25 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
+    },
     "node_modules/d3-path": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7212,6 +7279,19 @@
         "d3-interpolate": "1.2.0 - 3",
         "d3-time": "2.1.1 - 3",
         "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
       },
       "engines": {
         "node": ">=12"
@@ -7522,16 +7602,6 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -8473,6 +8543,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -8487,6 +8571,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/force-graph": {
+      "version": "1.51.4",
+      "resolved": "https://registry.npmjs.org/force-graph/-/force-graph-1.51.4.tgz",
+      "integrity": "sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "bezier-js": "3 - 6",
+        "canvas-color-tracker": "^1.3",
+        "d3-array": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-zoom": "2 - 3",
+        "float-tooltip": "^1.7",
+        "index-array-by": "1",
+        "kapsule": "^1.16",
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/format": {
@@ -9022,6 +9132,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/index-array-by": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/index-array-by/-/index-array-by-1.4.2.tgz",
+      "integrity": "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/inline-style-parser": {
@@ -9574,6 +9693,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -9588,7 +9716,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -9711,6 +9838,18 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/keyv": {
@@ -10034,6 +10173,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -10055,7 +10200,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -10125,19 +10269,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/marked": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
-      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {
@@ -11049,17 +11180,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/monaco-editor": {
-      "version": "0.55.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
-      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "dompurify": "3.2.7",
-        "marked": "14.0.0"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -11244,17 +11364,6 @@
         }
       }
     },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
-      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -11310,7 +11419,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11657,6 +11765,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/preact": {
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -11715,7 +11833,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -11931,11 +12048,43 @@
         "react": "^19.2.3"
       }
     },
+    "node_modules/react-force-graph-2d": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/react-force-graph-2d/-/react-force-graph-2d-1.29.1.tgz",
+      "integrity": "sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "force-graph": "^1.51",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.5.7.tgz",
+      "integrity": "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -13086,6 +13235,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -13383,7 +13538,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -14161,6 +14316,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/web_ui/package.json
+++ b/web_ui/package.json
@@ -30,6 +30,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-force-graph-2d": "^1.29.1",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^16.1.1",
     "reactflow": "^11.11.4",

--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -1,0 +1,250 @@
+"use client";
+// web_ui/src/components/GraphView/GraphView.tsx
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Phase 4-3 ➀: 지식 그래프 시각화 캔버스 컴포넌트
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//
+// [역할]
+// react-force-graph 의 ForceGraph2D 를 래핑하는 핵심 캔버스 컴포넌트입니다.
+// 이 파일은 반드시 GraphViewLoader.tsx 를 통해 동적(dynamic) 로드되어야 하며,
+// 직접 import 하면 Next.js SSR 단계에서 window 참조 오류가 발생합니다.
+//
+// [SSOT 연동]
+// - 그래프 데이터 타입: backend/schemas/graph.py → websocket.ts (GraphNode, GraphEdge)
+// - 설정 상수: src/config/graph.ts (MAX_GRAPH_NODES, 색상 등)
+// - 어댑터 타입: ./types.ts (ForceGraphNode, ForceGraphLink)
+//
+// [하드코딩 금지]
+// 모든 매직 넘버는 src/config/graph.ts 의 named export 를 참조합니다.
+//
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+import React, { useCallback, useRef, useState } from "react";
+import ForceGraph2D, {
+  type ForceGraphMethods,
+  type NodeObject,
+} from "react-force-graph-2d";
+
+import type { GraphNode } from "@/types/websocket";
+import { NodeType } from "@/types/websocket";
+import {
+  MAX_GRAPH_NODES,
+  GRAPH_BG_COLOR,
+  GRAPH_NODE_COLOR_NOTE,
+  GRAPH_NODE_COLOR_KEYWORD,
+  GRAPH_NODE_COLOR_TAG,
+  GRAPH_NODE_COLOR_CATEGORY,
+  GRAPH_LINK_COLOR,
+  GRAPH_HIGHLIGHT_COLOR,
+  GRAPH_NODE_RADIUS,
+  GRAPH_NODE_SELECTED_SCALE,
+  GRAPH_COOLDOWN_TICKS,
+} from "@/config/graph";
+import type {
+  ForceGraphNode,
+  ForceGraphLink,
+  GraphViewData,
+  OnNodeClickCallback,
+} from "./types";
+
+// ─────────────────────────────────────────
+// 헬퍼: NodeType → 색상 매핑
+// ─────────────────────────────────────────
+
+/** NodeType enum 값을 캔버스 렌더링 색상으로 변환합니다. */
+function resolveNodeColor(nodeType: NodeType): string {
+  switch (nodeType) {
+    case NodeType.NOTE:
+      return GRAPH_NODE_COLOR_NOTE;
+    case NodeType.KEYWORD:
+      return GRAPH_NODE_COLOR_KEYWORD;
+    case NodeType.TAG:
+      return GRAPH_NODE_COLOR_TAG;
+    case NodeType.CATEGORY:
+      return GRAPH_NODE_COLOR_CATEGORY;
+    default:
+      // 백엔드에서 새 NodeType 이 추가될 경우의 안전한 폴백
+      return GRAPH_NODE_COLOR_NOTE;
+  }
+}
+
+// ─────────────────────────────────────────
+// 헬퍼: GraphViewData → ForceGraph 입력 변환
+// ─────────────────────────────────────────
+
+/**
+ * 백엔드 GraphDataResponse 를 react-force-graph 입력 형태로 변환합니다.
+ *
+ * MAX_GRAPH_NODES 초과 시 앞에서부터 자르며, 자른 경우 콘솔 경고를 출력합니다.
+ * (Phase 4-3 2단계의 중심 노드 우선 슬라이싱은 별도 구현 예정)
+ */
+function adaptGraphData(data: GraphViewData): {
+  nodes: ForceGraphNode[];
+  links: ForceGraphLink[];
+} {
+  const rawNodes = data.nodes;
+  const truncated = rawNodes.length > MAX_GRAPH_NODES;
+
+  let allowedNodes = rawNodes;
+
+  if (truncated) {
+    console.warn(
+      `[GraphView] 노드 수(${rawNodes.length})가 MAX_GRAPH_NODES(${MAX_GRAPH_NODES})를 초과합니다. ` +
+        `연결 수(Degree)가 높은 중심 노드 위주로 ${MAX_GRAPH_NODES}개만 필터링하여 렌더링합니다.`
+    );
+
+    // 1. 각 노드의 Degree(연결된 엣지 수) 계산
+    const degreeMap = new Map<string, number>();
+    for (const edge of data.edges) {
+      degreeMap.set(edge.source, (degreeMap.get(edge.source) || 0) + 1);
+      degreeMap.set(edge.target, (degreeMap.get(edge.target) || 0) + 1);
+    }
+
+    // 2. Degree 기준 내림차순 정렬 후 최대 개수만큼 슬라이싱
+    // 원본 배열 불변성 유지를 위해 복사 후 정렬
+    const sortedNodes = [...rawNodes].sort((a, b) => {
+      const degA = degreeMap.get(a.id) || 0;
+      const degB = degreeMap.get(b.id) || 0;
+      return degB - degA; // 내림차순
+    });
+
+    allowedNodes = sortedNodes.slice(0, MAX_GRAPH_NODES);
+  }
+
+  const allowedNodeIds = new Set(allowedNodes.map((n) => n.id));
+
+  // 양 끝점 노드가 모두 허용 범위 내에 있는 엣지만 포함
+  const links: ForceGraphLink[] = data.edges
+    .filter((e) => allowedNodeIds.has(e.source) && allowedNodeIds.has(e.target))
+    .map((e) => ({ ...e }));
+
+  return {
+    nodes: allowedNodes.map((n) => ({ ...n })),
+    links,
+  };
+}
+
+// ─────────────────────────────────────────
+// Props 정의
+// ─────────────────────────────────────────
+
+export interface GraphViewProps {
+  /** 렌더링할 그래프 데이터 (백엔드 GraphDataResponse 형태) */
+  data: GraphViewData;
+  /** 캔버스 너비 (px). 미지정 시 부모 컨테이너 너비 사용. */
+  width?: number;
+  /** 캔버스 높이 (px). 기본값은 컨테이너에서 CSS로 제어. */
+  height?: number;
+  /** 노드 클릭 시 호출되는 콜백 */
+  onNodeClick?: OnNodeClickCallback;
+}
+
+// ─────────────────────────────────────────
+// GraphView 메인 컴포넌트
+// ─────────────────────────────────────────
+
+/**
+ * 지식 그래프 2D 캔버스 시각화 컴포넌트.
+ *
+ * [사용 방법]
+ * 반드시 GraphViewLoader(SSR-safe wrapper) 를 통해 렌더링하세요.
+ * ```tsx
+ * import { GraphViewLoader } from "@/components/GraphView";
+ * <GraphViewLoader data={graphData} onNodeClick={handleClick} />
+ * ```
+ */
+export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewProps) {
+  const graphRef = useRef<ForceGraphMethods | undefined>(undefined);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+
+  // SSOT 에서 변환한 데이터
+  const { nodes, links } = adaptGraphData(data);
+
+  // ── 노드 클릭 핸들러 ──────────────────────────────────────
+  const handleNodeClick = useCallback(
+    (rawNode: NodeObject<ForceGraphNode>) => {
+      const node = rawNode as ForceGraphNode;
+      setSelectedNodeId((prev) => (prev === node.id ? null : node.id));
+
+      if (onNodeClick) {
+        // ForceGraphNode 는 GraphNode 를 상속하므로 안전하게 캐스팅
+        onNodeClick(node as GraphNode);
+      }
+    },
+    [onNodeClick]
+  );
+
+  // ── 노드 캔버스 렌더러 ───────────────────────────────────
+  const paintNode = useCallback(
+    (rawNode: NodeObject<ForceGraphNode>, ctx: CanvasRenderingContext2D) => {
+      const node = rawNode as ForceGraphNode;
+      const nx = node.x ?? 0;
+      const ny = node.y ?? 0;
+      const isSelected = node.id === selectedNodeId;
+      const radius = GRAPH_NODE_RADIUS * (isSelected ? GRAPH_NODE_SELECTED_SCALE : 1);
+      const color = resolveNodeColor(node.node_type);
+
+      // 선택 시 후광(glow) 효과
+      if (isSelected) {
+        ctx.beginPath();
+        ctx.arc(nx, ny, radius + 4, 0, Math.PI * 2);
+        ctx.fillStyle = `${GRAPH_HIGHLIGHT_COLOR}22`;
+        ctx.fill();
+      }
+
+      // 노드 원
+      ctx.beginPath();
+      ctx.arc(nx, ny, radius, 0, Math.PI * 2);
+      ctx.fillStyle = isSelected ? GRAPH_HIGHLIGHT_COLOR : color;
+      ctx.fill();
+
+      // 라벨 (작은 폰트로 노드 아래에 표시)
+      const fontSize = Math.max(4, radius * 0.9);
+      ctx.font = `${fontSize}px Inter, sans-serif`;
+      ctx.fillStyle = isSelected ? GRAPH_HIGHLIGHT_COLOR : "rgba(220,220,240,0.85)";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "top";
+      ctx.fillText(node.label, nx, ny + radius + 2);
+    },
+    [selectedNodeId]
+  );
+
+  return (
+    <ForceGraph2D<ForceGraphNode, ForceGraphLink>
+      ref={graphRef}
+      graphData={{ nodes, links }}
+      width={width}
+      height={height}
+      backgroundColor={GRAPH_BG_COLOR}
+      // 링크 스타일
+      linkColor={() => GRAPH_LINK_COLOR}
+      linkWidth={(link: unknown) => {
+        const l = link as ForceGraphLink;
+        // 엣지 weight(0~1)를 링크 두께(0.5~3px)에 선형 매핑
+        return 0.5 + (l.weight ?? 1) * 2.5;
+      }}
+      // 노드 커스텀 렌더러
+      nodeCanvasObject={paintNode}
+      nodeCanvasObjectMode={() => "replace"}
+      // 노드 포인터 영역 — 라벨 영역까지 포함하도록 반경 확장
+      nodePointerAreaPaint={(rawNode: unknown, color: string, ctx: CanvasRenderingContext2D) => {
+        const node = rawNode as ForceGraphNode;
+        const nx = node.x ?? 0;
+        const ny = node.y ?? 0;
+        const radius = GRAPH_NODE_RADIUS * GRAPH_NODE_SELECTED_SCALE + 6;
+        ctx.beginPath();
+        ctx.arc(nx, ny, radius, 0, Math.PI * 2);
+        ctx.fillStyle = color;
+        ctx.fill();
+      }}
+      // 이벤트
+      onNodeClick={handleNodeClick}
+      // 물리 시뮬레이션 설정
+      cooldownTicks={GRAPH_COOLDOWN_TICKS}
+      // 성능: 줌/패닝 시 라벨 렌더링 일시 중단
+      enableNodeDrag
+      enableZoomInteraction
+      enablePanInteraction
+    />
+  );
+}

--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -19,10 +19,11 @@
 //
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useRef, useState, useMemo } from "react";
 import ForceGraph2D, {
   type ForceGraphMethods,
   type NodeObject,
+  type LinkObject,
 } from "react-force-graph-2d";
 
 import type { GraphNode } from "@/types/websocket";
@@ -75,8 +76,8 @@ function resolveNodeColor(nodeType: NodeType): string {
 /**
  * 백엔드 GraphDataResponse 를 react-force-graph 입력 형태로 변환합니다.
  *
- * MAX_GRAPH_NODES 초과 시 앞에서부터 자르며, 자른 경우 콘솔 경고를 출력합니다.
- * (Phase 4-3 2단계의 중심 노드 우선 슬라이싱은 별도 구현 예정)
+ * MAX_GRAPH_NODES 초과 시, OOM(Out of Memory) 방지를 위해
+ * 연결 수(Degree)가 높은 중심 노드 위주로 상위 N개만 필터링합니다.
  */
 function adaptGraphData(data: GraphViewData): {
   nodes: ForceGraphNode[];
@@ -154,11 +155,16 @@ export interface GraphViewProps {
  * ```
  */
 export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewProps) {
-  const graphRef = useRef<ForceGraphMethods | undefined>(undefined);
+  const graphRef = useRef<
+    ForceGraphMethods<
+      NodeObject<ForceGraphNode>,
+      LinkObject<ForceGraphNode, ForceGraphLink>
+    > | undefined
+  >(undefined);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
-  // SSOT 에서 변환한 데이터
-  const { nodes, links } = adaptGraphData(data);
+  // SSOT 에서 변환한 데이터 (재계산 방지를 위해 메모이제이션)
+  const { nodes, links } = useMemo(() => adaptGraphData(data), [data]);
 
   // ── 노드 클릭 핸들러 ──────────────────────────────────────
   const handleNodeClick = useCallback(

--- a/web_ui/src/components/GraphView/GraphViewLoader.tsx
+++ b/web_ui/src/components/GraphView/GraphViewLoader.tsx
@@ -1,0 +1,24 @@
+"use client";
+// web_ui/src/components/GraphView/GraphViewLoader.tsx
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Phase 4-3: SSR 회피용 래퍼 컴포넌트
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+import dynamic from "next/dynamic";
+import { type GraphViewProps } from "./GraphView";
+
+// react-force-graph 는 window/document 객체에 의존하므로
+// Next.js 의 서버 사이드 렌더링(SSR) 단계에서 로드하면 에러가 발생합니다.
+// ssr: false 옵션을 통해 클라이언트 사이드에서만 로드되도록 강제합니다.
+const GraphViewDynamic = dynamic<GraphViewProps>(
+  () => import("./GraphView").then((mod) => mod.GraphView),
+  { ssr: false }
+);
+
+/**
+ * GraphView 의 SSR-safe 래퍼 컴포넌트입니다.
+ * 외부에서는 항상 이 컴포넌트를 import 하여 사용해야 합니다.
+ */
+export function GraphViewLoader(props: GraphViewProps) {
+  return <GraphViewDynamic {...props} />;
+}

--- a/web_ui/src/components/GraphView/index.ts
+++ b/web_ui/src/components/GraphView/index.ts
@@ -1,0 +1,8 @@
+// web_ui/src/components/GraphView/index.ts
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Phase 4-3: GraphView 모듈 진입점 (Barrel Export)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+export { GraphViewLoader as GraphView } from "./GraphViewLoader";
+export type { GraphViewProps } from "./GraphView";
+export type { GraphViewData, OnNodeClickCallback } from "./types";

--- a/web_ui/src/components/GraphView/types.ts
+++ b/web_ui/src/components/GraphView/types.ts
@@ -1,0 +1,74 @@
+// web_ui/src/components/GraphView/types.ts
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Phase 4-3: GraphView 내부 전용 타입 정의
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//
+// [SSOT 연동]
+// 이 파일의 GraphNode / GraphEdge 타입은
+// backend/schemas/graph.py → OpenAPI → 자동 생성된
+// web_ui/src/types/websocket.ts 의 타입을 재사용합니다.
+// (수동 하드코딩 금지)
+//
+// react-force-graph 가 요구하는 `NodeObject` / `LinkObject` 형태로
+// 매핑하는 어댑터 타입을 여기서 정의합니다.
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+import type { GraphNode, GraphEdge } from "@/types/websocket";
+
+// ─────────────────────────────────────────
+// react-force-graph 어댑터 타입
+// ─────────────────────────────────────────
+
+/**
+ * react-force-graph 의 `NodeObject` 로 사용할 어댑터 타입.
+ *
+ * react-force-graph 는 런타임에 `x`, `y`, `vx`, `vy` 등의 물리 시뮬레이션
+ * 속성을 노드 객체에 직접 주입합니다. 이 타입은 그 시뮬레이션 속성을
+ * 포함하면서 SSOT 타입인 GraphNode 를 확장합니다.
+ *
+ * `id` 는 react-force-graph 가 string | number 를 모두 허용하므로
+ * GraphNode.id(string) 을 그대로 사용합니다.
+ */
+export type ForceGraphNode = GraphNode & {
+  /** 시뮬레이션 X 좌표 (react-force-graph 런타임 주입) */
+  x?: number;
+  /** 시뮬레이션 Y 좌표 (react-force-graph 런타임 주입) */
+  y?: number;
+  /** X축 속도 벡터 (react-force-graph 런타임 주입) */
+  vx?: number;
+  /** Y축 속도 벡터 (react-force-graph 런타임 주입) */
+  vy?: number;
+};
+
+/**
+ * react-force-graph 의 `LinkObject` 로 사용할 어댑터 타입.
+ *
+ * react-force-graph 는 `source` / `target` 을 초기에 string 으로 받고,
+ * 시뮬레이션 시작 후 실제 노드 객체 참조로 교체합니다.
+ * 이 타입은 두 상태를 모두 수용합니다.
+ */
+export type ForceGraphLink = Omit<GraphEdge, "source" | "target"> & {
+  /** 출발 노드 id (초기값) 또는 노드 객체 참조 (시뮬레이션 후) */
+  source: string | ForceGraphNode;
+  /** 도착 노드 id (초기값) 또는 노드 객체 참조 (시뮬레이션 후) */
+  target: string | ForceGraphNode;
+};
+
+/**
+ * GraphView 컴포넌트에 전달되는 그래프 데이터.
+ * 백엔드 GraphDataResponse 와 1:1 대응합니다.
+ */
+export interface GraphViewData {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+// ─────────────────────────────────────────
+// 콜백 / 이벤트 타입
+// ─────────────────────────────────────────
+
+/**
+ * 노드 클릭 시 호출되는 콜백 타입.
+ * 클릭된 노드의 SSOT 타입(GraphNode) 을 그대로 전달합니다.
+ */
+export type OnNodeClickCallback = (node: GraphNode) => void;

--- a/web_ui/src/config/graph.ts
+++ b/web_ui/src/config/graph.ts
@@ -46,7 +46,8 @@ export const GRAPH_NODES_DEFAULT = 500;
  * - 유효 범위(GRAPH_NODES_MIN ~ GRAPH_NODES_MAX) 를 벗어날 경우: Clamping 후 경고 로그 출력.
  */
 function loadMaxGraphNodes(): number {
-  const raw = process.env[ENV_KEY_MAX_GRAPH_NODES];
+  // Next.js 환경에서는 동적 키(process.env[Key])가 빌드 타임에 치환되지 않으므로 직접 명시해야 합니다.
+  const raw = process.env.NEXT_PUBLIC_MAX_GRAPH_NODES;
   if (raw === undefined || raw === "") {
     return GRAPH_NODES_DEFAULT;
   }

--- a/web_ui/src/config/graph.ts
+++ b/web_ui/src/config/graph.ts
@@ -1,0 +1,109 @@
+// web_ui/src/config/graph.ts
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Phase 4-3: 프론트엔드 지식 그래프 시각화 설정 (SSOT)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//
+// [SSOT 정책]
+// 이 파일은 GraphView 컴포넌트에 필요한 모든 설정 상수의 단일 진실 공급원입니다.
+// - 하드코딩 절대 금지. 모든 매직 넘버는 이 파일의 상수를 참조해야 합니다.
+// - 최대 노드 수(NEXT_PUBLIC_MAX_GRAPH_NODES)는 백엔드 GraphConfig와 동일한
+//   환경 변수를 읽어 동기화합니다.
+//
+// [환경 변수 연동]
+// 백엔드: backend/core/config/graph.py ENV_MAX_GRAPH_NODES = "NEXT_PUBLIC_MAX_GRAPH_NODES"
+// 기본값: DEFAULT_MAX_GRAPH_NODES = 500  (유효 범위: 50 ~ 2000)
+//
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+// ─────────────────────────────────────────
+// 환경 변수 키 (문자열 하드코딩 금지)
+// ─────────────────────────────────────────
+
+/** 최대 렌더링 노드 수 환경 변수 키 (백엔드 ENV_MAX_GRAPH_NODES 와 동일) */
+const ENV_KEY_MAX_GRAPH_NODES = "NEXT_PUBLIC_MAX_GRAPH_NODES";
+
+// ─────────────────────────────────────────
+// 유효 범위 (백엔드 MAX_GRAPH_NODES_RANGE 와 동기화)
+// ─────────────────────────────────────────
+
+/** 렌더링 노드 수 최솟값 (백엔드 MAX_GRAPH_NODES_RANGE.min = 50) */
+export const GRAPH_NODES_MIN = 50;
+
+/** 렌더링 노드 수 최댓값 (백엔드 MAX_GRAPH_NODES_RANGE.max = 2000) */
+export const GRAPH_NODES_MAX = 2000;
+
+/** 렌더링 노드 수 기본값 (백엔드 DEFAULT_MAX_GRAPH_NODES = 500) */
+export const GRAPH_NODES_DEFAULT = 500;
+
+// ─────────────────────────────────────────
+// 환경 변수 로딩 (Clamping 적용)
+// ─────────────────────────────────────────
+
+/**
+ * 환경 변수 `NEXT_PUBLIC_MAX_GRAPH_NODES` 를 읽어 렌더링 최대 노드 수를 반환합니다.
+ *
+ * - 값이 없거나 파싱 불가능한 경우: 기본값(GRAPH_NODES_DEFAULT) 사용.
+ * - 유효 범위(GRAPH_NODES_MIN ~ GRAPH_NODES_MAX) 를 벗어날 경우: Clamping 후 경고 로그 출력.
+ */
+function loadMaxGraphNodes(): number {
+  const raw = process.env[ENV_KEY_MAX_GRAPH_NODES];
+  if (raw === undefined || raw === "") {
+    return GRAPH_NODES_DEFAULT;
+  }
+
+  const parsed = parseInt(raw, 10);
+  if (isNaN(parsed)) {
+    console.warn(
+      `[GraphConfig] ${ENV_KEY_MAX_GRAPH_NODES}="${raw}" 파싱 실패. ` +
+        `기본값 ${GRAPH_NODES_DEFAULT} 을 사용합니다.`
+    );
+    return GRAPH_NODES_DEFAULT;
+  }
+
+  const clamped = Math.min(Math.max(parsed, GRAPH_NODES_MIN), GRAPH_NODES_MAX);
+  if (clamped !== parsed) {
+    console.warn(
+      `[GraphConfig] ${ENV_KEY_MAX_GRAPH_NODES}=${parsed} 은 ` +
+        `유효 범위 [${GRAPH_NODES_MIN}, ${GRAPH_NODES_MAX}] 를 벗어납니다. ` +
+        `${clamped} 으로 조정합니다.`
+    );
+  }
+  return clamped;
+}
+
+/** 렌더링 최대 노드 수 (환경 변수 기반, Clamping 적용) */
+export const MAX_GRAPH_NODES: number = loadMaxGraphNodes();
+
+// ─────────────────────────────────────────
+// 시각화 레이아웃 상수
+// ─────────────────────────────────────────
+
+/** 캔버스 초기 배경색 */
+export const GRAPH_BG_COLOR = "#0f0f14";
+
+/** 노드 기본 색상 (NOTE 타입) */
+export const GRAPH_NODE_COLOR_NOTE = "#6c63ff";
+
+/** 노드 색상 — KEYWORD 타입 */
+export const GRAPH_NODE_COLOR_KEYWORD = "#00c896";
+
+/** 노드 색상 — TAG 타입 */
+export const GRAPH_NODE_COLOR_TAG = "#f4a261";
+
+/** 노드 색상 — CATEGORY 타입 */
+export const GRAPH_NODE_COLOR_CATEGORY = "#e76f51";
+
+/** 엣지(링크) 기본 색상 */
+export const GRAPH_LINK_COLOR = "rgba(150, 150, 200, 0.4)";
+
+/** 호버/선택 시 하이라이트 색상 */
+export const GRAPH_HIGHLIGHT_COLOR = "#ffffff";
+
+/** 노드 기본 크기(반경) */
+export const GRAPH_NODE_RADIUS = 6;
+
+/** 선택된 노드 크기 배율 */
+export const GRAPH_NODE_SELECTED_SCALE = 1.8;
+
+/** 캔버스 워밍업(물리 시뮬레이션 냉각) 이후 정지까지 대기 틱 수 */
+export const GRAPH_COOLDOWN_TICKS = 120;

--- a/web_ui/src/types/websocket.ts
+++ b/web_ui/src/types/websocket.ts
@@ -180,6 +180,8 @@ export interface WsConflict {
 export enum NodeType {
   CATEGORY = "category",
   NOTE = "note",
+  KEYWORD = "keyword",
+  TAG = "tag",
 }
 
 /**


### PR DESCRIPTION
✨ feat [#12.3.14]: Phase 4-3 - ➀ GraphView 뼈대 구축 및 중심 노드 필터링 최적화 
☘️ refactor [#12.3.14]: 1차 개선 - 성능 최적화(useMemo), 버그 수정 및 타입 에러 해결

## Summary by Sourcery

SSR에 안전한 로딩과 노드 제한 및 스타일링에 대한 중앙 집중식 설정을 갖춘 클라이언트 사이드 지식 그래프 시각화 캔버스를 도입합니다.

New Features:
- `react-force-graph-2d`를 사용하여 노드 선택 및 사용자 정의 스타일을 지원하는 인터랙티브 2D 지식 그래프를 렌더링하는 `GraphView` 컴포넌트를 추가합니다.
- Next.js에서 그래프 시각화를 클라이언트에서만 안전하게 로드할 수 있도록 `GraphViewLoader` 래퍼를 노출합니다.

Enhancements:
- 더 풍부한 그래프 의미를 위해 `NodeType`을 확장하여 키워드 및 태그 노드를 지원합니다.
- 최대 노드 수 및 시각적 상수 등을 포함한 그래프 시각화 설정을 중앙 집중화하고, 백엔드 설정과 정렬된 환경 변수 기반 제한을 적용합니다.

Build:
- 그래프 렌더링을 위한 새로운 프론트엔드 의존성으로 `react-force-graph-2d`를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a client-side knowledge graph visualization canvas with SSR-safe loading and centralized configuration for node limits and styling.

New Features:
- Add a GraphView component using react-force-graph-2d to render interactive 2D knowledge graphs with node selection and custom styling.
- Expose a GraphViewLoader wrapper to safely load the graph visualization only on the client in Next.js.

Enhancements:
- Extend NodeType to support keyword and tag nodes for richer graph semantics.
- Centralize graph visualization configuration, including max node count and visual constants, with environment-driven limits aligned to backend settings.

Build:
- Add react-force-graph-2d as a new frontend dependency for graph rendering.

</details>