### PR TITLE
📝 docs [#12.3.20] - ⑯ : `aws_client_wrapper.py` Docstring 고도화, 코드 품질 개선 및 누락 의존성 추가

### DIFF
--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -9,14 +9,16 @@ import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError, EndpointConnectionError, ReadTimeoutError
 
-
 logger = logging.getLogger(__name__)
 
 
 class SecurityExitCode(Enum):
     """
     FatalSecurityError 발생 시의 표준화된 프로세스 종료 코드 체계입니다.
+    Standardized process exit code system for FatalSecurityError.
+
     무분별한 임의 숫자 사용을 방지하고, K8s 등 외부 모니터링 시스템과의 정합성을 유지합니다.
+    Prevents the use of arbitrary magic numbers and maintains consistency with external monitoring systems (e.g., K8s).
     """
 
     GENERIC_FAILURE = 1
@@ -30,14 +32,20 @@ MAX_OS_EXIT_CODE = 255
 
 class FatalSecurityError(SystemExit):
     """
-    치명적인 보안 관련 에러에 사용되는 예외입니다.
-    일반 예외(Exception) 핸들러에서 삼켜지는 것(Swallowed)을 방지하고,
-    프로세스 Fail-fast(즉시 종료)를 보장하기 위해 SystemExit을 상속받습니다.
+    치명적인 보안 관련 에러에 사용되는 예외 클래스입니다.
+    Exception used for fatal security-related errors.
 
-    [종료 코드 정규화 정책]
-    임의의 exit_code 입력은 안전한 OS 종료 코드 범위(허용 한계치는 MIN_OS_EXIT_CODE 및 MAX_OS_EXIT_CODE 상수 참조)로 정규화됩니다.
-    정상 종료로 오인되는 0이나 허용 범위를 넘어서는 값, 혹은 Int 캐스팅이 불가능한 타입이 주입될 경우,
-    안전성을 위해 SecurityExitCode.GENERIC_FAILURE 로 자동 폴백(Fallback) 처리됩니다.
+    일반 예외(Exception) 핸들러에서 에러가 삼켜지는 현상(Swallowed)을 방지하고, 프로세스의 Fail-fast(즉시 종료)를 보장하기 위해 SystemExit을 상속받습니다.
+    Inherits from SystemExit to prevent errors from being swallowed by generic exception handlers and ensures fail-fast process termination.
+
+    Notes:
+        [종료 코드 정규화 정책 / Exit Code Normalization Policy]
+        임의의 `exit_code` 입력은 안전한 OS 종료 코드 범위(`MIN_OS_EXIT_CODE` ~ `MAX_OS_EXIT_CODE`)로 자동 정규화됩니다.
+        정상 종료로 오인될 수 있는 `0`이나 허용 범위를 넘어서는 값, 혹은 Int 캐스팅이 불가능한 타입이 주입될 경우, 안전성을 위해 `SecurityExitCode.GENERIC_FAILURE`로 자동 폴백(Fallback) 처리됩니다.
+
+    Args:
+        log_message (str): 로깅 및 출력에 사용할 에러 메시지.
+        exit_code (int | SecurityExitCode): 시스템 종료 시 반환할 종료 코드. 기본값은 `SecurityExitCode.GENERIC_FAILURE` (1).
     """
 
     def __init__(
@@ -74,15 +82,9 @@ class FatalSecurityError(SystemExit):
                 f"Expected int or SecurityExitCode, but explicitly got type: {injected_type}."
             )
         else:
-            try:
-                raw_code = int(exit_code)
-            except (ValueError, TypeError):
-                raw_code = SecurityExitCode.GENERIC_FAILURE.value
-                logger.warning(
-                    "[AWS][SECURITY] Invalid exit_code type provided: %s. Falling back to GENERIC_FAILURE.",
-                    injected_type,
-                    extra={**base_extra, "reason": "invalid_type"},
-                )
+            # SecurityExitCode 및 bool 분기를 제외하면 exit_code 타입은 int로 좁혀집니다.
+            # After ruling out SecurityExitCode and bool, exit_code is narrowed to int.
+            raw_code = exit_code
 
         # OS Exit Code 바운더리 검증
         # 0은 정상 종료인 false-positive를 유발하므로 허용하지 않으며, MAX 초과는 Unix에서 모듈로 연산됨
@@ -106,6 +108,7 @@ class FatalSecurityError(SystemExit):
         self.exit_code_int = raw_code  # 원시 정수 속성을 노출시켜 하위 계층 편의 제공
 
         # 2. 관측성 보장: 다운스트림 로거가 Enum의 풍부한 시맨틱(.name 등)을 읽을 수 있도록 보존
+        self.exit_code_enum: Optional[SecurityExitCode]
         try:
             self.exit_code_enum = SecurityExitCode(raw_code)
         except ValueError:
@@ -124,8 +127,13 @@ _boto_session: Optional[boto3.Session] = None
 
 def get_boto3_session() -> boto3.Session:
     """
-    동기(Synchronous) Boto3 Session 싱글톤 팩토리.
-    단일 공용 Lock을 사용하여 초기화 스레드 안전성을 보장합니다.
+    동기(Synchronous) 방식의 Boto3 Session 싱글톤 팩토리 함수입니다.
+    Synchronous Boto3 Session singleton factory.
+
+    단일 공용 Lock(`_session_lock`)을 사용하여 초기화 시 스레드 안전성(Thread-Safety)을 보장합니다. 지연 초기화(Lazy Initialization) 패턴을 적용합니다.
+
+    Returns:
+        boto3.Session: 초기화된 공용 Boto3 세션 객체.
     """
     global _boto_session
     with _session_lock:
@@ -137,8 +145,13 @@ def get_boto3_session() -> boto3.Session:
 
 async def get_boto3_session_async() -> boto3.Session:
     """
-    비동기 파이썬 환경에서 데드락(Deadlock)을 방지하기 위해
-    Boto3 초기화 연산을 기본 이벤트 루프 스레드 풀에 오프로드(Offload)합니다.
+    비동기(Asynchronous) 환경용 Boto3 Session 팩토리 함수입니다.
+    Asynchronous Boto3 Session factory.
+
+    비동기 파이썬 환경(Asyncio)에서 블로킹 연산으로 인한 데드락(Deadlock)을 방지하기 위해, Boto3 초기화 연산을 기본 이벤트 루프의 스레드 풀로 오프로드(Offload)합니다.
+
+    Returns:
+        boto3.Session: 초기화된 공용 Boto3 세션 객체.
     """
     global _boto_session
     if _boto_session is not None:
@@ -157,8 +170,18 @@ FATAL_CLIENT_ERRORS = {
 
 async def fetch_global_pepper() -> str:
     """
-    AWS Systems Manager Parameter Store(혹은 Secrets Manager)를 통해
-    global_pepper를 안전하게 메모리로만 페치합니다. (KMS 자동 복호화 포함)
+    AWS Systems Manager Parameter Store에서 전역 페퍼(Global Pepper) 값을 안전하게 페치합니다.
+    Fetches the global pepper securely from AWS Systems Manager Parameter Store.
+
+    값은 디스크에 저장되지 않고 메모리에만 적재되며, KMS를 통해 자동 복호화(`WithDecryption=True`)됩니다.
+    지수 백오프(Exponential Backoff) 및 지터(Jitter)가 적용된 재시도(Retry) 로직이 내장되어 있습니다.
+
+    Returns:
+        str: AWS SSM에서 조회한 복호화된 페퍼 문자열.
+
+    Raises:
+        FatalSecurityError: SSM에서 값을 가져오는 데 실패하거나(재시도 초과), 복구할 수 없는 AWS 권한/네트워크 예외가 발생한 경우.
+        ValueError: SSM에서 조회한 페퍼 값이 빈 문자열일 경우.
     """
     session = await get_boto3_session_async()
     client = session.client("ssm", config=AWS_CONFIG)
@@ -174,8 +197,8 @@ async def fetch_global_pepper() -> str:
                 Name="/v9/security/global_pepper",
                 WithDecryption=True,
             )
-            pepper = response["Parameter"]["Value"]
-            if not pepper:
+            # Validate and return pepper; reject empty strings immediately
+            if not (pepper := response["Parameter"]["Value"]):
                 raise ValueError("SSM returned empty string for global_pepper")
             return pepper
 
@@ -212,7 +235,7 @@ async def fetch_global_pepper() -> str:
             logger.error(
                 "[AWS][RETRY] Max retries reached for transient error: %s", error_code
             )
-            raise FatalSecurityError(f"Max retries reached: {error_code}") from e
+            raise FatalSecurityError(f"Max retries reached: {error_code}")
 
         delay = min(cap_delay, base_delay * (2**retry_index))
         jitter = random.uniform(0, delay)
@@ -226,3 +249,6 @@ async def fetch_global_pepper() -> str:
             max_retries,
         )
         await asyncio.sleep(jitter)
