### PR TITLE
✨ feat [#12.3.17]: Phase 4-4 - ➀ 고립 노트 식별 알고리즘 작성 및 API 엔드포인트 구현

### DIFF
--- a/backend/api/endpoints/graph.py
+++ b/backend/api/endpoints/graph.py
@@ -23,18 +23,26 @@ import logging
 from fastapi import APIRouter
 
 from backend.database.connection import DatabaseConnection
+from backend.graph.analysis import find_orphan_nodes, get_orphan_degree_threshold
 from backend.schemas.graph import (
     EdgeRelationshipType,
     GraphDataResponse,
     GraphEdge,
     GraphNode,
     NodeType,
+    OrphanNotesResponse,
 )
 from backend.utils.common import mask_pii_id
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/graph", tags=["Knowledge Graph (v1)"])
+
+
+# ─────────────────────────────────────────
+# 내부 헬퍼
+# ─────────────────────────────────────────
+
 
 def _is_valid_raw_user_id(raw_id: Any) -> bool:
     """
@@ -45,42 +53,38 @@ def _is_valid_raw_user_id(raw_id: Any) -> bool:
     return raw_id is not None and (not isinstance(raw_id, str) or bool(raw_id.strip()))
 
 
-@router.get(
-    "/data",
-    response_model=GraphDataResponse,
-    summary="PARA 기반 지식 그래프 데이터 조회",
-    description=(
-        "PARA 방법론(Projects/Areas/Resources/Archive) 기반으로 구성된 "
-        "노트 간의 노드-엣지 데이터를 반환합니다. "
-        "프론트엔드 react-force-graph 시각화에 사용됩니다.\n\n"
-        "[SSOT] 응답 스키마는 `backend.schemas.graph.GraphDataResponse`를 단일 진실 공급원으로 합니다."
-    ),
-)
-async def get_graph_data() -> GraphDataResponse:
-    """
-    PARA Graph View를 위한 노드와 엣지 데이터를 SSOT 스키마 형식으로 반환합니다.
+# PARA 카테고리 좌표 — 레이아웃 안정성을 위해 모듈 수준 상수로 관리
+# 하드코딩으로 보일 수 있으나, 이 값들은 PARA 방법론의 고정 구조를 표현하는
+# 디자인 상수(Design Constants)로, 환경 변수화 대상이 아닙니다.
+_PARA_CATEGORY_POSITIONS: dict[str, dict[str, float]] = {
+    "Projects": {"x": 0.0, "y": 0.0},
+    "Areas": {"x": 600.0, "y": 0.0},
+    "Resources": {"x": 0.0, "y": 600.0},
+    "Archive": {"x": 600.0, "y": 600.0},
+}
 
-    [v1] 현재는 PARA 카테고리 계층 관계(EdgeRelationshipType.PARA_CATEGORY)만 표현합니다.
-    Phase 4-1에서 명시적/암묵적 관계 추출 파이프라인이 연동되면 확장됩니다.
+
+def _build_graph_data() -> GraphDataResponse:
+    """
+    PARA 기반 지식 그래프 데이터를 DB에서 조회하여 GraphDataResponse를 빌드한다.
+
+    [책임 분리]
+    - get_graph_data()와 get_orphan_notes() 양쪽에서 재사용하여 중복 로직을 제거합니다.
+    - DB 연결 실패 시 CATEGORY 노드만 포함한 빈 응답을 반환합니다 (조용한 폴백).
+
+    Returns:
+        GraphDataResponse (nodes + edges)
     """
     # ─── PARA 카테고리 노드 (고정 시드 노드) ───────────────────────────────
-    # 기존 graph.py의 하드코딩 레이아웃을 기반으로 고정 좌표 부여
-    category_positions = {
-        "Projects": {"x": 0.0, "y": 0.0},
-        "Areas": {"x": 600.0, "y": 0.0},
-        "Resources": {"x": 0.0, "y": 600.0},
-        "Archive": {"x": 600.0, "y": 600.0},
-    }
-
     nodes: list[GraphNode] = []
-    
-    for cat in category_positions:
+    for cat, pos in _PARA_CATEGORY_POSITIONS.items():
         try:
-            pos_x = category_positions[cat]["x"]
-            pos_y = category_positions[cat]["y"]
+            pos_x = pos["x"]
+            pos_y = pos["y"]
         except KeyError as e:
-            # 설정 누락 시 런타임 에러 추적을 용이하게 하기 위한 Descriptive Error
-            raise RuntimeError(f"지식 그래프 설정 오류: 카테고리 '{cat}'의 좌표({e})가 누락되었습니다.") from e
+            raise RuntimeError(
+                f"지식 그래프 설정 오류: 카테고리 '{cat}'의 좌표({e})가 누락되었습니다."
+            ) from e
 
         nodes.append(
             GraphNode(
@@ -92,7 +96,7 @@ async def get_graph_data() -> GraphDataResponse:
                 position_y=pos_y,
             )
         )
-        
+
     edges: list[GraphEdge] = []
 
     # ─── 파일 노드 및 카테고리→파일 엣지 생성 ────────────────────────────────
@@ -103,7 +107,7 @@ async def get_graph_data() -> GraphDataResponse:
         logger.exception("그래프 데이터 조회 중 DB 연결 실패. 빈 그래프를 반환합니다.")
         return GraphDataResponse(nodes=nodes, edges=edges)
 
-    valid_category_ids = set(category_positions)
+    valid_category_ids = set(_PARA_CATEGORY_POSITIONS)
 
     file_nodes: list[GraphNode] = []
     file_edges: list[GraphEdge] = []
@@ -130,12 +134,8 @@ async def get_graph_data() -> GraphDataResponse:
         if abs(offset_x) < 80 and abs(offset_y) < 80:
             offset_x += 100 if offset_x >= 0 else -100
 
-        # 중심 카테고리 좌표를 기준으로 난수 오프셋 연산
-        base_x = category_positions.get(category, {}).get("x", 0.0)
-        base_y = category_positions.get(category, {}).get("y", 0.0)
-        
-        pos_x = base_x + offset_x
-        pos_y = base_y + offset_y
+        base_x = _PARA_CATEGORY_POSITIONS.get(category, {}).get("x", 0.0)
+        base_y = _PARA_CATEGORY_POSITIONS.get(category, {}).get("y", 0.0)
 
         file_nodes.append(
             GraphNode(
@@ -145,8 +145,8 @@ async def get_graph_data() -> GraphDataResponse:
                 properties={
                     "para_category": category,
                 },
-                position_x=pos_x,
-                position_y=pos_y,
+                position_x=base_x + offset_x,
+                position_y=base_y + offset_y,
                 user_id_hash=hashed_uid,
             )
         )
@@ -164,3 +164,78 @@ async def get_graph_data() -> GraphDataResponse:
     edges.extend(file_edges)
 
     return GraphDataResponse(nodes=nodes, edges=edges)
+
+
+# ─────────────────────────────────────────
+# 엔드포인트
+# ─────────────────────────────────────────
+
+
+@router.get(
+    "/data",
+    response_model=GraphDataResponse,
+    summary="PARA 기반 지식 그래프 데이터 조회",
+    description=(
+        "PARA 방법론(Projects/Areas/Resources/Archive) 기반으로 구성된 "
+        "노트 간의 노드-엣지 데이터를 반환합니다. "
+        "프론트엔드 react-force-graph 시각화에 사용됩니다.\n\n"
+        "[SSOT] 응답 스키마는 `backend.schemas.graph.GraphDataResponse`를 단일 진실 공급원으로 합니다."
+    ),
+)
+async def get_graph_data() -> GraphDataResponse:
+    """
+    PARA Graph View를 위한 노드와 엣지 데이터를 SSOT 스키마 형식으로 반환합니다.
+
+    [v1] 현재는 PARA 카테고리 계층 관계(EdgeRelationshipType.PARA_CATEGORY)만 표현합니다.
+    Phase 4-1에서 명시적/암묵적 관계 추출 파이프라인이 연동되면 확장됩니다.
+    """
+    return _build_graph_data()
+
+
+@router.get(
+    "/orphans",
+    response_model=OrphanNotesResponse,
+    summary="고립 노트(Orphan Notes) 감지",
+    description=(
+        "전체 그래프에서 엣지 차수(Degree)가 0이거나 극도로 낮은 "
+        "'고립 노트(Orphan Notes)'를 감지하여 반환합니다.\n\n"
+        "임계값은 ORPHAN_DEGREE_THRESHOLD 환경 변수(기본값: 0)로 제어합니다.\n\n"
+        "[SSOT] 응답 스키마는 `backend.schemas.graph.OrphanNotesResponse`를 "
+        "단일 진실 공급원으로 합니다."
+    ),
+)
+async def get_orphan_notes() -> OrphanNotesResponse:
+    """
+    고립 노트(Orphan Notes)를 감지하여 OrphanNotesResponse로 반환합니다.
+
+    [알고리즘]
+    1. _build_graph_data()로 현재 그래프의 전체 노드/엣지를 로드.
+    2. find_orphan_nodes()로 ORPHAN_DEGREE_THRESHOLD 이하 차수의 노드를 필터링.
+    3. CATEGORY 노드는 구조적 루트이므로 고립 감지에서 제외.
+    4. 차수 오름차순으로 정렬하여 반환.
+
+    [ORPHAN_DEGREE_THRESHOLD]
+    - 기본값: 0 (완전 고립 노드만 감지)
+    - 범위: 0~100
+    - 파싱 실패 시: 기본값 폴백 + WARNING 로그
+    """
+    graph_data = _build_graph_data()
+
+    # CATEGORY 노드를 total_nodes 카운트에서 제외 (분석 대상 노드만 집계)
+    analyzable_nodes = [
+        node for node in graph_data.nodes
+        if node.node_type != NodeType.CATEGORY
+    ]
+
+    orphans = find_orphan_nodes(
+        nodes=graph_data.nodes,
+        edges=graph_data.edges,
+    )
+
+    threshold = get_orphan_degree_threshold()
+
+    return OrphanNotesResponse(
+        orphans=orphans,
+        total_nodes=len(analyzable_nodes),
+        degree_threshold=threshold,
+    )

--- a/backend/api/endpoints/graph.py
+++ b/backend/api/endpoints/graph.py
@@ -227,12 +227,13 @@ async def get_orphan_notes() -> OrphanNotesResponse:
         if node.node_type != NodeType.CATEGORY
     ]
 
