### PR TITLE
📝 docs [#12.3.20] - ⑫ `config_validator.py` Docstring 구조 고도화 및 전면 영문화

### DIFF
--- a/backend/core/config_validator.py
+++ b/backend/core/config_validator.py
@@ -1,28 +1,29 @@
 # backend/core/config_validator.py
 
 """
-Global Configuration Validation Policy — v9.0 Phase 2 (Personalized RAG) / Phase 3 (Realtime Streaming)
+Global Configuration Validation Policy - v9.0 Phase 2 (Personalized RAG) / Phase 3 (Realtime Streaming)
 =========================================================================================================
 
-장애 전파 범위(Blast Radius) 정책:
+Blast Radius Policy:
 
-  [Global Hard Failure]
-    필수 보안 설정(STORAGE_BASE_PATH, PBKDF2_ITERATIONS 등) 파싱 오류 시
-    → 보안 오염 방지를 위해 SystemExit(1)으로 전체 애플리케이션 기동 즉시 중단.
+[Global Hard Failure]
+On parsing failure for required security settings (STORAGE_BASE_PATH, PBKDF2_ITERATIONS, etc.),
+the entire application exits immediately via SystemExit(1) to prevent security contamination.
 
-  [Subsystem Hard Failure]
-    선택적 부가 설정(FAISS_COMPACTION_*, TOPIC_CLUSTER_CACHE_TTL,
-    SSE_KEEPALIVE_INTERVAL_SECS 등) 파싱 오류 시
-    → Silent Fallback 금지. 해당 서브시스템만 비활성화하고 핵심 REST API는 유지.
-    → HealthRegistry를 통해 DEGRADED 상태를 노출하여 상태 은폐 방지.
+[Subsystem Hard Failure]
+On parsing failure for optional subsystem settings
+(FAISS_COMPACTION_*, TOPIC_CLUSTER_CACHE_TTL, SSE_KEEPALIVE_INTERVAL_SECS, etc.),
+silent fallback is prohibited. Only the affected subsystem is disabled; the core REST API remains operational.
+The DEGRADED status is exposed via HealthRegistry to prevent status concealment.
 
-  [Graceful Fallback / Clamping]
-    범위 기반 설정(AWS_WRAPPER_MAX_WORKERS 등) 값이 10 미만(< 10) 또는 100 초과(> 100)인 경우
-    → 크래시 없이 안전 범위 내로 자율 보정(Clamp) + WARNING 로그 (환경변수명, 원래값, 보정값, 이유 포함).
-    → 비정수/미설정 시 heuristic 기본값으로 폴백 + WARNING 로그.
+[Graceful Fallback / Clamping]
+For range-based settings (AWS_WRAPPER_MAX_WORKERS, etc.), values below the minimum or above the maximum
+are autonomously clamped to the safe range with a WARNING log
+(env var name, original value, clamped value, and reason are all included).
+On non-integer or unset values, falls back to a heuristic default with a WARNING log.
 
-이 모듈은 하나의 프로세스에서 한 번만 초기화됩니다 (bootstrap 단계).
-민감 정보(시크릿, 키, 경로값)는 절대 로그에 기록하지 않습니다.
+This module is initialized once per process during the bootstrap phase.
+Sensitive data (secrets, keys, paths) must never be written to logs.
 """
 
 from __future__ import annotations
@@ -32,38 +33,44 @@ import os
 from enum import Enum
 from typing import Callable, ClassVar, Dict, Mapping
 
-# 프로젝트 공통 유틸 재사용 — 중복 구현 금지
+# Reuse shared project utilities — do not re-implement
 from backend.config import ConfigRange, _clamp
 
 logger = logging.getLogger(__name__)
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# 서브시스템 식별자
-# ─────────────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# Subsystem identifiers
+# ---------------------------------------------------------------------------
 
 
 class Subsystem(str, Enum):
-    """서브시스템 식별자 (HealthRegistry 키로 사용)."""
+    """Subsystem identifiers used as HealthRegistry keys.
 
-    FAISS_COMPACTION = "faiss_compaction"
-    TOPIC_CLUSTERING = "topic_clustering"
-    HYBRID_SEARCH = "hybrid_search"
-    PERSONALIZED_INDEX = "personalized_index"
-    REALTIME_STREAMING = "realtime_streaming"  # Phase 3: 실시간 스트리밍 서브시스템
-    GRAPH_ENGINE = "graph_engine"  # Phase 4: 지식 그래프 엔진 서브시스템
+    Each member's str value is used directly as the HealthRegistry registration key.
+    When adding a new subsystem, define a member here and include the key
+    in the corresponding _log_subsystem_state call site.
+    """
+
+    FAISS_COMPACTION = "faiss_compaction"  # Phase 2: FAISS vector index compaction
+    TOPIC_CLUSTERING = "topic_clustering"  # Phase 2: Topic clustering cache
+    HYBRID_SEARCH = "hybrid_search"  # Phase 2: Personalized/global hybrid search
+    PERSONALIZED_INDEX = "personalized_index"  # Phase 2: Per-user personalized index
+    REALTIME_STREAMING = "realtime_streaming"  # Phase 3: Realtime streaming subsystem
+    GRAPH_ENGINE = "graph_engine"  # Phase 4: Knowledge graph engine subsystem
 
 
 class SubsystemHealthState(str, Enum):
-    """서브시스템 상태 식별자 및 로그 레벨 SSOT (로깅·가시성).
+    """Subsystem health state identifiers and log-level SSOT (logging/observability).
 
-    각 멤버는 (label, log_level)을 함께 정의한다.
-    신규 상태 추가 시 __new__에 표준 logging 레벨 상수를 반드시 지정한다.
-    log_level은 읽기 전용 property로만 노출된다.
+    Each member defines both a label and a log_level together.
+    When adding a new state, assign a standard logging-module constant in __new__.
+    log_level is exposed as a read-only property only.
     """
 
-    # 이 enum 전용 — 표준 logging 모듈 상수만 허용 (임의 정수 하드코딩 금지)
-    # dunder(__) 이름을 사용하여 Enum 멤버로 취급되는 것을 완전히 차단하고, 일반 ClassVar로 동작하게 한다.
+    # For this enum only — only standard logging module constants are allowed (no hardcoded integers).
+    # Using dunder (__) names prevents Enum from treating this as a member,
+    # making it behave as a regular ClassVar.
     __ALLOWED_LOG_LEVELS__: ClassVar[frozenset[int]] = frozenset(
         {
             logging.NOTSET,
@@ -98,21 +105,24 @@ class SubsystemHealthState(str, Enum):
 
     @property
     def log_level(self) -> int:
-        """이 상태에 대응하는 표준 logging 레벨 (읽기 전용)."""
+        """Standard logging level corresponding to this state (read-only)."""
         return self._log_level
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# 내부 파서 헬퍼 (모듈 내부 전용)
-# ─────────────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# Internal parser helpers (module-private)
+# ---------------------------------------------------------------------------
 
 
 def _parse_str_critical(env_key: str) -> str:
-    """
-    필수 문자열 환경 변수를 파싱한다.
-    미설정 또는 빈 값이면 CRITICAL 로그 후 SystemExit(1) — Global Hard Failure.
+    """Parse a required string environment variable.
 
-    주의: 값 자체(경로, 식별자)는 보안상 로그에 기록하지 않는다.
+    If the variable is not set or is empty, logs CRITICAL and exits immediately
+    via SystemExit(1). (Global Hard Failure — see module-level Blast Radius Policy.)
+
+    Reads the OS environment variable specified by env_key, strips whitespace,
+    and returns the non-empty string value. The value itself (path, identifier, etc.)
+    is never written to logs per the security policy.
     """
     raw = os.environ.get(env_key, "").strip()
     if not raw:
@@ -126,9 +136,13 @@ def _parse_str_critical(env_key: str) -> str:
 
 
 def _parse_int_critical(env_key: str, *, min_val: int | None = None) -> int:
-    """
-    필수 정수 환경 변수를 파싱한다.
-    파싱 실패 또는 min_val 미달 시 CRITICAL 로그 후 SystemExit(1) — Global Hard Failure.
+    """Parse a required integer environment variable.
+
+    If parsing fails or the value is below min_val, logs CRITICAL and exits
+    via SystemExit(1). (Global Hard Failure — see module-level Blast Radius Policy.)
+
+    Reads the environment variable specified by env_key and converts it to int.
+    If min_val is provided, performs a minimum-value check; otherwise skips it.
     """
     raw = os.environ.get(env_key)
     if raw is None:
@@ -169,8 +183,20 @@ def _log_clamp_warning(
     clamped: int | float,
     range_: ConfigRange,
 ) -> None:
-    """Clamping 로그 일관화 헬퍼."""
-    reason = "범위 미만 보정" if original < range_.min else "범위 초과 보정"
+    """Internal helper that emits a structured WARNING log when clamping occurs.
+
+    Logs env var name, original value, clamped value, allowed range, and reason
+    in a consistent format so operators can identify misconfigured settings immediately.
+
+    Args:
+        env_key:  Name of the environment variable being clamped.
+        original: The original value before clamping.
+        clamped:  The value after clamping to the safe range.
+        range_:   The ConfigRange instance defining the allowed min/max bounds.
+    """
+    reason = (
+        "below-range correction" if original < range_.min else "above-range correction"
+    )
     logger.warning(
         "[CONFIG][CLAMP] '%s'=%g is outside safe range [%g, %g]; "
         "clamped to %g (%s). "
@@ -192,15 +218,24 @@ def _parse_int_subsystem(
     range_: ConfigRange | None = None,
     subsystem: Subsystem,
 ) -> tuple[int, bool]:
-    """
-    선택적 정수 환경 변수를 파싱한다 (서브시스템 설정용).
+    """Parse an optional integer environment variable for a subsystem setting.
+
+    On parse failure, disables only the affected subsystem instead of terminating
+    the entire application. (Subsystem Hard Failure — see module-level Blast Radius Policy.)
+    If range_ is provided, applies clamping and emits a WARNING log.
+
+    Args:
+        env_key:   Name of the OS environment variable.
+        default:   Fallback value when the variable is not set.
+        range_:    Allowed range as a ConfigRange instance (None to skip range check).
+        subsystem: Subsystem identifier for log context.
 
     Returns:
-        (value, ok): ok=False → 해당 서브시스템 비활성화 (Subsystem Hard Failure).
+        A tuple[int, bool] where the bool is True on success and False on parse failure.
     """
     raw = os.environ.get(env_key)
     if raw is None:
-        # 미설정은 기본값 사용 — 실패가 아님
+        # Not set — use default; this is not a failure.
         return default, True
 
     try:
@@ -231,11 +266,20 @@ def _parse_float_subsystem(
     range_: ConfigRange | None = None,
     subsystem: Subsystem,
 ) -> tuple[float, bool]:
-    """
-    선택적 float 환경 변수를 파싱한다 (서브시스템 설정용).
+    """Parse an optional float environment variable for a subsystem setting.
+
+    On parse failure, disables only the affected subsystem instead of terminating
+    the entire application. (Subsystem Hard Failure — see module-level Blast Radius Policy.)
+    If range_ is provided, applies clamping and emits a WARNING log.
+
+    Args:
+        env_key:   Name of the OS environment variable.
+        default:   Fallback value when the variable is not set.
+        range_:    Allowed range as a ConfigRange instance (None to skip range check).
+        subsystem: Subsystem identifier for log context.
 
     Returns:
-        (value, ok): ok=False → 해당 서브시스템 비활성화 (Subsystem Hard Failure).
+        A tuple[float, bool] where the bool is True on success and False on parse failure.
     """
     raw = os.environ.get(env_key)
     if raw is None:
@@ -268,13 +312,18 @@ def _parse_int_clamped(
     default_factory: Callable[[], int],
     range_: ConfigRange,
 ) -> int:
-    """
-    범위 기반 정수 환경 변수를 파싱한다 (Graceful Fallback / Clamping).
+    """Parse a range-based integer environment variable with Graceful Fallback/Clamping.
 
-    - 미설정 또는 비정수: heuristic 기본값으로 폴백 + WARNING 로그
-    - 값이 10 미만(< 10) 또는 100 초과(> 100): 경계로 보정 + WARNING 로그
-      (10과 100은 유효한 경계값으로 보정 대상 제외)
-    - 환경변수명·원래값·보정값·폴백 이유를 모두 WARNING 로그에 포함
+    Autonomously clamps the value to the safe range without disabling any subsystem.
+    All corrections and fallback reasons are recorded in a structured WARNING log.
+    (Graceful Fallback — see module-level Blast Radius Policy.)
+
+    Behavior rules:
+    - If unset or non-integer: falls back to default_factory() result with a WARNING log.
+    - If out of range: clamps to the boundary value with a WARNING log.
+      (Boundary values themselves are not subject to further clamping.)
+    - Env var name, original value, clamped value, and fallback reason are all
+      included in the WARNING log.
     """
     default = default_factory()
     raw = os.environ.get(env_key)
@@ -311,8 +360,11 @@ def _parse_float_clamped(
     default: float,
     range_: ConfigRange,
 ) -> float:
-    """
-    범위 기반 float 환경 변수를 파싱한다 (Graceful Fallback / Clamping).
+    """Parse a range-based float environment variable with Graceful Fallback/Clamping.
+
+    Autonomously clamps the value to the safe range without disabling any subsystem.
+    (Graceful Fallback — see module-level Blast Radius Policy.)
+    If the variable is not set, returns the default silently without logging.
     """
     raw = os.environ.get(env_key)
 
@@ -342,21 +394,21 @@ def _log_subsystem_state(
     *,
     state_label: SubsystemHealthState = SubsystemHealthState.DISABLED,
 ) -> None:
-    """서브시스템 비정상 상태(DISABLED·DEGRADED) 운영 가시성 로깅 헬퍼.
+    """Observability logging helper for abnormal subsystem states (DISABLED, DEGRADED).
 
-    지원 상태 (2종, SubsystemHealthState SSOT):
-      - DISABLED: 파싱 실패 등으로 서브시스템 비활성 → ERROR
-      - DEGRADED: Clamping 후 부분 격하 → WARNING
+    Supported state types:
+    - DISABLED: subsystem deactivated due to parse failure, etc. (ERROR-level log).
+    - DEGRADED: subsystem partially degraded after clamping (WARNING-level log).
 
     Args:
-        subsystem_ok: 서브시스템별 상태 플래그 (True: 정상, False: state_label 해당).
-        state_label: 비정상 서브시스템에 부여할 상태 레이블 (호출부에서 DISABLED 또는 DEGRADED).
+        subsystem_ok: Mapping of per-subsystem health flags (True=active, False=inactive).
+        state_label:  Health state label to assign to failed subsystems.
     """
     log_level = state_label.log_level
 
     for sub, ok in subsystem_ok.items():
         if not ok:
-            # sub는 Subsystem 타입임이 보장되므로, 명시적으로 .value를 호출하여 str로 변환
+            # sub is guaranteed to be Subsystem type; call .value explicitly for str conversion
             sub_name: str = sub.value
 
             logger.log(
@@ -369,35 +421,34 @@ def _log_subsystem_state(
             )
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Phase 2 통합 설정 클래스
-# ─────────────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# Phase 2 integrated configuration class
+# ---------------------------------------------------------------------------
 
 
 class PersonalizedRAGConfig:
+    """Configuration validation class for v9.0 Phase 2 Personalized RAG.
+
+    Usage:
+        cfg = PersonalizedRAGConfig.from_env()  # call once during bootstrap
+
+    Required environment variables (application cannot start if unset):
+        STORAGE_BASE_PATH       - Root path for user data storage
+        PBKDF2_ITERATIONS       - Key derivation iteration count (security minimum: 600,000)
+
+    Optional environment variables (parse failure disables only the affected subsystem):
+        FAISS_COMPACTION_VECTOR_THRESHOLD   (int, default: 500, min: 100)
+        FAISS_COMPACTION_DELETE_RATIO       (float, default: 0.15, range: 0.0-1.0)
+        TOPIC_CLUSTER_CACHE_TTL             (int, seconds, default: 3600)
+        REDIS_FALLBACK_TTL_SECS             (int, seconds, default: 300)
+        PERSONALIZED_INDEX_WEIGHT           (float, default: 0.6, range: 0.0-1.0)
+        GLOBAL_INDEX_WEIGHT                 (float, default: 0.4, range: 0.0-1.0)
+
+    Range-clamped environment variables:
+        AWS_WRAPPER_MAX_WORKERS (int, default: heuristic, recommended range: 10-100)
     """
-    v9.0 Phase 2 Personalized RAG 전용 검증 설정 클래스.
 
-    사용법:
-        cfg = PersonalizedRAGConfig.from_env()  # bootstrap 단계에서 1회 호출
-
-    필수 환경 변수 (미설정 시 애플리케이션 기동 불가):
-        STORAGE_BASE_PATH       - 사용자 데이터 루트 경로
-        PBKDF2_ITERATIONS       - 키 파생 반복 횟수 (보안 최소값: 600,000)
-
-    선택적 환경 변수 (파싱 오류 시 해당 서브시스템만 비활성화):
-        FAISS_COMPACTION_VECTOR_THRESHOLD   (int, 기본: 500, 최소: 100)
-        FAISS_COMPACTION_DELETE_RATIO       (float, 기본: 0.15, 범위: 0.0~1.0)
-        TOPIC_CLUSTER_CACHE_TTL             (int, 초 단위, 기본: 3600)
-        REDIS_FALLBACK_TTL_SECS             (int, 초 단위, 기본: 300)
-        PERSONALIZED_INDEX_WEIGHT           (float, 기본: 0.6, 범위: 0.0~1.0)
-        GLOBAL_INDEX_WEIGHT                 (float, 기본: 0.4, 범위: 0.0~1.0)
-
-    범위 보정(Clamping) 환경 변수:
-        AWS_WRAPPER_MAX_WORKERS (int, 기본: heuristic, 권장 범위: 10~100)
-    """
-
-    # 공유 ConfigRange 상수
+    # Shared ConfigRange constants
     _WEIGHT_RANGE: ClassVar[ConfigRange] = ConfigRange(min=0.0, max=1.0)
     _FAISS_RATIO_RANGE: ClassVar[ConfigRange] = ConfigRange(min=0.0, max=1.0)
     _FAISS_THRESHOLD_RANGE: ClassVar[ConfigRange] = ConfigRange(min=100, max=100_000)
@@ -424,6 +475,31 @@ class PersonalizedRAGConfig:
         # Subsystem health map
         subsystem_ok: Dict[Subsystem, bool],
     ) -> None:
+        """Initialize a PersonalizedRAGConfig instance.
+
+        Use the :meth:`from_env` class method instead of calling this directly.
+        All arguments are keyword-only.
+
+        Args:
+            storage_base_path:                  Root path for user data (STORAGE_BASE_PATH).
+            pbkdf2_iterations:                  Key derivation iteration count (PBKDF2_ITERATIONS).
+            faiss_compaction_vector_threshold:  FAISS compaction trigger vector count threshold
+                                                (FAISS_COMPACTION_VECTOR_THRESHOLD).
+            faiss_compaction_delete_ratio:      FAISS compaction delete ratio 0.0-1.0
+                                                (FAISS_COMPACTION_DELETE_RATIO).
+            topic_cluster_cache_ttl:            Topic cluster cache TTL in seconds
+                                                (TOPIC_CLUSTER_CACHE_TTL).
+            redis_fallback_ttl_secs:            Redis fallback TTL in seconds
+                                                (REDIS_FALLBACK_TTL_SECS).
+            personalized_index_weight:          Personalized index weight 0.0-1.0
+                                                (PERSONALIZED_INDEX_WEIGHT).
+            global_index_weight:                Global index weight 0.0-1.0
+                                                (GLOBAL_INDEX_WEIGHT).
+            aws_wrapper_max_workers:            Max AWS wrapper worker count (clamped)
+                                                (AWS_WRAPPER_MAX_WORKERS).
+            subsystem_ok:                       Per-subsystem active status map
+                                                (True=active, False=inactive).
+        """
         self.storage_base_path = storage_base_path
         self.pbkdf2_iterations = pbkdf2_iterations
         self.faiss_compaction_vector_threshold = faiss_compaction_vector_threshold
@@ -433,21 +509,21 @@ class PersonalizedRAGConfig:
         self.personalized_index_weight = personalized_index_weight
         self.global_index_weight = global_index_weight
         self.aws_wrapper_max_workers = aws_wrapper_max_workers
-        # 서브시스템 가동 여부 맵 (True=활성, False=비활성)
+        # Per-subsystem active status map (True=active, False=inactive)
         self.subsystem_ok: Dict[Subsystem, bool] = subsystem_ok
 
     @classmethod
     def from_env(cls) -> "PersonalizedRAGConfig":
+        """Parse settings from environment variables and return a PersonalizedRAGConfig instance.
+
+        On critical parse failure: raises SystemExit(1) — Global Hard Failure.
         """
-        환경 변수에서 설정을 파싱하여 PersonalizedRAGConfig 인스턴스를 반환한다.
-        Critical 설정 파싱 실패 시 SystemExit(1) — Global Hard Failure.
-        """
-        # ── 1. Critical 설정 (Global Hard Failure) ────────────────────────
+        # -- 1. Critical settings (Global Hard Failure) -----------------------
         storage_base_path = _parse_str_critical("STORAGE_BASE_PATH")
         pbkdf2_iterations = _parse_int_critical("PBKDF2_ITERATIONS", min_val=600_000)
 
-        # ── 2. 서브시스템 설정 (Subsystem Hard Failure) ───────────────────
-        # subsystem_ok 키는 항상 Subsystem Enum으로 통일 — 타입 안전성 보장
+        # -- 2. Subsystem settings (Subsystem Hard Failure) -------------------
+        # subsystem_ok keys always use Subsystem Enum — ensures type safety
         subsystem_ok: Dict[Subsystem, bool] = {}
 
         faiss_threshold, ok_ft = _parse_int_subsystem(
@@ -462,7 +538,7 @@ class PersonalizedRAGConfig:
             range_=cls._FAISS_RATIO_RANGE,
             subsystem=Subsystem.FAISS_COMPACTION,
         )
-        # 두 설정 중 하나라도 실패하면 FAISS Compaction 서브시스템 비활성화
+        # Disable FAISS Compaction subsystem if either setting fails
         subsystem_ok[Subsystem.FAISS_COMPACTION] = ok_ft and ok_fr
 
         topic_ttl, ok_ttl = _parse_int_subsystem(
@@ -492,13 +568,13 @@ class PersonalizedRAGConfig:
             range_=cls._WEIGHT_SUM_TOLERANCE_RANGE,
         )
 
-        # Weight 합계 검증: 운영자 오설정 조기 감지
-        # 정규화는 Silent 수정으로 Zero Trust 원칙 위반 — WARNING 로그만 출력하고 원래 값 유지
+        # Weight sum validation: catches operator misconfiguration early.
+        # Normalization is a silent modification that violates Zero Trust — only log WARNING.
         weight_sum = p_weight + g_weight
         if abs(weight_sum - 1.0) > tolerance:
             logger.warning(
                 "[CONFIG] PERSONALIZED_INDEX_WEIGHT=%.4f + GLOBAL_INDEX_WEIGHT=%.4f "
-                "= %.4f (expected ~1.0, tolerance=±%.2f). "
+                "= %.4f (expected ~1.0, tolerance=+/-%.2f). "
                 "Verify weights are configured correctly.",
                 p_weight,
                 g_weight,
@@ -506,14 +582,14 @@ class PersonalizedRAGConfig:
                 tolerance,
             )
 
-        # Redis 폴백 TTL은 인프라 설정이므로 Subsystem 비활성화 없이 기본값 적용
+        # Redis fallback TTL is an infra setting — use default without disabling subsystem
         redis_ttl, _ = _parse_int_subsystem(
             "REDIS_FALLBACK_TTL_SECS",
             default=300,
             subsystem=Subsystem.PERSONALIZED_INDEX,
         )
 
-        # ── 3. 범위 보정(Clamping) 설정 ───────────────────────────────────
+        # -- 3. Range-clamped settings ----------------------------------------
         def _cpu_heuristic() -> int:
             cpu = os.cpu_count() or 1
             return min(32, cpu + 4)
@@ -524,7 +600,7 @@ class PersonalizedRAGConfig:
             range_=cls._AWS_WORKERS_RANGE,
         )
 
-        # ── 4. 서브시스템 상태(DISABLED) 운영 가시성 로깅 ──────────
+        # -- 4. Subsystem DISABLED observability logging ----------------------
         _log_subsystem_state(subsystem_ok)
 
         return cls(
@@ -541,37 +617,35 @@ class PersonalizedRAGConfig:
         )
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Phase 3 스트리밍 설정 검증 클래스
-# ─────────────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# Phase 3 streaming configuration validation class
+# ---------------------------------------------------------------------------
 
 
 class RealtimeStreamingConfig:
-    """
-    v9.0 Phase 3 Realtime Streaming 전용 검증 설정 클래스.
+    """Configuration validation class for v9.0 Phase 3 Realtime Streaming.
 
-    사용법:
-        cfg = RealtimeStreamingConfig.from_env()  # bootstrap 단계에서 1회 호출
+    Usage:
+        cfg = RealtimeStreamingConfig.from_env()  # call once during bootstrap
 
-    책임 (3-0/3-5 SSOT 정책 준수):
-        - StreamingConfig(backend/core/config/streaming.py)에서 정의된
-          스키마와 기본값을 바탕으로 OS 환경 변수를 로드한다.
-        - 바운더리 체크(Clamping) 및 유효성 검증을 중앙에서 강제한다.
-        - 파싱 오류 시 REALTIME_STREAMING 서브시스템만 DEGRADED 처리하고
-          기존 비스트리밍 엔드포인트 생존성을 유지한다 (Subsystem Hard Failure).
+    Responsibilities (per 3-0/3-5 SSOT policy):
+        - Loads OS environment variables based on the schema and defaults defined
+          in StreamingConfig (backend/core/config/streaming.py).
+        - Centrally enforces boundary checks (clamping) and validity validation.
+        - On parse failure, marks only the REALTIME_STREAMING subsystem as DEGRADED
+          while keeping existing non-streaming endpoints alive (Subsystem Hard Failure).
 
-    검증 시점 (Fail-Fast):
-        사용자 요청 시점(Request-time)이 아닌 애플리케이션 시작(Bootstrap/Startup)
-        시점에 즉각 수행되어야 한다.
+    Validation timing (Fail-Fast):
+        Must be performed at application startup (Bootstrap/Startup), not at request time.
 
-    선택적 환경 변수 (파싱 오류 시 해당 서브시스템만 비활성화):
-        SSE_KEEPALIVE_INTERVAL_SECS  (int, 기본: 15, 범위: 5~60)
-        STREAM_BUFFER_MAX_SIZE       (int, 기본: 100, 범위: 10~1000)
-        STREAM_TIMEOUT_SECS          (int, 기본: 120, 범위: 30~600)
-        LANGGRAPH_STREAM_VERSION     (str, 기본: "v2", 허용: "v1"/"v2")
+    Optional environment variables (parse failure disables only the affected subsystem):
+        SSE_KEEPALIVE_INTERVAL_SECS  (int, default: 15, range: 5-60)
+        STREAM_BUFFER_MAX_SIZE       (int, default: 100, range: 10-1000)
+        STREAM_TIMEOUT_SECS          (int, default: 120, range: 30-600)
+        LANGGRAPH_STREAM_VERSION     (str, default: "v2", allowed: "v1"/"v2")
 
-    보안 원칙:
-        민감 정보(사용자 ID, 토큰 등)는 절대 로그에 기록하지 않는다.
+    Security policy:
+        Sensitive data (user IDs, tokens, etc.) must never be written to logs.
     """
 
     def __init__(
@@ -583,21 +657,39 @@ class RealtimeStreamingConfig:
         stream_version: str,
         subsystem_ok: Dict[Subsystem, bool],
     ) -> None:
+        """Initialize a RealtimeStreamingConfig instance.
+
+        Use the :meth:`from_env` class method instead of calling this directly.
+        All arguments are keyword-only.
+
+        Args:
+            keepalive_interval_secs: SSE keepalive send interval in seconds
+                                     (SSE_KEEPALIVE_INTERVAL_SECS).
+            buffer_max_size:         Maximum streaming buffer size
+                                     (STREAM_BUFFER_MAX_SIZE).
+            timeout_secs:            Maximum streaming session duration in seconds
+                                     (STREAM_TIMEOUT_SECS).
+            stream_version:          LangGraph streaming protocol version ("v1" or "v2")
+                                     (LANGGRAPH_STREAM_VERSION).
+            subsystem_ok:            Per-subsystem active status map
+                                     (True=active, False=DEGRADED).
+        """
         self.keepalive_interval_secs = keepalive_interval_secs
         self.buffer_max_size = buffer_max_size
         self.timeout_secs = timeout_secs
         self.stream_version = stream_version
-        # 서브시스템 가동 여부 맵: Enum 키로 내부 관리, 경계에서만 .value 변환
+        # Per-subsystem active status map: managed internally with Enum keys;
+        # convert to .value only at the boundary.
         self.subsystem_ok: Dict[Subsystem, bool] = subsystem_ok
 
     @classmethod
     def from_env(cls) -> "RealtimeStreamingConfig":
+        """Parse streaming settings from environment variables and return a RealtimeStreamingConfig instance.
+
+        On parse failure: marks REALTIME_STREAMING subsystem as inactive — Subsystem Hard Failure.
+        Does not halt the server; existing non-streaming APIs remain operational.
         """
-        환경 변수에서 스트리밍 설정을 파싱하여 RealtimeStreamingConfig 인스턴스를 반환한다.
-        파싱 오류 시 REALTIME_STREAMING 서브시스템 비활성화 — Subsystem Hard Failure.
-        전체 서버 부팅을 중단하지 않으며 기존 비스트리밍 API는 정상 유지된다.
-        """
-        # 공개 상수 별칭을 통해 임포트 (밑줄 접두 내부 상수 직접 참조 금지)
+        # Reference public constant aliases — do not reference underscore-prefixed internal constants directly
         from backend.core.config.streaming import (
             STREAMING_BUFFER_MAX_SIZE_RANGE,
             STREAMING_DEFAULT_BUFFER_MAX_SIZE,
@@ -613,10 +705,10 @@ class RealtimeStreamingConfig:
             STREAMING_VALID_STREAM_VERSIONS,
         )
 
-        # Dict[Subsystem, bool]: Enum 키로 내부 타입 안전성 확보
+        # Dict[Subsystem, bool]: Enum keys ensure internal type safety
         subsystem_ok: Dict[Subsystem, bool] = {}
 
-        # ── 서브시스템 설정 (Subsystem Hard Failure) ──────────────────────
+        # -- Subsystem settings (Subsystem Hard Failure) ----------------------
         keepalive, ok_ka = _parse_int_subsystem(
             STREAMING_ENV_KEEPALIVE_INTERVAL,
             default=STREAMING_DEFAULT_KEEPALIVE_INTERVAL_SECS,
@@ -636,8 +728,8 @@ class RealtimeStreamingConfig:
             subsystem=Subsystem.REALTIME_STREAMING,
         )
 
-        # 문자열 열거형 검증 (허용 버전 이외 값 → 기본값 폴백)
-        # ENV key 존재 여부를 먼저 확인하여 기본값에 불필요한 .strip() 방지
+        # String enum validation (invalid version falls back to default)
+        # Check ENV key existence first to avoid unnecessary .strip() on default value
         if STREAMING_ENV_STREAM_VERSION in os.environ:
             raw_version = os.environ[STREAMING_ENV_STREAM_VERSION].strip()
         else:
@@ -658,12 +750,12 @@ class RealtimeStreamingConfig:
             stream_version = raw_version
             ok_ver = True
 
-        # 하나라도 실패하면 REALTIME_STREAMING 서브시스템 비활성화
+        # Disable REALTIME_STREAMING subsystem if any setting fails
         subsystem_ok[Subsystem.REALTIME_STREAMING] = (
             ok_ka and ok_buf and ok_to and ok_ver
         )
 
-        # ── 서브시스템 상태(DEGRADED) 운영 가시성 로깅 ──
+        # -- Subsystem DEGRADED observability logging -------------------------
         _log_subsystem_state(subsystem_ok, state_label=SubsystemHealthState.DEGRADED)
 
         return cls(
@@ -675,35 +767,34 @@ class RealtimeStreamingConfig:
         )
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Phase 4 지식 그래프 설정 검증 클래스
-# ─────────────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# Phase 4 knowledge graph configuration validation class
+# ---------------------------------------------------------------------------
 
 
 class GraphEngineConfig:
-    """
-    v9.0 Phase 4 Knowledge Graph 전용 검증 설정 클래스.
+    """Configuration validation class for v9.0 Phase 4 Knowledge Graph.
 
-    사용법:
-        cfg = GraphEngineConfig.from_env()  # bootstrap 단계에서 1회 호출
+    Usage:
+        cfg = GraphEngineConfig.from_env()  # call once during bootstrap
 
-    책임 (4-5 SSOT 정책 준수):
-        - backend.core.config.graph 모듈에서 정의된 상수(ENV 키·기본값·범위)를
-          참조하여 OS 환경 변수를 로드한다. (하드코딩 절대 금지)
-        - 정수 범위 이탈 시 경계값으로 Clamping 보정 + WARNING 구조화 로그 출력.
-        - GRAPH_DB_URL 미설정·빈 값 시 networkx 인메모리 폴백 (INFO 로그, 오류 아님).
-        - 정수 파싱 자체가 불가한 경우(비정수 값) GRAPH_ENGINE 서브시스템만
-          DEGRADED 처리 (Subsystem Fail-fast). 전체 서버 부팅은 유지.
+    Responsibilities (per 4-5 SSOT policy):
+        - Loads OS environment variables by referencing constants (ENV keys, defaults,
+          ranges) defined in the backend.core.config.graph module. (No hardcoding.)
+        - On integer range violation: clamps to boundary + emits a structured WARNING log.
+        - On GRAPH_DB_URL unset or empty: falls back to networkx in-memory (INFO log, not an error).
+        - On integer parse failure (non-integer value): marks only the GRAPH_ENGINE subsystem
+          as DEGRADED (Subsystem Fail-fast). Overall server startup is not interrupted.
 
-    검증 대상 환경 변수 (모두 GraphConfig SSOT 상수로 참조):
-        GRAPH_MAX_TRAVERSAL_DEPTH             (int, 기본: 3,     범위: 1~5)
-        NEXT_PUBLIC_MAX_GRAPH_NODES           (int, 기본: 500,   범위: 50~2000)
-        GRAPH_DB_URL                          (str, 기본: "",    빈 값 시 networkx Fallback)
-        GRAPH_MIGRATION_NODE_THRESHOLD        (int, 기본: 10000, 범위: 5000~50000)
-        GRAPH_MIGRATION_CONCURRENCY_THRESHOLD (int, 기본: 10,    범위: 5~100)
+    Environment variables under validation (all referenced via GraphConfig SSOT constants):
+        GRAPH_MAX_TRAVERSAL_DEPTH             (int, default: 3,     range: 1-5)
+        NEXT_PUBLIC_MAX_GRAPH_NODES           (int, default: 500,   range: 50-2000)
+        GRAPH_DB_URL                          (str, default: "",    empty falls back to networkx)
+        GRAPH_MIGRATION_NODE_THRESHOLD        (int, default: 10000, range: 5000-50000)
+        GRAPH_MIGRATION_CONCURRENCY_THRESHOLD (int, default: 10,    range: 5-100)
 
-    보안 원칙:
-        DB 연결 문자열(GRAPH_DB_URL) 값 자체는 절대 로그에 기록하지 않는다.
+    Security policy:
+        The DB connection string (GRAPH_DB_URL) value must never be written to logs.
     """
 
     def __init__(
@@ -716,26 +807,45 @@ class GraphEngineConfig:
         migration_concurrency_threshold: int,
         subsystem_ok: Dict[Subsystem, bool],
     ) -> None:
+        """Initialize a GraphEngineConfig instance.
+
+        Use the :meth:`from_env` class method instead of calling this directly.
+        All arguments are keyword-only.
+
+        Args:
+            max_traversal_depth:             Maximum graph traversal depth
+                                             (GRAPH_MAX_TRAVERSAL_DEPTH).
+            max_graph_nodes:                 Maximum node count for frontend rendering
+                                             (NEXT_PUBLIC_MAX_GRAPH_NODES).
+            db_url:                          External graph DB connection URL.
+                                             Empty string means networkx in-memory fallback.
+                                             (GRAPH_DB_URL) Security: never log this value.
+            migration_node_threshold:        Node count threshold that triggers migration
+                                             (GRAPH_MIGRATION_NODE_THRESHOLD).
+            migration_concurrency_threshold: Max concurrent migration operations
+                                             (GRAPH_MIGRATION_CONCURRENCY_THRESHOLD).
+            subsystem_ok:                    Per-subsystem active status map
+                                             (True=active, False=DEGRADED).
+        """
         self.max_traversal_depth = max_traversal_depth
         self.max_graph_nodes = max_graph_nodes
-        # 보안: DB URL은 인스턴스 변수로만 보관, 절대 로그 출력 금지
+        # Security: DB URL is kept only as an instance variable; never log it
         self.db_url = db_url
         self.migration_node_threshold = migration_node_threshold
         self.migration_concurrency_threshold = migration_concurrency_threshold
-        # 서브시스템 가동 여부 맵 (True=활성, False=DEGRADED)
+        # Per-subsystem active status map (True=active, False=DEGRADED)
         self.subsystem_ok: Dict[Subsystem, bool] = subsystem_ok
 
     @classmethod
     def from_env(cls) -> "GraphEngineConfig":
-        """
-        환경 변수에서 그래프 설정을 파싱하여 GraphEngineConfig 인스턴스를 반환한다.
+        """Parse graph settings from environment variables and return a GraphEngineConfig instance.
 
-        - 정수 파싱 실패(비정수 값): GRAPH_ENGINE 서브시스템 DEGRADED — Subsystem Hard Failure.
-        - 정수 범위 이탈: Clamping 보정 + WARNING 로그 — Graceful Fallback.
-        - GRAPH_DB_URL 미설정·빈 값: networkx 인메모리 폴백 — INFO 로그 (오류 아님).
-        - 전체 서버 부팅은 어떠한 경우에도 중단하지 않는다.
+        - Integer parse failure (non-integer value): GRAPH_ENGINE subsystem DEGRADED — Subsystem Hard Failure.
+        - Integer out of range: clamped + WARNING log — Graceful Fallback.
+        - GRAPH_DB_URL unset or empty: networkx in-memory fallback — INFO log (not an error).
+        - Server startup is never interrupted under any condition.
         """
-        # SSOT: 모든 상수를 graph.py에서 import — 하드코딩 금지
+        # SSOT: import all constants from graph.py — no hardcoding
         from backend.core.config.graph import (
             DEFAULT_DB_URL,
             DEFAULT_MAX_GRAPH_NODES,
@@ -753,10 +863,10 @@ class GraphEngineConfig:
             MIGRATION_NODE_THRESHOLD_RANGE,
         )
 
-        # subsystem_ok 키는 항상 Subsystem Enum으로 통일 — 타입 안전성 보장
+        # subsystem_ok keys always use Subsystem Enum — ensures type safety
         subsystem_ok: Dict[Subsystem, bool] = {}
 
-        # ── 정수 설정: Clamp + WARNING (범위 이탈) / DEGRADED (파싱 불가) ─────
+        # -- Integer settings: Clamp + WARNING (out of range) / DEGRADED (parse failure) --
         max_depth, ok_depth = _parse_int_subsystem(
             ENV_MAX_TRAVERSAL_DEPTH,
             default=DEFAULT_MAX_TRAVERSAL_DEPTH,
@@ -782,8 +892,8 @@ class GraphEngineConfig:
             subsystem=Subsystem.GRAPH_ENGINE,
         )
 
-        # ── GRAPH_DB_URL: 빈 값 = networkx 폴백 (오류 아님) ───────────────
-        # 보안 원칙: DB URL 값 자체는 절대 로그에 기록하지 않음
+        # -- GRAPH_DB_URL: empty value = networkx fallback (not an error) -----
+        # Security policy: DB URL value itself must never be written to logs
         raw_db_url = os.environ.get(ENV_DB_URL, DEFAULT_DB_URL).strip()
         if not raw_db_url:
             logger.info(
@@ -793,12 +903,12 @@ class GraphEngineConfig:
             )
         db_url = raw_db_url
 
-        # ── 서브시스템 건강 판정: 하나라도 파싱 실패 시 DEGRADED ──────────
-        # GRAPH_DB_URL 파싱 실패는 서브시스템 비활성화 조건에 포함하지 않음
-        # (빈 값은 유효한 상태이므로)
+        # -- Subsystem health decision: DEGRADED if any parse failure ---------
+        # GRAPH_DB_URL parse failure is NOT a subsystem deactivation condition
+        # (empty value is a valid state)
         subsystem_ok[Subsystem.GRAPH_ENGINE] = ok_depth and ok_nodes and ok_mn and ok_mc
 
-        # ── 서브시스템 상태(DEGRADED) 운영 가시성 로깅 ───────────────────────
+        # -- Subsystem DEGRADED observability logging -------------------------
         _log_subsystem_state(subsystem_ok, state_label=SubsystemHealthState.DEGRADED)
 
         return cls(


### PR DESCRIPTION
- **[Docstring 구조 고도화 (Args/Returns 명시)]**
  - 기존의 단일 줄 주석들을 구체적인 `Args`, `Returns`, `Raises` 섹션을 포함한 구조화된 형태로 확장 (Google Style 기반).
  - 모듈 상단의 장애 전파 범위(Blast Radius) 정책과 일치하도록 각 함수의 에러 핸들링 및 Clamping 정책 명확히 서술.
  - `PersonalizedRAGConfig`, `RealtimeStreamingConfig`, `GraphEngineConfig`의 `__init__` 메서드에 모든 인자의 설명과 환경 변수 맵핑 정보 추가.

- **[Pyrefly 정적 분석 파싱 에러(Parse Error) 해결을 위한 영문화]**
  - 원인: IDE의 정적 분석 도구(Pyrefly)가 Docstring 내부의 한국어 텍스트 및 특수문자를 Python 식별자로 잘못 파싱하여 대량의 구문 오류 발생.
  - 조치: `backend/core/config_validator.py` 파일 내의 모든 클래스 및 함수 Docstring을 영문으로 전면 번역하여 교체.
  - 효과: 로직 변경 없이 주석의 언어와 포맷만 ASCII/Python 호환 형식으로 맞추어 개발 환경의 IDE 에러를 완전히 제거.

🔗 Related: Issue [#1048]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개인화 RAG, 실시간 스트리밍, 그래프 엔진 설정 전반에 걸쳐 설정 검증 동작과 blast radius 정책을 문서화하고 명확히 하며, `config_validator.py`의 모든 docstring과 주석을 구조화된 영어로 변환합니다.

Documentation:
- 설정 파서 헬퍼와 서브시스템 enum에 대해 상세한 Google 스타일의 영어 docstring을 추가하여 blast radius, clamping, 실패 동작을 문서화합니다.
- `PersonalizedRAGConfig`, `RealtimeStreamingConfig`, `GraphEngineConfig`의 클래스 수준 및 `__init__` 문서를 확장하여 필수/선택 환경 변수와 서브시스템 헬스(sehealth) 의미를 설명합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document and clarify configuration validation behavior and blast radius policies across personalized RAG, realtime streaming, and graph engine configs, while converting all docstrings and comments in config_validator.py to structured English.

Documentation:
- Add detailed, Google-style English docstrings for configuration parser helpers and subsystem enums, documenting blast radius, clamping, and failure behaviors.
- Expand class-level and __init__ documentation for PersonalizedRAGConfig, RealtimeStreamingConfig, and GraphEngineConfig to describe required/optional environment variables and subsystem health semantics.

</details>