### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/components/GraphView/useGraphData.ts
+++ b/web_ui/src/components/GraphView/useGraphData.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState, useRef } from "react";
 import { toast } from "sonner";
-import { API_BASE } from "@/lib/api";
+import { API_BASE, isAbortError } from "@/lib/api";
 import type { GraphViewData } from "./types";
 
 export function useGraphData() {
@@ -25,8 +25,7 @@ export function useGraphData() {
       const fetchedData: GraphViewData = await res.json();
       setData(fetchedData);
     } catch (error) {
-      // 안전한 타입 가드: error가 객체이고 name 속성이 존재하는지 확인
-      if (error && typeof error === "object" && "name" in error && (error as Error).name === "AbortError") {
+      if (isAbortError(error)) {
         return;
       }
       console.error("Error fetching graph data:", error);

--- a/web_ui/src/components/GraphView/useGraphData.ts
+++ b/web_ui/src/components/GraphView/useGraphData.ts
@@ -25,7 +25,10 @@ export function useGraphData() {
       const fetchedData: GraphViewData = await res.json();
       setData(fetchedData);
     } catch (error) {
-      if ((error as Error).name === "AbortError") return; // Ignore abort errors
+      // 안전한 타입 가드: error가 객체이고 name 속성이 존재하는지 확인
+      if (error && typeof error === "object" && "name" in error && (error as Error).name === "AbortError") {
+        return;
+      }
       console.error("Error fetching graph data:", error);
       toast.error("Failed to load graph data");
     } finally {

--- a/web_ui/src/lib/api.ts
+++ b/web_ui/src/lib/api.ts
@@ -70,3 +70,10 @@ export const validateResponse = <T>(
   }
   return data as T;
 };
+
+/**
+ * 통신 취소(AbortError) 여부를 확인하는 타입 가드
+ */
+export const isAbortError = (error: unknown): error is { name: "AbortError" } => {
+  return typeof error === "object" && error !== null && "name" in error && (error as { name: unknown }).name === "AbortError";
+};


### PR DESCRIPTION
🛡️ fix [#12.3.16]: 6차 개선 - GraphView 예외 처리 타입 안정성(Type Safety) 강화 
☘️ refactor [#12.3.16]: 7차 개선 - GraphView 예외 처리 공통 헬퍼 분리 및 단언(Assertion) 완벽 제거

## Summary by Sourcery

GraphView의 네트워크 오류 처리를 강화하기 위해, 공유 가능한 타입 안전 AbortError 가드(type-safe AbortError guard)를 도입하고 이를 그래프 데이터 페칭에 적용했습니다.

개선사항:
- API 호출에서 AbortError 인스턴스를 감지하기 위한 재사용 가능한 타입 가드 헬퍼를 추가했습니다.
- GraphView 데이터 페칭에서 취소(cancellation) 처리를 위해 인라인 단언문 대신 공유 AbortError 가드에 의존하도록 로직을 다듬었습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen GraphView network error handling by introducing a shared, type-safe AbortError guard and adopting it in graph data fetching.

Enhancements:
- Add a reusable type guard helper to detect AbortError instances in API calls.
- Refine GraphView data fetching to rely on the shared AbortError guard instead of inline assertions for cancellation handling.

</details>