### PR TITLE
📝 docs [#12.3.20] - ⑰ `routes.py` 및 `endpoints/__init__.py` Docstring 고도화

### DIFF
--- a/backend/api/endpoints/__init__.py
+++ b/backend/api/endpoints/__init__.py
@@ -1,6 +1,24 @@
 # backend/api/endpoints/__init__.py
 
-"""Endpoints Module"""
+"""
+도메인별 FastAPI 라우터 서브모듈을 집계하여 외부로 노출하는 패키지 초기화 모듈입니다.
+Package initializer that aggregates domain-specific FastAPI router sub-modules.
+
+각 서브모듈의 `router` 인스턴스를 `*_router` 별칭으로 노출하여,
+`backend.api.routes` 에서 단일 진입점으로 등록할 수 있게 합니다.
+Each sub-module's `router` instance is re-exported under a `*_router` alias,
+allowing `backend.api.routes` to register them through a single entry point.
+
+노출되는 라우터:
+    - classify_router   : 분류(Classification) 도메인
+    - search_router     : 검색(Search) 도메인
+    - metadata_router   : 메타데이터(Metadata) 도메인
+    - automation_router : 자동화(Automation) 도메인
+    - chat_router       : 채팅(Chat) 도메인
+    - chat_stream_router: 채팅 스트리밍(SSE) 도메인
+    - admin_router      : 어드민(Admin) 도메인
+    - privacy_router    : 개인정보(Privacy, GDPR) 도메인
+"""
 
 from .admin import router as admin_router
 from .automation import router as automation_router

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -1,6 +1,23 @@
 # backend/api/routes.py
 
-"""Main API Router"""
+"""
+중앙 집중식 API 라우터 엔트리포인트 모듈입니다.
+Centralized API router entry point module.
+
+이 모듈은 FastAPI 애플리케이션의 모든 하위 도메인 라우터를 단일 `APIRouter` 인스턴스(`router`)로
+통합하여 `prefix="/api"`를 기준으로 마운트합니다.
+This module aggregates all domain-specific sub-routers into a single `APIRouter` instance (`router`)
+mounted under the `/api` prefix.
+
+포함된 도메인 라우터:
+    - `/classify` : 분류(Classification) 관련 엔드포인트
+    - `/search`   : 검색(Search, 하이브리드 RAG) 관련 엔드포인트
+    - `/metadata` : 파일 메타데이터 처리 엔드포인트
+    - `/chat`     : 채팅(Chat) 및 세션 관리 엔드포인트
+    - `/chat`     : 채팅 스트리밍(SSE) 엔드포인트
+    - `/admin`    : 어드민 전용 관리 엔드포인트
+    - `/privacy`  : GDPR 기반 개인정보 삭제권(Right-to-Erasure) 엔드포인트
+"""
 
 from fastapi import APIRouter, Depends
 
@@ -15,21 +32,39 @@ router = APIRouter(prefix="/api")
 # Health check endpoint
 @router.get("/health", response_model=HealthCheckResponse)
 async def health_check(locale: str = Depends(get_locale)) -> HealthCheckResponse:
-    """서버 상태 확인 (다국어 지원)"""
+    """
+    서버 상태를 확인하는 헬스체크 엔드포인트입니다.
+    Health check endpoint that confirms the server is running and responsive.
+
+    클라이언트의 `Accept-Language` 헤더를 기반으로 `get_locale` 의존성을 통해 로케일을 주입받으며,
+    다국어(i18n)로 응답 메시지를 반환합니다.
+
+    Args:
+        locale (str): FastAPI `get_locale` 의존성을 통해 주입된 로케일 코드 (예: 'ko', 'en').
+
+    Returns:
+        HealthCheckResponse: 서버 상태(`status`)와 다국어 메시지(`message`)가 포함된 응답 객체.
+    """
     return HealthCheckResponse(
         status="success", message=get_message("status_ok", locale)
     )
 
 
-# Include endpoint routers
+# 도메인별 하위 라우터 등록
+# [분류] 노트/파일 분류 관련 엔드포인트 (prefix: /classify)
 router.include_router(endpoints.classify_router)
+# [검색] 하이브리드 RAG 검색 엔드포인트 (prefix: /search)
 router.include_router(endpoints.search_router)
+# [메타데이터] 파일 메타데이터 처리 엔드포인트 (prefix: /metadata)
 router.include_router(endpoints.metadata_router)
+# [채팅] 채팅, 대화 히스토리 및 세션 관리 엔드포인트 (prefix: /chat)
 router.include_router(endpoints.chat_router)
+# [채팅 스트리밍] SSE 기반 실시간 채팅 스트리밍 엔드포인트 (prefix: /chat)
 router.include_router(endpoints.chat_stream_router)
+# [어드민] 내부 운영 전용 관리자 엔드포인트 (prefix: /admin)
 router.include_router(endpoints.admin_router)
 
-# GDPR Right-to-Erasure 엔드포인트 (Phase 2-4)
-# schedule_audit_log_cleanup()은 FastAPI lifespan 또는 Celery Beat에서 등록 필요
+# [개인정보] GDPR 삭제권(Right-to-Erasure) 엔드포인트 (prefix: /privacy)
+# NOTE: schedule_audit_log_cleanup()은 FastAPI lifespan 또는 Celery Beat에서 별도 등록 필요합니다.
 # 참조: backend.core.audit_logger.schedule_audit_log_cleanup
 router.include_router(endpoints.privacy_router)


### PR DESCRIPTION
- **[문서화] `backend/api/routes.py` 모듈 Docstring 표준 템플릿 적용**
  - 기존: `"""Main API Router"""` 한 줄 설명만 존재.
  - 수정: 모듈 목적, 마운트 기준(`prefix="/api"`), 포함된 전체 도메인 라우터 목록을 한국어 + 영어 병기로 명시.

- **[문서화] `health_check` 엔드포인트 Docstring 표준화**
  - 기존: `"""서버 상태 확인 (다국어 지원)"""` 한 줄 설명만 존재.
  - 수정: 기능 설명, Args(`locale`), Returns(`HealthCheckResponse`) 섹션을 표준 템플릿에 맞게 구조화.

- **[가독성] `include_router` 블록 인라인 주석 보강**
  - 기존: 단순 `# Include endpoint routers` 한 줄 주석.
  - 수정: 등록되는 각 라우터의 도메인 역할(`[분류]`, `[검색]`, `[채팅]` 등)과 `prefix`를 인라인 주석으로 명시하여 탐색성(Navigability) 강화.
  - GDPR 프라이버시 라우터의 `schedule_audit_log_cleanup()` 별도 등록 필요 사항 NOTE 주석으로 개선.

- **[문서화] `backend/api/endpoints/__init__.py` Docstring 고도화**
  - 기존: `"""Endpoints Module"""` 한 줄 설명만 존재.
  - 수정: 패키지 목적, `*_router` 별칭 노출 방식, 노출되는 전체 라우터 목록을 한국어 + 영어 병기로 표준화.

🔗 Related: Issue [#1044]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

health check 엔드포인트와 라우터 등록에 대한 API 문서를 표준화하고 확장하여 도메인 책임과 사용 방법을 명확히 합니다.

개선 사항:
- health_check 엔드포인트의 docstring을 구조화된 이중 언어(영문/국문) 설명으로 개선하여 동작, 인자, 응답을 명확히 기술합니다.
- 포함된 라우터에 대한 인라인 주석을 보강하여 각 라우터의 도메인 역할, prefix, GDPR 감사 로그 정리(클린업) 관련 고려 사항을 문서화합니다.

문서화:
- 백엔드 API 라우팅 코드의 모듈 및 패키지 docstring을 개선하여 목적과 노출되는 라우터를 설명하는 표준화된 이중 언어 문서 템플릿을 따르도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize and expand API documentation for the health check endpoint and router registrations to clarify domain responsibilities and usage.

Enhancements:
- Improve health_check endpoint docstring with structured, bilingual description of behavior, arguments, and response.
- Enrich inline comments for included routers to document their domain roles, prefixes, and GDPR audit log cleanup considerations.

Documentation:
- Enhance module and package docstrings in backend API routing code to follow a standardized, bilingual documentation template for purpose and exposed routers.

</details>