### PR TITLE
Feature/v9 adaptive intelligence

### DIFF
--- a/web_ui/src/lib/utils.ts
+++ b/web_ui/src/lib/utils.ts
@@ -43,9 +43,6 @@ export const assertNever = (x: never, context?: string): never => {
 /**
  * 통신 취소(AbortError) 여부를 확인하는 타입 가드
  */
-export const isAbortError = (error: unknown): error is (Error | DOMException) & { name: "AbortError" } => {
-  const errName = (error as { name?: unknown })?.name;
-  if (errName !== "AbortError") return false;
-
-  return error instanceof Error || (typeof DOMException !== "undefined" && error instanceof DOMException);
+export const isAbortError = (error: unknown): error is { name: "AbortError" } => {
+  return typeof error === "object" && error !== null && "name" in error && (error as { name: unknown }).name === "AbortError";
 };

--- a/web_ui/src/lib/utils.ts
+++ b/web_ui/src/lib/utils.ts
@@ -41,8 +41,22 @@ export const assertNever = (x: never, context?: string): never => {
 };
 
 /**
- * 통신 취소(AbortError) 여부를 확인하는 타입 가드
+ * AbortError의 구조적 계약(Structural Contract)을 나타내는 타입 별칭.
+ * isAbortError 타입 가드와 호출 측에서 동일한 계약을 일관되게 참조할 수 있습니다.
  */
-export const isAbortError = (error: unknown): error is { name: "AbortError" } => {
-  return typeof error === "object" && error !== null && "name" in error && (error as { name: unknown }).name === "AbortError";
+export type AbortErrorLike = { name: "AbortError" };
+
+/**
+ * 통신 취소(AbortError) 여부를 확인하는 타입 가드.
+ * name 프로퍼티가 문자열 "AbortError"인 모든 객체를 감지하여
+ * Error·DOMException 이외의 크로스-렐름 AbortError도 포착합니다.
+ */
+export const isAbortError = (error: unknown): error is AbortErrorLike => {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    typeof (error as { name: unknown }).name === "string" &&
+    (error as { name: string }).name === "AbortError"
+  );
 };


### PR DESCRIPTION
☘️ refactor [#12.3.16]: 13차 개선 - isAbortError 타입 가드를 순수 구조적 타이핑(Structural Typing)으로 변경
☘️ refactor [#12.3.16]: 14차 개선 - AbortErrorLike 타입 별칭 추출 및 name 문자열 타입 가드 강화

## Summary by Sourcery

`AbortError` 감지 방식을 구조적이며 이름 기반의 계약으로 다듬고, 이를 공용 타입 별칭을 통해 노출하여 일관되게 사용할 수 있도록 합니다.

향상 사항:
- `AbortError` 유사 객체의 구조적 계약을 표현하기 위해 `AbortErrorLike` 타입 별칭을 도입합니다.
- 교차 realm 인스턴스를 포함해, `name === "AbortError"` 인 모든 객체를 `AbortErrorLike`로 취급하도록 `isAbortError` 타입 가드를 완화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine AbortError detection to use a structural, name-based contract and expose it via a shared type alias for consistent usage.

Enhancements:
- Introduce an AbortErrorLike type alias to represent the structural contract of AbortError-like objects.
- Relax the isAbortError type guard to treat any object with name === "AbortError" as an AbortErrorLike, including cross-realm instances.

</details>