### PR TITLE
☘️ refactor [#12.3.14]: 11차 개선 - 엣지(Edge) 스키마 방어막 추가 및 식별자 추출 헬퍼 분리

### DIFF
--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -78,14 +78,16 @@ function isValidGraphNode(node: Partial<GraphNode>): node is GraphNode {
 function isValidGraphLink(link: unknown): link is ForceGraphLink {
   if (typeof link !== "object" || link === null) return false;
   const l = link as Partial<ForceGraphLink>;
-  return l.source !== undefined && l.target !== undefined;
+  // [Confirm] null과 undefined를 모두 차단 (nullish check)
+  return l.source != null && l.target != null;
 }
 
 // ─────────────────────────────────────────
 // 헬퍼: Link의 source/target 식별자 안전 추출
 // ─────────────────────────────────────────
 function getLinkId(endpoint: string | NodeObj | unknown): string {
-  if (!endpoint) return "";
+  // [Confirm] !endpoint 대신 == null 을 사용하여 0, false 등 유효한 falsy 값이 누락되는 버그(Bug Risk) 차단
+  if (endpoint == null) return "";
   return typeof endpoint === "object" && endpoint !== null ? (endpoint as NodeObj).id : String(endpoint);
 }
 

--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -75,6 +75,20 @@ function isValidGraphNode(node: Partial<GraphNode>): node is GraphNode {
   return typeof node.id === "string" && typeof node.node_type === "string";
 }
 
+function isValidGraphLink(link: unknown): link is ForceGraphLink {
+  if (typeof link !== "object" || link === null) return false;
+  const l = link as Partial<ForceGraphLink>;
+  return l.source !== undefined && l.target !== undefined;
+}
+
+// ─────────────────────────────────────────
+// 헬퍼: Link의 source/target 식별자 안전 추출
+// ─────────────────────────────────────────
+function getLinkId(endpoint: string | NodeObj | unknown): string {
+  if (!endpoint) return "";
+  return typeof endpoint === "object" && endpoint !== null ? (endpoint as NodeObj).id : String(endpoint);
+}
+
 // ─────────────────────────────────────────
 // 헬퍼: NodeType → 색상 매핑
 // ─────────────────────────────────────────
@@ -160,9 +174,20 @@ function adaptGraphData(data: GraphViewData): {
   // 렌더링되지 않고 안전하게 함께 소거(Cascade)됩니다.
   const links: ForceGraphLink[] = data.edges
     .filter((e) => {
-      const sourceId = typeof e.source === "object" ? (e.source as NodeObj).id : e.source;
-      const targetId = typeof e.target === "object" ? (e.target as NodeObj).id : e.target;
-      return allowedNodeIds.has(sourceId as string) && allowedNodeIds.has(targetId as string);
+      // 1. 엣지 자체의 스키마 유효성 검증
+      if (!isValidGraphLink(e)) {
+        devWarn("Dropped invalid edge missing source or target", {
+          edge: e as Record<string, unknown>,
+        });
+        return false;
+      }
+      
+      // 2. 헬퍼를 사용한 안전한 식별자 추출
+      const sourceId = getLinkId(e.source);
+      const targetId = getLinkId(e.target);
+      
+      // 3. 고아 엣지 방어
+      return allowedNodeIds.has(sourceId) && allowedNodeIds.has(targetId);
     })
     .map((e) => ({ ...e }));
 


### PR DESCRIPTION
- [Refactor] 엣지의 양 끝점 식별자를 파싱하는 복잡한 인라인 삼항연산자 로직을 `getLinkId` 헬퍼로 분리하여 가독성(Readability) 및 재사용성 향상
- [Refactor] 노드에 이어 엣지(Edge) 전용 런타임 타입 가드(`isValidGraphLink`)를 도입하여, 소스/타겟이 누락된 불량 엣지 유입 시 렌더링을 차단하고 구조화된 로그(devWarn)를 남기도록 아키텍처 대칭성(Symmetry) 완성
- 5차 교차 검토를 통해 엄격한 린트 룰(no-explicit-any) 준수 및 Nullish 방어 로직의 무결성(Robustness) 최종 검증 완료

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1553#pullrequestreview-4433571427)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

GraphView에서 더 엄격한 엣지 검증과 헬퍼 기반 ID 추출을 도입하여 견고성과 가독성을 향상했습니다.

버그 수정:
- 엣지 스키마를 사용 전에 검증하여 source 또는 target이 누락된 잘못된 엣지가 렌더링되는 것을 방지합니다.

개선 사항:
- 노드와 마찬가지로 그래프 링크를 대칭적으로 검증하기 위해, 엣지 전용 런타임 타입 가드를 추가했습니다.
- source/target 식별자 파싱을 재사용 가능한 헬퍼로 분리하여, 링크 ID 추출을 더 안전하고 가독성 있게 만들었습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce stricter edge validation and helper-based ID extraction in GraphView to improve robustness and readability.

Bug Fixes:
- Prevent rendering of invalid edges missing source or target by validating edge schema before use.

Enhancements:
- Add an edge-specific runtime type guard to symmetrically validate graph links alongside nodes.
- Extract source/target identifier parsing into a reusable helper for safer and more readable link ID extraction.

</details>