### PR TITLE
📝 docs [#12.3.20] - ➉ 2차 개선:  코어 로깅 모듈(audit_logger) 예외 처리 스펙 명확화 및 컨벤션 롤백

### DIFF
--- a/backend/core/audit_logger.py
+++ b/backend/core/audit_logger.py
@@ -187,7 +187,8 @@ def get_audit_log_backend() -> str:
 
     Returns:
         str: 설정된 백엔드 심볼 (예: ``"file"``, ``"db"``, ``"cloudwatch"``).
-             환경 변수가 설정되지 않거나 유효하지 않으면 시스템 기본값이 반환됩니다.
+             초기화 시점에 환경 변수를 검증 및 정규화하며, 값이 누락되거나
+             유효하지 않은 경우 시스템 기본값으로 안전하게 대체되어 반환됩니다.
     """
     return AUDIT_LOG_BACKEND
 
@@ -199,8 +200,8 @@ def get_audit_log_file_path() -> str:
     ``file`` 백엔드 사용 시 감사 로그를 기록할 대상 경로로 사용됩니다.
 
     Returns:
-        str: 감사 로그 파일 경로. 환경 변수가 설정되지 않은 경우
-             시스템 기본 경로가 반환됩니다.
+        str: 감사 로그 파일 경로. 초기화 시점에 설정 여부를 검증하며,
+             값이 누락된 경우 시스템 기본 경로로 정규화되어 반환됩니다.
     """
     return AUDIT_LOG_FILE_PATH
 
@@ -213,7 +214,8 @@ def get_audit_log_retention_days() -> int:
 
     Returns:
         int: 보관 일수 (단위: 일).
-             환경 변수가 유효하지 않으면 시스템 기본 보관 일수가 반환됩니다.
+             초기화 시점에 타입 및 유효 범위를 검증하며, 잘못된 설정일 경우
+             시스템 기본 보관 일수로 자동 정규화되어 반환됩니다.
     """
     return AUDIT_LOG_RETENTION_DAYS
 
@@ -226,7 +228,8 @@ def get_masked_uid_prefix_len() -> int:
 
     Returns:
         int: 마스킹되지 않고 노출할 앞 자릿수.
-             환경 변수가 유효하지 않으면 시스템 기본값이 반환됩니다.
+             초기화 시점에 검증을 거치며, 유효하지 않은 값이 주입되면
+             시스템 기본값으로 안전하게 강제 변환(coerced)되어 반환됩니다.
     """
     return MASKED_UID_PREFIX_LEN
 
@@ -383,13 +386,16 @@ def _write_to_file(record: dict[str, Any]) -> None:
                                  PII가 포함되지 않아야 합니다.
 
     Raises:
-        일반적인 파일 I/O 오류(예: ``OSError``)는 내부적으로 처리되어
-        예외를 발생시키지 않도록 설계되었으나, 예상치 못한 시스템 환경 문제 등
-        예외적인 상황에서는 오류가 전파될 수 있습니다.
+        일반적인 I/O 예외(예: ``OSError``, ``PermissionError``)는 의도적으로
+        포착하여 표준 로거로 폴백 처리(Best-effort)하며 프로세스 중단을 방지합니다.
+        단, I/O와 무관한 예외(예: 직렬화 실패 ``TypeError``, 메모리 부족 등)나
+        시스템 레벨의 치명적 오류는 포착하지 않고 상위로 전파됩니다.
     """
     log_path = get_audit_log_file_path()
     try:
-        if log_dir := os.path.dirname(log_path):
+        # sourcery skip: use-named-expression
+        log_dir = os.path.dirname(log_path)
+        if log_dir:
             os.makedirs(log_dir, exist_ok=True)
         with open(log_path, "a", encoding="utf-8") as f:
             f.write(json.dumps(record, ensure_ascii=False) + "\n")


### PR DESCRIPTION
- **[getter 함수 정규화 시점 문서화 보완]**
  - `_DEFAULT_*` 내부 변수를 노출하지 않으면서도, 초기화(import) 시점에 환경 변수 검증 및 강제 변환(coercion)이 일어남을 명시하여 트러블슈팅 편의성 증대

- **[_write_to_file() 예외 보장 범위의 구체화]**
  - 모호한 '예상치 못한 시스템 문제' 표현을 제거
  - OSError 등 I/O 예외는 폴백(Best-effort) 처리하나, TypeError(직렬화 실패) 등은 의도적으로 전파시킴을 명확히 문서화

- **[Python 버전 베이스라인 컨벤션 준수]**
  - 가독성 및 팀 일관성을 위해 왈러스 연산자(:=) 최적화를 롤백하고 명시적인 두 줄 할당/조건문 패턴으로 원복
  - Sourcery IDE의 왈러스 연산자 강제 경고를 억제하는 skip 주석 추가

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1623#pullrequestreview-4539256775)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

프로젝트의 Python 스타일 규칙과 일치하도록 구현을 정리하면서, 감사(audit) 로거 설정 및 오류 처리 동작을 명확히 합니다.

Enhancements:
- 프로젝트의 Python 버전 및 스타일 규칙을 준수하기 위해 `_write_to_file()`에서 사용하던 바다코끼리 연산자(walrus operator)를 명시적 할당과 조건 검사로 대체하고, 해당 블록에 Sourcery의 walrus 제안이 나오지 않도록 주석을 추가합니다.

Documentation:
- 감사 로거 getter 함수들이 모듈 import 시점에 환경 변수를 검증하고 정규화하며, 값이 없거나 잘못된 경우 안전한 기본값으로 폴백(fallback)한다는 점을 문서화합니다.
- `_write_to_file()`의 오류 처리 보장 사항을 명확히 하여, I/O 예외에 대해서는 최선의 처리(best-effort)를 시도하는 것과, 비 I/O 또는 치명적인 오류에 대해서는 의도적으로 예외를 전파한다는 점을 구분해 설명합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify audit logger configuration and error-handling behavior while aligning implementation with project Python style conventions.

Enhancements:
- Replace the walrus operator in _write_to_file() with explicit assignment and condition checks to comply with the project's Python version and style conventions, and annotate the block to suppress Sourcery walrus suggestions.

Documentation:
- Document that audit logger getter functions validate and normalize environment variables at import time, falling back to safe defaults when values are missing or invalid.
- Clarify _write_to_file() error-handling guarantees, distinguishing between best-effort handling of I/O exceptions and intentional propagation of non-I/O or critical errors.

</details>