### PR TITLE
☘️ refactor [#12.3.20] - 1차 개선 : 예외 처리 모듈 Docstring 품질 고도화

### DIFF
--- a/backend/api/exceptions.py
+++ b/backend/api/exceptions.py
@@ -91,10 +91,10 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> JSONRe
             }
 
     Note:
-        지원되는 status_code ↔ message_key 매핑:
-        400 → "bad_request", 401 → "unauthorized", 403 → "forbidden",
-        404 → "not_found", 405 → "method_not_allowed", 413 → "payload_too_large",
-        422 → "validation_error", 500 → "server_error".
+        함수 내부에 정의된 ``status_to_key`` 로컬 딕셔너리를 기준으로 status_code를
+        message_key로 매핑합니다. 지원 상태 코드와 키 심볼을 확인하려면
+        이 함수의 코드 바디를 직접 참조하십시오.
+        매핑에 없는 status_code는 ``exc.detail``을 그대로 사용합니다.
     """
     from .deps import extract_locale_from_header
 
@@ -159,6 +159,12 @@ async def validation_exception_handler(
              이를 통해 의도치 않은 예외가 이 핸들러에 잘못 라우팅되는 것을 방지합니다.
 
     Note:
+        이 핸들러는 ``RequestValidationError``를 전용으로 처리합니다.
+        시그니처가 ``exc: Exception``으로 넓게 선언되어 있지만, 실제로 타입 판별(isinstance)을
+        통해 ``RequestValidationError``인 경우에만 응답을 반환하며, 그 외에는 원본 예외를
+        re-raise합니다. ``app.add_exception_handler(RequestValidationError, ...)``로
+        등록하여 사용하십시오.
+
         ``errors`` 필드는 프론트엔드가 필드별 에러 메시지를 표시할 때 활용할 수 있습니다.
         단, 각 오류 항목에 사용자 입력값(``input``)이 포함될 수 있으므로
         로그 저장 시 개인정보 포함 여부를 반드시 확인하십시오.


### PR DESCRIPTION
- [http_exception_handler() Note 개선]
  - 하드코딩된 `status_code` ↔ `message_key` 목록 제거 (SSOT 원칙 준수)
  - 실제 매핑 정의 위치(status_to_key 로컬 딕셔너리)를 참조하도록 안내로 대체
  - 매핑 변경 시 Docstring 불일치 리스크 해소

- [validation_exception_handler() Note 개선]
  - 핸들러 처리 대상(RequestValidationError)을 Note 첫 항목에 명시
  - exc: Exception 시그니처의 실제 동작 범위(타입 판별 후 re-raise)를 Note에 설명 추가
  - errors 필드 활용법 및 개인정보 보호 주의사항 유지

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1620#pullrequestreview-4536723558)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

HTTP 및 검증 예외 핸들러에 대한 문서를 명확히 하고 개선합니다.

향상 사항:
- 문서와 코드 간의 불일치를 방지하기 위해, HTTP 상태와 메시지 키 매핑을 하드코딩된 목록 대신 내부의 `status_to_key` 딕셔너리를 기준으로 설명합니다.
- `validation_exception_handler`의 실제 동작과 의도된 사용 방법을 설명하며, `RequestValidationError`에 초점이 있다는 점과 다른 예외에 대해서는 재발생(re-raise)한다는 동작을 명시합니다.

문서화:
- 예외 핸들러에 대한 docstring과 노트를 다듬어, 오류 필드 처리 및 프라이버시에 관한 기존 안내는 유지하면서도 사용 및 유지보수에 더 도움이 되도록 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify and improve documentation for HTTP and validation exception handlers.

Enhancements:
- Describe HTTP status-to-message-key mapping in terms of the internal status_to_key dictionary instead of a hardcoded list to avoid doc/code drift.
- Explain the actual behavior and intended usage of the validation_exception_handler, including its RequestValidationError focus and re-raise behavior for other exceptions.

Documentation:
- Refine docstrings and notes for exception handlers to better guide usage and maintenance while preserving existing guidance on error field handling and privacy.

</details>