### PR TITLE
☘️ refactor [#12.3.16]: 15차 개선 - `hasAbortErrorName` 내부 헬퍼 추출 및 호출 지점 감사 결과 문서화

### DIFF
--- a/web_ui/src/lib/utils.ts
+++ b/web_ui/src/lib/utils.ts
@@ -43,8 +43,23 @@ export const assertNever = (x: never, context?: string): never => {
 /**
  * AbortError의 구조적 계약(Structural Contract)을 나타내는 타입 별칭.
  * isAbortError 타입 가드와 호출 측에서 동일한 계약을 일관되게 참조할 수 있습니다.
+ *
+ * [호출 지점 감사(Caller Audit) 결과]
+ * 모든 호출 측(useFetch, useStreamingChat, stream-client, HybridSearch,
+ * websocket-monitor, useGraphData, chat/route)은 isAbortError 통과 후
+ * 즉시 early return 패턴만 사용하며 .message / .stack 등의 Error 전용
+ * 속성에 접근하지 않습니다. 따라서 현재 { name: "AbortError" } 계약으로 충분합니다.
  */
 export type AbortErrorLike = { name: "AbortError" };
+
+/**
+ * error의 name 속성이 문자열 "AbortError"인지 확인하는 내부 헬퍼.
+ * isAbortError 내부의 반복적인 타입 단언을 한 곳에 집중시켜 일관성을 보장합니다.
+ */
+function hasAbortErrorName(error: object): error is AbortErrorLike {
+  const name = (error as Record<string, unknown>)["name"];
+  return typeof name === "string" && name === "AbortError";
+}
 
 /**
  * 통신 취소(AbortError) 여부를 확인하는 타입 가드.
@@ -52,11 +67,5 @@ export type AbortErrorLike = { name: "AbortError" };
  * Error·DOMException 이외의 크로스-렐름 AbortError도 포착합니다.
  */
 export const isAbortError = (error: unknown): error is AbortErrorLike => {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "name" in error &&
-    typeof (error as { name: unknown }).name === "string" &&
-    (error as { name: string }).name === "AbortError"
-  );
+  return typeof error === "object" && error !== null && hasAbortErrorName(error);
 };

--- a/web_ui/src/lib/utils.ts
+++ b/web_ui/src/lib/utils.ts
@@ -53,11 +53,16 @@ export const assertNever = (x: never, context?: string): never => {
 export type AbortErrorLike = { name: "AbortError" };
 
 /**
- * error의 name 속성이 문자열 "AbortError"인지 확인하는 내부 헬퍼.
- * isAbortError 내부의 반복적인 타입 단언을 한 곳에 집중시켜 일관성을 보장합니다.
+ * error가 문자열 "AbortError" name 속성을 가진 객체인지 확인하는 내부 헬퍼.
+ * null/object 검사부터 name 문자열 검사까지 모든 가드를 한 곳에 집중시켜
+ * isAbortError가 단순 위임(pure delegation)만 하도록 합니다.
+ * 'name' in error → { name: unknown } 패턴으로 Record 광범위 캐스트 없이
+ * 필요한 속성만 타입 안전하게 좁힙니다.
  */
-function hasAbortErrorName(error: object): error is AbortErrorLike {
-  const name = (error as Record<string, unknown>)["name"];
+function hasAbortErrorName(error: unknown): error is AbortErrorLike {
+  if (typeof error !== "object" || error === null) return false;
+  if (!("name" in error)) return false;
+  const { name } = error as { name: unknown };
   return typeof name === "string" && name === "AbortError";
 }
 
@@ -66,6 +71,4 @@ function hasAbortErrorName(error: object): error is AbortErrorLike {
  * name 프로퍼티가 문자열 "AbortError"인 모든 객체를 감지하여
  * Error·DOMException 이외의 크로스-렐름 AbortError도 포착합니다.
  */
-export const isAbortError = (error: unknown): error is AbortErrorLike => {
-  return typeof error === "object" && error !== null && hasAbortErrorName(error);
-};
+export const isAbortError = (error: unknown): error is AbortErrorLike => hasAbortErrorName(error);


### PR DESCRIPTION
- 반복적인 타입 단언을 비공개 헬퍼 hasAbortErrorName()에 집중시켜 isAbortError 본문 단순화 및 향후 확장 시 일관성 보장
- 7개 파일 8개 호출 지점 감사 완료: 모두 early return 패턴만 사용, `message`/`stack` 접근 없음을 JSDoc에 명문화
- AbortErrorLike { name: 'AbortError' } 계약이 충분함을 확인

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1587#pullrequestreview-4457056922)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Abort 에러 감지를 리팩터링하여, 내부 헬퍼를 분리하고 AbortError‑유사 객체(AbortError-like objects)에 대한 구조적 계약과 호출자 측 감사(audit)를 문서화했습니다.

Enhancements:
- 내부 `hasAbortErrorName` 헬퍼를 추출하여 `isAbortError` 내 AbortError 이름 체크를 중앙화하고, 타입 가드 로직을 단순화했습니다.

Documentation:
- `AbortErrorLike` JSDoc을 확장하여 구조적 계약과 현재 모든 `isAbortError` 호출 지점에 대한 감사를 문서화하고, `{ name: "AbortError" }` 만으로도 충분하다는 점을 명확히 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor abort error detection by extracting an internal helper and documenting the structural contract and caller audit for AbortError-like objects.

Enhancements:
- Extract internal hasAbortErrorName helper to centralize AbortError name checks in isAbortError and simplify the type guard logic.

Documentation:
- Extend AbortErrorLike JSDoc to document the structural contract and audit of all current isAbortError call sites, clarifying that { name: "AbortError" } is sufficient.

</details>