### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -78,14 +78,16 @@ function isValidGraphNode(node: Partial<GraphNode>): node is GraphNode {
 function isValidGraphLink(link: unknown): link is ForceGraphLink {
   if (typeof link !== "object" || link === null) return false;
   const l = link as Partial<ForceGraphLink>;
-  return l.source !== undefined && l.target !== undefined;
+  // [Confirm] null과 undefined를 모두 차단 (nullish check)
+  return l.source != null && l.target != null;
 }
 
 // ─────────────────────────────────────────
 // 헬퍼: Link의 source/target 식별자 안전 추출
 // ─────────────────────────────────────────
 function getLinkId(endpoint: string | NodeObj | unknown): string {
-  if (!endpoint) return "";
+  // [Confirm] !endpoint 대신 == null 을 사용하여 0, false 등 유효한 falsy 값이 누락되는 버그(Bug Risk) 차단
+  if (endpoint == null) return "";
   return typeof endpoint === "object" && endpoint !== null ? (endpoint as NodeObj).id : String(endpoint);
 }
 

--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -75,6 +75,20 @@ function isValidGraphNode(node: Partial<GraphNode>): node is GraphNode {
   return typeof node.id === "string" && typeof node.node_type === "string";
 }
 
+function isValidGraphLink(link: unknown): link is ForceGraphLink {
+  if (typeof link !== "object" || link === null) return false;
+  const l = link as Partial<ForceGraphLink>;
+  return l.source !== undefined && l.target !== undefined;
+}
+
+// ─────────────────────────────────────────
+// 헬퍼: Link의 source/target 식별자 안전 추출
+// ─────────────────────────────────────────
+function getLinkId(endpoint: string | NodeObj | unknown): string {
+  if (!endpoint) return "";
+  return typeof endpoint === "object" && endpoint !== null ? (endpoint as NodeObj).id : String(endpoint);
+}
+
 // ─────────────────────────────────────────
 // 헬퍼: NodeType → 색상 매핑
 // ─────────────────────────────────────────
@@ -160,9 +174,20 @@ function adaptGraphData(data: GraphViewData): {
   // 렌더링되지 않고 안전하게 함께 소거(Cascade)됩니다.
   const links: ForceGraphLink[] = data.edges
     .filter((e) => {
-      const sourceId = typeof e.source === "object" ? (e.source as NodeObj).id : e.source;
-      const targetId = typeof e.target === "object" ? (e.target as NodeObj).id : e.target;
-      return allowedNodeIds.has(sourceId as string) && allowedNodeIds.has(targetId as string);
+      // 1. 엣지 자체의 스키마 유효성 검증
+      if (!isValidGraphLink(e)) {
+        devWarn("Dropped invalid edge missing source or target", {
+          edge: e as Record<string, unknown>,
+        });
+        return false;
+      }
+      
+      // 2. 헬퍼를 사용한 안전한 식별자 추출
+      const sourceId = getLinkId(e.source);
+      const targetId = getLinkId(e.target);
+      
+      // 3. 고아 엣지 방어
+      return allowedNodeIds.has(sourceId) && allowedNodeIds.has(targetId);
     })
     .map((e) => ({ ...e }));
 


### PR DESCRIPTION
☘️ refactor [#12.3.14]: 11차 개선 - 엣지(Edge) 스키마 방어막 추가 및 식별자 추출 헬퍼 분리 
☘️ refactor [#12.3.14]: 12차 개선 - 엣지(Edge) 헬퍼의 Nullish 타입 가드 정밀화 및 Falsy 버그 차단

## Summary by Sourcery

그래프 엣지 처리를 강화하기 위해 엣지 스키마를 검증하고, 안전한 링크 식별자 추출을 중앙집중화합니다.

개선 사항:
- 그래프 링크 객체를 사용하기 전에 source와 target 필드가 null이 아님을 보장하여 검증하는 가드를 추가했습니다.
- 유효한 falsy 값은 유지하면서 링크 엔드포인트 식별자를 안전하게 추출하는 헬퍼를 도입했습니다.
- 새로운 검증 및 식별자 헬퍼를 사용해 엣지를 필터링함으로써 고아 엣지(orphan)나 잘못된 형식의 엣지가 렌더링되지 않도록 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen graph edge handling by validating edge schema and centralizing safe link identifier extraction.

Enhancements:
- Add a guard to validate graph link objects by ensuring non-null source and target fields before use.
- Introduce a helper to safely extract link endpoint identifiers without dropping valid falsy values.
- Filter edges using the new validation and identifier helpers to avoid rendering orphan or malformed edges.

</details>