### PR TITLE
☘️ refactor [#12.3.18]: 2차 개선 - 고립 노트 엣지 필터링 논리 교정 및 빌더 최적화

### DIFF
--- a/backend/celery_app/tasks/graph.py
+++ b/backend/celery_app/tasks/graph.py
@@ -25,8 +25,12 @@ def detect_orphan_notes_for_all_users(self):
     graph_data = build_graph_data()
     threshold = get_orphan_degree_threshold()
     
+    # 글로벌 CATEGORY 노드 ID 수집 (교차 테넌트 접근 방지 시 허용할 공용 엔드포인트)
+    category_ids = {n.id for n in graph_data.nodes if n.node_type == NodeType.CATEGORY}
+    
     # 2. 사용자별 노드 그룹화 (보안 필수 요건: hashed_user_id 기반 컨텍스트 주입 및 격리)
     nodes_by_user: Dict[str, List[GraphNode]] = defaultdict(list)
+    nodes_missing_user_id_hash: List[GraphNode] = []
     
     for node in graph_data.nodes:
         if node.node_type == NodeType.CATEGORY:
@@ -35,11 +39,23 @@ def detect_orphan_notes_for_all_users(self):
         # 보안 장치: PII 마스킹된 hashed_user_id를 기준 키로 사용
         # 식별되지 않은 파일의 경우 분석 대상에서 제외하여 테넌트 믹스(Data Leakage) 원천 차단
         if not node.user_id_hash:
-            logger.warning("[%s] user_id_hash가 없는 노드(%s) 발견. 보안 격리를 위해 스캔에서 제외합니다.", task_name, node.id)
+            nodes_missing_user_id_hash.append(node)
             continue
             
         uid = node.user_id_hash
         nodes_by_user[uid].append(node)
+        
+    if nodes_missing_user_id_hash:
+        sample_size = 5
+        sample_ids = [n.id for n in nodes_missing_user_id_hash[:sample_size]]
+        logger.warning(
+            "[%s] user_id_hash가 없는 노드가 총 %d개 발견되었습니다. "
+            "보안 격리를 위해 스캔에서 제외합니다. (샘플 node_id: %s%s)",
+            task_name,
+            len(nodes_missing_user_id_hash),
+            sample_ids,
+            " ..." if len(nodes_missing_user_id_hash) > sample_size else "",
+        )
         
     total_orphans_found = 0
     users_scanned = len(nodes_by_user)
@@ -50,11 +66,14 @@ def detect_orphan_notes_for_all_users(self):
     for uid, user_nodes in nodes_by_user.items():
         logger.debug("[%s] 사용자 컨텍스트 스캔 시작 (user_id_hash=%s, 노드 수=%d)", task_name, uid, len(user_nodes))
         
-        # 엣지 필터링: 해당 사용자의 노드 간 연결만 추출 (교차 접근 차단)
+        # 엣지 필터링: 해당 사용자의 노드 간 연결이거나, 글로벌 CATEGORY 노드와의 연결인 경우만 추출
+        # (타 사용자의 노트 식별자인 경우 교차 접근 차단됨)
         user_node_ids = {n.id for n in user_nodes}
+        valid_endpoint_ids = user_node_ids | category_ids
+        
         user_edges = [
             e for e in graph_data.edges 
-            if e.source in user_node_ids and e.target in user_node_ids
+            if e.source in valid_endpoint_ids and e.target in valid_endpoint_ids
         ]
         
         # 해당 사용자 컨텍스트 안에서만 orphan 판별

--- a/backend/celery_app/tasks/graph.py
+++ b/backend/celery_app/tasks/graph.py
@@ -30,7 +30,9 @@ def detect_orphan_notes_for_all_users(self):
     
     # 2. 사용자별 노드 그룹화 (보안 필수 요건: hashed_user_id 기반 컨텍스트 주입 및 격리)
     nodes_by_user: Dict[str, List[GraphNode]] = defaultdict(list)
-    nodes_missing_user_id_hash: List[GraphNode] = []
+    missing_user_id_count = 0
+    missing_user_id_samples: List[str] = []
+    MAX_SAMPLES = 5
     
     for node in graph_data.nodes:
         if node.node_type == NodeType.CATEGORY:
@@ -39,22 +41,22 @@ def detect_orphan_notes_for_all_users(self):
         # 보안 장치: PII 마스킹된 hashed_user_id를 기준 키로 사용
         # 식별되지 않은 파일의 경우 분석 대상에서 제외하여 테넌트 믹스(Data Leakage) 원천 차단
         if not node.user_id_hash:
-            nodes_missing_user_id_hash.append(node)
+            missing_user_id_count += 1
+            if len(missing_user_id_samples) < MAX_SAMPLES:
+                missing_user_id_samples.append(node.id)
             continue
             
         uid = node.user_id_hash
         nodes_by_user[uid].append(node)
         
-    if nodes_missing_user_id_hash:
-        sample_size = 5
-        sample_ids = [n.id for n in nodes_missing_user_id_hash[:sample_size]]
+    if missing_user_id_count > 0:
         logger.warning(
             "[%s] user_id_hash가 없는 노드가 총 %d개 발견되었습니다. "
             "보안 격리를 위해 스캔에서 제외합니다. (샘플 node_id: %s%s)",
             task_name,
-            len(nodes_missing_user_id_hash),
-            sample_ids,
-            " ..." if len(nodes_missing_user_id_hash) > sample_size else "",
+            missing_user_id_count,
+            missing_user_id_samples,
+            " ..." if missing_user_id_count > MAX_SAMPLES else "",
         )
         
     total_orphans_found = 0

--- a/backend/graph/builder.py
+++ b/backend/graph/builder.py
@@ -33,6 +33,12 @@ _PARA_CATEGORY_POSITIONS: dict[str, dict[str, float]] = {
     "Archive": {"x": 600.0, "y": 600.0},
 }
 
+for cat, pos in _PARA_CATEGORY_POSITIONS.items():
+    if "x" not in pos or "y" not in pos:
+        raise RuntimeError(
+            f"지식 그래프 설정 오류: 카테고리 '{cat}'의 좌표('x' 또는 'y')가 누락되었습니다."
+        )
+
 def build_graph_data() -> GraphDataResponse:
     """
     PARA 기반 지식 그래프 데이터를 DB에서 조회하여 GraphDataResponse를 빌드한다.
@@ -47,13 +53,8 @@ def build_graph_data() -> GraphDataResponse:
     # ─── PARA 카테고리 노드 (고정 시드 노드) ───────────────────────────────
     nodes: list[GraphNode] = []
     for cat, pos in _PARA_CATEGORY_POSITIONS.items():
-        try:
-            pos_x = pos["x"]
-            pos_y = pos["y"]
-        except KeyError as e:
-            raise RuntimeError(
-                f"지식 그래프 설정 오류: 카테고리 '{cat}'의 좌표({e})가 누락되었습니다."
-            ) from e
+        pos_x = pos["x"]
+        pos_y = pos["y"]
 
         nodes.append(
             GraphNode(
@@ -103,8 +104,8 @@ def build_graph_data() -> GraphDataResponse:
         if abs(offset_x) < 80 and abs(offset_y) < 80:
             offset_x += 100 if offset_x >= 0 else -100
 
-        base_x = _PARA_CATEGORY_POSITIONS.get(category, {}).get("x", 0.0)
-        base_y = _PARA_CATEGORY_POSITIONS.get(category, {}).get("y", 0.0)
+        base_pos = _PARA_CATEGORY_POSITIONS[category]
+        base_x, base_y = base_pos["x"], base_pos["y"]
 
         file_nodes.append(
             GraphNode(


### PR DESCRIPTION
- [Bugfix] 고립 노트 판정 시 글로벌 CATEGORY 노드와의 엣지가 무시되어 모든 노트가 Orphan으로 오탐지되는 문제 해결 (valid_endpoint_ids에 category_ids 포함)
- [Performance] user_id_hash 누락 노드 발견 시 루프 내 반복되는 Warning 로그 스팸을 방지하기 위해 집계형 요약 로그(Aggregated Summary Log) 패턴 적용
- [Refactor] _PARA_CATEGORY_POSITIONS의 무결성 검증 로직을 함수 내부(Hot path)에서 모듈 임포트 시점으로 분리(Import-time validation)하여 분기 오버헤드 제거
- [Refactor] Graph Builder에서 카테고리 좌표 조회 시 중첩된 .get() 체인을 제거하고 직접 인덱싱(Branch-free lookup)으로 코드 단순화

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1597#pullrequestreview-4473567237)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

전역 카테고리 노드를 고려하도록 고아 노트(orphan note) 감지 로직을 조정하고, 그래프 빌더의 검증 및 로깅을 최적화합니다.

버그 수정:
- 전역 CATEGORY 노드로 이어지는 엣지를 고려하도록 고아 노트 감지를 수정하여, 모든 노트가 잘못 고아로 분류되는 문제를 방지했습니다.

개선 사항:
- `user_id_hash`가 없는 노드에 대한 경고를 하나의 요약 로그로 집계하여, 반복적인 로그 노이즈를 줄였습니다.
- 가져오기(import) 시점에 PARA 카테고리의 위치 좌표를 검증하고, 그래프 빌더에서 카테고리 좌표 조회를 단순화하여 런타임 오버헤드를 줄였습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust orphan note detection to account for global category nodes and optimize graph builder validation and logging.

Bug Fixes:
- Fix orphan note detection so edges to global CATEGORY nodes are considered, preventing all notes from being misclassified as orphans.

Enhancements:
- Aggregate warnings for nodes missing user_id_hash into a single summary log to reduce repetitive logging noise.
- Validate PARA category position coordinates at import time and simplify category coordinate lookups in the graph builder for reduced runtime overhead.

</details>