### PR TITLE
☘️ refactor [#12.3.14]: 2차 개선 - 타입 안정성(Type-safe) 강화 및 휴먼 에러 방지

### DIFF
--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -63,9 +63,11 @@ function resolveNodeColor(nodeType: NodeType): string {
       return GRAPH_NODE_COLOR_TAG;
     case NodeType.CATEGORY:
       return GRAPH_NODE_COLOR_CATEGORY;
-    default:
-      // 백엔드에서 새 NodeType 이 추가될 경우의 안전한 폴백
+    default: {
+      const _exhaustiveCheck: never = nodeType;
+      console.warn(`[GraphView] Unknown nodeType: ${_exhaustiveCheck}`);
       return GRAPH_NODE_COLOR_NOTE;
+    }
   }
 }
 
@@ -156,11 +158,8 @@ export interface GraphViewProps {
  */
 export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewProps) {
   const graphRef = useRef<
-    ForceGraphMethods<
-      NodeObject<ForceGraphNode>,
-      LinkObject<ForceGraphNode, ForceGraphLink>
-    > | undefined
-  >(undefined);
+    ForceGraphMethods<ForceGraphNode, ForceGraphLink> | null
+  >(null);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
   // SSOT 에서 변환한 데이터 (재계산 방지를 위해 메모이제이션)
@@ -182,8 +181,7 @@ export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewP
 
   // ── 노드 캔버스 렌더러 ───────────────────────────────────
   const paintNode = useCallback(
-    (rawNode: NodeObject<ForceGraphNode>, ctx: CanvasRenderingContext2D) => {
-      const node = rawNode as ForceGraphNode;
+    (node: NodeObject<ForceGraphNode>, ctx: CanvasRenderingContext2D) => {
       const nx = node.x ?? 0;
       const ny = node.y ?? 0;
       const isSelected = node.id === selectedNodeId;
@@ -217,24 +215,23 @@ export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewP
 
   return (
     <ForceGraph2D<ForceGraphNode, ForceGraphLink>
-      ref={graphRef}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ref={graphRef as any}
       graphData={{ nodes, links }}
       width={width}
       height={height}
       backgroundColor={GRAPH_BG_COLOR}
       // 링크 스타일
       linkColor={() => GRAPH_LINK_COLOR}
-      linkWidth={(link: unknown) => {
-        const l = link as ForceGraphLink;
+      linkWidth={(link: LinkObject<ForceGraphNode, ForceGraphLink>) => {
         // 엣지 weight(0~1)를 링크 두께(0.5~3px)에 선형 매핑
-        return 0.5 + (l.weight ?? 1) * 2.5;
+        return 0.5 + (link.weight ?? 1) * 2.5;
       }}
       // 노드 커스텀 렌더러
       nodeCanvasObject={paintNode}
       nodeCanvasObjectMode={() => "replace"}
       // 노드 포인터 영역 — 라벨 영역까지 포함하도록 반경 확장
-      nodePointerAreaPaint={(rawNode: unknown, color: string, ctx: CanvasRenderingContext2D) => {
-        const node = rawNode as ForceGraphNode;
+      nodePointerAreaPaint={(node: NodeObject<ForceGraphNode>, color: string, ctx: CanvasRenderingContext2D) => {
         const nx = node.x ?? 0;
         const ny = node.y ?? 0;
         const radius = GRAPH_NODE_RADIUS * GRAPH_NODE_SELECTED_SCALE + 6;

--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -49,6 +49,13 @@ import type {
 } from "./types";
 
 // ─────────────────────────────────────────
+// 로컬 타입 별칭 (가독성 향상 및 런타임 캐스팅 방지)
+// ─────────────────────────────────────────
+type NodeObj = NodeObject<ForceGraphNode>;
+type LinkObj = LinkObject<ForceGraphNode, ForceGraphLink>;
+type FGMethods = ForceGraphMethods<NodeObj, LinkObj>;
+
+// ─────────────────────────────────────────
 // 헬퍼: NodeType → 색상 매핑
 // ─────────────────────────────────────────
 
@@ -157,9 +164,7 @@ export interface GraphViewProps {
  * ```
  */
 export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewProps) {
-  const graphRef = useRef<
-    ForceGraphMethods<ForceGraphNode, ForceGraphLink> | null
-  >(null);
+  const graphRef = useRef<FGMethods | undefined>(undefined);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
   // SSOT 에서 변환한 데이터 (재계산 방지를 위해 메모이제이션)
@@ -167,7 +172,7 @@ export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewP
 
   // ── 노드 클릭 핸들러 ──────────────────────────────────────
   const handleNodeClick = useCallback(
-    (rawNode: NodeObject<ForceGraphNode>) => {
+    (rawNode: NodeObj) => {
       const node = rawNode as ForceGraphNode;
       setSelectedNodeId((prev) => (prev === node.id ? null : node.id));
 
@@ -181,7 +186,7 @@ export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewP
 
   // ── 노드 캔버스 렌더러 ───────────────────────────────────
   const paintNode = useCallback(
-    (node: NodeObject<ForceGraphNode>, ctx: CanvasRenderingContext2D) => {
+    (node: NodeObj, ctx: CanvasRenderingContext2D) => {
       const nx = node.x ?? 0;
       const ny = node.y ?? 0;
       const isSelected = node.id === selectedNodeId;
@@ -215,15 +220,14 @@ export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewP
 
   return (
     <ForceGraph2D<ForceGraphNode, ForceGraphLink>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ref={graphRef as any}
+      ref={graphRef}
       graphData={{ nodes, links }}
       width={width}
       height={height}
       backgroundColor={GRAPH_BG_COLOR}
       // 링크 스타일
       linkColor={() => GRAPH_LINK_COLOR}
-      linkWidth={(link: LinkObject<ForceGraphNode, ForceGraphLink>) => {
+      linkWidth={(link: LinkObj) => {
         // 엣지 weight(0~1)를 링크 두께(0.5~3px)에 선형 매핑
         return 0.5 + (link.weight ?? 1) * 2.5;
       }}
@@ -231,7 +235,7 @@ export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewP
       nodeCanvasObject={paintNode}
       nodeCanvasObjectMode={() => "replace"}
       // 노드 포인터 영역 — 라벨 영역까지 포함하도록 반경 확장
-      nodePointerAreaPaint={(node: NodeObject<ForceGraphNode>, color: string, ctx: CanvasRenderingContext2D) => {
+      nodePointerAreaPaint={(node: NodeObj, color: string, ctx: CanvasRenderingContext2D) => {
         const nx = node.x ?? 0;
         const ny = node.y ?? 0;
         const radius = GRAPH_NODE_RADIUS * GRAPH_NODE_SELECTED_SCALE + 6;


### PR DESCRIPTION
- [Safe] `resolveNodeColor`에 Exhaustiveness Check(`never` 할당)를 추가하여, 향후 신규 `NodeType` 추가 시 컴파일 에러로 경고하도록 휴먼 에러 원천 차단
- [Typing]
  - `ForceGraph2D` 콜백 핸들러에서 사용하던 `unknown` 런타임 캐스팅(`as ForceGraphNode`)을 제거하고 정확한 제네릭 모델 적용
  - `useRef` 제네릭을 `ForceGraphMethods<ForceGraphNode, ForceGraphLink>`로 간소화
- [Fix] 라이브러리 내부 타입 충돌 및 ESLint 경고 우회 처리 완료

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1544#pullrequestreview-4433361373)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

GraphView의 force-graph 통합에서 타입 안정성과 완전성을 강화하고, ref 타입 정의를 단순화하며 안전하지 않은 캐스트를 제거합니다.

버그 수정:
- `resolveNodeColor`에 완전성(exhaustiveness) 체크를 추가하여, 알 수 없는 `NodeType` 값이 컴파일 타임에 드러나도록 하고, 런타임에는 로그를 남기도록 합니다.
- 내부 타입 충돌과 ESLint 경고를 피하기 위해 `ForceGraph2D` ref 타입 정의와 사용 방식을 조정합니다.

개선 사항:
- `ForceGraph2D` ref 제네릭을 단순화하여 `ForceGraphMethods<ForceGraphNode, ForceGraphLink>`를 사용하고, null-safe 초기값을 사용하도록 합니다.
- `ForceGraph2D` 콜백이 런타임 캐스트가 필요한 `unknown` 대신, 강하게 타입이 지정된 `NodeObject`와 `LinkObject` 파라미터를 사용하도록 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen type safety and exhaustiveness in GraphView’s force-graph integration while simplifying ref typings and eliminating unsafe casts.

Bug Fixes:
- Add an exhaustiveness check in resolveNodeColor to surface unknown NodeType values at compile time and log them at runtime.
- Adjust ForceGraph2D ref typing and usage to avoid internal type conflicts and ESLint warnings.

Enhancements:
- Simplify ForceGraph2D ref generics to use ForceGraphMethods<ForceGraphNode, ForceGraphLink> with a null-safe initial value.
- Update ForceGraph2D callbacks to use strongly typed NodeObject and LinkObject parameters instead of unknown with runtime casts.

</details>