### PR TITLE
⚡️ perf [#12.3.16]: 4차 개선 - GraphView 동시성 제어 및 렌더링 최적화

### DIFF
--- a/web_ui/src/components/GraphView/useGraphData.ts
+++ b/web_ui/src/components/GraphView/useGraphData.ts
@@ -25,13 +25,14 @@ export function useGraphData() {
       const fetchedData: GraphViewData = await res.json();
       setData(fetchedData);
     } catch (error) {
-      if (error instanceof Error && error.name === "AbortError") return; // Ignore abort errors
+      if ((error as Error).name === "AbortError") return; // Ignore abort errors
       console.error("Error fetching graph data:", error);
       toast.error("Failed to load graph data");
     } finally {
-      // 현재 실행 중인 요청과 완료된 요청이 일치할 때만 로딩 상태 해제
+      // 현재 실행 중인 요청과 완료된 요청이 일치할 때만 로딩 상태 해제 및 참조 초기화
       if (abortControllerRef.current === controller) {
         setLoading(false);
+        abortControllerRef.current = null;
       }
     }
   }, []);

--- a/web_ui/src/components/GraphView/useGraphData.ts
+++ b/web_ui/src/components/GraphView/useGraphData.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useRef } from "react";
 import { toast } from "sonner";
 import { API_BASE } from "@/lib/api";
 import type { GraphViewData } from "./types";
@@ -6,11 +6,21 @@ import type { GraphViewData } from "./types";
 export function useGraphData() {
   const [data, setData] = useState<GraphViewData | null>(null);
   const [loading, setLoading] = useState(true);
+  const abortControllerRef = useRef<AbortController | null>(null);
 
-  const fetchData = useCallback(async (signal?: AbortSignal) => {
+  const fetchData = useCallback(async () => {
+    // 이전 요청이 있다면 취소
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+    
+    // 새로운 컨트롤러 생성
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
     try {
       setLoading(true);
-      const res = await fetch(`${API_BASE}/api/graph/data`, { signal });
+      const res = await fetch(`${API_BASE}/api/graph/data`, { signal: controller.signal });
       if (!res.ok) throw new Error("Failed to fetch graph data");
       const fetchedData: GraphViewData = await res.json();
       setData(fetchedData);
@@ -19,15 +29,19 @@ export function useGraphData() {
       console.error("Error fetching graph data:", error);
       toast.error("Failed to load graph data");
     } finally {
-      setLoading(false);
+      // 현재 실행 중인 요청과 완료된 요청이 일치할 때만 로딩 상태 해제
+      if (abortControllerRef.current === controller) {
+        setLoading(false);
+      }
     }
   }, []);
 
   useEffect(() => {
-    const controller = new AbortController();
-    fetchData(controller.signal);
+    fetchData();
     return () => {
-      controller.abort();
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
     };
   }, [fetchData]);
 


### PR DESCRIPTION
- `useGraphData.ts` 내부에서 `AbortController`를 `useRef`로 직접 관리하여, 다중 `reload` 호출 시 이전 요청을 자동 취소하고 가장 최신 데이터만 상태에 반영하도록 Race Condition 완벽 차단
- `GraphContainer.tsx`의 Retry 버튼 `onClick` 핸들러에 전달되던 불필요한 인라인 화살표 함수 람다(`() => reload()`)를 제거하고, 안정된 참조(`reload`)를 직접 주입하여 렌더링 성능 최적화

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1575#pullrequestreview-4455581495)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

그래프 뷰 데이터 가져오기 동시성 제어를 개선하여 레이스 컨디션을 방지하고, 가장 최신 요청만이 상태를 업데이트하도록 합니다.

버그 수정:
- 새로운 리로드가 발생하거나 컴포넌트가 언마운트될 때 진행 중인 그래프 데이터 가져오기를 취소하여 레이스 컨디션을 방지합니다.

개선 사항:
- `useGraphData`에서 안정적인 ref를 통해 `AbortController`를 관리하여, 가장 최신 네트워크 요청만이 로딩 상태를 제어하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve GraphView data fetching concurrency control to avoid race conditions and ensure only the latest request updates state.

Bug Fixes:
- Prevent race conditions by cancelling in-flight graph data fetches when new reloads occur or the component unmounts.

Enhancements:
- Manage AbortController via a stable ref in useGraphData so only the latest network request controls the loading state.

</details>