### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -89,29 +89,25 @@ function isValidGraphLink(link: unknown): link is ForceGraphLink {
 function getLinkId(endpoint: unknown): string | null {
   if (endpoint == null) return null;
 
-  // 1. 원시 타입(Primitive)인 경우 안전하게 직접 변환
-  if (
-    typeof endpoint === "string" ||
-    typeof endpoint === "number" ||
-    typeof endpoint === "boolean" ||
-    typeof endpoint === "symbol" ||
-    typeof endpoint === "bigint"
-  ) {
-    return String(endpoint);
-  }
-
-  // 2. 객체인 경우: 내부의 `id` 속성 또한 원시 타입이어야만 허용
+  // 1. 객체인 경우: 내부의 `id` 속성 추출
   if (typeof endpoint === "object") {
     const { id } = endpoint as { id?: unknown };
     if (id == null) return null;
     
-    // [Confirm] id 자체가 객체나 함수인 경우 (예: id: {}) [object Object] 반환을 막기 위해 철저히 거부
-    if (typeof id === "object" || typeof id === "function") return null;
-    
-    return String(id);
+    // [Confirm] 왕복 변환(Round-trip)이 불가능한 symbol/bigint 및 객체/함수 등은 모두 거부하고, 
+    // 오직 직렬화 가능한 string, number, boolean 만 허용
+    if (typeof id === "string" || typeof id === "number" || typeof id === "boolean") {
+      return String(id);
+    }
+    return null;
   }
 
-  // 3. 함수 등 전혀 예상치 못한 타입은 명시적 드롭
+  // 2. 원시 타입(Primitive)이 직접 사용된 경우
+  if (typeof endpoint === "string" || typeof endpoint === "number" || typeof endpoint === "boolean") {
+    return String(endpoint);
+  }
+
+  // 3. 함수, symbol, bigint 등 기타 모든 예상치 못한 타입은 명시적 드롭
   return null;
 }
 

--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -84,6 +84,13 @@ function isValidGraphLink(link: unknown): link is ForceGraphLink {
 }
 
 // ─────────────────────────────────────────
+// 헬퍼: 직렬화 가능한 원시 타입(Primitive) 여부 확인
+// ─────────────────────────────────────────
+function isSerializablePrimitive(val: unknown): val is string | number | boolean {
+  return typeof val === "string" || typeof val === "number" || typeof val === "boolean";
+}
+
+// ─────────────────────────────────────────
 // 헬퍼: Link의 source/target 식별자 엄격한 추출
 // ─────────────────────────────────────────
 function getLinkId(endpoint: unknown): string | null {
@@ -96,14 +103,14 @@ function getLinkId(endpoint: unknown): string | null {
     
     // [Confirm] 왕복 변환(Round-trip)이 불가능한 symbol/bigint 및 객체/함수 등은 모두 거부하고, 
     // 오직 직렬화 가능한 string, number, boolean 만 허용
-    if (typeof id === "string" || typeof id === "number" || typeof id === "boolean") {
+    if (isSerializablePrimitive(id)) {
       return String(id);
     }
     return null;
   }
 
   // 2. 원시 타입(Primitive)이 직접 사용된 경우
-  if (typeof endpoint === "string" || typeof endpoint === "number" || typeof endpoint === "boolean") {
+  if (isSerializablePrimitive(endpoint)) {
     return String(endpoint);
   }
 


### PR DESCRIPTION
☘️ refactor [#12.3.14]: 16차 개선 - 영속성(Persistence) 버그 방지를 위한 식별자 허용 범위 축소 및 로직 선형화
☘️ refactor [#12.3.14]: 17차 개선 - 식별자 원시 타입 검증 로직 중앙화 (DRY 원칙 적용)

## Summary by Sourcery

GraphView에서 링크 엔드포인트 식별자 처리 범위를 제한하고 중앙화하여, 더 안전한 영속성을 위해 직렬화 가능한 원시 ID만 허용하도록 합니다.

버그 수정:
- 소스/타깃 ID를 엄격히 검증하여 객체, 심벌, bigint 등과 같은 잘못되었거나 직렬화 불가능한 링크 식별자가 사용되지 않도록 방지합니다.

개선사항:
- 직렬화 가능한 원시 값을 감지하는 재사용 가능한 헬퍼를 도입하고, 이를 링크 식별자 추출 로직 전반에 재사용하여 일관된 검증을 강제합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restrict and centralize link endpoint identifier handling in GraphView to only allow serializable primitive IDs for safer persistence.

Bug Fixes:
- Prevent invalid or non-serializable link identifiers (e.g., objects, symbols, bigints) from being used by strictly validating source/target IDs.

Enhancements:
- Introduce a reusable helper to detect serializable primitive values and reuse it across link identifier extraction logic to enforce consistent validation.

</details>