### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -83,12 +83,22 @@ function isValidGraphLink(link: unknown): link is ForceGraphLink {
 }
 
 // ─────────────────────────────────────────
-// 헬퍼: Link의 source/target 식별자 안전 추출
+// 헬퍼: Link의 source/target 식별자 엄격한 추출
 // ─────────────────────────────────────────
-function getLinkId(endpoint: string | NodeObj | unknown): string {
-  // [Confirm] !endpoint 대신 == null 을 사용하여 0, false 등 유효한 falsy 값이 누락되는 버그(Bug Risk) 차단
-  if (endpoint == null) return "";
-  return typeof endpoint === "object" && endpoint !== null ? (endpoint as NodeObj).id : String(endpoint);
+function getLinkId(endpoint: unknown): string | null {
+  if (endpoint == null) return null;
+
+  // 원시 타입 허용
+  if (typeof endpoint === "string") return endpoint;
+  if (typeof endpoint === "number" || typeof endpoint === "boolean") return String(endpoint);
+
+  // 객체인 경우 id 속성이 존재할 때만 추출
+  if (typeof endpoint === "object" && "id" in endpoint && (endpoint as Record<string, unknown>).id != null) {
+    return String((endpoint as Record<string, unknown>).id);
+  }
+
+  // [Confirm] 예상치 못한 객체([object Object] 등)는 암묵적 형변환을 막고 즉시 null 반환
+  return null;
 }
 
 // ─────────────────────────────────────────
@@ -179,16 +189,24 @@ function adaptGraphData(data: GraphViewData): {
       // 1. 엣지 자체의 스키마 유효성 검증
       if (!isValidGraphLink(e)) {
         devWarn("Dropped invalid edge missing source or target", {
-          edge: e as Record<string, unknown>,
+          edge: e as unknown as Record<string, unknown>,
         });
         return false;
       }
       
-      // 2. 헬퍼를 사용한 안전한 식별자 추출
+      // 2. 헬퍼를 사용한 엄격한 식별자 추출
       const sourceId = getLinkId(e.source);
       const targetId = getLinkId(e.target);
       
-      // 3. 고아 엣지 방어
+      // 3. 조기 종료(Short-circuit): 식별자를 추출할 수 없는 구조적 결함이 있으면 명시적 드롭
+      if (sourceId === null || targetId === null) {
+        devWarn("Dropped edge due to unresolvable or malformed source/target IDs", {
+          edge: e as unknown as Record<string, unknown>,
+        });
+        return false;
+      }
+
+      // 4. 고아 엣지 방어
       return allowedNodeIds.has(sourceId) && allowedNodeIds.has(targetId);
     })
     .map((e) => ({ ...e }));

--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -58,7 +58,7 @@ type FGMethods = ForceGraphMethods<NodeObj, LinkObj>;
 // ─────────────────────────────────────────
 // 헬퍼: 구조화된 개발 환경 전용 로깅 (DRY 패턴 & 민감정보 보호)
 // ─────────────────────────────────────────
-function devWarn(message: string, payload?: Record<string, unknown>) {
+function devWarn(message: string, payload?: unknown) {
   if (process.env.NODE_ENV !== "production") {
     if (payload) {
       console.warn(`[GraphView] ${message}`, payload);
@@ -88,17 +88,13 @@ function isValidGraphLink(link: unknown): link is ForceGraphLink {
 function getLinkId(endpoint: unknown): string | null {
   if (endpoint == null) return null;
 
-  // 원시 타입 허용
-  if (typeof endpoint === "string") return endpoint;
-  if (typeof endpoint === "number" || typeof endpoint === "boolean") return String(endpoint);
-
-  // 객체인 경우 id 속성이 존재할 때만 추출
-  if (typeof endpoint === "object" && "id" in endpoint && (endpoint as Record<string, unknown>).id != null) {
-    return String((endpoint as Record<string, unknown>).id);
+  if (typeof endpoint === "object") {
+    const { id } = endpoint as { id?: unknown };
+    return id == null ? null : String(id);
   }
 
-  // [Confirm] 예상치 못한 객체([object Object] 등)는 암묵적 형변환을 막고 즉시 null 반환
-  return null;
+  // 원시 타입(string, number, boolean 등) 안전 변환
+  return String(endpoint);
 }
 
 // ─────────────────────────────────────────
@@ -188,9 +184,7 @@ function adaptGraphData(data: GraphViewData): {
     .filter((e) => {
       // 1. 엣지 자체의 스키마 유효성 검증
       if (!isValidGraphLink(e)) {
-        devWarn("Dropped invalid edge missing source or target", {
-          edge: e as unknown as Record<string, unknown>,
-        });
+        devWarn("Dropped invalid edge missing source or target", { edge: e });
         return false;
       }
       
@@ -200,9 +194,7 @@ function adaptGraphData(data: GraphViewData): {
       
       // 3. 조기 종료(Short-circuit): 식별자를 추출할 수 없는 구조적 결함이 있으면 명시적 드롭
       if (sourceId === null || targetId === null) {
-        devWarn("Dropped edge due to unresolvable or malformed source/target IDs", {
-          edge: e as unknown as Record<string, unknown>,
-        });
+        devWarn("Dropped edge due to unresolvable or malformed source/target IDs", { edge: e });
         return false;
       }
 


### PR DESCRIPTION
☘️ refactor [#12.3.14]: 13차 개선 - 엣지 식별자 엄격 추출 및 조기 종료(Short-circuit) 로직 적용
☘️ refactor [#12.3.14]: 14차 개선 - 식별자 추출 헬퍼 간소화 및 중복 타입 캐스팅 제거(Clean Code)

## Summary by Sourcery

GraphView에서 엣지 식별자 추출을 강화하여 링크 엔드포인트를 엄격히 검증하고, 그래프 변환 과정에서 잘못된 엣지를 더 이른 시점에 제거합니다.

Enhancements:
- 개발 환경에서만 사용하는 로깅은 유지하면서, 어떤 형태의 payload라도 받을 수 있도록 devWarn의 payload 타입 제약을 완화했습니다.
- 구조적으로 올바르지 않은 엔드포인트에 대해서는 `null`을 반환하고, 유효한 ID만 문자열로 변환하도록 링크 ID 추출 로직을 강화했습니다.
- 고아 엣지(orphan edge) 검사 이전에, 해석할 수 없는 source/target 식별자를 가진 엣지를 제거하기 위한 단락(short-circuit) 필터링을 도입했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten edge identifier extraction in GraphView to strictly validate link endpoints and drop malformed edges earlier during graph adaptation.

Enhancements:
- Relax devWarn payload typing to accept any payload shape while preserving development-only logging.
- Harden link ID extraction to return null for structurally invalid endpoints and convert only valid IDs to strings.
- Introduce short-circuit filtering to drop edges with unresolvable source/target identifiers before orphan-edge checks.

</details>