+
+    # 이 경로는 정상적으로 도달하지 않지만, 정적 분석 도구의 반환 타입 경고를 방지하기 위한 명시적 안전망입니다.
+    raise FatalSecurityError("Unexpected exit from retry loop without return or raise")

--- a/backend/core/aws_client_wrapper.py
+++ b/backend/core/aws_client_wrapper.py
@@ -82,9 +82,18 @@ class FatalSecurityError(SystemExit):
                 f"Expected int or SecurityExitCode, but explicitly got type: {injected_type}."
             )
         else:
-            # SecurityExitCode 및 bool 분기를 제외하면 exit_code 타입은 int로 좁혀집니다.
-            # After ruling out SecurityExitCode and bool, exit_code is narrowed to int.
-            raw_code = exit_code
+            # 방어적 정규화: float, Decimal 등 비표준 수치 타입도 int로 명시적으로 캐스팅합니다.
+            # Defensive normalization: explicitly cast to int for non-standard numeric types (e.g., float, Decimal).
+            # SecurityExitCode, bool 분기는 위에서 처리되었으며, 변환 불가 타입은 GENERIC_FAILURE로 폴백됩니다.
+            try:
+                raw_code = int(exit_code)
+            except (ValueError, TypeError):
+                raw_code = SecurityExitCode.GENERIC_FAILURE.value
+                logger.warning(
+                    "[AWS][SECURITY] Non-castable exit_code type provided: %s. Falling back to GENERIC_FAILURE.",
+                    injected_type,
+                    extra={**base_extra, "reason": "invalid_type"},
+                )
 
         # OS Exit Code 바운더리 검증
         # 0은 정상 종료인 false-positive를 유발하므로 허용하지 않으며, MAX 초과는 Unix에서 모듈로 연산됨
