### PR TITLE
☘️ refactor [#12.3.15]: 6차 개선 - `deepClone` 헬퍼 도입으로 `structuredClone` 환경 의존성 완전 해소

### DIFF
--- a/web_ui/src/components/GraphView/__tests__/GraphView.test.ts
+++ b/web_ui/src/components/GraphView/__tests__/GraphView.test.ts
@@ -47,6 +47,18 @@ function createMockEdge(
   };
 }
 
+/**
+ * 테스트 전용 딥 카피(Deep Copy) 유틸리티.
+ * structuredClone이 지원되면 사용하고, 미지원 환경에서는 JSON 직렬화로 폴백합니다.
+ * (GraphViewData는 JSON-safe 값만 포함하므로 폴백도 안전합니다.)
+ */
+function deepClone<T>(val: T): T {
+  if (typeof structuredClone === "function") {
+    return structuredClone(val);
+  }
+  return JSON.parse(JSON.stringify(val)) as T;
+}
+
 describe("adaptGraphData", () => {
   it("should filter out invalid nodes and links", () => {
     const data: GraphViewData = {
@@ -77,8 +89,6 @@ describe("adaptGraphData", () => {
   });
 
   it("should not mutate the input nodes and edges", () => {
-    // [Confirm] 픽스처 요소를 이름 있는 변수로 추출하여,
-    // assertion 본문에서 타입 캐스팅 없이 직접 참조 비교를 수행합니다.
     const node1Fixture = createMockNode("node1", "Node 1", NodeType.NOTE);
     const node2Fixture = createMockNode("node2", "Node 2", NodeType.NOTE);
     const edge1Fixture = createMockEdge("edge1", "node1", "node2");
@@ -88,21 +98,14 @@ describe("adaptGraphData", () => {
       edges: [edge1Fixture],
     };
 
-    // [Confirm] structuredClone은 Node.js 17.0.0+ 전역으로 지원됩니다.
-    // 이 프로젝트의 Vitest는 jsdom 환경에서 실행되지만, jsdom은 Node.js(v22+) 위에서
-    // 동작하므로 Node.js 전역 structuredClone이 정상 작동합니다.
-    // JSON.parse(JSON.stringify())와 달리 undefined, Symbol, Date, NaN 등 비-JSON 값도
-    // 안전하게 복제합니다.
-    const originalSnapshot: GraphViewData = structuredClone(data);
+    const originalSnapshot = deepClone(data);
 
     const result = adaptGraphData(data);
 
-    // Input should remain deeply equal to the original snapshot
+    // Input data must remain unchanged after the adapter runs
     expect(data).toEqual(originalSnapshot);
 
-    // Verify that the adapted structures do not reuse the same references.
-    // 픽스처 변수를 직접 참조하므로 타입 캐스팅이 불필요합니다.
-    // toBe()는 unknown을 허용하므로 ForceGraphLink vs GraphEdge 타입 불일치가 없습니다.
+    // Result must not share array or object references with the input
     expect(result.nodes).not.toBe(data.nodes);
     expect(result.links).not.toBe(data.edges);
     expect(result.nodes[0]).not.toBe(node1Fixture);


### PR DESCRIPTION
- 테스트 전용 deepClone<T>() 헬퍼 추가: `structuredClone` 지원 환경에서는 사용하고, 미지원 환경(구형 jsdom 등)에서는 JSON 직렬화로 폴백하여 환경 무관하게 동작 보장
- 불변성 테스트 내 구현 결정 이유 설명 주석(7줄)을 제거하고 테스트 동작 설명 주석(2줄)으로 교체
- 환경 설명은 deepClone 함수의 JSDoc으로 집중시켜 관심사 분리

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1569#pullrequestreview-4443455262)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

GraphView 테스트에서 `structuredClone`에 직접 의존하지 않도록 테스트 전용 `deepClone` 헬퍼를 도입하고, 불변성 테스트의 의도를 더 명확하게 합니다.

Enhancements:
- `structuredClone`을 우선 사용하고, 이를 지원하지 않는 환경에서는 JSON 기반 방식을 사용하는 범용 `deepClone` 테스트 헬퍼를 추가합니다.
- GraphView 불변성 테스트의 주석을 단순화하고 다시 서술하여, 환경별 구현 세부사항보다는 동작 자체에 초점을 맞추도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a test-only deepClone helper to remove direct structuredClone dependence in GraphView tests and clarify immutability test intent.

Enhancements:
- Add a generic deepClone test helper that prefers structuredClone with a JSON-based fallback for non-supporting environments.
- Simplify and reword comments in the GraphView immutability test to focus on behavior rather than environment-specific implementation details.

</details>