### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -63,9 +63,11 @@ function resolveNodeColor(nodeType: NodeType): string {
       return GRAPH_NODE_COLOR_TAG;
     case NodeType.CATEGORY:
       return GRAPH_NODE_COLOR_CATEGORY;
-    default:
-      // 백엔드에서 새 NodeType 이 추가될 경우의 안전한 폴백
+    default: {
+      const _exhaustiveCheck: never = nodeType;
+      console.warn(`[GraphView] Unknown nodeType: ${_exhaustiveCheck}`);
       return GRAPH_NODE_COLOR_NOTE;
+    }
   }
 }
 
@@ -156,11 +158,8 @@ export interface GraphViewProps {
  */
 export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewProps) {
   const graphRef = useRef<
-    ForceGraphMethods<
-      NodeObject<ForceGraphNode>,
-      LinkObject<ForceGraphNode, ForceGraphLink>
-    > | undefined
-  >(undefined);
+    ForceGraphMethods<ForceGraphNode, ForceGraphLink> | null
+  >(null);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
   // SSOT 에서 변환한 데이터 (재계산 방지를 위해 메모이제이션)
@@ -182,8 +181,7 @@ export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewP
 
   // ── 노드 캔버스 렌더러 ───────────────────────────────────
   const paintNode = useCallback(
-    (rawNode: NodeObject<ForceGraphNode>, ctx: CanvasRenderingContext2D) => {
-      const node = rawNode as ForceGraphNode;
+    (node: NodeObject<ForceGraphNode>, ctx: CanvasRenderingContext2D) => {
       const nx = node.x ?? 0;
       const ny = node.y ?? 0;
       const isSelected = node.id === selectedNodeId;
@@ -217,24 +215,23 @@ export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewP
 
   return (
     <ForceGraph2D<ForceGraphNode, ForceGraphLink>
-      ref={graphRef}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ref={graphRef as any}
       graphData={{ nodes, links }}
       width={width}
       height={height}
       backgroundColor={GRAPH_BG_COLOR}
       // 링크 스타일
       linkColor={() => GRAPH_LINK_COLOR}
-      linkWidth={(link: unknown) => {
-        const l = link as ForceGraphLink;
+      linkWidth={(link: LinkObject<ForceGraphNode, ForceGraphLink>) => {
         // 엣지 weight(0~1)를 링크 두께(0.5~3px)에 선형 매핑
-        return 0.5 + (l.weight ?? 1) * 2.5;
+        return 0.5 + (link.weight ?? 1) * 2.5;
       }}
       // 노드 커스텀 렌더러
       nodeCanvasObject={paintNode}
       nodeCanvasObjectMode={() => "replace"}
       // 노드 포인터 영역 — 라벨 영역까지 포함하도록 반경 확장
-      nodePointerAreaPaint={(rawNode: unknown, color: string, ctx: CanvasRenderingContext2D) => {
-        const node = rawNode as ForceGraphNode;
+      nodePointerAreaPaint={(node: NodeObject<ForceGraphNode>, color: string, ctx: CanvasRenderingContext2D) => {
         const nx = node.x ?? 0;
         const ny = node.y ?? 0;
         const radius = GRAPH_NODE_RADIUS * GRAPH_NODE_SELECTED_SCALE + 6;

--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -49,6 +49,13 @@ import type {
 } from "./types";
 
 // ─────────────────────────────────────────
+// 로컬 타입 별칭 (가독성 향상 및 런타임 캐스팅 방지)
+// ─────────────────────────────────────────
+type NodeObj = NodeObject<ForceGraphNode>;
+type LinkObj = LinkObject<ForceGraphNode, ForceGraphLink>;
+type FGMethods = ForceGraphMethods<NodeObj, LinkObj>;
+
+// ─────────────────────────────────────────
 // 헬퍼: NodeType → 색상 매핑
 // ─────────────────────────────────────────
 
@@ -157,9 +164,7 @@ export interface GraphViewProps {
  * ```
  */
 export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewProps) {
-  const graphRef = useRef<
-    ForceGraphMethods<ForceGraphNode, ForceGraphLink> | null
-  >(null);
+  const graphRef = useRef<FGMethods | undefined>(undefined);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
   // SSOT 에서 변환한 데이터 (재계산 방지를 위해 메모이제이션)
@@ -167,7 +172,7 @@ export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewP
 
   // ── 노드 클릭 핸들러 ──────────────────────────────────────
   const handleNodeClick = useCallback(
-    (rawNode: NodeObject<ForceGraphNode>) => {
+    (rawNode: NodeObj) => {
       const node = rawNode as ForceGraphNode;
       setSelectedNodeId((prev) => (prev === node.id ? null : node.id));
 
@@ -181,7 +186,7 @@ export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewP
 
   // ── 노드 캔버스 렌더러 ───────────────────────────────────
   const paintNode = useCallback(
-    (node: NodeObject<ForceGraphNode>, ctx: CanvasRenderingContext2D) => {
+    (node: NodeObj, ctx: CanvasRenderingContext2D) => {
       const nx = node.x ?? 0;
       const ny = node.y ?? 0;
       const isSelected = node.id === selectedNodeId;
@@ -215,15 +220,14 @@ export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewP
 
   return (
     <ForceGraph2D<ForceGraphNode, ForceGraphLink>
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ref={graphRef as any}
+      ref={graphRef}
       graphData={{ nodes, links }}
       width={width}
       height={height}
       backgroundColor={GRAPH_BG_COLOR}
       // 링크 스타일
       linkColor={() => GRAPH_LINK_COLOR}
-      linkWidth={(link: LinkObject<ForceGraphNode, ForceGraphLink>) => {
+      linkWidth={(link: LinkObj) => {
         // 엣지 weight(0~1)를 링크 두께(0.5~3px)에 선형 매핑
         return 0.5 + (link.weight ?? 1) * 2.5;
       }}
@@ -231,7 +235,7 @@ export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewP
       nodeCanvasObject={paintNode}
       nodeCanvasObjectMode={() => "replace"}
       // 노드 포인터 영역 — 라벨 영역까지 포함하도록 반경 확장
-      nodePointerAreaPaint={(node: NodeObject<ForceGraphNode>, color: string, ctx: CanvasRenderingContext2D) => {
+      nodePointerAreaPaint={(node: NodeObj, color: string, ctx: CanvasRenderingContext2D) => {
         const nx = node.x ?? 0;
         const ny = node.y ?? 0;
         const radius = GRAPH_NODE_RADIUS * GRAPH_NODE_SELECTED_SCALE + 6;


### PR DESCRIPTION
☘️ refactor [#12.3.14]: 2차 개선 - 타입 안정성(Type-safe) 강화 및 휴먼 에러 방지 
☘️ refactor [#12.3.14]: 3차 개선 - 로컬 타입 별칭(Type Alias) 도입 및 완벽한 타입 안전성(Type-safe) 확보

## Summary by Sourcery

GraphView에서 로컬 타입 별칭을 도입하고 안전하지 않은 런타임 캐스트를 제거하여 타입 안정성을 강화합니다.

Enhancements:
- 가독성과 타입 명확성을 높이기 위해 force-graph 노드, 링크, 메서드에 대한 로컬 타입 별칭을 도입합니다.
- 기본 노드 타입 처리 방식을, 알려지지 않은 노드 타입을 로그로 남기고 안전한 시각적 폴백을 유지하는 완전한(포괄적인) 타입 체크로 대체합니다.
- GraphView 콜백과 렌더러가 제네릭 또는 알 수 없는 타입 대신 강하게 타입이 지정된 노드 및 링크 객체를 대상으로 동작하도록 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen type safety in GraphView by introducing local type aliases and removing unsafe runtime casts.

Enhancements:
- Introduce local type aliases for force-graph nodes, links, and methods to improve readability and type clarity.
- Replace default node type handling with an exhaustive type check that logs unknown node types and maintains a safe visual fallback.
- Update GraphView callbacks and renderers to operate on strongly-typed node and link objects instead of generic or unknown types.

</details>