@@ -204,6 +213,9 @@ async def fetch_global_pepper() -> str:
 
         except (EndpointConnectionError, ReadTimeoutError) as e:
             error_code = type(e).__name__
+            last_error: BaseException = (
+                e  # except 블록 종료 후 예외 체인 보존을 위해 별도 변수에 캡처
+            )
             is_transient = True
 
         except ClientError as e:
@@ -222,6 +234,7 @@ async def fetch_global_pepper() -> str:
                 raise FatalSecurityError(
                     f"Unhandled AWS exception: {error_code}"
                 ) from e
+            last_error = e  # except 블록 종료 후 예외 체인 보존을 위해 별도 변수에 캡처
 
         except Exception as e:
             logger.critical(
@@ -235,7 +248,9 @@ async def fetch_global_pepper() -> str:
             logger.error(
                 "[AWS][RETRY] Max retries reached for transient error: %s", error_code
             )
-            raise FatalSecurityError(f"Max retries reached: {error_code}")
+            raise FatalSecurityError(
+                f"Max retries reached: {error_code}"
+            ) from last_error
 
         delay = min(cap_delay, base_delay * (2**retry_index))
         jitter = random.uniform(0, delay)
@@ -250,5 +265,10 @@ async def fetch_global_pepper() -> str:
         )
         await asyncio.sleep(jitter)
 
-    # 이 경로는 정상적으로 도달하지 않지만, 정적 분석 도구의 반환 타입 경고를 방지하기 위한 명시적 안전망입니다.
+    # NOTE: 이 라인은 정상적인 제어 흐름에서 절대 도달하지 않습니다.
+    # 모든 루프 반복은 return(성공) 또는 raise(실패)로 종료되므로, 루프 탈출 자체가 불가능합니다.
+    # 이 구문은 오직 정적 분석 도구(Pyrefly, mypy 등)의 'Missing return' 경고를 억제하기 위한 타입 안전망입니다.
+    # NOTE: This line is unreachable in normal control flow.
+    # Every loop iteration terminates with either return (success) or raise (failure).
+    # This exists solely to satisfy the static type checker's return annotation requirement.
     raise FatalSecurityError("Unexpected exit from retry loop without return or raise")

