### PR TITLE
☘️ refactor [#12.3.16]: 13차 개선 - isAbortError 타입 가드를 순수 구조적 타이핑(Structural Typing)으로 변경

### DIFF
--- a/web_ui/src/lib/utils.ts
+++ b/web_ui/src/lib/utils.ts
@@ -43,9 +43,6 @@ export const assertNever = (x: never, context?: string): never => {
 /**
  * 통신 취소(AbortError) 여부를 확인하는 타입 가드
  */
-export const isAbortError = (error: unknown): error is (Error | DOMException) & { name: "AbortError" } => {
-  const errName = (error as { name?: unknown })?.name;
-  if (errName !== "AbortError") return false;
-
-  return error instanceof Error || (typeof DOMException !== "undefined" && error instanceof DOMException);
+export const isAbortError = (error: unknown): error is { name: "AbortError" } => {
+  return typeof error === "object" && error !== null && "name" in error && (error as { name: unknown }).name === "AbortError";
 };

--- a/web_ui/src/lib/utils.ts
+++ b/web_ui/src/lib/utils.ts
@@ -41,8 +41,22 @@ export const assertNever = (x: never, context?: string): never => {
 };
 
 /**
- * 통신 취소(AbortError) 여부를 확인하는 타입 가드
+ * AbortError의 구조적 계약(Structural Contract)을 나타내는 타입 별칭.
+ * isAbortError 타입 가드와 호출 측에서 동일한 계약을 일관되게 참조할 수 있습니다.
  */
-export const isAbortError = (error: unknown): error is { name: "AbortError" } => {
-  return typeof error === "object" && error !== null && "name" in error && (error as { name: unknown }).name === "AbortError";
+export type AbortErrorLike = { name: "AbortError" };
+
+/**
+ * 통신 취소(AbortError) 여부를 확인하는 타입 가드.
+ * name 프로퍼티가 문자열 "AbortError"인 모든 객체를 감지하여
+ * Error·DOMException 이외의 크로스-렐름 AbortError도 포착합니다.
+ */
+export const isAbortError = (error: unknown): error is AbortErrorLike => {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    typeof (error as { name: unknown }).name === "string" &&
+    (error as { name: string }).name === "AbortError"
+  );
 };


### PR DESCRIPTION
- `isAbortError`가 `Error`나 `DOMException` 인스턴스임을 보장하는 대신, 순수하게 `{ name: 'AbortError' }` 형태만을 보장하도록 타입 프레디케이트와 구현을 일치시킴
- JS 생태계의 덕 타이핑(Duck Typing) 관례 준수 및 호출 측에서 존재하지 않는 Error 속성에 접근할 수 있는 잠재적 런타임 버그 리스크 원천 차단

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1585#pullrequestreview-4456930192)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개선 사항:
- `isAbortError` 타입 프레디케이트와 구현을 `name` 프로퍼티에 대한 순수 구조적 검사로 정렬하여, Error/DOMException 전용 필드에 대한 가정을 피하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Align the isAbortError type predicate and implementation to a pure structural check on the name property, preventing assumptions about Error/DOMException-specific fields.

</details>