### PR TITLE
✨ feat [#12.3.18]: Phase 4-4 - ➁ 보안 격리 기반 고립 노트 스캔 백그라운드 스케줄러 구현

### DIFF
--- a/backend/api/endpoints/graph.py
+++ b/backend/api/endpoints/graph.py
@@ -39,131 +39,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/graph", tags=["Knowledge Graph (v1)"])
 
 
-# ─────────────────────────────────────────
-# 내부 헬퍼
-# ─────────────────────────────────────────
-
-
-def _is_valid_raw_user_id(raw_id: Any) -> bool:
-    """
-    원본 user_id가 해싱을 수행할 만큼 유효한 값인지 검증하는 헬퍼 함수입니다.
-    None, 빈 문자열(""), 공백 문자열("   ") 등은 결측치로 간주하여 False를 반환합니다.
-    숫자(예: 0) 등 그 외의 값은 유효한 Falsy/Truthy 값으로 간주하여 True를 반환합니다.
-    """
-    return raw_id is not None and (not isinstance(raw_id, str) or bool(raw_id.strip()))
-
-
-# PARA 카테고리 좌표 — 레이아웃 안정성을 위해 모듈 수준 상수로 관리
-# 하드코딩으로 보일 수 있으나, 이 값들은 PARA 방법론의 고정 구조를 표현하는
-# 디자인 상수(Design Constants)로, 환경 변수화 대상이 아닙니다.
-_PARA_CATEGORY_POSITIONS: dict[str, dict[str, float]] = {
-    "Projects": {"x": 0.0, "y": 0.0},
-    "Areas": {"x": 600.0, "y": 0.0},
-    "Resources": {"x": 0.0, "y": 600.0},
-    "Archive": {"x": 600.0, "y": 600.0},
-}
-
-
-def _build_graph_data() -> GraphDataResponse:
-    """
-    PARA 기반 지식 그래프 데이터를 DB에서 조회하여 GraphDataResponse를 빌드한다.
-
-    [책임 분리]
-    - get_graph_data()와 get_orphan_notes() 양쪽에서 재사용하여 중복 로직을 제거합니다.
-    - DB 연결 실패 시 CATEGORY 노드만 포함한 빈 응답을 반환합니다 (조용한 폴백).
-
-    Returns:
-        GraphDataResponse (nodes + edges)
-    """
-    # ─── PARA 카테고리 노드 (고정 시드 노드) ───────────────────────────────
-    nodes: list[GraphNode] = []
-    for cat, pos in _PARA_CATEGORY_POSITIONS.items():
-        try:
-            pos_x = pos["x"]
-            pos_y = pos["y"]
-        except KeyError as e:
-            raise RuntimeError(
-                f"지식 그래프 설정 오류: 카테고리 '{cat}'의 좌표({e})가 누락되었습니다."
-            ) from e
-
-        nodes.append(
-            GraphNode(
-                id=cat,
-                label=cat,
-                node_type=NodeType.CATEGORY,
-                properties={"para_category": cat},
-                position_x=pos_x,
-                position_y=pos_y,
-            )
-        )
-
-    edges: list[GraphEdge] = []
-
-    # ─── 파일 노드 및 카테고리→파일 엣지 생성 ────────────────────────────────
-    try:
-        with DatabaseConnection() as db:
-            files = db.get_files_with_para()
-    except Exception:
-        logger.exception("그래프 데이터 조회 중 DB 연결 실패. 빈 그래프를 반환합니다.")
-        return GraphDataResponse(nodes=nodes, edges=edges)
-
-    valid_category_ids = set(_PARA_CATEGORY_POSITIONS)
-
-    file_nodes: list[GraphNode] = []
-    file_edges: list[GraphEdge] = []
-
-    for file in files:
-        file_id = str(file["id"])
-        filename = file.get("filename", "")
-        category = file.get("para_category", "")
-
-        if not category or category not in valid_category_ids:
-            continue
-
-        # 파일 노드 ID: 'file-{id}' 형식 (GraphEdge.id 규약과 동일)
-        file_node_id = f"file-{file_id}"
-
-        # [PII 보안] user_id가 유효한 값(공백 제외)인 경우에만 해싱
-        raw_user_id = file.get("user_id")
-        hashed_uid = mask_pii_id(raw_user_id) if _is_valid_raw_user_id(raw_user_id) else None
-
-        # Deterministic position: 파일 ID 시드를 사용하여 리로드 시에도 레이아웃 안정 보장
-        rng = random.Random(file_id)
-        offset_x = rng.randint(-200, 200)
-        offset_y = rng.randint(-200, 200)
-        if abs(offset_x) < 80 and abs(offset_y) < 80:
-            offset_x += 100 if offset_x >= 0 else -100
-
-        base_x = _PARA_CATEGORY_POSITIONS.get(category, {}).get("x", 0.0)
-        base_y = _PARA_CATEGORY_POSITIONS.get(category, {}).get("y", 0.0)
-
-        file_nodes.append(
-            GraphNode(
-                id=file_node_id,
-                label=filename,
-                node_type=NodeType.NOTE,
-                properties={
-                    "para_category": category,
-                },
-                position_x=base_x + offset_x,
-                position_y=base_y + offset_y,
-                user_id_hash=hashed_uid,
-            )
-        )
-        file_edges.append(
-            GraphEdge(
-                id=f"e-{category}-{file_node_id}",
-                source=category,
-                target=file_node_id,
-                relationship_type=EdgeRelationshipType.PARA_CATEGORY,
-                weight=1.0,
-            )
-        )
-
-    nodes.extend(file_nodes)
-    edges.extend(file_edges)
-
-    return GraphDataResponse(nodes=nodes, edges=edges)
+from backend.graph.builder import build_graph_data
 
 
 # ─────────────────────────────────────────
@@ -189,7 +65,7 @@ async def get_graph_data() -> GraphDataResponse:
     [v1] 현재는 PARA 카테고리 계층 관계(EdgeRelationshipType.PARA_CATEGORY)만 표현합니다.
     Phase 4-1에서 명시적/암묵적 관계 추출 파이프라인이 연동되면 확장됩니다.
     """
-    return _build_graph_data()
+    return build_graph_data()
 
 
 @router.get(
@@ -219,7 +95,7 @@ async def get_orphan_notes() -> OrphanNotesResponse:
     - 범위: 0~100
     - 파싱 실패 시: 기본값 폴백 + WARNING 로그
     """
-    graph_data = _build_graph_data()
+    graph_data = build_graph_data()
 
     # CATEGORY 노드를 total_nodes 카운트에서 제외 (분석 대상 노드만 집계)
     analyzable_nodes = [

--- a/backend/celery_app/celery.py
+++ b/backend/celery_app/celery.py
@@ -52,4 +52,9 @@ app.conf.beat_schedule = {
         "task": "backend.celery_app.tasks.maintenance.cleanup_old_logs",
         "schedule": crontab(hour=4, minute=0, day_of_week=0),
     },
+    # 8. 고립 노트 스캔 (Daily - 매일 새벽 5시)
+    "daily-orphan-notes-scan": {
+        "task": "backend.celery_app.tasks.graph.detect_orphan_notes_for_all_users",
+        "schedule": crontab(hour=5, minute=0),
+    },
 }

--- a/backend/celery_app/tasks/__init__.py
+++ b/backend/celery_app/tasks/__init__.py
@@ -10,4 +10,5 @@ from . import (
     monitoring,
     maintenance,
     classification,  # Added classification task
+    graph,           # Knowledge Graph background tasks
 )

--- a/backend/celery_app/tasks/graph.py
+++ b/backend/celery_app/tasks/graph.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from typing import Dict, List
 
 from backend.celery_app.celery import app
-from backend.api.endpoints.graph import _build_graph_data
+from backend.graph.builder import build_graph_data
 from backend.graph.analysis import find_orphan_nodes, get_orphan_degree_threshold
 from backend.schemas.graph import NodeType, GraphNode
 
@@ -22,7 +22,7 @@ def detect_orphan_notes_for_all_users(self):
     logger.info("[%s] 전역 고립 노트 스캔 스케줄러가 시작되었습니다.", task_name)
     
     # 1. 전체 데이터베이스에서 노드와 엣지 빌드 (내부적으로 PARA CATEGORY 등 포함)
-    graph_data = _build_graph_data()
+    graph_data = build_graph_data()
     threshold = get_orphan_degree_threshold()
     
     # 2. 사용자별 노드 그룹화 (보안 필수 요건: hashed_user_id 기반 컨텍스트 주입 및 격리)
@@ -33,8 +33,12 @@ def detect_orphan_notes_for_all_users(self):
             continue
         
         # 보안 장치: PII 마스킹된 hashed_user_id를 기준 키로 사용
-        # 식별되지 않은 파일의 경우 "unassigned" 풀로 격리
-        uid = node.user_id_hash or "unassigned"
+        # 식별되지 않은 파일의 경우 분석 대상에서 제외하여 테넌트 믹스(Data Leakage) 원천 차단
+        if not node.user_id_hash:
+            logger.warning("[%s] user_id_hash가 없는 노드(%s) 발견. 보안 격리를 위해 스캔에서 제외합니다.", task_name, node.id)
+            continue
+            
+        uid = node.user_id_hash
         nodes_by_user[uid].append(node)
         
     total_orphans_found = 0
@@ -50,7 +54,7 @@ def detect_orphan_notes_for_all_users(self):
         user_node_ids = {n.id for n in user_nodes}
         user_edges = [
             e for e in graph_data.edges 
-            if e.source in user_node_ids or e.target in user_node_ids
+            if e.source in user_node_ids and e.target in user_node_ids
         ]
         
         # 해당 사용자 컨텍스트 안에서만 orphan 판별

--- a/backend/celery_app/tasks/graph.py
+++ b/backend/celery_app/tasks/graph.py
@@ -1,0 +1,72 @@
+# backend/celery_app/tasks/graph.py
+
+import logging
+from collections import defaultdict
+from typing import Dict, List
+
+from backend.celery_app.celery import app
+from backend.api.endpoints.graph import _build_graph_data
+from backend.graph.analysis import find_orphan_nodes, get_orphan_degree_threshold
+from backend.schemas.graph import NodeType, GraphNode
+
+logger = logging.getLogger(__name__)
+
+@app.task(bind=True)
+def detect_orphan_notes_for_all_users(self):
+    """
+    [고립 노트 감지 워커]
+    전체 그래프 데이터에서 사용자별로 컨텍스트를 완벽히 격리한 후 고립 노트를 스캔합니다.
+    (Data Leakage 방지: 타 사용자의 노트 내용 섞임 원천 차단)
+    """
+    task_name = "detect-orphan-notes"
+    logger.info("[%s] 전역 고립 노트 스캔 스케줄러가 시작되었습니다.", task_name)
+    
+    # 1. 전체 데이터베이스에서 노드와 엣지 빌드 (내부적으로 PARA CATEGORY 등 포함)
+    graph_data = _build_graph_data()
+    threshold = get_orphan_degree_threshold()
+    
+    # 2. 사용자별 노드 그룹화 (보안 필수 요건: hashed_user_id 기반 컨텍스트 주입 및 격리)
+    nodes_by_user: Dict[str, List[GraphNode]] = defaultdict(list)
+    
+    for node in graph_data.nodes:
+        if node.node_type == NodeType.CATEGORY:
+            continue
+        
+        # 보안 장치: PII 마스킹된 hashed_user_id를 기준 키로 사용
+        # 식별되지 않은 파일의 경우 "unassigned" 풀로 격리
+        uid = node.user_id_hash or "unassigned"
+        nodes_by_user[uid].append(node)
+        
+    total_orphans_found = 0
+    users_scanned = len(nodes_by_user)
+    
+    logger.info("[%s] 총 %d명의 사용자 격리 컨텍스트가 준비되었습니다.", task_name, users_scanned)
+    
+    # 3. 각 격리된 테넌트 컨텍스트 내에서 스캔 수행
+    for uid, user_nodes in nodes_by_user.items():
+        logger.debug("[%s] 사용자 컨텍스트 스캔 시작 (user_id_hash=%s, 노드 수=%d)", task_name, uid, len(user_nodes))
+        
+        # 엣지 필터링: 해당 사용자의 노드 간 연결만 추출 (교차 접근 차단)
+        user_node_ids = {n.id for n in user_nodes}
+        user_edges = [
+            e for e in graph_data.edges 
+            if e.source in user_node_ids or e.target in user_node_ids
+        ]
+        
+        # 해당 사용자 컨텍스트 안에서만 orphan 판별
+        if orphans := find_orphan_nodes(
+            nodes=user_nodes,
+            edges=user_edges,
+            degree_threshold=threshold,
+        ):
+            logger.info(
+                "[%s] user_id_hash=%s 컨텍스트에서 %d개의 고립 노트를 발견했습니다.", 
+                task_name, uid, len(orphans)
+            )
+            total_orphans_found += len(orphans)
+            
+            # TODO: 향후 이 시점에서 사용자에게 '연결 추천' Notification/Email 트리거 로직 추가 가능
+            
+    logger.info("[%s] 전역 스캔 완료. 총 %d명의 사용자에 대해 %d개의 고립 노트를 감지했습니다.", task_name, users_scanned, total_orphans_found)
+    
+    return f"Success: {users_scanned} users scanned, {total_orphans_found} orphans found."

--- a/backend/graph/builder.py
+++ b/backend/graph/builder.py
@@ -1,0 +1,135 @@
+# backend/graph/builder.py
+import logging
+import random
+from typing import Any
+
+from backend.database.connection import DatabaseConnection
+from backend.schemas.graph import (
+    EdgeRelationshipType,
+    GraphDataResponse,
+    GraphEdge,
+    GraphNode,
+    NodeType,
+)
+from backend.utils.common import mask_pii_id
+
+logger = logging.getLogger(__name__)
+
+def _is_valid_raw_user_id(raw_id: Any) -> bool:
+    """
+    원본 user_id가 해싱을 수행할 만큼 유효한 값인지 검증하는 헬퍼 함수입니다.
+    None, 빈 문자열(""), 공백 문자열("   ") 등은 결측치로 간주하여 False를 반환합니다.
+    숫자(예: 0) 등 그 외의 값은 유효한 Falsy/Truthy 값으로 간주하여 True를 반환합니다.
+    """
+    return raw_id is not None and (not isinstance(raw_id, str) or bool(raw_id.strip()))
+
+# PARA 카테고리 좌표 — 레이아웃 안정성을 위해 모듈 수준 상수로 관리
+# 하드코딩으로 보일 수 있으나, 이 값들은 PARA 방법론의 고정 구조를 표현하는
+# 디자인 상수(Design Constants)로, 환경 변수화 대상이 아닙니다.
+_PARA_CATEGORY_POSITIONS: dict[str, dict[str, float]] = {
+    "Projects": {"x": 0.0, "y": 0.0},
+    "Areas": {"x": 600.0, "y": 0.0},
+    "Resources": {"x": 0.0, "y": 600.0},
+    "Archive": {"x": 600.0, "y": 600.0},
+}
+
+def build_graph_data() -> GraphDataResponse:
+    """
+    PARA 기반 지식 그래프 데이터를 DB에서 조회하여 GraphDataResponse를 빌드한다.
+
+    [책임 분리]
+    - API 엔드포인트(get_graph_data, get_orphan_notes) 및 백그라운드 태스크에서 재사용합니다.
+    - DB 연결 실패 시 CATEGORY 노드만 포함한 빈 응답을 반환합니다 (조용한 폴백).
+
+    Returns:
+        GraphDataResponse (nodes + edges)
+    """
+    # ─── PARA 카테고리 노드 (고정 시드 노드) ───────────────────────────────
+    nodes: list[GraphNode] = []
+    for cat, pos in _PARA_CATEGORY_POSITIONS.items():
+        try:
+            pos_x = pos["x"]
+            pos_y = pos["y"]
+        except KeyError as e:
+            raise RuntimeError(
+                f"지식 그래프 설정 오류: 카테고리 '{cat}'의 좌표({e})가 누락되었습니다."
+            ) from e
+
+        nodes.append(
+            GraphNode(
+                id=cat,
+                label=cat,
+                node_type=NodeType.CATEGORY,
+                properties={"para_category": cat},
+                position_x=pos_x,
+                position_y=pos_y,
+            )
+        )
+
+    edges: list[GraphEdge] = []
+
+    # ─── 파일 노드 및 카테고리→파일 엣지 생성 ────────────────────────────────
+    try:
+        with DatabaseConnection() as db:
+            files = db.get_files_with_para()
+    except Exception:
+        logger.exception("그래프 데이터 조회 중 DB 연결 실패. 빈 그래프를 반환합니다.")
+        return GraphDataResponse(nodes=nodes, edges=edges)
+
+    valid_category_ids = set(_PARA_CATEGORY_POSITIONS)
+
+    file_nodes: list[GraphNode] = []
+    file_edges: list[GraphEdge] = []
+
+    for file in files:
+        file_id = str(file.get("id"))
+        filename = file.get("filename", "")
+        category = file.get("para_category", "")
+
+        if not category or category not in valid_category_ids:
+            continue
+
+        # 파일 노드 ID: 'file-{id}' 형식 (GraphEdge.id 규약과 동일)
+        file_node_id = f"file-{file_id}"
+
+        # [PII 보안] user_id가 유효한 값(공백 제외)인 경우에만 해싱
+        raw_user_id = file.get("user_id")
+        hashed_uid = mask_pii_id(raw_user_id) if _is_valid_raw_user_id(raw_user_id) else None
+
+        # Deterministic position: 파일 ID 시드를 사용하여 리로드 시에도 레이아웃 안정 보장
+        rng = random.Random(file_id)
+        offset_x = rng.randint(-200, 200)
+        offset_y = rng.randint(-200, 200)
+        if abs(offset_x) < 80 and abs(offset_y) < 80:
+            offset_x += 100 if offset_x >= 0 else -100
+
+        base_x = _PARA_CATEGORY_POSITIONS.get(category, {}).get("x", 0.0)
+        base_y = _PARA_CATEGORY_POSITIONS.get(category, {}).get("y", 0.0)
+
+        file_nodes.append(
+            GraphNode(
+                id=file_node_id,
+                label=filename,
+                node_type=NodeType.NOTE,
+                properties={
+                    "para_category": category,
+                },
+                position_x=base_x + offset_x,
+                position_y=base_y + offset_y,
+                user_id_hash=hashed_uid,
+            )
+        )
+        file_edges.append(
+            GraphEdge(
+                id=f"e-{category}-{file_node_id}",
+                source=category,
+                target=file_node_id,
+                relationship_type=EdgeRelationshipType.PARA_CATEGORY,
+                weight=1.0,
+            )
+        )
+
+    nodes.extend(file_nodes)
+    edges.extend(file_edges)
+
+    return GraphDataResponse(nodes=nodes, edges=edges)


### PR DESCRIPTION
- Celery 비동기 워커 환경을 활용하여 앱 프로세스와 분리된 독립적인 고립 노트 감지(Orphan Notes Scan) 태스크(`detect_orphan_notes_for_all_users`)를 신규 추가.
- PII 보안 정책에 따라, 노드 스캔 전 `hashed_user_id`를 기준으로 노드 그룹을 분리(Grouping)하여 타 사용자의 노트 내용과 엣지가 섞이지 않는 완벽한 테넌트 보안 격리(Data Leakage 방지) 컨텍스트 주입.
- `celery.py`에 `daily-orphan-notes-scan` 비트 스케줄(매일 새벽 5시) 추가.
- 태스크 자동 탐색을 위해 `backend/celery_app/tasks/__init__.py` 익스포트 목록 갱신.
- Pythonic한 리팩토링(Sourcery 권장 사항 반영)으로 할당식(Walrus operator)을 사용하여 간결성 확보.

🔗 Related: Issue [#1048]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

테넌트가 엄격히 분리된 그래프 시스템에서, 사용자별 고아 노트를 스캔하는 예약 백그라운드 작업을 추가합니다.

New Features:
- 해시된 식별자를 기반으로 한 사용자별 그래프 격리를 유지하면서, 모든 사용자의 고아 노트를 탐지하는 Celery 태스크를 도입합니다.
- Celery beat을 통해 매일 새벽 5시에 실행되는 고아 노트 스캔 작업을 예약합니다.

Enhancements:
- 지식 그래프 백그라운드 처리를 체계적으로 관리하기 위해 Celery 태스크 패키지에 새로운 그래프 태스크 모듈을 등록합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a scheduled background task to scan for orphan notes per user with strict tenant isolation in the graph system.

New Features:
- Introduce a Celery task to detect orphan notes for all users with per-user graph isolation based on hashed identifiers.
- Schedule a daily orphan-note scan job to run at 5 AM via Celery beat.

Enhancements:
- Register a new graph task module in the Celery task package to organize knowledge-graph background processing.

</details>