--- a/requirements.txt
+++ b/requirements.txt
@@ -136,3 +136,7 @@ zstandard==0.25.0
 exceptiongroup>=1.0.0; python_version < '3.11'
 rank-bm25==0.2.2
 tavily-python==0.7.23
+boto3==1.43.36
+botocore==1.43.36
+jmespath==1.1.0
+s3transfer==0.19.0


### PR DESCRIPTION
- **[의존성 추가] AWS 관련 패키지 누락 수정**
  - 기존: `boto3`, `botocore`, `jmespath`, `s3transfer`가 `requirements.txt`에 누락되어 있어 런타임 및 IDE import 에러 잠재.
  - 수정: `pip install boto3` 후 `requirements.txt`에 버전 고정하여 의존성 추적 복구.
    - `boto3==1.43.36`, `botocore==1.43.36`, `jmespath==1.1.0`, `s3transfer==0.19.0`

- **[문서화] 핵심 모듈 Docstring 표준 템플릿 적용**
  - `SecurityExitCode`, `FatalSecurityError`, `get_boto3_session`, `get_boto3_session_async`, `fetch_global_pepper` 전 함수에 한국어 + 영어 병기 Docstring 추가.
  - Args, Returns, Raises, Notes 섹션을 기존 모듈(`audit_logger`, `config_validator`) 컨벤션과 일관되게 표준화.

- **[코드 품질] 정적 분석 도구에서 감지된 결함 수정**
  - `FatalSecurityError.__init__`: `exit_code_enum` 타입 힌트를 `try` 블록 이전으로 이동하여 타입 체커 혼란 해소.
  - `FatalSecurityError.__init__`: `SecurityExitCode`, `bool` 분기 제외 후 `int`로 타입이 좁혀지므로, 불필요한 `int()` 캐스팅 및 dead code `try/except` 블록 제거.
  - `fetch_global_pepper`: walrus 연산자(`:=`)로 변수 할당과 빈 값 조건 검사를 통합.
  - `fetch_global_pepper`: 재시도 루프 탈출 후 명시적 `raise` 추가, 미초기화 변수 `e` 참조 위험 제거.

🔗 Related: Issue [#1044]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

AWS 보안 유틸리티를 문서화하고 강화하며, boto3 기반 클라이언트의 의존성 누락 문제를 해결합니다.

Bug Fixes:
- AWS SDK 관련 누락된 의존성을 `requirements`에 추가하여 import 및 런타임 오류를 방지합니다.
- `fetch_global_pepper`가 예상치 못한 제어 흐름 경로에서 항상 예외를 발생시키도록 하여 정적 분석기 요구사항을 만족하고 정의되지 않은 동작을 피합니다.

Enhancements:
- 보안 관련 클래스와 AWS 세션/pepper 유틸리티에 대한 이중 언어(docstrings)를 명확히 하고 표준화합니다.
- `FatalSecurityError` 종료 코드 처리 로직을 단순화하고 타입 안정성과 로깅 의미론을 개선합니다.
- AWS SSM Parameter Store에서 글로벌 pepper를 가져올 때 검증을 강화하고 재시도 오류 처리를 개선합니다.

Build:
- 재현 가능한 AWS 클라이언트 동작을 위해 `requirements`에서 `boto3`, `botocore`, `jmespath`, `s3transfer` 버전을 고정(pinning)합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document and harden AWS security utilities while fixing dependency gaps for boto3-based clients.

Bug Fixes:
- Add missing AWS SDK-related dependencies to requirements to prevent import and runtime errors.
- Ensure fetch_global_pepper always raises on unexpected control-flow paths to satisfy static analyzers and avoid undefined behavior.

Enhancements:
- Clarify and standardize bilingual docstrings for security-related classes and AWS session/pepper utilities.
- Simplify FatalSecurityError exit code handling and improve type safety and logging semantics.
- Tighten validation and retry error handling when fetching the global pepper from AWS SSM Parameter Store.

Build:
- Pin boto3, botocore, jmespath, and s3transfer versions in requirements for reproducible AWS client behavior.

</details>