### PR TITLE
🔖 chore [#12.3.20] - ➅ 코드 품질 향상을 위한 미사용 임포트(Unused Imports) 일괄 정리

### DIFF
--- a/backend/agent/chat/graph.py
+++ b/backend/agent/chat/graph.py
@@ -1,7 +1,7 @@
 # backend/agent/chat/graph.py
 
 # TYPE_CHECKING
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from langgraph.graph import END, START, StateGraph
 

--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -5,7 +5,7 @@ import numbers
 import re
 from collections.abc import Mapping, Sequence
 from itertools import islice
-from typing import Any, Dict, List, Literal, Optional, TypedDict, cast
+from typing import Any, Dict, List, Literal, TypedDict, cast
 
 from langchain_core.messages import (  # type: ignore[import, import-untyped, reportMissingImports]
     AIMessage,

--- a/backend/agent/chat/state.py
+++ b/backend/agent/chat/state.py
@@ -1,7 +1,7 @@
 # backend/agent/chat/state.py
 
 import operator
-from typing import Annotated, Any, NotRequired, Optional, TypedDict
+from typing import Annotated, NotRequired, Optional, TypedDict
 
 from langchain_core.messages import BaseMessage
 

--- a/backend/agent/nodes.py
+++ b/backend/agent/nodes.py
@@ -1,7 +1,7 @@
 import logging
 from contextlib import asynccontextmanager
 from functools import lru_cache
-from typing import Any, AsyncGenerator, Dict, List, Literal, Optional, Protocol
+from typing import Any, AsyncGenerator, Dict, Literal, Protocol
 
 from langchain_core.output_parsers import PydanticOutputParser
 from langchain_core.prompts import ChatPromptTemplate
@@ -87,7 +87,6 @@ class LifespanApp(Protocol):
     비어있는 상태(빈 프로토콜)로 정의되어 결합도를 최소화합니다.
     """
 
-    pass
 
 
 @asynccontextmanager

--- a/backend/agent/streaming.py
+++ b/backend/agent/streaming.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import AsyncIterator, Mapping
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from langchain_core.runnables import RunnableConfig
 from langgraph.errors import GraphRecursionError

--- a/backend/agent/utils.py
+++ b/backend/agent/utils.py
@@ -3,7 +3,7 @@ import logging
 import os
 import re
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 import redis
 from dotenv import load_dotenv

--- a/backend/api/endpoints/admin.py
+++ b/backend/api/endpoints/admin.py
@@ -6,7 +6,7 @@ import hmac
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Header, HTTPException
 from pydantic import BaseModel, Field
 
 from backend.config import AdminConfig

--- a/backend/api/endpoints/chat.py
+++ b/backend/api/endpoints/chat.py
@@ -5,11 +5,10 @@
 """
 
 import logging
-import os
 import threading
 import time
 from collections import OrderedDict
-from typing import Dict, Optional
+from typing import Optional
 
 from fastapi import (
     APIRouter,

--- a/backend/api/endpoints/conflict_resolver_agent.py
+++ b/backend/api/endpoints/conflict_resolver_agent.py
@@ -8,11 +8,8 @@ Conflict Resolution Agent (LangGraph 기반)
 
 import json
 import logging
-from pathlib import Path
 from typing import Any, Dict, List, TypedDict
 
-from langchain_core.output_parsers import StrOutputParser
-from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 from langgraph.graph import END, START, StateGraph
 
@@ -26,7 +23,6 @@ from backend.models import (
     ConflictType,
     ResolutionMethod,
     ResolutionStatus,
-    ResolutionStrategy,
 )
 
 logger = logging.getLogger(__name__)

--- a/backend/api/endpoints/graph.py
+++ b/backend/api/endpoints/graph.py
@@ -17,22 +17,15 @@
 from __future__ import annotations
 
 import logging
-import random
-from typing import Any
 
 from fastapi import APIRouter
 
-from backend.database.connection import DatabaseConnection
 from backend.graph.analysis import find_orphan_nodes, get_orphan_degree_threshold
 from backend.schemas.graph import (
-    EdgeRelationshipType,
     GraphDataResponse,
-    GraphEdge,
-    GraphNode,
     NodeType,
     OrphanNotesResponse,
 )
-from backend.utils.common import mask_pii_id
 
 logger = logging.getLogger(__name__)
 

--- a/backend/api/endpoints/search.py
+++ b/backend/api/endpoints/search.py
@@ -12,7 +12,6 @@ import logging
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from fastapi.concurrency import run_in_threadpool
 
 from backend.api.deps import get_current_user, get_locale
 from backend.api.models import (

--- a/backend/api/endpoints/sync.py
+++ b/backend/api/endpoints/sync.py
@@ -12,13 +12,11 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from backend.config.mcp_config import mcp_config
-from backend.models.external_sync import ExternalToolType, SyncStatus
 from backend.services.diff_service import generate_diff
-from backend.services.obsidian_sync import ObsidianSyncService
 
 logger = logging.getLogger(__name__)
 

--- a/backend/celery_app/tasks/archiving.py
+++ b/backend/celery_app/tasks/archiving.py
@@ -7,7 +7,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import List, Optional, Set, Tuple
+from typing import List, Optional, Set
 
 from backend.celery_app.celery import app
 from backend.config import AppConfig, PathConfig

--- a/backend/celery_app/tasks/classification.py
+++ b/backend/celery_app/tasks/classification.py
@@ -7,7 +7,7 @@ import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Optional
 
 from backend.celery_app.celery import app
 

--- a/backend/celery_app/tasks/monitoring.py
+++ b/backend/celery_app/tasks/monitoring.py
@@ -1,7 +1,6 @@
 # backend/celery_app/tasks/monitoring.py
 
 import asyncio
-import json
 import logging
 import uuid
 from datetime import datetime

--- a/backend/celery_app/tasks/reporting.py
+++ b/backend/celery_app/tasks/reporting.py
@@ -5,20 +5,16 @@ import json
 import logging
 import uuid
 from datetime import datetime, timedelta
-from pathlib import Path
-from typing import Any, Dict, List
+from typing import Dict, List
 
 from backend.celery_app.celery import app
 from backend.config import PathConfig
 from backend.models.automation import (
-    ArchivingRecord,
     AutomationLog,
     AutomationStatus,
     AutomationTaskType,
-    ReclassificationRecord,
 )
 from backend.models.report import Report, ReportMetric, ReportType
-from backend.services.file_access_logger import FileAccessLogger
 
 logger = logging.getLogger(__name__)
 

--- a/backend/classifier/base_classifier.py
+++ b/backend/classifier/base_classifier.py
@@ -39,7 +39,6 @@ class BaseClassifier(ABC):
                 "metadata": dict       # 추가 정보
             }
         """
-        pass
 
     def validate_result(self, result: Dict[str, Any]) -> Tuple[bool, str]:
         """분류 결과 검증"""

--- a/backend/classifier/conflict_resolver.py
+++ b/backend/classifier/conflict_resolver.py
@@ -5,7 +5,7 @@ Conflict Resolver
 """
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)

--- a/backend/classifier/context_injector.py
+++ b/backend/classifier/context_injector.py
@@ -7,7 +7,6 @@
 import json
 import logging
 import os
-import re
 import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -38,9 +37,6 @@ sys.path.insert(0, str(PROJECT_ROOT))
 # 3. 임포트
 # ============================================================
 
-from langchain_core.output_parsers import StrOutputParser
-from langchain_core.prompts import ChatPromptTemplate
-from langchain_openai import ChatOpenAI
 
 # ============================================================
 # 4. Config Import (3-tier Fallback)

--- a/backend/classifier/langchain_integration.py
+++ b/backend/classifier/langchain_integration.py
@@ -14,7 +14,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from dotenv import load_dotenv
 
@@ -35,7 +35,6 @@ sys.path.insert(0, str(PROJECT_ROOT))
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.prompts import PromptTemplate
 from langchain_openai import ChatOpenAI
-from pydantic import BaseModel, Field
 
 # 통합 모델 마이그레이션 임포트
 from backend.models import PARAClassificationOutput

--- a/backend/classifier/metadata_classifier.py
+++ b/backend/classifier/metadata_classifier.py
@@ -4,10 +4,9 @@
 메타데이터 기반 PARA 분류 전용 클래스
 """
 
-import json
 import logging
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
 

--- a/backend/classifier/para_agent.py
+++ b/backend/classifier/para_agent.py
@@ -1,17 +1,14 @@
 # backend/classifier/para_agent.py
 
 import asyncio
-from datetime import datetime
 from typing import TypedDict
 
-from langchain_openai import ChatOpenAI
 from langgraph.graph import END, START, StateGraph
 
 from backend.classifier.conflict_resolver import ClassificationResult, ConflictResolver
 from backend.classifier.keyword import KeywordClassifier
 from backend.classifier.langchain_integration import classify_with_langchain
 from backend.classifier.snapshot_manager import SnapshotManager
-from backend.config import ModelConfig
 
 
 # 🔷 State 정의

--- a/backend/classifier/para_classifier.py
+++ b/backend/classifier/para_classifier.py
@@ -9,7 +9,7 @@ PARA 분류기 - LangChain 기반
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional
 
 prompt_path = Path(__file__).parent / "prompts" / "para_system.txt"
 

--- a/backend/classifier/snapshot_manager.py
+++ b/backend/classifier/snapshot_manager.py
@@ -7,10 +7,9 @@ Snapshot 관리 클래스
 """
 
 import copy
-import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import List
 
 
 @dataclass

--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -1,17 +1,14 @@
 import asyncio
 import logging
-import os
 import random
 import threading
-from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
-from typing import Any, Callable, Optional, Union
+from typing import Optional
 
 import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError, EndpointConnectionError, ReadTimeoutError
 
-from backend.core.config_validator import PersonalizedRAGConfig
 
 logger = logging.getLogger(__name__)
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -4,7 +4,6 @@
 Application configuration settings
 """
 
-from typing import Optional
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 

--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import logging
 import os
 from enum import Enum
-from typing import Callable, ClassVar, Dict, Literal, Mapping
+from typing import Callable, ClassVar, Dict, Mapping
 
 # 프로젝트 공통 유틸 재사용 — 중복 구현 금지
 from backend.config import ConfigRange, _clamp

--- a/backend/data_manager.py
+++ b/backend/data_manager.py
@@ -7,7 +7,6 @@ CSV/JSON 파일 I/O + 사용자 데이터 관리
 
 import csv
 import json
-import os
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional

--- a/backend/embedding.py
+++ b/backend/embedding.py
@@ -11,7 +11,6 @@ from backend.config import (
     EMBEDDING_COSTS,
     EMBEDDING_MODEL,
     ModelConfig,
-    get_embedding_model,
 )
 from backend.utils import count_tokens, estimate_cost
 

--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -10,14 +10,12 @@
 class FlowNoteError(Exception):
     """FlowNote 기본 에러 정의"""
 
-    pass
 
 
 class FileValidationError(FlowNoteError):
     """파일 검증 실패 에러
     - 확장자가 이상하거나 크기가 너무 클 경우"""
 
-    pass
 
 
 class QueryValidationError(FlowNoteError):
@@ -25,25 +23,21 @@ class QueryValidationError(FlowNoteError):
     - 검색창에 너무 짧은 검색어를 입력한 경우
     - 빈 칸만 입력한 경우"""
 
-    pass
 
 
 class APIKeyError(FlowNoteError):
     """API 키 설정 오류 에러
     - API 키가 잘못되었거나 없는 경우"""
 
-    pass
 
 
 class EmbeddingError(FlowNoteError):
     """임베딩 생성 처리 오류 에러
     - 임베딩 생성 실패했을 경우"""
 
-    pass
 
 
 class SearchError(FlowNoteError):
     """검색 및 조회 처리 오류 에러
     - 검색하는 과정에서 문제가 생겼을 경우"""
 
-    pass

--- a/backend/graph/base.py
+++ b/backend/graph/base.py
@@ -25,13 +25,11 @@ from typing import Any, Generator, Iterator
 class GraphError(Exception):
     """그래프 도메인 관련 최상위 예외"""
 
-    pass
 
 
 class GraphLoadError(GraphError):
     """그래프 데이터를 스토리지에서 불러오는 중 발생하는 예외"""
 
-    pass
 
 
 class AbstractGraphRepository(abc.ABC):

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,6 @@ FastAPI 메인 서버
 """
 
 import logging
-import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 

--- a/backend/mcp/server.py
+++ b/backend/mcp/server.py
@@ -9,7 +9,7 @@ import asyncio
 import json
 import logging
 import threading
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from mcp.server.fastmcp import FastMCP
 

--- a/backend/mcp/sync_map_manager.py
+++ b/backend/mcp/sync_map_manager.py
@@ -9,7 +9,6 @@ import json
 import logging
 import threading
 from datetime import datetime
-from pathlib import Path
 from typing import Dict, List, Optional
 
 from backend.config import PathConfig

--- a/backend/metadata.py
+++ b/backend/metadata.py
@@ -10,7 +10,7 @@ import json
 import os
 import uuid  # 추가!
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 
 class FileMetadata:

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -9,8 +9,7 @@
 - Context 관련 (UserContext)
 """
 
-from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from pydantic import BaseModel, ConfigDict, Field
 

--- a/backend/modules/pdf_helper.py
+++ b/backend/modules/pdf_helper.py
@@ -6,8 +6,6 @@
 FlowNote MVP - PDF 처리 모듈
 """
 
-from pathlib import Path
-from typing import Union
 
 import pypdf
 

--- a/backend/routes/api_models.py
+++ b/backend/routes/api_models.py
@@ -13,7 +13,6 @@ Conflict 관련 모델:
 - ConflictResolutionResponse
 """
 
-from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/backend/routes/classifier_routes.py
+++ b/backend/routes/classifier_routes.py
@@ -10,11 +10,9 @@
 
 import json
 import logging
-import os
-from typing import List, Optional
+from typing import Optional
 
 from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
-from pydantic import BaseModel
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # 통합 모델 Import

--- a/backend/routes/onboarding_routes.py
+++ b/backend/routes/onboarding_routes.py
@@ -15,7 +15,7 @@ Refactored:
 """
 
 import logging
-from typing import Any, TypedDict
+from typing import TypedDict
 
 from fastapi import APIRouter, HTTPException, Query
 

--- a/backend/services/automation_manager.py
+++ b/backend/services/automation_manager.py
@@ -7,7 +7,6 @@ Automation Manager Service
 
 import json
 import logging
-from datetime import datetime
 from itertools import islice
 from pathlib import Path
 from typing import Any, Dict, List, Optional

--- a/backend/services/chat_history_service.py
+++ b/backend/services/chat_history_service.py
@@ -1,6 +1,5 @@
 # backend/services/chat_history_service.py
 
-import hashlib
 import json
 import logging
 from datetime import datetime, timezone

--- a/backend/services/chat_service.py
+++ b/backend/services/chat_service.py
@@ -1,13 +1,11 @@
 # backend/services/chat_service.py
 
 import asyncio
-import hashlib
 import json
 import logging
 import re
 import time
 from functools import lru_cache
-from itertools import islice
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -17,7 +15,6 @@ from typing import (
     Optional,
     Tuple,
     TypedDict,
-    cast,
 )
 
 if TYPE_CHECKING:

--- a/backend/services/classification_service.py
+++ b/backend/services/classification_service.py
@@ -14,7 +14,7 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from backend.classifier.hybrid_classifier import HybridClassifier
 from backend.classifier.keyword import KeywordClassifier

--- a/backend/services/conflict_resolution_service.py
+++ b/backend/services/conflict_resolution_service.py
@@ -6,11 +6,9 @@ Conflict Resolution Service
 """
 
 import logging
-import os
 import shutil
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
 from uuid import uuid4
 
 from backend.mcp.sync_map_manager import SyncMapManager
@@ -20,9 +18,8 @@ from backend.models.conflict import (
     ResolutionStatus,
     ResolutionStrategy,
     SyncConflict,
-    SyncConflictType,
 )
-from backend.models.external_sync import ExternalSyncLog, ExternalToolType, SyncStatus
+from backend.models.external_sync import ExternalSyncLog, SyncStatus
 from backend.services.ignore_manager import ignore_manager
 from backend.services.sync_service import SyncServiceBase
 

--- a/backend/services/conflict_service.py
+++ b/backend/services/conflict_service.py
@@ -9,9 +9,8 @@
 
 import asyncio
 import logging
-import uuid
 from datetime import datetime
-from typing import Any, Awaitable, Dict, Optional
+from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/backend/services/file_access_logger.py
+++ b/backend/services/file_access_logger.py
@@ -9,7 +9,7 @@ import logging
 from collections import Counter
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
 

--- a/backend/services/ignore_manager.py
+++ b/backend/services/ignore_manager.py
@@ -3,7 +3,7 @@
 import threading
 import time
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict
 
 
 class IgnoreManager:

--- a/backend/services/obsidian_sync.py
+++ b/backend/services/obsidian_sync.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from backend.models.conflict import SyncConflict
-from backend.models.external_sync import ExternalToolConnection, SyncStatus
+from backend.models.external_sync import ExternalToolConnection
 from backend.services.ignore_manager import ignore_manager
 from backend.services.sync_service import SyncServiceBase
 

--- a/backend/services/obsidian_watcher.py
+++ b/backend/services/obsidian_watcher.py
@@ -1,10 +1,8 @@
 # backend/services/obsidian_watcher.py
 
 import logging
-import threading
-import time
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer

--- a/backend/services/rule_engine.py
+++ b/backend/services/rule_engine.py
@@ -7,7 +7,7 @@ RuleEngine - 규칙 기반 분류 엔진
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal, Optional, TypedDict
+from typing import Any, Dict, List, Literal, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/backend/services/sync_service.py
+++ b/backend/services/sync_service.py
@@ -8,14 +8,11 @@ Sync Service Abstraction
 import hashlib
 import logging
 from abc import ABC, abstractmethod
-from datetime import datetime
-from typing import Any, List, Optional
+from typing import List, Optional
 
-from backend.models.conflict import ResolutionMethod, SyncConflict, SyncConflictType
+from backend.models.conflict import SyncConflict, SyncConflictType
 from backend.models.external_sync import (
-    ExternalFileMapping,
     ExternalToolConnection,
-    SyncStatus,
 )
 
 logger = logging.getLogger(__name__)
@@ -38,22 +35,18 @@ class SyncServiceBase(ABC):
     @abstractmethod
     async def connect(self) -> bool:
         """도구 연결 확인"""
-        pass
 
     @abstractmethod
     async def sync_all(self) -> List[SyncConflict]:
         """전체 동기화 수행"""
-        pass
 
     @abstractmethod
     async def pull_file(self, external_id: str) -> Optional[str]:
         """외부 파일 가져오기 (내용 반환)"""
-        pass
 
     @abstractmethod
     async def push_file(self, internal_id: str, content: str) -> bool:
         """내부 파일을 외부로 내보내기"""
-        pass
 
     def calculate_file_hash(self, content: str) -> str:
         """

--- a/backend/services/topic_clustering_service.py
+++ b/backend/services/topic_clustering_service.py
@@ -31,7 +31,6 @@ from functools import lru_cache
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 import numpy as np
-import redis.exceptions
 from fastapi.concurrency import run_in_threadpool  # type: ignore[import]
 from redis.exceptions import RedisError  # 연결/타임아웃/명령 실패 포괄
 from sklearn.cluster import KMeans

--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -12,7 +12,7 @@ import os
 from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional
 
 import tiktoken  # type: ignore[import]
 

--- a/backend/utils/observability.py
+++ b/backend/utils/observability.py
@@ -5,7 +5,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
 
 import httpx
 

--- a/backend/validators.py
+++ b/backend/validators.py
@@ -21,7 +21,6 @@ from typing import Optional, Tuple
 class ValidationError(Exception):
     """커스텀 검증 에러 클래스"""
 
-    pass
 
 
 class FileValidator:


### PR DESCRIPTION
- `autoflake`를 활용하여 `backend/` 내 미사용 임포트 줄 일괄 제거
- 패키지 외부 노출 목적의 임포트를 보존하기 위해 `__init__.py` 파일은 정리 대상에서 안전하게 제외
- 프로덕션 코드 로직 변경 없이 코드 가독성 향상 및 린트 가이드 준수

🔗 Related: Issue [#1048]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

런타임 동작을 변경하지 않고, 백엔드 모듈 전반에서 사용되지 않는 import와 중복된 보일러플레이트를 정리하여 코드 가독성을 개선합니다.

Enhancements:
- 서비스, API 엔드포인트, 분류기, 코어 유틸리티 등을 포함한 여러 백엔드 모듈에서 사용되지 않는 import를 제거하여 코드 잡음을 줄이고 린트 규칙과 일치시키았습니다.
- 비어 있는 예외 서브클래스, 추상 메서드, 프로토콜 정의에서 불필요한 `pass` 문을 제거하여 클래스와 인터페이스 정의를 더 깔끔하게 만들었습니다.
- 더 이상 필요하지 않은 제네릭 매개변수와 `Optional` 애노테이션을 제거하여 타입 힌트를 더 간결하고 명확하게 다듬었습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clean up unused imports and redundant boilerplate across backend modules to improve code readability without changing runtime behavior.

Enhancements:
- Remove unused imports from various backend modules, including services, API endpoints, classifiers, and core utilities, to reduce clutter and align with linting rules.
- Drop redundant pass statements from empty exception subclasses, abstract methods, and protocol definitions for cleaner class and interface definitions.
- Tighten type hints by removing unused generic parameters and Optional annotations where no longer needed.

</details>