### PR TITLE
☘️ refactor [#12.3.15]: 2차 개선 - GraphView 어댑터의 불변성(Immutability) 검증 테스트 추가

### DIFF
--- a/web_ui/src/components/GraphView/__tests__/GraphView.test.ts
+++ b/web_ui/src/components/GraphView/__tests__/GraphView.test.ts
@@ -87,25 +87,22 @@ describe("adaptGraphData", () => {
       ],
     };
 
-    // Take a deep snapshot of the original input
-    const originalSnapshot: GraphViewData = JSON.parse(JSON.stringify(data));
+    // [Confirm] JSON.parse(JSON.stringify())는 undefined, Symbol, Date, Infinity, NaN 등을 조용히 누락시키므로,
+    // structuredClone을 사용하여 안전하고 완전한 딥 카피를 수행합니다.
+    const originalSnapshot: GraphViewData = structuredClone(data);
 
     const result = adaptGraphData(data);
 
     // Input should remain deeply equal to the original snapshot
     expect(data).toEqual(originalSnapshot);
 
-    // Optionally, verify that the adapted structures do not reuse the same references
+    // Verify that the adapted structures do not reuse the same references.
+    // 테스트 픽스처에 node 2개, edge 1개가 명확히 보장되어 있으므로,
+    // 조건문 없이 무조건적으로 단언하여 테스트를 더 엄격하게 유지합니다.
     expect(result.nodes).not.toBe(data.nodes);
     expect(result.links).not.toBe(data.edges as any);
-
-    if (result.nodes.length > 0 && data.nodes.length > 0) {
-      expect(result.nodes[0]).not.toBe(data.nodes[0]);
-    }
-
-    if (result.links.length > 0 && data.edges.length > 0) {
-      expect(result.links[0]).not.toBe(data.edges[0] as any);
-    }
+    expect(result.nodes[0]).not.toBe(data.nodes[0]);
+    expect(result.links[0]).not.toBe(data.edges[0] as any);
   });
 
   it("should truncate nodes exceeding MAX_GRAPH_NODES based on degree", () => {

--- a/web_ui/src/components/GraphView/__tests__/GraphView.test.ts
+++ b/web_ui/src/components/GraphView/__tests__/GraphView.test.ts
@@ -76,6 +76,38 @@ describe("adaptGraphData", () => {
     expect(result.links).toHaveLength(0);
   });
 
+  it("should not mutate the input nodes and edges", () => {
+    const data: GraphViewData = {
+      nodes: [
+        createMockNode("node1", "Node 1", NodeType.NOTE),
+        createMockNode("node2", "Node 2", NodeType.NOTE),
+      ],
+      edges: [
+        createMockEdge("edge1", "node1", "node2"),
+      ],
+    };
+
+    // Take a deep snapshot of the original input
+    const originalSnapshot: GraphViewData = JSON.parse(JSON.stringify(data));
+
+    const result = adaptGraphData(data);
+
+    // Input should remain deeply equal to the original snapshot
+    expect(data).toEqual(originalSnapshot);
+
+    // Optionally, verify that the adapted structures do not reuse the same references
+    expect(result.nodes).not.toBe(data.nodes);
+    expect(result.links).not.toBe(data.edges as any);
+
+    if (result.nodes.length > 0 && data.nodes.length > 0) {
+      expect(result.nodes[0]).not.toBe(data.nodes[0]);
+    }
+
+    if (result.links.length > 0 && data.edges.length > 0) {
+      expect(result.links[0]).not.toBe(data.edges[0] as any);
+    }
+  });
+
   it("should truncate nodes exceeding MAX_GRAPH_NODES based on degree", () => {
     // MAX_GRAPH_NODES is mocked to 3.
     // We provide 5 nodes: node1 (deg 3), node2 (deg 2), node3 (deg 1), node4 (deg 0), node5 (deg 4)


### PR DESCRIPTION
- `adaptGraphData`가 순수 함수로서 입력 데이터(nodes, edges)를 변형(Mutate)하지 않는지 보장하는 테스트 케이스 추가
- 반환되는 결과 객체의 얕은 복사본(Shallow copy)이 원본 입력 객체와 참조가 다름을 엄격하게 단언(Assert)
- 리뷰어의 피드백을 수용하여, 향후 다른 개발자의 로직 수정 시 발생할 수 있는 원본 훼손 부작용(Side Effect) 원천 차단

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1565#pullrequestreview-4443356733)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Sourcery 요약

Tests:
- `adaptGraphData`가 입력 `nodes`와 `edges`를 변경(mutate)하지 않으며, 공유되지 않은(독립적인) node/link 참조를 반환하는지를 보장하는 회귀 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Add a regression test ensuring adaptGraphData does not mutate input nodes and edges and returns non-shared node/link references.

</details>