### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/components/GraphView/GraphContainer.tsx
+++ b/web_ui/src/components/GraphView/GraphContainer.tsx
@@ -48,7 +48,7 @@ export function GraphContainer() {
       <div className="flex h-[600px] w-full items-center justify-center p-10 bg-white border border-gray-200 rounded-lg shadow-sm">
         <div className="flex flex-col items-center gap-4 text-muted-foreground">
           <p>Failed to load graph data.</p>
-          <Button variant="outline" onClick={reload}>
+          <Button variant="outline" onClick={() => reload()} disabled={loading}>
             Retry
           </Button>
         </div>

--- a/web_ui/src/components/GraphView/GraphContainer.tsx
+++ b/web_ui/src/components/GraphView/GraphContainer.tsx
@@ -1,77 +1,19 @@
 "use client";
 
-import React, { useCallback, useEffect, useState, useRef } from "react";
-import { toast } from "sonner";
-import { Badge } from "@/components/ui/badge";
-import { useWebSocket } from "@/hooks/useWebSocket";
-import { getWebSocketUrl } from "@/config/websocket";
-import { isWebSocketEvent, WS_EVENT_TYPE, NodeType, GraphNode } from "@/types/websocket";
-import { logger } from "@/lib/logger";
-import { UI_CONFIG } from "@/config/ui";
-import { API_BASE } from "@/lib/api";
-import { getToastThrottleDelay } from "@/lib/ui";
-import { GraphViewLoader as GraphView } from "./GraphViewLoader";
-import { GraphViewData } from "./types";
+import React, { useCallback } from "react";
 import { useRouter } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-
-const GRAPH_UPDATE_THROTTLE = getToastThrottleDelay("GRAPH_UPDATE");
+import { toast } from "sonner";
+import { NodeType, GraphNode } from "@/types/websocket";
+import { GraphViewLoader as GraphView } from "./GraphViewLoader";
+import { useGraphData } from "./useGraphData";
+import { useGraphLiveUpdates } from "./useGraphLiveUpdates";
 
 export function GraphContainer() {
   const router = useRouter();
-  const [data, setData] = useState<GraphViewData | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  const fetchData = useCallback(async () => {
-    try {
-      setLoading(true);
-      const res = await fetch(`${API_BASE}/api/graph/data`);
-      if (!res.ok) {
-        throw new Error("Failed to fetch graph data");
-      }
-      const fetchedData: GraphViewData = await res.json();
-      setData(fetchedData);
-    } catch (error) {
-      console.error("Error fetching graph data:", error);
-      toast.error("Failed to load graph data");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
-
-  // WebSocket Integration
-  const { isConnected, lastMessage } = useWebSocket(getWebSocketUrl(), {
-    autoConnect: true,
-    reconnect: true,
-  });
-
-  const lastToastTimeRef = useRef<number>(0);
-
-  useEffect(() => {
-    if (!lastMessage) return;
-
-    if (!isWebSocketEvent(lastMessage)) return;
-
-    if (lastMessage.type === WS_EVENT_TYPE.GRAPH_UPDATED) {
-      logger.debug("[GraphView] Graph updated event received, reloading data...");
-      
-      fetchData();
-
-      const now = Date.now();
-      
-      if (now - lastToastTimeRef.current > GRAPH_UPDATE_THROTTLE) {
-        toast.info("Graph data updated", {
-          description: "Real-time sync from backend",
-          id: UI_CONFIG.TOAST.IDS.GRAPH_UPDATE,
-        });
-        lastToastTimeRef.current = now;
-      }
-    }
-  }, [lastMessage, fetchData]);
+  const { data, loading, reload } = useGraphData();
+  const { isConnected } = useGraphLiveUpdates(reload);
 
   const handleNodeClick = useCallback(
     (node: GraphNode) => {
@@ -106,7 +48,7 @@ export function GraphContainer() {
       <div className="flex h-[600px] w-full items-center justify-center p-10 bg-white border border-gray-200 rounded-lg shadow-sm">
         <div className="flex flex-col items-center gap-4 text-muted-foreground">
           <p>Failed to load graph data.</p>
-          <Button variant="outline" onClick={fetchData}>
+          <Button variant="outline" onClick={reload}>
             Retry
           </Button>
         </div>

--- a/web_ui/src/components/GraphView/GraphView.tsx
+++ b/web_ui/src/components/GraphView/GraphView.tsx
@@ -164,6 +164,8 @@ export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewP
       ctx.beginPath();
       ctx.arc(nx, ny, radius, 0, Math.PI * 2);
       ctx.fillStyle = isSelected ? GRAPH_HIGHLIGHT_COLOR : color;
+      ctx.fill();
+
       if (isHovered && !isSelected) {
         // 호버 시 외곽선 추가
         ctx.save();
@@ -172,7 +174,6 @@ export function GraphView({ data, width, height = 600, onNodeClick }: GraphViewP
         ctx.stroke();
         ctx.restore();
       }
-      ctx.fill();
 
       // 라벨 (작은 폰트로 노드 아래에 표시)
       // 호버되거나 선택된 노드는 라벨을 더 선명하게 표시

--- a/web_ui/src/components/GraphView/useGraphData.ts
+++ b/web_ui/src/components/GraphView/useGraphData.ts
@@ -1,0 +1,30 @@
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { API_BASE } from "@/lib/api";
+import type { GraphViewData } from "./types";
+
+export function useGraphData() {
+  const [data, setData] = useState<GraphViewData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await fetch(`${API_BASE}/api/graph/data`);
+      if (!res.ok) throw new Error("Failed to fetch graph data");
+      const fetchedData: GraphViewData = await res.json();
+      setData(fetchedData);
+    } catch (error) {
+      console.error("Error fetching graph data:", error);
+      toast.error("Failed to load graph data");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return { data, loading, reload: fetchData };
+}

--- a/web_ui/src/components/GraphView/useGraphData.ts
+++ b/web_ui/src/components/GraphView/useGraphData.ts
@@ -7,14 +7,15 @@ export function useGraphData() {
   const [data, setData] = useState<GraphViewData | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (signal?: AbortSignal) => {
     try {
       setLoading(true);
-      const res = await fetch(`${API_BASE}/api/graph/data`);
+      const res = await fetch(`${API_BASE}/api/graph/data`, { signal });
       if (!res.ok) throw new Error("Failed to fetch graph data");
       const fetchedData: GraphViewData = await res.json();
       setData(fetchedData);
     } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") return; // Ignore abort errors
       console.error("Error fetching graph data:", error);
       toast.error("Failed to load graph data");
     } finally {
@@ -23,7 +24,11 @@ export function useGraphData() {
   }, []);
 
   useEffect(() => {
-    fetchData();
+    const controller = new AbortController();
+    fetchData(controller.signal);
+    return () => {
+      controller.abort();
+    };
   }, [fetchData]);
 
   return { data, loading, reload: fetchData };

--- a/web_ui/src/components/GraphView/useGraphLiveUpdates.ts
+++ b/web_ui/src/components/GraphView/useGraphLiveUpdates.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { useWebSocket } from "@/hooks/useWebSocket";
+import { getWebSocketUrl } from "@/config/websocket";
+import { isWebSocketEvent, WS_EVENT_TYPE } from "@/types/websocket";
+import { logger } from "@/lib/logger";
+import { UI_CONFIG } from "@/config/ui";
+import { getToastThrottleDelay } from "@/lib/ui";
+
+const GRAPH_UPDATE_THROTTLE = getToastThrottleDelay("GRAPH_UPDATE");
+
+export function useGraphLiveUpdates(onGraphUpdated: () => void) {
+  const { isConnected, lastMessage } = useWebSocket(getWebSocketUrl(), {
+    autoConnect: true,
+    reconnect: true,
+  });
+
+  const lastToastTimeRef = useRef<number>(0);
+
+  useEffect(() => {
+    if (!lastMessage || !isWebSocketEvent(lastMessage)) return;
+    if (lastMessage.type !== WS_EVENT_TYPE.GRAPH_UPDATED) return;
+
+    logger.debug("[GraphView] Graph updated event received, reloading data...");
+    onGraphUpdated();
+
+    const now = Date.now();
+    if (now - lastToastTimeRef.current > GRAPH_UPDATE_THROTTLE) {
+      toast.info("Graph data updated", {
+        description: "Real-time sync from backend",
+        id: UI_CONFIG.TOAST.IDS.GRAPH_UPDATE,
+      });
+      lastToastTimeRef.current = now;
+    }
+  }, [lastMessage, onGraphUpdated]);
+
+  return { isConnected };
+}

--- a/web_ui/src/components/GraphView/useGraphLiveUpdates.ts
+++ b/web_ui/src/components/GraphView/useGraphLiveUpdates.ts
@@ -16,13 +16,18 @@ export function useGraphLiveUpdates(onGraphUpdated: () => void) {
   });
 
   const lastToastTimeRef = useRef<number>(0);
+  const onGraphUpdatedRef = useRef(onGraphUpdated);
+
+  useEffect(() => {
+    onGraphUpdatedRef.current = onGraphUpdated;
+  }, [onGraphUpdated]);
 
   useEffect(() => {
     if (!lastMessage || !isWebSocketEvent(lastMessage)) return;
     if (lastMessage.type !== WS_EVENT_TYPE.GRAPH_UPDATED) return;
 
     logger.debug("[GraphView] Graph updated event received, reloading data...");
-    onGraphUpdated();
+    onGraphUpdatedRef.current();
 
     const now = Date.now();
     if (now - lastToastTimeRef.current > GRAPH_UPDATE_THROTTLE) {
@@ -32,7 +37,7 @@ export function useGraphLiveUpdates(onGraphUpdated: () => void) {
       });
       lastToastTimeRef.current = now;
     }
-  }, [lastMessage, onGraphUpdated]);
+  }, [lastMessage]);
 
   return { isConnected };
 }


### PR DESCRIPTION
☘️ refactor [#12.3.16]: 2차 개선 - GraphView 렌더링 버그 수정 및 로직 분리(SoC) 
🚀 perf [#12.3.16]: 3차 개선 - GraphView 성능 최적화 및 메모리 누수 방지

## Summary by Sourcery

GraphContainer에서 그래프 데이터 패칭 및 실시간 업데이트 로직을 전용 훅으로 분리하고, GraphView에서의 노드 렌더링 문제를 수정했습니다.

버그 수정:
- GraphView 캔버스에서 노드에 마우스를 올렸을 때(fill/hover) 잘못 채워질 수 있던 렌더링 버그를 해결했습니다.

개선 사항:
- 그래프 데이터 패칭, 로딩 상태, 재로딩 로직을 관리하고, 중단 가능한 요청을 지원하는 재사용 가능한 `useGraphData` 훅을 도입했습니다.
- WebSocket 기반 그래프 업데이트 처리와 토스트 알림의 스로틀(throttle) 처리를 캡슐화한 `useGraphLiveUpdates` 훅을 도입했습니다.
- GraphContainer가 새로운 훅들을 사용하도록 리팩터링하여 관심사의 분리를 개선하고 재시도 처리 로직을 개선했습니다.
- GraphView의 노드 렌더링을 조정해, 호버 아웃라인을 적용하기 전에 노드를 올바르게 채우도록 하여 렌더링 글리치를 방지했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract graph data fetching and live update logic from GraphContainer into dedicated hooks and fix a node rendering issue in GraphView.

Bug Fixes:
- Resolve GraphView canvas rendering bug where nodes could be improperly filled when hovered.

Enhancements:
- Introduce a reusable useGraphData hook to manage graph data fetching, loading state, and reload logic with abortable requests.
- Introduce a useGraphLiveUpdates hook to encapsulate WebSocket-based graph update handling and throttled toast notifications.
- Refine GraphContainer to consume the new hooks for cleaner separation of concerns and improved retry handling.
- Adjust GraphView node rendering to correctly fill nodes before applying hover outlines, preventing rendering glitches.

</details>