### PR TITLE
☘️ refactor [#12.3.14]: 4차 개선 - 런타임 캐스팅 잔재 제거 및 프로덕션 로그 가드 적용

### DIFF
--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -56,6 +56,15 @@ type LinkObj = LinkObject<ForceGraphNode, ForceGraphLink>;
 type FGMethods = ForceGraphMethods<NodeObj, LinkObj>;
 
 // ─────────────────────────────────────────
+// 헬퍼: 개발 환경 전용 로깅 (DRY 패턴)
+// ─────────────────────────────────────────
+function devWarn(message: string) {
+  if (process.env.NODE_ENV !== "production") {
+    console.warn(message);
+  }
+}
+
+// ─────────────────────────────────────────
 // 헬퍼: NodeType → 색상 매핑
 // ─────────────────────────────────────────
 
@@ -72,9 +81,7 @@ function resolveNodeColor(nodeType: NodeType): string {
       return GRAPH_NODE_COLOR_CATEGORY;
     default: {
       const _exhaustiveCheck: never = nodeType;
-      if (process.env.NODE_ENV !== "production") {
-        console.warn(`[GraphView] Unknown nodeType: ${_exhaustiveCheck}`);
-      }
+      devWarn(`[GraphView] Unknown nodeType: ${_exhaustiveCheck}`);
       return GRAPH_NODE_COLOR_NOTE;
     }
   }
@@ -100,7 +107,7 @@ function adaptGraphData(data: GraphViewData): {
   let allowedNodes = rawNodes;
 
   if (truncated) {
-    console.warn(
+    devWarn(
       `[GraphView] 노드 수(${rawNodes.length})가 MAX_GRAPH_NODES(${MAX_GRAPH_NODES})를 초과합니다. ` +
         `연결 수(Degree)가 높은 중심 노드 위주로 ${MAX_GRAPH_NODES}개만 필터링하여 렌더링합니다.`
     );

--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -72,7 +72,9 @@ function resolveNodeColor(nodeType: NodeType): string {
       return GRAPH_NODE_COLOR_CATEGORY;
     default: {
       const _exhaustiveCheck: never = nodeType;
-      console.warn(`[GraphView] Unknown nodeType: ${_exhaustiveCheck}`);
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(`[GraphView] Unknown nodeType: ${_exhaustiveCheck}`);
+      }
       return GRAPH_NODE_COLOR_NOTE;
     }
   }
@@ -172,8 +174,7 @@ export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewP
 
   // ── 노드 클릭 핸들러 ──────────────────────────────────────
   const handleNodeClick = useCallback(
-    (rawNode: NodeObj) => {
-      const node = rawNode as ForceGraphNode;
+    (node: NodeObj) => {
       setSelectedNodeId((prev) => (prev === node.id ? null : node.id));
 
       if (onNodeClick) {


### PR DESCRIPTION
- [Refactor] 이전 작업에서 도입한 로컬 타입 별칭(`NodeObj`)의 효력을 극대화하기 위해, 핸들러 내부에 남아있던 불필요한 `as ForceGraphNode` 런타임 캐스팅 잔재 완벽 제거
- [Safe] Exhaustiveness Check 의 경고 로그(`console.warn`)에 `NODE_ENV` 가드를 적용하여, 프로덕션 환경에서 발생할 수 있는 로그 노이즈(Log Noise) 방지
- 5차 교차 검토를 통해 추가적인 타입 우회나 하드코딩 잔재가 없음을 확인

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1546#pullrequestreview-4433413497)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

프로덕션이 아닌 환경에서만 GraphView의 포괄성(exhaustiveness) 경고 로그를 출력하도록 보호하고, NodeObj 타입 별칭에 의존하여 노드 클릭 핸들러를 단순화합니다.

버그 수정:
- 프로덕션 빌드에서 알 수 없는 nodeType 포괄성 경고가 로그로 남지 않도록 방지합니다.

개선 사항:
- 기존의 NodeObj 타입 별칭을 활용하여 GraphView 노드 클릭 핸들러에서 불필요한 런타임 캐스팅을 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard GraphView exhaustiveness warning logs in non-production and simplify node click handler by relying on the NodeObj type alias.

Bug Fixes:
- Prevent unknown nodeType exhaustiveness warnings from logging in production builds.

Enhancements:
- Remove redundant runtime casting in the GraphView node click handler in favor of the existing NodeObj type alias.

</details>