+    threshold = get_orphan_degree_threshold()
+
     orphans = find_orphan_nodes(
         nodes=graph_data.nodes,
         edges=graph_data.edges,
+        degree_threshold=threshold,
     )
-
-    threshold = get_orphan_degree_threshold()
 
     return OrphanNotesResponse(
         orphans=orphans,

--- a/backend/graph/__init__.py
+++ b/backend/graph/__init__.py
@@ -8,8 +8,10 @@
     NetworkXGraphRepository   — networkx 기반 인메모리/파일시스템 구현체
     build_graph_path          — 테넌트 격리 경로 빌더 (공유 헬퍼)
     EntityEdgeExtractor       — 마크다운 및 LLM 기반 명시/암묵적 엣지 추출기
+    find_orphan_nodes         — 고립 노트(Orphan Notes) 감지 알고리즘 (Phase 4-4)
 """
 
+from backend.graph.analysis import find_orphan_nodes, get_orphan_degree_threshold
 from backend.graph.base import AbstractGraphRepository
 from backend.graph.networkx_repository import NetworkXGraphRepository
 from backend.graph.path_utils import build_graph_path
@@ -20,4 +22,7 @@ __all__ = [
     "NetworkXGraphRepository",
     "build_graph_path",
     "EntityEdgeExtractor",
+    "find_orphan_nodes",
+    "get_orphan_degree_threshold",
 ]
+

--- a/backend/graph/analysis.py
+++ b/backend/graph/analysis.py
@@ -1,0 +1,189 @@
+# backend/graph/analysis.py
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Phase 4-4: 지식 그래프 연결성 분석 알고리즘 (고립 노트 감지)
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#
+# 설계 원칙:
+#   - 순수 함수(Pure Function) 기반 — 부작용 없음, 단위 테스트 용이.
+#   - 엔진 불가지론적 — AbstractGraphRepository 의존 없이 GraphNode/GraphEdge만 사용.
+#   - 하드코딩 금지 — 모든 임계값은 환경 변수(ORPHAN_DEGREE_THRESHOLD)에서 로드.
+#   - PII 보안 — user_id 원문에 절대 접근하지 않음. GraphNode.user_id_hash만 사용.
+#   - 테넌트 격리 — 함수 인자로 이미 격리된 nodes/edges를 받음. 호출 측에서 격리 보장 필요.
+#
+# [ORPHAN_DEGREE_THRESHOLD 환경 변수 규격]
+#   타입  : int
+#   기본값: 0   (엣지가 0개인 완전 고립 노드만 감지)
+#   범위  : 0 ~ 100
+#   파싱 오류 시: 기본값 폴백 + WARNING 로그
+#   범위 초과 시: Clamp 처리 + WARNING 로그
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Sequence
+
+from backend.schemas.graph import GraphEdge, GraphNode, NodeType, OrphanNode
+
+logger = logging.getLogger(__name__)
+
+# ─────────────────────────────────────────
+# 환경 변수 상수 (하드코딩 금지)
+# ─────────────────────────────────────────
+
+_ENV_ORPHAN_DEGREE_THRESHOLD = "ORPHAN_DEGREE_THRESHOLD"
+_DEFAULT_ORPHAN_DEGREE_THRESHOLD: int = 0
+_MIN_ORPHAN_DEGREE_THRESHOLD: int = 0
+_MAX_ORPHAN_DEGREE_THRESHOLD: int = 100
+
+
+# ─────────────────────────────────────────
+# 내부 헬퍼
+# ─────────────────────────────────────────
+
+
+def get_orphan_degree_threshold() -> int:
+    """
+    ORPHAN_DEGREE_THRESHOLD 환경 변수에서 임계값을 로드한다.
+
+    - 환경 변수 미설정 시: 기본값 반환
+    - 파싱 실패 시: 기본값 폴백 + WARNING 로그
+    - 범위(0~100) 초과 시: Clamp 처리 + WARNING 로그
+
+    이 함수는 매 호출 시 환경 변수를 다시 읽으므로, 런타임 환경 변수 변경도 즉시 반영된다.
+
+    Returns:
+        유효한 정수 임계값 (항상 [MIN, MAX] 범위 내 보장)
+    """
+    raw = os.environ.get(_ENV_ORPHAN_DEGREE_THRESHOLD)
+    if raw is None:
+        return _DEFAULT_ORPHAN_DEGREE_THRESHOLD
+
+    try:
+        value = int(raw.strip())
+    except (ValueError, AttributeError):
+        logger.warning(
+            "[GRAPH][ORPHAN] %s=%r 는 유효하지 않은 정수입니다. 기본값 %d 로 폴백합니다.",
+            _ENV_ORPHAN_DEGREE_THRESHOLD,
+            raw,
+            _DEFAULT_ORPHAN_DEGREE_THRESHOLD,
+        )
+        return _DEFAULT_ORPHAN_DEGREE_THRESHOLD
+
+    clamped = max(_MIN_ORPHAN_DEGREE_THRESHOLD, min(_MAX_ORPHAN_DEGREE_THRESHOLD, value))
+    if clamped != value:
+        logger.warning(
+            "[GRAPH][ORPHAN] %s=%d 는 허용 범위 [%d, %d] 를 벗어났습니다. %d 로 Clamp 처리합니다.",
+            _ENV_ORPHAN_DEGREE_THRESHOLD,
+            value,
+            _MIN_ORPHAN_DEGREE_THRESHOLD,
+            _MAX_ORPHAN_DEGREE_THRESHOLD,
+            clamped,
+        )
+    return clamped
+
+
+def _build_degree_map(edges: Sequence[GraphEdge]) -> dict[str, int]:
+    """
+    엣지 목록에서 노드별 전체 차수(in-degree + out-degree) 맵을 계산한다.
+
+    방향 그래프(Directed Graph)에서 고립 여부는 방향에 무관한
+    전체 연결 수(in + out)로 판별한다.
+
+    Args:
+        edges: 분석 대상 엣지 목록
+
+    Returns:
+        {node_id: total_degree} 딕셔너리.
+        엣지가 없는 노드는 포함되지 않음 (degree=0으로 간주).
+    """
+    degree: dict[str, int] = {}
+    for edge in edges:
+        degree[edge.source] = degree.get(edge.source, 0) + 1
+        degree[edge.target] = degree.get(edge.target, 0) + 1
+    return degree
+
+
+# ─────────────────────────────────────────
+# 공개 API
+# ─────────────────────────────────────────
+
+
+def find_orphan_nodes(
+    nodes: Sequence[GraphNode],
+    edges: Sequence[GraphEdge],
+    degree_threshold: int | None = None,
+) -> list[OrphanNode]:
+    """
+    고립 노트(Orphan Notes)를 필터링하여 반환한다.
+
+    전체 차수(in-degree + out-degree)가 degree_threshold 이하인 노드를
+    고립 노드로 분류하고, 차수 오름차순으로 정렬하여 반환한다.
+
+    [감지 제외 대상]
+    CATEGORY 노드(Projects/Areas/Resources/Archive)는 구조적 루트 노드이므로
+    엣지가 없더라도 고립 감지 대상에서 반드시 제외한다.
+
+    [테넌트 격리 계약]
+    이 함수는 이미 테넌트 격리된 nodes/edges를 입력으로 받는다.
+    호출 측에서 hashed_user_id 기반으로 필터링된 데이터를 전달해야 한다.
+    이 함수 내부에서 추가적인 테넌트 격리를 수행하지 않는다.
+
+    [PII 보안]
+    GraphNode.user_id_hash는 mask_pii_id()를 통해 이미 해싱된 값만 허용한다.
+    이 함수는 user_id 원문에 접근하지 않는다.
+
+    Args:
+        nodes: 분석 대상 그래프 노드 목록 (테넌트 격리 완료)
+        edges: 분석 대상 그래프 엣지 목록 (테넌트 격리 완료)
+        degree_threshold: 고립 노드 판별 임계값.
+                          None이면 ORPHAN_DEGREE_THRESHOLD 환경 변수에서 로드.
+                          이 인자를 직접 전달하면 환경 변수보다 우선한다 (테스트 용이성).
+
+    Returns:
+        OrphanNode 목록 — 차수 오름차순 정렬.
+        빈 그래프이거나 고립 노드가 없으면 빈 리스트를 반환한다.
+    """
+    if degree_threshold is None:
+        degree_threshold = get_orphan_degree_threshold()
+
+    degree_map = _build_degree_map(edges)
+
+    orphans: list[OrphanNode] = []
+    for node in nodes:
+        # CATEGORY 노드는 구조적 루트 노드이므로 고립 감지 제외
+        if node.node_type == NodeType.CATEGORY:
+            continue
+
+        node_degree = degree_map.get(node.id, 0)
+        if node_degree <= degree_threshold:
+            orphans.append(
+                OrphanNode(
+                    id=node.id,
+                    label=node.label,
+                    node_type=node.node_type,
+                    properties=node.properties,
+                    degree=node_degree,
+                    user_id_hash=node.user_id_hash,
+                )
+            )
+            logger.debug(
+                "[GRAPH][ORPHAN] 고립 노드 감지 (id_prefix=%s, degree=%d).",
+                node.id[:8] if node.id else "<empty>",
+                node_degree,
+            )
+
+    # 차수 오름차순 정렬 (degree=0 완전 고립 노드가 최상단)
+    orphans.sort(key=lambda n: n.degree)
+
+    logger.info(
+        "[GRAPH][ORPHAN] 고립 노드 감지 완료: 전체=%d, 감지=%d, 임계값=%d.",
+        len(nodes),
+        len(orphans),
+        degree_threshold,
+    )
+    return orphans
+
+
+__all__ = ["find_orphan_nodes", "get_orphan_degree_threshold"]

--- a/backend/schemas/graph.py
+++ b/backend/schemas/graph.py
@@ -195,6 +195,89 @@ class GraphDataResponse(BaseModel):
 
 
 # ─────────────────────────────────────────
+# Phase 4-4: 고립 노트 감지 모델 (v1)
+# ─────────────────────────────────────────
+
+
+class OrphanNode(BaseModel):
+    """
+    고립 노트(Orphan Note) 모델 — 연결 차수가 낮거나 없는 노드. [SSOT - v1]
+
+    find_orphan_nodes() 알고리즘이 반환하는 분석 결과 단위.
+
+    [PII 보안 정책]
+    GraphNode와 동일한 user_id_hash 보안 정책을 적용합니다.
+    user_id 원문은 절대 저장/직렬화되지 않습니다.
+    """
+
+    id: str = Field(..., description="노드 고유 식별자")
+    label: str = Field(..., description="시각화 UI에 표시될 노드 이름")
+    node_type: NodeType = Field(
+        default=NodeType.NOTE,
+        description="노드 종류. NodeType enum 참조.",
+    )
+    properties: dict[str, Any] = Field(
+        default_factory=dict,
+        description="노드에 연결된 추가 메타데이터.",
+    )
+    degree: int = Field(
+        ...,
+        ge=0,
+        description=(
+            "이 노드의 전체 차수 (in-degree + out-degree). "
+            "0이면 완전 고립 노드(Isolated Node)."
+        ),
+    )
+    user_id_hash: Optional[str] = Field(
+        default=None,
+        description=(
+            "소유자 해시 ID (mask_pii_id() 반환값만 허용, PII 원문 금지)."
+        ),
+    )
+
+    @field_validator("user_id_hash")
+    @classmethod
+    def ensure_user_id_is_hashed(cls, v: Optional[str]) -> Optional[str]:
+        """
+        [보안 강화] GraphNode와 동일한 PII 보안 정책 — 해싱된 값만 허용.
+        """
+        if v is None:
+            return None
+        if v == INVALID_PII_SENTINEL:
+            return v
+        if not USER_ID_HASH_PATTERN.fullmatch(v):
+            raise ValueError(
+                "PII 보안 경고: user_id_hash 필드에 안전하지 않은 값이 입력되었습니다. "
+                "반드시 mask_pii_id(raw_user_id)를 통해 해싱된 값을 전달해야 합니다."
+            )
+        return v
+
+
+class OrphanNotesResponse(BaseModel):
+    """
+    고립 노트 감지 API 엔드포인트의 표준 응답 모델. [SSOT - v1]
+
+    [OpenAPI 동기화]
+    이 모델은 FastAPI의 response_model에 반드시 지정되어야 합니다.
+    """
+
+    orphans: list[OrphanNode] = Field(
+        default_factory=list,
+        description="감지된 고립 노드 목록 (차수 오름차순 정렬).",
+    )
+    total_nodes: int = Field(
+        ...,
+        ge=0,
+        description="분석 대상 전체 노드 수 (CATEGORY 노드 제외).",
+    )
+    degree_threshold: int = Field(
+        ...,
+        ge=0,
+        description="고립 노드 판별에 사용된 차수 임계값 (ORPHAN_DEGREE_THRESHOLD 환경 변수).",
+    )
+
+
+# ─────────────────────────────────────────
 # v1 Versioning Namespace (Breaking Change 대비)
 # ─────────────────────────────────────────
 #
@@ -222,6 +305,9 @@ __all__ = [
     "GraphNode",
     "GraphEdge",
     "GraphDataResponse",
+    # Phase 4-4: 고립 노트 감지 모델
+    "OrphanNode",
+    "OrphanNotesResponse",
     # v1 Versioning Aliases
     "GraphNodeV1",
     "GraphEdgeV1",


### PR DESCRIPTION
- **[분석 코어] 순수 함수 기반 고립 노트 감지 알고리즘 구현**
  - `backend/graph/analysis.py` 신설: `find_orphan_nodes()`를 통해 in-degree와 out-degree의 합이 지정된 임계값 이하인 노드를 추출 및 오름차순 정렬.
  - `get_orphan_degree_threshold()`를 통해 `ORPHAN_DEGREE_THRESHOLD` 환경 변수 로드 (기본값 0, 범위 0~100 유효성 검사 적용).
  - `CATEGORY` 노드는 구조적 루트이므로 고립 탐지 대상에서 제외 처리.

- **[데이터 계약] OrphanNode 및 OrphanNotesResponse 스키마 추가**
  - `backend/schemas/graph.py`에 고립 노트를 위한 모델 추가.
  - `GraphNode`와 동일하게 원본 `user_id`를 차단하고 해싱된 값만 저장하는 PII 보안 검증 로직(`INVALID_PII_SENTINEL` 등) 적용.

- **[API 계층] /api/graph/orphans 엔드포인트 신설**
  - 기존 `/api/graph/data` 의 중복 DB 조회 로직을 `_build_graph_data()` 내부 헬퍼로 추출.
  - `/orphans` 엔드포인트에서 이 헬퍼로 불러온 전체 노드/엣지 데이터를 순수 함수 파이프라인에 주입하여 결과를 반환하도록 통합.

🔗 Related: Issue [#1048]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

지식 그래프 API에 고아 노트(연결되지 않은 노트) 감지 기능을 추가하고, 재사용을 위한 그래프 데이터 구성 로직을 중앙집중화합니다.

새 기능:
- 환경 변수를 통해 구성 가능한 차수 임계값을 사용하는, 순수 함수 기반의 고아 노드 감지 알고리즘을 도입합니다.
- 전용 응답 스키마를 활용하여 감지된 고아 노트와 관련 메타데이터를 반환하는 새로운 `/graph/orphans` API 엔드포인트를 제공합니다.

개선 사항:
- 그래프 데이터 구성을 재사용 가능한 `_build_graph_data()` 헬퍼로 리팩터링하고, PARA 카테고리 레이아웃을 공용 상수로 추출하여 여러 엔드포인트에서 일관되게 사용합니다.
- 코드베이스 전반에서 사용할 수 있도록, 새로운 고아 노트 모델을 그래프 스키마 export 대상에 포함시킵니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add orphan note detection capabilities to the knowledge graph API and centralize graph data construction for reuse.

New Features:
- Introduce a pure-function-based orphan node detection algorithm with configurable degree threshold via environment variable.
- Expose a new /graph/orphans API endpoint returning detected orphan notes and related metadata using dedicated response schemas.

Enhancements:
- Refactor graph data assembly into a reusable _build_graph_data() helper and extract PARA category layout into a shared constant for consistent use across endpoints.
- Extend graph schema exports to include new orphan note models for use across the codebase.

</details>