### PR TITLE
🛡️ fix [#12.3.16]: 12차 개선 - AbortError 타입 가드의 반환 타입 확장(Widening)을 통한 타입 안전성 보장

### DIFF
--- a/web_ui/src/lib/utils.ts
+++ b/web_ui/src/lib/utils.ts
@@ -43,7 +43,7 @@ export const assertNever = (x: never, context?: string): never => {
 /**
  * 통신 취소(AbortError) 여부를 확인하는 타입 가드
  */
-export const isAbortError = (error: unknown): error is Error & { name: "AbortError" } => {
+export const isAbortError = (error: unknown): error is (Error | DOMException) & { name: "AbortError" } => {
   const errName = (error as { name?: unknown })?.name;
   if (errName !== "AbortError") return false;
 


### PR DESCRIPTION
- `isAbortError`의 반환 타입을 `error is (Error | DOMException) & { name: 'AbortError' }`로 확장하여, 런타임 반환 값과 타입 시스템 간의 불일치로 발생할 수 있는 런타임 버그 리스크 원천 차단

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1583#pullrequestreview-4456855537)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

`isAbortError` 타입 가드를 확장하여, 이름이 `"AbortError"`인 `Error`와 `DOMException` 둘 다를 중단(abort) 에러로 처리하도록 합니다. 이를 통해 런타임 동작을 TypeScript 타입 시스템과 일치시키고, 타입 안정성을 향상합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Widen the isAbortError type guard to treat both Error and DOMException with name "AbortError" as abort errors, aligning the runtime behavior with the TypeScript type system to improve type safety.

</details>