### PR TITLE
☘️ refactor [#12.3.20] - ⑮ 4차 개선: 가독성 향상 및 매직 넘버 제거

### DIFF
--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -22,6 +22,9 @@ logger = logging.getLogger(__name__)
 # OAuth2 스키마 정의
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
+# 상수 정의
+MIN_Q_VALUE = float("-inf")
+
 # [Security] Mock User Definitions (Centralized)
 # Separate mocks for different roles to detect permission issues in dev environment.
 MOCK_ADMIN_USER: Dict[str, Any] = {"username": "dev_admin", "id": 1, "role": "admin"}
@@ -246,7 +249,7 @@ def extract_locale_from_header(accept_language: Optional[str]) -> str:
             continue
 
         # Keep only the highest q-value for each primary language
-        if entry.q_value > lang_map.get(entry.primary_tag, -1.0):
+        if entry.q_value > lang_map.get(entry.primary_tag, MIN_Q_VALUE):
             lang_map[entry.primary_tag] = entry.q_value
 
     if not lang_map:
@@ -257,10 +260,9 @@ def extract_locale_from_header(accept_language: Optional[str]) -> str:
 
     # Sort by q-value (descending) and find first supported locale
     sorted_langs = sorted(lang_map.items(), key=lambda x: x[1], reverse=True)
-    if match := next(
-        (lang for lang, _ in sorted_langs if lang in settings.SUPPORTED_LOCALES), None
-    ):
-        return match
+    for lang, _ in sorted_langs:
+        if lang in settings.SUPPORTED_LOCALES:
+            return lang
 
     # Fallback to default if no supported locale found
     logger.debug(

--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -22,8 +22,6 @@ logger = logging.getLogger(__name__)
 # OAuth2 스키마 정의
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
-# 상수 정의
-MIN_Q_VALUE = float("-inf")
 
 # [Security] Mock User Definitions (Centralized)
 # Separate mocks for different roles to detect permission issues in dev environment.
@@ -224,6 +222,9 @@ def normalize_locale(locale: Optional[str]) -> Optional[str]:
     return locale.strip().lower() if locale else None
 
 
+MIN_LOCALE_Q_VALUE = float("-inf")
+
+
 def extract_locale_from_header(accept_language: Optional[str]) -> str:
     """
     Accept-Language 헤더에서 애플리케이션이 지원하는 가장 적합한 로케일을 추출하여 반환합니다.
@@ -249,7 +250,7 @@ def extract_locale_from_header(accept_language: Optional[str]) -> str:
             continue
 
         # Keep only the highest q-value for each primary language
-        if entry.q_value > lang_map.get(entry.primary_tag, MIN_Q_VALUE):
+        if entry.q_value > lang_map.get(entry.primary_tag, MIN_LOCALE_Q_VALUE):
             lang_map[entry.primary_tag] = entry.q_value
 
     if not lang_map:
@@ -260,8 +261,9 @@ def extract_locale_from_header(accept_language: Optional[str]) -> str:
 
     # Sort by q-value (descending) and find first supported locale
     sorted_langs = sorted(lang_map.items(), key=lambda x: x[1], reverse=True)
+    supported = set(settings.SUPPORTED_LOCALES)
     for lang, _ in sorted_langs:
-        if lang in settings.SUPPORTED_LOCALES:
+        if lang in supported:
             return lang
 
     # Fallback to default if no supported locale found


### PR DESCRIPTION
- **[가독성 향상] 복잡한 루프 구조 단순화**
  - 기존: `next`() 및 바다코끼리 연산자(`:=`)를 사용한 압축된 형태의 제너레이터 탐색.
  - 수정: 누구나 읽기 쉬운 기존의 직관적인 `for` 루프와 조기 반환(`return`) 패턴으로 복구하여 유지보수성 및 가독성 우선 확보.

- **[상수 정의] `q-value` 매직 넘버 제거**
  - 기존: 로케일 q-value 비교 시 `-1.0`을 기본값으로 하드코딩하여 사용.
  - 수정: 파일 상단에 `MIN_Q_VALUE = float('-inf')` 상수를 명시적으로 선언하여, '가능한 최소값'이라는 비즈니스 의도를 명확히 드러내고 타입 안전성(Type Safety) 확보.

🔗 Related:
- Issue [#1044]
- TODO.md P1
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1637#pullrequestreview-4581345736)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Accept-Language 헤더를 파싱할 때 로케일 추출의 가독성과 견고성을 개선합니다.

개선 사항:
- 로케일 q-value를 비교할 때 의도를 더 명확히 하기 위해, 하드코딩된 기본 q-value를 명명된 상수 `MIN_Q_VALUE`로 교체했습니다.
- 제너레이터/대입 표현식을 사용하던 기존의 지원 로케일 선택 로직을, 단순한 for-루프와 조기 반환 방식으로 교체하여 단순화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve locale extraction readability and robustness when parsing Accept-Language headers.

Enhancements:
- Replace the hardcoded default q-value with a named MIN_Q_VALUE constant to clarify intent when comparing locale q-values.
- Simplify supported-locale selection logic by replacing the generator/assignment expression with a straightforward for-loop and early return.

</details>