### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/components/GraphView/useGraphData.ts
+++ b/web_ui/src/components/GraphView/useGraphData.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, useRef } from "react";
 import { toast } from "sonner";
-import { API_BASE, isAbortError } from "@/lib/api";
+import { API_BASE } from "@/lib/api";
+import { isAbortError } from "@/lib/utils";
 import type { GraphViewData } from "./types";
 
 export function useGraphData() {

--- a/web_ui/src/lib/api.ts
+++ b/web_ui/src/lib/api.ts
@@ -70,10 +70,3 @@ export const validateResponse = <T>(
   }
   return data as T;
 };
-
-/**
- * 통신 취소(AbortError) 여부를 확인하는 타입 가드
- */
-export const isAbortError = (error: unknown): error is { name: "AbortError" } => {
-  return typeof error === "object" && error !== null && "name" in error && (error as { name: unknown }).name === "AbortError";
-};

--- a/web_ui/src/lib/utils.ts
+++ b/web_ui/src/lib/utils.ts
@@ -39,3 +39,10 @@ export const assertNever = (x: never, context?: string): never => {
   
   throw new ExhaustiveCheckError(context, kind);
 };
+
+/**
+ * 통신 취소(AbortError) 여부를 확인하는 타입 가드
+ */
+export const isAbortError = (error: unknown): error is Error & { name: "AbortError" } => {
+  return typeof error === "object" && error !== null && "name" in error && (error as { name: unknown }).name === "AbortError";
+};

--- a/web_ui/src/lib/utils.ts
+++ b/web_ui/src/lib/utils.ts
@@ -44,5 +44,5 @@ export const assertNever = (x: never, context?: string): never => {
  * 통신 취소(AbortError) 여부를 확인하는 타입 가드
  */
 export const isAbortError = (error: unknown): error is Error & { name: "AbortError" } => {
-  return typeof error === "object" && error !== null && "name" in error && (error as { name: unknown }).name === "AbortError";
+  return error instanceof Error && error.name === "AbortError";
 };


### PR DESCRIPTION
☘️ refactor [#12.3.16]: 8차 개선 - GraphView 예외 처리 타입 강화 및 헬퍼 모듈 분리(SoC) 
🛡️ fix [#12.3.16]: 9차 개선 - GraphView 예외 처리 타입 가드 무결성(Completeness) 보완

## Summary by Sourcery

GraphView 데이터 페칭에 사용되는 공유 유틸리티 모듈로 `AbortError` 타입 가드를 옮기고, 해당 타입 가드를 강화합니다.

버그 수정:
- `AbortError` 타입 가드를 `AbortError` 이름을 가진 `Error` 인스턴스에 의존하도록 더 엄격하게 하여, GraphView 요청 취소 처리의 신뢰성을 향상시켰습니다.

개선 사항:
- `AbortError` 감지 헬퍼를 API 모듈에서 공유 `utils` 모듈로 이동하여, 관심사의 분리를 개선하고 재사용성을 높였습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen the AbortError type guard and relocate it to a shared utility module used by GraphView data fetching.

Bug Fixes:
- Tighten the AbortError type guard to rely on Error instances with the AbortError name, improving reliability of GraphView request cancellation handling.

Enhancements:
- Relocate the AbortError detection helper from the API module to the shared utils module for better separation of concerns and reuse.

</details>