### PR TITLE
📝 docs [#12.3.20] - ➄ 프로젝트 내 잔여 TODO 주석 정리 및 추적 문서 생성

### DIFF
--- a/docs/A/TODO.md
+++ b/docs/A/TODO.md
@@ -2,31 +2,46 @@
 
 본 문서는 코드베이스 전반에 산재되어 있는 `TODO` 및 `FIXME` 주석들을 중앙에서 추적하고 관리하기 위해 생성되었습니다.
 
-## 🛠 Backend API & Deps
-- [ ] `backend/api/deps.py` (L46): `Route this through backend.config.AppConfig when available.`
-- [ ] `backend/api/deps.py` (L65, L91): `[Phase 2] verify_token(token)` 로직 구현 필요
-- [ ] `backend/api/endpoints/metadata.py` (L19, L34): 실제 메타데이터 조회 및 업데이트 기능 구현
-- [ ] `backend/api/endpoints/automation.py` (L202): Celery 태스크 트리거 구현
-- [ ] `backend/api/endpoints/automation.py` (L250): 실제로는 파일 시스템 또는 DB에서 조회하도록 변경
-- [ ] `backend/api/endpoints/automation.py` (L301): 실제 데이터 집계 로직 구현
-- [ ] `backend/api/endpoints/sync.py` (L114): 실제 `last_sync`는 `SyncMapManager`에서 조회하도록 연동
-- [ ] `backend/api/endpoints/sync.py` (L137, L143, L144): 실제 MCP 서버 상태 및 클라이언트 목록 연동
-- [ ] `backend/api/endpoints/sync.py` (L176): `ExternalSyncLog`에서 충돌 이력 조회 연동
-- [ ] `backend/api/endpoints/sync.py` (L195): DB에서 `conflict_id`로 경로 정보 조회 연동
-- [ ] `backend/api/endpoints/sync.py` (L232): `ConflictResolutionService`를 통해 실제 충돌 해결 연동
+## 🔴 [P1] Phase 2: Authentication & Core DB 연동
+보안 및 핵심 데이터 무결성과 직결되므로 최우선으로 해결해야 할 부채입니다.
 
-## ⚙️ Backend Services & Managers
-- [ ] `backend/services/scheduler_service.py` (L43): 차후에 `session_id`와 `message_id`를 통해 실제 `ChatHistory`와 조인
-- [ ] `backend/services/sync_service.py` (L164): DB에 충돌 레코드 저장
-- [ ] `backend/services/automation_manager.py` (L123, L140, L160, L177): DB 연동 후 실제 규칙 조회/저장/수정/삭제 구현
-- [ ] `backend/services/conflict_resolution_service.py` (L244): JSONL 파일에 기록 (`PathConfig` 사용)
+- [ ] **Authentication (`backend/api/deps.py`)**
+  - `get_current_user` 및 `get_current_user_ws` 함수: 현재 Mock 사용 중인 부분을 `verify_token(token)` 기반 실제 인증 로직으로 대체.
+  - 전역 의존성을 `backend.config.AppConfig`를 통해 라우팅하도록 개선.
+- [ ] **Sync DB (`backend/services/sync_service.py`)**
+  - `_handle_conflict` 메서드: 충돌 발생 시 DB에 충돌 레코드를 영구 저장하는 로직.
+- [ ] **Conflict Resolution (`backend/services/conflict_resolution_service.py`)**
+  - 파일 시스템(JSONL) 안전 기록 및 `PathConfig` 활용 보완.
 
-## 🔄 Celery Tasks & MCP
-- [ ] `backend/celery_app/tasks/reporting.py` (L74): 추후 DB 쿼리로 개선 권장
-- [ ] `backend/celery_app/tasks/graph.py` (L93): DB/캐시에서 임베딩 로드 로직으로 교체
-- [ ] `backend/mcp/obsidian_server.py` (L143): 실제 동기화(sync) 로직 구현
-- [ ] `backend/mcp/obsidian_server.py` (L153): 내부 DB 해시와 대조(Match)하는 로직 구현
-- [ ] `backend/mcp/server.py` (L57): 임베딩의 영구적 로딩(Persistent loading) 구현 (`FAISSRetriever` 등에서)
+## 🟠 [P2] Phase 3: Automation & Scheduler 구현
+자동화 작업의 실질적인 동작과 데이터 신뢰성을 보장하는 항목입니다.
+
+- [ ] **Automation Rules DB 연동 (`backend/services/automation_manager.py`)**
+  - `get_automation_rules`, `create_automation_rule` 등 규칙 CRUD 전체 메서드: 파일/Mock 기반에서 DB 연동으로 전환.
+- [ ] **Celery 연동 (`backend/api/endpoints/automation.py`)**
+  - `trigger_automation_task` 엔드포인트: 실제 Celery 태스크 지연 실행(`task.delay()`) 트리거 활성화.
+- [ ] **Golden Dataset 조인 (`backend/services/scheduler_service.py`)**
+  - `extract_and_serialize_golden_dataset` 함수: 피드백 텍스트뿐만 아니라 `session_id`, `message_id`를 활용해 실제 `ChatHistory`와 조인하여 컨텍스트 보강.
+
+## 🟡 [P3] Phase 4: MCP & Obsidian Sync 실시간 연동
+외부 에이전트 및 로컬 에디터와의 동기화 완결성을 위한 작업입니다.
+
+- [ ] **Obsidian Sync Logic (`backend/mcp/obsidian_server.py`)**
+  - 실제 파일 동기화(Sync) 로직 및 내부 DB 해시와 대조(Match)하는 핵심 비교 엔진 구현.
+- [ ] **Persistent Embeddings (`backend/mcp/server.py` & `backend/celery_app/tasks/graph.py`)**
+  - 임베딩 메모리 로드 방식을 DB/Cache 기반 영구 로딩(Persistent loading) 로직으로 교체 (`FAISSRetriever` 활용).
+- [ ] **Sync Status API (`backend/api/endpoints/sync.py`)**
+  - `get_sync_status`, `get_mcp_status`, `get_conflicts` 등: 상태 응답을 `SyncMapManager`, `ExternalSyncLog` 등의 실제 매니저/DB에서 동적으로 조회하도록 연결.
+
+## 🟢 [P4] 기타: Dashboard & Metadata (MVP 이후)
+운영 가시성 및 사용자 부가 정보 제공 영역입니다.
+
+- [ ] **Dashboard Stats (`backend/api/endpoints/automation.py`)**
+  - `get_dashboard_summary`, `get_watchdog_events` 함수: 임시 수치 대신 실제 로그와 시스템 지표 집계 로직 반영.
+- [ ] **Metadata API (`backend/api/endpoints/metadata.py`)**
+  - `get_metadata`, `update_metadata` 함수: 파일 메타데이터의 실제 조회 및 업데이트 기능 연동.
+- [ ] **Reporting Task (`backend/celery_app/tasks/reporting.py`)**
+  - 파일 파싱 등 메모리 위주의 작업을 추후 DB 쿼리 기반으로 성능 개선(최적화).
 
 ---
-*참고: 이미 해결된 `TODO` 항목이 있다면 본 문서에서 체크표시(`[x]`) 후 소스 코드 내의 주석은 제거해 주시면 됩니다.*
+*💡 관리 가이드: 해결된 항목은 본 문서에서 체크표시(`[x]`) 처리하고, 실제 소스 코드 상의 주석을 제거하여 단일 진실 공급원(SSOT)을 유지합니다.*

--- a/docs/A/TODO.md
+++ b/docs/A/TODO.md
@@ -1,0 +1,32 @@
+# FlowNote MVP - TODO & FIXME 추적 문서
+
+본 문서는 코드베이스 전반에 산재되어 있는 `TODO` 및 `FIXME` 주석들을 중앙에서 추적하고 관리하기 위해 생성되었습니다.
+
+## 🛠 Backend API & Deps
+- [ ] `backend/api/deps.py` (L46): `Route this through backend.config.AppConfig when available.`
+- [ ] `backend/api/deps.py` (L65, L91): `[Phase 2] verify_token(token)` 로직 구현 필요
+- [ ] `backend/api/endpoints/metadata.py` (L19, L34): 실제 메타데이터 조회 및 업데이트 기능 구현
+- [ ] `backend/api/endpoints/automation.py` (L202): Celery 태스크 트리거 구현
+- [ ] `backend/api/endpoints/automation.py` (L250): 실제로는 파일 시스템 또는 DB에서 조회하도록 변경
+- [ ] `backend/api/endpoints/automation.py` (L301): 실제 데이터 집계 로직 구현
+- [ ] `backend/api/endpoints/sync.py` (L114): 실제 `last_sync`는 `SyncMapManager`에서 조회하도록 연동
+- [ ] `backend/api/endpoints/sync.py` (L137, L143, L144): 실제 MCP 서버 상태 및 클라이언트 목록 연동
+- [ ] `backend/api/endpoints/sync.py` (L176): `ExternalSyncLog`에서 충돌 이력 조회 연동
+- [ ] `backend/api/endpoints/sync.py` (L195): DB에서 `conflict_id`로 경로 정보 조회 연동
+- [ ] `backend/api/endpoints/sync.py` (L232): `ConflictResolutionService`를 통해 실제 충돌 해결 연동
+
+## ⚙️ Backend Services & Managers
+- [ ] `backend/services/scheduler_service.py` (L43): 차후에 `session_id`와 `message_id`를 통해 실제 `ChatHistory`와 조인
+- [ ] `backend/services/sync_service.py` (L164): DB에 충돌 레코드 저장
+- [ ] `backend/services/automation_manager.py` (L123, L140, L160, L177): DB 연동 후 실제 규칙 조회/저장/수정/삭제 구현
+- [ ] `backend/services/conflict_resolution_service.py` (L244): JSONL 파일에 기록 (`PathConfig` 사용)
+
+## 🔄 Celery Tasks & MCP
+- [ ] `backend/celery_app/tasks/reporting.py` (L74): 추후 DB 쿼리로 개선 권장
+- [ ] `backend/celery_app/tasks/graph.py` (L93): DB/캐시에서 임베딩 로드 로직으로 교체
+- [ ] `backend/mcp/obsidian_server.py` (L143): 실제 동기화(sync) 로직 구현
+- [ ] `backend/mcp/obsidian_server.py` (L153): 내부 DB 해시와 대조(Match)하는 로직 구현
+- [ ] `backend/mcp/server.py` (L57): 임베딩의 영구적 로딩(Persistent loading) 구현 (`FAISSRetriever` 등에서)
+
+---
+*참고: 이미 해결된 `TODO` 항목이 있다면 본 문서에서 체크표시(`[x]`) 후 소스 코드 내의 주석은 제거해 주시면 됩니다.*


### PR DESCRIPTION
- **[문서화] TODO & FIXME 중앙 추적 문서 신설**
  - `docs/A/TODO.md` 파일을 생성하여 코드베이스 전반에 흩어져 있던 기술 부채(TODO)를 한곳에 모아 리스트업.
  - Backend API, Services, Celery Tasks, MCP 서버 등 컴포넌트별로 항목을 그룹화하여 가독성 및 관리 용이성 확보.
  - 향후 해결 완료된 작업은 해당 문서에서 체크(`[x]`)하고 실제 소스 코드에서 주석을 제거하는 방식으로 관리 단일화.

- **[정리] 주요 미해결 과제 가시성 확보**
  - DB 연동 로직(`automation_manager.py`, `sync_service.py`), 페이즈 2 인증 로직(`deps.py`) 등 남은 후속 작업들을 명확히 식별

🔗 Related: Issue [#1048]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Documentation:
- 백엔드 API, 서비스, Celery 작업, MCP 서버 전반에 걸친 미해결 TODO 및 FIXME 항목을 중앙에서 추적하기 위해 `docs/A/TODO.md`를 도입합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Introduce docs/A/TODO.md to centrally track outstanding TODO and FIXME items across backend APIs, services, Celery tasks, and MCP servers.

</details>