### PR TITLE
🛡️ fix [#12.3.16]: 6차 개선 - GraphView 예외 처리 타입 안정성(Type Safety) 강화

### DIFF
--- a/web_ui/src/components/GraphView/useGraphData.ts
+++ b/web_ui/src/components/GraphView/useGraphData.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState, useRef } from "react";
 import { toast } from "sonner";
-import { API_BASE } from "@/lib/api";
+import { API_BASE, isAbortError } from "@/lib/api";
 import type { GraphViewData } from "./types";
 
 export function useGraphData() {
@@ -25,8 +25,7 @@ export function useGraphData() {
       const fetchedData: GraphViewData = await res.json();
       setData(fetchedData);
     } catch (error) {
-      // 안전한 타입 가드: error가 객체이고 name 속성이 존재하는지 확인
-      if (error && typeof error === "object" && "name" in error && (error as Error).name === "AbortError") {
+      if (isAbortError(error)) {
         return;
       }
       console.error("Error fetching graph data:", error);

--- a/web_ui/src/components/GraphView/useGraphData.ts
+++ b/web_ui/src/components/GraphView/useGraphData.ts
@@ -25,7 +25,10 @@ export function useGraphData() {
       const fetchedData: GraphViewData = await res.json();
       setData(fetchedData);
     } catch (error) {
-      if ((error as Error).name === "AbortError") return; // Ignore abort errors
+      // 안전한 타입 가드: error가 객체이고 name 속성이 존재하는지 확인
+      if (error && typeof error === "object" && "name" in error && (error as Error).name === "AbortError") {
+        return;
+      }
       console.error("Error fetching graph data:", error);
       toast.error("Failed to load graph data");
     } finally {

--- a/web_ui/src/lib/api.ts
+++ b/web_ui/src/lib/api.ts
@@ -70,3 +70,10 @@ export const validateResponse = <T>(
   }
   return data as T;
 };
+
+/**
+ * 통신 취소(AbortError) 여부를 확인하는 타입 가드
+ */
+export const isAbortError = (error: unknown): error is { name: "AbortError" } => {
+  return typeof error === "object" && error !== null && "name" in error && (error as { name: unknown }).name === "AbortError";
+};


### PR DESCRIPTION
- `useGraphData.ts`의 catch 블록에서 위험한 타입 단언(`as Error`)을 제거하고, `error` 객체의 형태를 런타임에 안전하게 검사하는 타입 가드 적용
- 문자열이나 `undefined` 등 예상치 못한 값이 throw 되었을 때 발생할 수 있는 잠재적인 런타임 크래시 차단

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1577#pullrequestreview-4455639689)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

버그 수정:
- GraphView 데이터 가져오기 중에 `Error`가 아닌 값이 throw될 때도 런타임 크래시가 발생하지 않도록 처리했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Handle non-Error values thrown during GraphView data fetching without causing runtime crashes.

</details>