### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -60,7 +60,8 @@ type FGMethods = ForceGraphMethods<NodeObj, LinkObj>;
 // ─────────────────────────────────────────
 function devWarn(message: string, payload?: unknown) {
   if (process.env.NODE_ENV !== "production") {
-    if (payload) {
+    // [Confirm] payload가 0, false, "" 등 falsy 값이어도 정상 출력되도록 명시적 undefined 체크
+    if (payload !== undefined) {
       console.warn(`[GraphView] ${message}`, payload);
     } else {
       console.warn(`[GraphView] ${message}`);
@@ -88,13 +89,30 @@ function isValidGraphLink(link: unknown): link is ForceGraphLink {
 function getLinkId(endpoint: unknown): string | null {
   if (endpoint == null) return null;
 
-  if (typeof endpoint === "object") {
-    const { id } = endpoint as { id?: unknown };
-    return id == null ? null : String(id);
+  // 1. 원시 타입(Primitive)인 경우 안전하게 직접 변환
+  if (
+    typeof endpoint === "string" ||
+    typeof endpoint === "number" ||
+    typeof endpoint === "boolean" ||
+    typeof endpoint === "symbol" ||
+    typeof endpoint === "bigint"
+  ) {
+    return String(endpoint);
   }
 
-  // 원시 타입(string, number, boolean 등) 안전 변환
-  return String(endpoint);
+  // 2. 객체인 경우: 내부의 `id` 속성 또한 원시 타입이어야만 허용
+  if (typeof endpoint === "object") {
+    const { id } = endpoint as { id?: unknown };
+    if (id == null) return null;
+    
+    // [Confirm] id 자체가 객체나 함수인 경우 (예: id: {}) [object Object] 반환을 막기 위해 철저히 거부
+    if (typeof id === "object" || typeof id === "function") return null;
+    
+    return String(id);
+  }
+
+  // 3. 함수 등 전혀 예상치 못한 타입은 명시적 드롭
+  return null;
 }
 
 // ─────────────────────────────────────────


### PR DESCRIPTION
☘️ refactor [#12.3.14]: 15차 개선 - 식별자(ID) 추출의 이중 방어막 구축 및 로거(Logger) 신뢰성 향상

## Summary by Sourcery

GraphView에서 링크 식별자 추출과 개발용 로깅 동작을 강화하여, 엣지 케이스를 더 안전하고 예측 가능하게 처리합니다.

개선 사항:
- payload가 falsy이지만 정의되어 있는 경우에도 devWarn이 해당 payload를 로그하도록 보장합니다.
- `getLinkId` 로직을 강화하여, 원시 타입(primitive) 식별자만 허용하고 객체, 함수 및 기타 예상치 못한 타입은 거부함으로써 안전하지 않은 문자열 변환(stringification)을 방지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen link identifier extraction and dev logging behavior in GraphView to handle edge cases more safely and predictably.

Enhancements:
- Ensure devWarn logs payloads even when they are falsy but defined.
- Tighten getLinkId logic to only accept primitive identifiers and reject object, function, and other unexpected types to prevent unsafe stringification.

</details>