### PR TITLE
☘️ refactor [#12.3.16]: 8차 개선 - GraphView 예외 처리 타입 강화 및 헬퍼 모듈 분리(SoC)

### DIFF
--- a/web_ui/src/components/GraphView/useGraphData.ts
+++ b/web_ui/src/components/GraphView/useGraphData.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, useRef } from "react";
 import { toast } from "sonner";
-import { API_BASE, isAbortError } from "@/lib/api";
+import { API_BASE } from "@/lib/api";
+import { isAbortError } from "@/lib/utils";
 import type { GraphViewData } from "./types";
 
 export function useGraphData() {

--- a/web_ui/src/lib/api.ts
+++ b/web_ui/src/lib/api.ts
@@ -70,10 +70,3 @@ export const validateResponse = <T>(
   }
   return data as T;
 };
-
-/**
- * 통신 취소(AbortError) 여부를 확인하는 타입 가드
- */
-export const isAbortError = (error: unknown): error is { name: "AbortError" } => {
-  return typeof error === "object" && error !== null && "name" in error && (error as { name: unknown }).name === "AbortError";
-};

--- a/web_ui/src/lib/utils.ts
+++ b/web_ui/src/lib/utils.ts
@@ -39,3 +39,10 @@ export const assertNever = (x: never, context?: string): never => {
   
   throw new ExhaustiveCheckError(context, kind);
 };
+
+/**
+ * 통신 취소(AbortError) 여부를 확인하는 타입 가드
+ */
+export const isAbortError = (error: unknown): error is Error & { name: "AbortError" } => {
+  return typeof error === "object" && error !== null && "name" in error && (error as { name: unknown }).name === "AbortError";
+};

--- a/web_ui/src/lib/utils.ts
+++ b/web_ui/src/lib/utils.ts
@@ -44,5 +44,5 @@ export const assertNever = (x: never, context?: string): never => {
  * 통신 취소(AbortError) 여부를 확인하는 타입 가드
  */
 export const isAbortError = (error: unknown): error is Error & { name: "AbortError" } => {
-  return typeof error === "object" && error !== null && "name" in error && (error as { name: unknown }).name === "AbortError";
+  return error instanceof Error && error.name === "AbortError";
 };


### PR DESCRIPTION
- `isAbortError` 커스텀 타입 가드의 반환 타입을 `Error & { name: "AbortError" }`로 정교화하여, 호출부에서 표준 에러 속성(`.message` 등)에 안전하게 접근할 수 있도록 타입 추론(Type Inference) 강화
- 해당 헬퍼 함수가 특정 API 설정에 종속되지 않도록 `lib/api.ts`에서 범용 유틸리티 모듈인 `lib/utils.ts`로 이동시켜 관심사의 분리(Separation of Concerns) 실현

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1579#pullrequestreview-4456616577)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

AbortError 처리 로직을 강화하고, 해당 헬퍼를 API 전용 코드에서 분리합니다.

개선 사항:
- `isAbortError` 타입 가드를 `Error & { name: "AbortError" }`로 한정하여 표준 에러 프로퍼티에 더 안전하게 접근할 수 있도록 개선합니다.
- `isAbortError` 헬퍼를 API 모듈에서 공용 유틸리티 모듈로 옮겨 관심사를 분리하고, 여러 컴포넌트에서 재사용할 수 있도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen AbortError handling and decouple its helper from API-specific code.

Enhancements:
- Refine the isAbortError type guard to narrow to Error & { name: "AbortError" } for safer access to standard error properties.
- Relocate the isAbortError helper from the API module to a shared utilities module to separate concerns and reuse it across components.

</details>