### PR TITLE
☘️ refactor [#12.3.19]: 2차 개선 - 추천 파이프라인 구조 최적화 및 예외 방어 로직 추가

### DIFF
--- a/backend/celery_app/tasks/graph.py
+++ b/backend/celery_app/tasks/graph.py
@@ -1,7 +1,9 @@
 # backend/celery_app/tasks/graph.py
 
 import logging
+import os
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 from backend.celery_app.celery import app
@@ -24,6 +26,9 @@ from backend.schemas.graph import (
 
 logger = logging.getLogger(__name__)
 
+# 임베딩 파이프라인 기능 플래그 (현재 DB 임베딩 부재로 False)
+_EMBEDDINGS_ENABLED = os.environ.get("FEATURE_ENABLE_LINK_RECOMMENDATIONS", "false").lower() == "true"
+
 # ─────────────────────────────────────────
 # 내부 헬퍼
 # ─────────────────────────────────────────
@@ -36,18 +41,15 @@ def _collect_category_ids(graph_data: GraphDataResponse) -> set[str]:
     return {n.id for n in graph_data.nodes if n.node_type == NodeType.CATEGORY}
 
 
-def _group_nodes_by_user(
-    graph_data: GraphDataResponse,
-) -> tuple[Dict[str, List[GraphNode]], int, List[str]]:
-    """
-    비CATEGORY 노드를 user_id_hash 기준으로 그룹화한다.
+@dataclass
+class UserGroupingResult:
+    nodes_by_user: Dict[str, List[GraphNode]]
+    missing_count: int
+    missing_samples: List[str]
 
-    Returns:
-        (nodes_by_user, missing_count, missing_samples)
-        - nodes_by_user: {user_id_hash: [GraphNode, ...]}
-        - missing_count: user_id_hash가 없는 노드 수
-        - missing_samples: 샘플 node_id 목록 (최대 _MAX_MISSING_UID_SAMPLES개)
-    """
+
+def _group_nodes_by_user(graph_data: GraphDataResponse) -> UserGroupingResult:
+    """비CATEGORY 노드를 user_id_hash 기준으로 그룹화한다."""
     nodes_by_user: Dict[str, List[GraphNode]] = defaultdict(list)
     missing_count = 0
     missing_samples: List[str] = []
@@ -62,7 +64,7 @@ def _group_nodes_by_user(
             continue
         nodes_by_user[node.user_id_hash].append(node)
 
-    return nodes_by_user, missing_count, missing_samples
+    return UserGroupingResult(nodes_by_user, missing_count, missing_samples)
 
 
 def _filter_user_edges(
@@ -79,20 +81,10 @@ def _filter_user_edges(
 
 
 def _load_embeddings_for_nodes(node_ids: list[str]) -> dict[str, list[float]]:
-    """
-    [임베딩 로더 스텁]
-    주어진 노드 ID 목록에 대한 임베딩 벡터를 로드한다.
+    """Return {node_id: embedding_vector} for given IDs.
 
-    [현재 구현]
-    현재 DB 스키마에 임베딩 컬럼이 없으므로 빈 딕셔너리를 반환한다.
-
-    [확장 가이드 — 임베딩 파이프라인 연동 시]
-    1. DB에 `file_embeddings` 테이블 추가 (file_id, embedding JSON/BLOB)
-    2. 이 함수에서 DB 조회 후 {node_id: embedding_vector} 반환
-    3. 임베딩이 없는 노드는 자연스럽게 건너뜀 (KeyError 없이 조용히 제외)
-
-    Returns:
-        {node_id: embedding_vector} — 현재는 항상 빈 딕셔너리.
+    현재는 임베딩 컬럼/테이블이 없어 빈 딕셔너리를 반환합니다.
+    추후 DB/캐시에서 임베딩을 조회하도록 교체합니다.
     """
     # TODO: DB/캐시에서 임베딩 로드 로직으로 교체
     return {}
@@ -176,8 +168,6 @@ def detect_orphan_notes_for_all_users(self):
     similarity_threshold = get_link_similarity_threshold()
     max_per_orphan = get_max_recommendations_per_orphan()
 
-    # 임베딩 파이프라인 기능 플래그 (현재 DB 임베딩 부재로 False)
-    _EMBEDDINGS_ENABLED = False
     if not _EMBEDDINGS_ENABLED:
         logger.info(
             "[%s] 임베딩 파이프라인이 비활성화되어 있습니다. "
@@ -186,16 +176,17 @@ def detect_orphan_notes_for_all_users(self):
         )
 
     category_ids = _collect_category_ids(graph_data)
-    nodes_by_user, missing_count, missing_samples = _group_nodes_by_user(graph_data)
+    grouping = _group_nodes_by_user(graph_data)
+    nodes_by_user = grouping.nodes_by_user
 
-    if missing_count > 0:
+    if grouping.missing_count > 0:
         logger.warning(
             "[%s] user_id_hash가 없는 노드가 총 %d개 발견되었습니다. "
             "보안 격리를 위해 스캔에서 제외합니다. (샘플 node_id: %s%s)",
             task_name,
-            missing_count,
-            missing_samples,
-            " ..." if missing_count > _MAX_MISSING_UID_SAMPLES else "",
+            grouping.missing_count,
+            grouping.missing_samples,
+            " ..." if grouping.missing_count > _MAX_MISSING_UID_SAMPLES else "",
         )
 
     users_scanned = len(nodes_by_user)
@@ -223,6 +214,10 @@ def detect_orphan_notes_for_all_users(self):
         )
         total_orphans_found += len(orphans)
 
+        if not _EMBEDDINGS_ENABLED:
+            # 추천이 비활성화된 경우, 고립 노트 감지만 수행
+            continue
+
         if pipeline_result := _run_recommendation_pipeline(
             uid=uid,
             orphans=orphans,
@@ -234,14 +229,23 @@ def detect_orphan_notes_for_all_users(self):
             agg_recommendations += pipeline_result.total_recommendations
             agg_notifications_sent += pipeline_result.total_notifications_sent
 
-    logger.info(
-        "[%s] 전역 스캔 완료: users=%d, orphans=%d, recommendations=%d, notifications=%d",
-        task_name, users_scanned, total_orphans_found, agg_recommendations, agg_notifications_sent,
-    )
-
-    return (
-        f"Success: {users_scanned} users scanned, "
-        f"{total_orphans_found} orphans found, "
-        f"{agg_recommendations} link recommendations generated, "
-        f"{agg_notifications_sent} notifications sent."
-    )
+    if _EMBEDDINGS_ENABLED:
+        logger.info(
+            "[%s] 전역 스캔 완료: users=%d, orphans=%d, recommendations=%d, notifications=%d",
+            task_name, users_scanned, total_orphans_found, agg_recommendations, agg_notifications_sent,
+        )
+        return (
+            f"Success: {users_scanned} users scanned, "
+            f"{total_orphans_found} orphans found, "
+            f"{agg_recommendations} link recommendations generated, "
+            f"{agg_notifications_sent} notifications sent."
+        )
+    else:
+        logger.info(
+            "[%s] 전역 스캔 완료: users=%d, orphans=%d (연결 추천 비활성화)",
+            task_name, users_scanned, total_orphans_found,
+        )
+        return (
+            f"Success: {users_scanned} users scanned, "
+            f"{total_orphans_found} orphans found (link recommendations disabled)."
+        )

--- a/backend/graph/similarity.py
+++ b/backend/graph/similarity.py
@@ -55,15 +55,18 @@ _MAX_MAX_RECOMMENDATIONS_PER_ORPHAN: int = 50
 # ─────────────────────────────────────────
 
 
-def _clamp_float(value: float, min_val: float, max_val: float, source: str, label: str) -> float:
-    """
-    float 값을 [min_val, max_val] 범위 내로 Clamp한다.
-    값이 변경되었을 경우 경고 로그를 출력한다.
-    """
+def _clamp(
+    value: float | int,
+    min_val: float | int,
+    max_val: float | int,
+    source: str,
+    label: str,
+    fmt: str,
+) -> float | int:
     clamped = max(min_val, min(max_val, value))
     if clamped != value:
         logger.warning(
-            "[GRAPH][SIMILARITY] %s 기준 %s=%.4f 는 허용 범위 [%.4f, %.4f] 를 벗어났습니다. %.4f 로 Clamp 처리합니다.",
+            f"[GRAPH][SIMILARITY] %s 기준 %s={fmt} 는 허용 범위 [{fmt}, {fmt}] 를 벗어났습니다. {fmt} 로 Clamp 처리합니다.",
             source,
             label,
             value,
@@ -72,25 +75,16 @@ def _clamp_float(value: float, min_val: float, max_val: float, source: str, labe
             clamped,
         )
     return clamped
+
+
+def _clamp_float(value: float, min_val: float, max_val: float, source: str, label: str) -> float:
+    """float 값을 [min_val, max_val] 범위 내로 Clamp한다."""
+    return float(_clamp(value, min_val, max_val, source, label, "%.4f"))
 
 
 def _clamp_int(value: int, min_val: int, max_val: int, source: str, label: str) -> int:
-    """
-    int 값을 [min_val, max_val] 범위 내로 Clamp한다.
-    값이 변경되었을 경우 경고 로그를 출력한다.
-    """
-    clamped = max(min_val, min(max_val, value))
-    if clamped != value:
-        logger.warning(
-            "[GRAPH][SIMILARITY] %s 기준 %s=%d 는 허용 범위 [%d, %d] 를 벗어났습니다. %d 로 Clamp 처리합니다.",
-            source,
-            label,
-            value,
-            min_val,
-            max_val,
-            clamped,
-        )
-    return clamped
+    """int 값을 [min_val, max_val] 범위 내로 Clamp한다."""
+    return int(_clamp(value, min_val, max_val, source, label, "%d"))
 
 
 def get_link_similarity_threshold() -> float:
@@ -182,6 +176,33 @@ def _cosine_similarity(vec_a: np.ndarray, vec_b: np.ndarray) -> float:
 # ─────────────────────────────────────────
 
 
+def _score_candidates_for_orphan(
+    orphan_id: str,
+    orphan_vec: np.ndarray,
+    a_candidate_vecs: dict[str, np.ndarray],
+    similarity_threshold: float,
+) -> list[tuple[float, str]]:
+    """고립 노드에 대해 유사도 임계값을 넘는 후보들을 평가하여 반환한다."""
+    scored: list[tuple[float, str]] = []
+    
+    for candidate_id, candidate_vec in a_candidate_vecs.items():
+        if candidate_id == orphan_id:
+            continue
+            
+        if len(orphan_vec) != len(candidate_vec):
+            logger.debug(
+                "[GRAPH][SIMILARITY] 차원 불일치로 건너뜀: orphan(%d) != candidate(%d)",
+                len(orphan_vec), len(candidate_vec)
+            )
+            continue
+            
+        sim = _cosine_similarity(orphan_vec, candidate_vec)
+        if sim >= similarity_threshold:
+            scored.append((sim, candidate_id))
+            
+    return scored
+
+
 def find_link_recommendations(
     orphan_nodes: Sequence[OrphanNode],
     candidate_nodes: Sequence[GraphNode],
@@ -251,32 +272,34 @@ def find_link_recommendations(
     # 후보 노드 ID → GraphNode 빠른 조회 맵
     candidate_map: dict[str, GraphNode] = {n.id: n for n in candidate_nodes}
     
-    # 사전에 후보 임베딩을 np.ndarray로 변환하여 캐싱 (성능 최적화)
+    # 사전에 후보/고립 임베딩을 np.ndarray로 변환하여 캐싱 (성능 최적화 및 대칭성 확보)
     a_candidate_vecs: dict[str, np.ndarray] = {
         cid: np.array(vec_raw, dtype=np.float32)
         for cid, vec_raw in candidate_embeddings.items()
     }
+    a_orphan_vecs: dict[str, np.ndarray] = {
+        oid: np.array(vec_raw, dtype=np.float32)
+        for oid, vec_raw in orphan_embeddings.items()
+    }
+
+    # 데이터 일관성 검사: 임베딩 맵에 존재하지만 실제 노드 목록에 없는 경우 경고 (Data Inconsistency 방어)
+    if missing_candidates := set(a_candidate_vecs.keys()) - set(candidate_map.keys()):
+        logger.debug(
+            "[GRAPH][SIMILARITY] candidate_embeddings에 %d개의 식별되지 않은 노드 ID가 있습니다. (무시됨)",
+            len(missing_candidates)
+        )
 
     for orphan in orphan_nodes:
-        orphan_vec_raw = orphan_embeddings.get(orphan.id)
-        if orphan_vec_raw is None:
-            # 임베딩 없는 고립 노드는 조용히 건너뜀
+        # 임베딩 없는 고립 노드는 조용히 건너뜀
+        if (orphan_vec := a_orphan_vecs.get(orphan.id)) is None:
             continue
 
-        orphan_vec = np.array(orphan_vec_raw, dtype=np.float32)
-
-        # 이 orphan에 대해 유사도 높은 후보를 수집
-        scored: list[tuple[float, str]] = []  # (similarity, candidate_id)
-
-        for candidate_id, candidate_vec in a_candidate_vecs.items():
-            # 자기 자신 제외
-            if candidate_id == orphan.id:
-                continue
-
-            sim = _cosine_similarity(orphan_vec, candidate_vec)
-
-            if sim >= similarity_threshold:
-                scored.append((sim, candidate_id))
+        scored = _score_candidates_for_orphan(
+            orphan_id=orphan.id,
+            orphan_vec=orphan_vec,
+            a_candidate_vecs=a_candidate_vecs,
+            similarity_threshold=similarity_threshold,
+        )
 
         # 유사도 내림차순 정렬
         scored.sort(key=lambda x: x[0], reverse=True)

--- a/backend/graph/similarity.py
+++ b/backend/graph/similarity.py
@@ -55,18 +55,22 @@ _MAX_MAX_RECOMMENDATIONS_PER_ORPHAN: int = 50
 # ─────────────────────────────────────────
 
 
-def _clamp(
-    value: float | int,
-    min_val: float | int,
-    max_val: float | int,
-    source: str,
-    label: str,
-    fmt: str,
-) -> float | int:
-    clamped = max(min_val, min(max_val, value))
+from typing import TypeVar
+
+T = TypeVar("T", int, float)
+
+
+def _clamp_core(value: T, min_val: T, max_val: T) -> T:
+    """값을 [min_val, max_val] 범위 내로 Clamp한다."""
+    return max(min_val, min(max_val, value))
+
+
+def _clamp_float(value: float, min_val: float, max_val: float, source: str, label: str) -> float:
+    """float 값을 [min_val, max_val] 범위 내로 Clamp한다."""
+    clamped = _clamp_core(value, min_val, max_val)
     if clamped != value:
         logger.warning(
-            f"[GRAPH][SIMILARITY] %s 기준 %s={fmt} 는 허용 범위 [{fmt}, {fmt}] 를 벗어났습니다. {fmt} 로 Clamp 처리합니다.",
+            "[GRAPH][SIMILARITY] %s 기준 %s=%.4f 는 허용 범위 [%.4f, %.4f] 를 벗어났습니다. %.4f 로 Clamp 처리합니다.",
             source,
             label,
             value,
@@ -77,14 +81,20 @@ def _clamp(
     return clamped
 
 
-def _clamp_float(value: float, min_val: float, max_val: float, source: str, label: str) -> float:
-    """float 값을 [min_val, max_val] 범위 내로 Clamp한다."""
-    return float(_clamp(value, min_val, max_val, source, label, "%.4f"))
-
-
 def _clamp_int(value: int, min_val: int, max_val: int, source: str, label: str) -> int:
     """int 값을 [min_val, max_val] 범위 내로 Clamp한다."""
-    return int(_clamp(value, min_val, max_val, source, label, "%d"))
+    clamped = _clamp_core(value, min_val, max_val)
+    if clamped != value:
+        logger.warning(
+            "[GRAPH][SIMILARITY] %s 기준 %s=%d 는 허용 범위 [%d, %d] 를 벗어났습니다. %d 로 Clamp 처리합니다.",
+            source,
+            label,
+            value,
+            min_val,
+            max_val,
+            clamped,
+        )
+    return clamped
 
 
 def get_link_similarity_threshold() -> float:


### PR DESCRIPTION
- [backend/graph/similarity.py]
  - `_clamp_float`와 `_clamp_int`의 중복 로직을 제네릭 `_clamp` 헬퍼로 통합
  - 후보(candidate) 임베딩뿐 아니라 고립(orphan) 임베딩도 루프 진입 전 np.ndarray로 사전 변환하여 코드 대칭성 및 성능 향상
  - np.dot 계산 전 orphan/candidate 벡터 차원(길이) 일치 여부를 검사하는 방어 로직 추가 (차원 불일치 시 태스크 크래시 방지)
  - candidate_embeddings에 존재하나 노드 맵에 없는 식별자 발견 시 묵시적 건너뜀 대신 DEBUG 로그 기록

- [backend/celery_app/tasks/graph.py]
  - _EMBEDDINGS_ENABLED 플래그를 환경 변수(FEATURE_ENABLE_LINK_RECOMMENDATIONS)와 연동하여 하드코딩 제거
  - `_group_nodes_by_user` 반환값을 명확한 UserGroupingResult dataclass로 대체하여 언패킹 복잡도 해소
  - _EMBEDDINGS_ENABLED가 False일 경우 메인 루프 내에서 추천 로직을 즉시 건너뛰도록 게이팅 로직 개선 및 최종 집계 로그 분리
  - `_load_embeddings_for_nodes` 스텁의 docstring을 간소화하여 인지 부하 감소

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1601#pullrequestreview-4478584399)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

그래프 유사도 기반 링크 추천 파이프라인과 작업 게이팅을 개선하여 견고성, 구성 가능성 및 로깅을 향상합니다.

버그 수정:
- 고아(orphan)/후보 임베딩 차원 불일치로 인한 크래시를 방지하기 위해, 디버그 로그를 남기면서 호환되지 않는 쌍을 건너뜁니다.

개선 사항:
- 타입별 래퍼와 경고는 유지하면서, `float`와 `int`에 대한 클램핑(clamping) 로직을 공통 헬퍼로 통합합니다.
- 고아 노드와 후보 노드 임베딩을 사전에 NumPy 배열로 변환하고, 스코어링 시 차원 검사를 추가하며, 노드 맵에 존재하지 않는 예상치 못한 후보 ID를 로그로 남겨 유사도 스코어링을 더욱 견고하게 만듭니다.
- 고아 후보 스코어링 로직을 전용 헬퍼로 분리하여, 고아 노드별 링크 추천 로직을 명확히 합니다.
- 그래프 노드를 사용자 단위로 그룹화하기 위한 `UserGroupingResult` 데이터클래스를 도입하여, 후속 사용을 더 명확하고 오류 가능성을 줄이도록 합니다.
- 임베딩 로더 스텁의 독스트링을 단순화하여, 현재 동작과 향후 확장 포인트에만 집중하도록 합니다.
- 환경 변수 기반 기능 플래그로 추천 파이프라인을 게이팅하고, 링크 추천이 있는 실행과 없는 실행에 대해 서로 다른 로깅/반환 메시지를 사용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the graph similarity-based link recommendation pipeline and task gating to improve robustness, configurability, and logging.

Bug Fixes:
- Prevent crashes due to orphan/candidate embedding dimension mismatches by skipping incompatible pairs with debug logging.

Enhancements:
- Unify float and int clamping logic behind a shared helper while keeping type-specific wrappers and warnings.
- Pre-convert orphan and candidate node embeddings to NumPy arrays, add dimensionality checks when scoring, and log unexpected candidate IDs missing from the node map to harden similarity scoring.
- Extract orphan candidate scoring into a dedicated helper to clarify link recommendation logic per orphan node.
- Introduce a UserGroupingResult dataclass for grouping graph nodes by user to make downstream usage clearer and less error-prone.
- Simplify the embedding loader stub docstring to focus on current behavior and future extension points.
- Gate the recommendation pipeline with an environment-driven feature flag and separate logging/return messages for runs with and without link recommendations.

</details>