### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -105,7 +105,18 @@ function adaptGraphData(data: GraphViewData): {
   nodes: ForceGraphNode[];
   links: ForceGraphLink[];
 } {
-  const rawNodes = data.nodes;
+  // [Confirm] 스키마 변경(Schema drift)에 대비하여 렌더링 전 유효하지 않은 노드(불량 데이터)를 원천 차단
+  const rawNodes = data.nodes.filter((node) => {
+    if (typeof node.id !== "string" || typeof node.node_type !== "string") {
+      devWarn("Dropped invalid node missing required fields before rendering", {
+        id: node.id,
+        node_type: node.node_type,
+      });
+      return false; // 불량 노드 렌더링 및 클릭 이벤트 대상에서 완전 제외
+    }
+    return true;
+  });
+
   const truncated = rawNodes.length > MAX_GRAPH_NODES;
 
   let allowedNodes = rawNodes;
@@ -189,18 +200,8 @@ export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewP
       setSelectedNodeId((prev) => (prev === node.id ? null : node.id));
 
       if (onNodeClick) {
-        // [Confirm] 백엔드 스키마 변경(Schema drift)으로 인한 필수 필드 누락 위험을 방어하는 런타임 가드
-        if (typeof node.id !== "string" || typeof node.node_type !== "string") {
-          devWarn("Clicked node is missing required GraphNode fields", {
-            id: node.id,
-            node_type: node.node_type,
-          });
-          // Silent failure 방지: 클릭 시 아무 반응이 없는 UX 문제를 막기 위한 Fallback
-          alert("데이터 오류: 유효하지 않은 노드입니다. 페이지를 새로고침해 주세요.");
-          return;
-        }
-
-        // 필수 필드 검증을 통과했으므로 다운캐스팅은 런타임에 안전합니다.
+        // [Confirm] adaptGraphData 에서 불량 데이터를 사전 차단(Pre-filter)하므로,
+        // 이곳으로 전달된 노드의 필수 필드 무결성은 100% 보장됩니다.
         onNodeClick(node as GraphNode);
       }
     },

--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -69,6 +69,13 @@ function devWarn(message: string, payload?: Record<string, unknown>) {
 }
 
 // ─────────────────────────────────────────
+// 헬퍼: 런타임 스키마 방어용 커스텀 타입 가드(Type Guard)
+// ─────────────────────────────────────────
+function isValidGraphNode(node: Partial<GraphNode>): node is GraphNode {
+  return typeof node.id === "string" && typeof node.node_type === "string";
+}
+
+// ─────────────────────────────────────────
 // 헬퍼: NodeType → 색상 매핑
 // ─────────────────────────────────────────
 
@@ -107,10 +114,10 @@ function adaptGraphData(data: GraphViewData): {
 } {
   // [Confirm] 스키마 변경(Schema drift)에 대비하여 렌더링 전 유효하지 않은 노드(불량 데이터)를 원천 차단
   const rawNodes = data.nodes.filter((node) => {
-    if (typeof node.id !== "string" || typeof node.node_type !== "string") {
+    if (!isValidGraphNode(node)) {
       devWarn("Dropped invalid node missing required fields before rendering", {
-        id: node.id,
-        node_type: node.node_type,
+        id: (node as Record<string, unknown>).id,
+        node_type: (node as Record<string, unknown>).node_type,
       });
       return false; // 불량 노드 렌더링 및 클릭 이벤트 대상에서 완전 제외
     }
@@ -145,11 +152,18 @@ function adaptGraphData(data: GraphViewData): {
     allowedNodes = sortedNodes.slice(0, MAX_GRAPH_NODES);
   }
 
+  // 제한된 노드 ID Set
   const allowedNodeIds = new Set(allowedNodes.map((n) => n.id));
 
-  // 양 끝점 노드가 모두 허용 범위 내에 있는 엣지만 포함
+  // [Confirm] allowedNodeIds를 기반으로 양 끝단(Source/Target)을 검사하므로, 
+  // 사전 필터링(불량 노드 제거)으로 인해 삭제된 노드를 참조하는 고아 엣지(Orphan edges)는 
+  // 렌더링되지 않고 안전하게 함께 소거(Cascade)됩니다.
   const links: ForceGraphLink[] = data.edges
-    .filter((e) => allowedNodeIds.has(e.source) && allowedNodeIds.has(e.target))
+    .filter((e) => {
+      const sourceId = typeof e.source === "object" ? (e.source as NodeObj).id : e.source;
+      const targetId = typeof e.target === "object" ? (e.target as NodeObj).id : e.target;
+      return allowedNodeIds.has(sourceId as string) && allowedNodeIds.has(targetId as string);
+    })
     .map((e) => ({ ...e }));
 
   return {


### PR DESCRIPTION
☘️ refactor [#12.3.15]: 9차 개선 - 렌더링 전 사전 필터링(Pre-filtering)을 통한 스키마 근원적 방어 및 차단형 UX 제거
☘️ refactor [#12.3.14]: 10차 개선 - 커스텀 타입 가드(Type Guard) 분리 및 고아 엣지(Orphan Edges) 필터링 문서화

## Summary by Sourcery

잘못된 노드를 사전에 필터링하고, 엣지와 클릭 처리 로직이 스키마에 유효한 그래프 데이터에 대해서만 동작하도록 하여 그래프 렌더링을 강화합니다.

New Features:
- 그래프 노드를 사용하기 전에 검증하기 위한 런타임 타입 가드를 추가합니다.

Bug Fixes:
- 필수 필드가 누락된 노드가 렌더링되거나 상호작용에 사용되지 않도록 막아, 스키마 드리프트 문제와 고아 엣지(연결되지 않은 엣지)를 방지합니다.

Enhancements:
- 소스 또는 타겟 노드가 허용된 노드 집합에 포함되지 않은 엣지를 필터링하며, 이는 엣지가 ID 대신 노드 객체를 참조하는 경우도 포함합니다.
- 핸들러 내부에서의 검증 대신, 사전에 검증된 그래프 데이터에 의존하도록 노드 클릭 처리 로직을 단순화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden graph rendering by pre-filtering invalid nodes and ensuring edges and click handling operate only on schema-valid graph data.

New Features:
- Introduce a runtime type guard to validate graph nodes before use.

Bug Fixes:
- Prevent rendering and interaction with nodes missing required fields to avoid schema drift issues and orphaned edges.

Enhancements:
- Filter out edges whose source or target nodes are not in the allowed node set, including when edges reference node objects instead of IDs.
- Simplify node click handling by relying on pre-validated graph data instead of in-handler validation.

</details>