### PR TITLE
📝 docs [#12.3.20] - ➈ 유지보수성 향상을 위한 핵심 예외 처리 모듈(exceptions) Docstring 고도화

### DIFF
--- a/backend/api/exceptions.py
+++ b/backend/api/exceptions.py
@@ -1,7 +1,15 @@
 # backend/api/exceptions.py
 
 """
-Custom exception handlers and utilities for i18n error responses
+Custom exception handlers and utilities for i18n (국제화) error responses.
+
+이 모듈은 FastAPI 애플리케이션의 전역 예외 처리를 담당합니다.
+Accept-Language 헤더를 기반으로 HTTP 에러 메시지를 현지화하며,
+일관된 JSON 에러 응답 구조({status, message, status_code})를 보장합니다.
+
+Registration:
+    app.add_exception_handler(HTTPException, http_exception_handler)
+    app.add_exception_handler(RequestValidationError, validation_exception_handler)
 """
 
 from typing import Optional
@@ -18,19 +26,34 @@ def localized_http_exception(
     status_code: int, message_key: str, locale: Optional[str] = None, **kwargs
 ) -> HTTPException:
     """
-    HTTPException을 생성하되, 로케일에 맞는 에러 메시지를 사용합니다.
+    지정된 HTTP 상태 코드와 i18n 메시지 키를 바탕으로 현지화된 HTTPException을 생성합니다.
+
+    라우터나 서비스 계층에서 예외를 raise할 때 직접 HTTPException을 생성하는 대신
+    이 함수를 사용하면 다국어 메시지가 자동으로 적용됩니다.
+    locale이 지원되지 않거나 None인 경우, settings.DEFAULT_LOCALE로 폴백합니다.
 
     Args:
-        status_code: HTTP 상태 코드
-        message_key: i18n 메시지 키
-        locale: 로케일 (기본값: None, 런타임에 settings.DEFAULT_LOCALE 사용)
-        **kwargs: 메시지 포맷팅에 사용될 추가 인자
+        status_code (int): 반환할 HTTP 상태 코드 (예: 400, 401, 404, 500).
+        message_key (str): i18n 메시지 딕셔너리에서 조회할 키
+                           (예: ``"not_found"``, ``"unauthorized"``).
+        locale (Optional[str]): 응답 언어 코드 (예: ``"ko"``, ``"en"``).
+                                None이면 ``settings.DEFAULT_LOCALE``을 사용합니다.
+        **kwargs: ``get_message()`` 호출 시 메시지 템플릿에 삽입할 추가 포맷 인자.
 
     Returns:
-        HTTPException 인스턴스
+        HTTPException: FastAPI가 자동으로 처리하는 HTTP 예외 인스턴스.
+                       ``detail`` 필드에 현지화된 메시지가 포함됩니다.
+
+    Raises:
+        이 함수 자체는 예외를 발생시키지 않습니다. 반환된 객체를 ``raise``해야 합니다.
 
     Example:
-        raise localized_http_exception(404, "not_found", locale="ko")
+        >>> # 라우터에서 사용 예시
+        >>> raise localized_http_exception(
+        ...     status_code=404,
+        ...     message_key="not_found",
+        ...     locale="ko",
+        ... )
     """
     from .deps import normalize_locale
 
@@ -45,9 +68,33 @@ def localized_http_exception(
 
 async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
     """
-    전역 HTTPException 핸들러 (다국어 지원)
+    FastAPI 전역 HTTPException 핸들러 (다국어 지원).
 
-    Accept-Language 헤더를 기반으로 에러 메시지를 현지화합니다.
+    ``app.add_exception_handler(HTTPException, http_exception_handler)``로 등록하여
+    앱 전체에서 발생하는 HTTPException을 일관된 JSON 형식으로 처리합니다.
+    요청의 ``Accept-Language`` 헤더를 파싱하여 지원 로케일 중 하나로 에러 메시지를 현지화하며,
+    미리 정의된 status_code ↔ message_key 매핑에 없는 코드는 원본 detail을 그대로 사용합니다.
+
+    Args:
+        request (Request): FastAPI Request 객체.
+                           ``Accept-Language`` 헤더 추출에 사용됩니다.
+        exc (HTTPException): FastAPI 또는 Starlette가 전달하는 HTTP 예외 인스턴스.
+                             ``exc.status_code``와 ``exc.detail``이 응답에 반영됩니다.
+
+    Returns:
+        JSONResponse: 다음 구조의 JSON 응답::
+
+            {
+                "status": "error",
+                "message": "<현지화된 에러 메시지>",
+                "status_code": <int>
+            }
+
+    Note:
+        지원되는 status_code ↔ message_key 매핑:
+        400 → "bad_request", 401 → "unauthorized", 403 → "forbidden",
+        404 → "not_found", 405 → "method_not_allowed", 413 → "payload_too_large",
+        422 → "validation_error", 500 → "server_error".
     """
     from .deps import extract_locale_from_header
 
@@ -85,7 +132,36 @@ async def validation_exception_handler(
     request: Request, exc: Exception
 ) -> JSONResponse:
     """
-    Pydantic 검증 오류 핸들러 (다국어 지원)
+    FastAPI 전역 Pydantic 검증 오류 핸들러 (다국어 지원).
+
+    ``app.add_exception_handler(RequestValidationError, validation_exception_handler)``로 등록합니다.
+    요청 바디·쿼리·경로 파라미터의 Pydantic 유효성 검사 실패 시 호출되며,
+    422 응답에 현지화된 메시지와 함께 상세 오류 목록(``errors`` 필드)을 반환합니다.
+
+    Args:
+        request (Request): FastAPI Request 객체.
+                           ``Accept-Language`` 헤더 추출에 사용됩니다.
+        exc (Exception): FastAPI가 전달하는 예외 객체.
+                         내부적으로 ``RequestValidationError`` 타입인지 검증합니다.
+
+    Returns:
+        JSONResponse: HTTP 422 응답, 다음 구조의 JSON 포함::
+
+            {
+                "status": "error",
+                "message": "<현지화된 검증 오류 메시지>",
+                "status_code": 422,
+                "errors": [<Pydantic 오류 상세 목록>]
+            }
+
+    Raises:
+        exc: ``exc``가 ``RequestValidationError``가 아닌 경우, 원본 예외를 다시 raise합니다.
+             이를 통해 의도치 않은 예외가 이 핸들러에 잘못 라우팅되는 것을 방지합니다.
+
+    Note:
+        ``errors`` 필드는 프론트엔드가 필드별 에러 메시지를 표시할 때 활용할 수 있습니다.
+        단, 각 오류 항목에 사용자 입력값(``input``)이 포함될 수 있으므로
+        로그 저장 시 개인정보 포함 여부를 반드시 확인하십시오.
     """
     from fastapi.exceptions import RequestValidationError
 


### PR DESCRIPTION
- [모듈 수준 Docstring에 역할 요약 및 핸들러 등록 예시 추가]
  - Registration 섹션: `app.add_exception_handler` 사용법 명시

- [localized_http_exception()]: `Args/Returns/Raises/Example` 형식으로 고도화
  - 각 파라미터 타입·역할·기본값 폴백 동작 명시
  - 함수 자체는 raise하지 않음을 Raises 섹션에 명시

- [http_exception_handler()]: `Args/Returns/Note` 형식으로 고도화
  - `status_code` ↔ `message_key` 전체 매핑표를 Note 섹션에 문서화
  - 응답 JSON 구조를 Returns에 코드 블록으로 명시

- [validation_exception_handler()]: `Args/Returns/Raises/Note` 형식으로 고도화
  - RequestValidationError 타입 검증 후 re-raise 동작을 Raises에 명시
  - errors 필드 활용법 및 개인정보 보호 주의사항을 Note에 명시

🔗 Related: Issue [#1048]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

핵심 HTTP 예외 유틸리티와 전역 예외 핸들러에 대한 문서를 개선하여 사용 방법, 로컬라이제이션 동작, 응답 형식을 명확히 합니다.

문서화:
- `localized_http_exception()`의 docstring을 확장하여 상세한 인자 설명, 로컬라이제이션 폴백 동작, 반환 의미, 사용 예제를 추가합니다.
- `http_exception_handler()`의 등록 방법, 요청 처리 방식, `status_code`와 `message_key` 간 매핑, 표준화된 JSON 오류 응답 구조를 문서화합니다.
- `validation_exception_handler()`의 등록 방법, `RequestValidationError`와 기타 예외에 대한 동작, 422 응답 스키마, 그리고 개인정보 보호를 고려한 `errors` 필드 사용에 대한 가이드를 문서화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve documentation for core HTTP exception utilities and global exception handlers to clarify usage, localization behavior, and response formats.

Documentation:
- Expand localized_http_exception() docstring with detailed arguments, localization fallback behavior, return semantics, and usage example.
- Document http_exception_handler() registration, request handling, status_code-to-message_key mapping, and standardized JSON error response structure.
- Document validation_exception_handler() registration, behavior for RequestValidationError vs other exceptions, 422 response schema, and guidance on using errors field with privacy considerations.

</details>