### PR TITLE
📝 docs [#12.3.20] - ➉ 3차 개선 - 코어 로깅 모듈(audit_logger) Docstring DRY 리팩터링 및 예외 계약 확인

### DIFF
--- a/backend/core/audit_logger.py
+++ b/backend/core/audit_logger.py
@@ -12,6 +12,8 @@ GDPR Audit Logger — v9.0 Phase 2-4 (Privacy & Compliance)
   - 백엔드 외부화: 로그 저장소 백엔드(file / db / cloudwatch)를 AUDIT_LOG_BACKEND 환경 변수로 제어.
   - 보관 정책: 90일 보관 후 자동 영구 삭제 (트리거 인터페이스만 제공, 실제 실행은 스케줄러에 위임).
   - 하드코딩 금지: 모든 상수는 환경 변수 또는 모듈 레벨 상수로 외부화.
+  - 설정 정규화: 모듈 초기화(import) 시점에 환경 변수의 유효성을 1회 검증하며,
+    누락되거나 잘못된 값 주입 시 안전한 시스템 기본값으로 강제 변환(coerced)됩니다.
 
 [수명 주기]
   - FastAPI lifespan 또는 Celery 훅에서 schedule_audit_log_cleanup()을 등록하여 보관 정책을 강제.
@@ -187,8 +189,6 @@ def get_audit_log_backend() -> str:
 
     Returns:
         str: 설정된 백엔드 심볼 (예: ``"file"``, ``"db"``, ``"cloudwatch"``).
-             초기화 시점에 환경 변수를 검증 및 정규화하며, 값이 누락되거나
-             유효하지 않은 경우 시스템 기본값으로 안전하게 대체되어 반환됩니다.
     """
     return AUDIT_LOG_BACKEND
 
@@ -200,8 +200,7 @@ def get_audit_log_file_path() -> str:
     ``file`` 백엔드 사용 시 감사 로그를 기록할 대상 경로로 사용됩니다.
 
     Returns:
-        str: 감사 로그 파일 경로. 초기화 시점에 설정 여부를 검증하며,
-             값이 누락된 경우 시스템 기본 경로로 정규화되어 반환됩니다.
+        str: 감사 로그 파일 경로.
     """
     return AUDIT_LOG_FILE_PATH
 
@@ -214,8 +213,6 @@ def get_audit_log_retention_days() -> int:
 
     Returns:
         int: 보관 일수 (단위: 일).
-             초기화 시점에 타입 및 유효 범위를 검증하며, 잘못된 설정일 경우
-             시스템 기본 보관 일수로 자동 정규화되어 반환됩니다.
     """
     return AUDIT_LOG_RETENTION_DAYS
 
@@ -228,8 +225,6 @@ def get_masked_uid_prefix_len() -> int:
 
     Returns:
         int: 마스킹되지 않고 노출할 앞 자릿수.
-             초기화 시점에 검증을 거치며, 유효하지 않은 값이 주입되면
-             시스템 기본값으로 안전하게 강제 변환(coerced)되어 반환됩니다.
     """
     return MASKED_UID_PREFIX_LEN
 


### PR DESCRIPTION
- **[getter 함수 Docstring 중복 제거]**
  - 4개의 getter 함수에 반복되던 '환경 변수 검증 및 정규화(coerced)' 설명을 제거하여 인터페이스 문서의 가독성 향상
  - 제거된 설명을 모듈 최상단 Docstring의 `설계 원칙` 섹션('설정 정규화')으로 단일화(SSOT)하여 향후 유지보수성 극대화

- **[_write_to_file() 예외 처리 계약 확인]**
  - 실제 코드가 포괄적인 `except Exception:`을 피하고, 문서화된 계약과 동일하게 `except OSError:`만 명시적으로 포착하고 있음을 재검증 완료 (수정 불필요)

🔗 Related:
- Issue [#1048]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1624#pullrequestreview-4539261356)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Documentation:
- 개별 getter의 docstring에 반복적으로 작성되던 환경 변수 검증 및 변환(coercion)에 대한 설명을 모듈 단위의 설계 원칙(section)으로 옮겨, 가독성을 높이고 단일한 진실 공급원(single source of truth)을 유지하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Move repeated explanations of environment variable validation and coercion from individual getter docstrings into the module-level design principles section to improve clarity and maintain a single source of truth.

</details>