### PR TITLE
☘️ refactor [#12.3.17]: 4차 개선 - 내부 헬퍼 캡슐화, 명시적 클램핑 로깅 및 문서화 개선

### DIFF
--- a/backend/graph/__init__.py
+++ b/backend/graph/__init__.py
@@ -11,7 +11,7 @@
     find_orphan_nodes         — 고립 노트(Orphan Notes) 감지 알고리즘 (Phase 4-4)
 """
 
-from backend.graph.analysis import clamp_orphan_degree_threshold, find_orphan_nodes, get_orphan_degree_threshold
+from backend.graph.analysis import find_orphan_nodes, get_orphan_degree_threshold
 from backend.graph.base import AbstractGraphRepository
 from backend.graph.networkx_repository import NetworkXGraphRepository
 from backend.graph.path_utils import build_graph_path
@@ -24,6 +24,5 @@ __all__ = [
     "EntityEdgeExtractor",
     "find_orphan_nodes",
     "get_orphan_degree_threshold",
-    "clamp_orphan_degree_threshold",
 ]
 

--- a/backend/graph/analysis.py
+++ b/backend/graph/analysis.py
@@ -43,7 +43,7 @@ _MAX_ORPHAN_DEGREE_THRESHOLD: int = 100
 # ─────────────────────────────────────────
 
 
-def clamp_orphan_degree_threshold(value: int) -> int:
+def _clamp_orphan_degree_threshold(value: int) -> int:
     """
     주어진 임계값을 안전한 [MIN, MAX] 범위 내로 정규화(Clamp)한다.
 
@@ -51,7 +51,7 @@ def clamp_orphan_degree_threshold(value: int) -> int:
         value: 클램프할 원본 정수 값
 
     Returns:
-        최소 0, 최대 100 사이로 보정된 정수 값
+        설정된 최소/최대 고립 노드 차수 임계값 상수를 기반으로 보정된 정수 값
     """
     return max(_MIN_ORPHAN_DEGREE_THRESHOLD, min(_MAX_ORPHAN_DEGREE_THRESHOLD, value))
 
@@ -84,7 +84,7 @@ def get_orphan_degree_threshold() -> int:
         )
         return _DEFAULT_ORPHAN_DEGREE_THRESHOLD
 
-    clamped = clamp_orphan_degree_threshold(value)
+    clamped = _clamp_orphan_degree_threshold(value)
     if clamped != value:
         logger.warning(
             "[GRAPH][ORPHAN] %s=%d 는 허용 범위 [%d, %d] 를 벗어났습니다. %d 로 Clamp 처리합니다.",
@@ -161,7 +161,14 @@ def find_orphan_nodes(
     if degree_threshold is None:
         degree_threshold = get_orphan_degree_threshold()
     else:
-        degree_threshold = clamp_orphan_degree_threshold(degree_threshold)
+        clamped = _clamp_orphan_degree_threshold(degree_threshold)
+        if clamped != degree_threshold:
+            logger.warning(
+                "[GRAPH][ORPHAN] 전달된 degree_threshold=%d 가 허용 범위를 벗어났습니다. %d 로 Clamp 처리합니다.",
+                degree_threshold,
+                clamped,
+            )
+        degree_threshold = clamped
 
     degree_map = _build_degree_map(edges)
 
@@ -201,4 +208,4 @@ def find_orphan_nodes(
     return orphans
 
 
-__all__ = ["find_orphan_nodes", "get_orphan_degree_threshold", "clamp_orphan_degree_threshold"]
+__all__ = ["find_orphan_nodes", "get_orphan_degree_threshold"]

--- a/backend/graph/analysis.py
+++ b/backend/graph/analysis.py
@@ -43,17 +43,29 @@ _MAX_ORPHAN_DEGREE_THRESHOLD: int = 100
 # ─────────────────────────────────────────
 
 
-def _clamp_orphan_degree_threshold(value: int) -> int:
+def _clamp_orphan_degree_threshold(value: int, source: str = "환경 변수") -> int:
     """
     주어진 임계값을 안전한 [MIN, MAX] 범위 내로 정규화(Clamp)한다.
+    값이 변경되었을 경우 경고 로그를 출력한다.
 
     Args:
         value: 클램프할 원본 정수 값
+        source: 로깅 시 표시할 값의 출처 (예: "환경 변수", "전달된 인자")
 
     Returns:
         설정된 최소/최대 고립 노드 차수 임계값 상수를 기반으로 보정된 정수 값
     """
-    return max(_MIN_ORPHAN_DEGREE_THRESHOLD, min(_MAX_ORPHAN_DEGREE_THRESHOLD, value))
+    clamped = max(_MIN_ORPHAN_DEGREE_THRESHOLD, min(_MAX_ORPHAN_DEGREE_THRESHOLD, value))
+    if clamped != value:
+        logger.warning(
+            "[GRAPH][ORPHAN] %s 기준 임계값 %d 는 허용 범위 [%d, %d] 를 벗어났습니다. %d 로 Clamp 처리합니다.",
+            source,
+            value,
+            _MIN_ORPHAN_DEGREE_THRESHOLD,
+            _MAX_ORPHAN_DEGREE_THRESHOLD,
+            clamped,
+        )
+    return clamped
 
 
 def get_orphan_degree_threshold() -> int:
@@ -84,17 +96,7 @@ def get_orphan_degree_threshold() -> int:
         )
         return _DEFAULT_ORPHAN_DEGREE_THRESHOLD
 
-    clamped = _clamp_orphan_degree_threshold(value)
-    if clamped != value:
-        logger.warning(
-            "[GRAPH][ORPHAN] %s=%d 는 허용 범위 [%d, %d] 를 벗어났습니다. %d 로 Clamp 처리합니다.",
-            _ENV_ORPHAN_DEGREE_THRESHOLD,
-            value,
-            _MIN_ORPHAN_DEGREE_THRESHOLD,
-            _MAX_ORPHAN_DEGREE_THRESHOLD,
-            clamped,
-        )
-    return clamped
+    return _clamp_orphan_degree_threshold(value, source=f"환경 변수({_ENV_ORPHAN_DEGREE_THRESHOLD})")
 
 
 def _build_degree_map(edges: Sequence[GraphEdge]) -> dict[str, int]:
@@ -161,14 +163,7 @@ def find_orphan_nodes(
     if degree_threshold is None:
         degree_threshold = get_orphan_degree_threshold()
     else:
-        clamped = _clamp_orphan_degree_threshold(degree_threshold)
-        if clamped != degree_threshold:
-            logger.warning(
-                "[GRAPH][ORPHAN] 전달된 degree_threshold=%d 가 허용 범위를 벗어났습니다. %d 로 Clamp 처리합니다.",
-                degree_threshold,
-                clamped,
-            )
-        degree_threshold = clamped
+        degree_threshold = _clamp_orphan_degree_threshold(degree_threshold, source="전달된 인자(degree_threshold)")
 
     degree_map = _build_degree_map(edges)
 


### PR DESCRIPTION
- [API 캡슐화] 클램프 헬퍼를 _clamp_orphan_degree_threshold로 변경하여 Private 속성을 부여하고, __init__.py 및 __all__의 공개 API 목록에서 제거하여 불필요한 외부 의존성 생성 방지

- [Predictability] find_orphan_nodes()에서 명시적 인자(degree_threshold)가 범위 밖이라서 클램핑(Clamp)될 경우, 조용히 넘기지 않고(Silent failure) 호출자에게 인지시키기 위해 logger.warning 피드백 추가

- [Docstring] 클램프 함수의 주석에서 [0, 100] 이라는 숫자 하드코딩을 제거하여 상수와 문서 간의 영구적인 동기화 보장

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1593#pullrequestreview-4465692519)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

고아 노드 차수 임계값을 보정(clamp)하는 헬퍼를 내부 구현 상세로 캡슐화하고, 입력값이 자동으로 보정될 때의 가시성을 개선합니다.

Enhancements:
- 고아 노드 차수 임계값 보정 헬퍼를 private으로 변경하고, 공개 그래프 API 표면에서 제거합니다.
- 제공된 `degree_threshold` 또는 설정 값이 허용 범위로 보정(clamp)될 때 고아 노드 분석에서 경고 로그를 추가합니다.
- 보정 헬퍼 문서를 수정하여, 하드코딩된 숫자 범위 대신 설정된 최소/최대 상수를 기준으로 보정을 설명합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Encapsulate the orphan degree threshold clamping helper as an internal implementation detail and improve visibility when inputs are auto-clamped.

Enhancements:
- Make the orphan degree threshold clamp helper private and remove it from the public graph API surface.
- Add warning logs in orphan node analysis when a provided degree_threshold or config value is clamped to the allowed range.
- Clarify clamp helper documentation to describe clamping in terms of configured min/max constants instead of hard-coded numeric bounds.

</details>