### PR TITLE
📝 docs [#12.3.20] - ⑰ 1차 개선: 하드코딩된 prefix 제거 및 NOTE 위치 정합성 개선

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -51,20 +51,19 @@ async def health_check(locale: str = Depends(get_locale)) -> HealthCheckResponse
 
 
 # 도메인별 하위 라우터 등록
-# [분류] 노트/파일 분류 관련 엔드포인트 (prefix: /classify)
+# [분류] 노트/파일 분류 관련 엔드포인트
 router.include_router(endpoints.classify_router)
-# [검색] 하이브리드 RAG 검색 엔드포인트 (prefix: /search)
+# [검색] 하이브리드 RAG 검색 엔드포인트
 router.include_router(endpoints.search_router)
-# [메타데이터] 파일 메타데이터 처리 엔드포인트 (prefix: /metadata)
+# [메타데이터] 파일 메타데이터 처리 엔드포인트
 router.include_router(endpoints.metadata_router)
-# [채팅] 채팅, 대화 히스토리 및 세션 관리 엔드포인트 (prefix: /chat)
+# [채팅] 채팅, 대화 히스토리 및 세션 관리 엔드포인트
 router.include_router(endpoints.chat_router)
-# [채팅 스트리밍] SSE 기반 실시간 채팅 스트리밍 엔드포인트 (prefix: /chat)
+# [채팅 스트리밍] SSE 기반 실시간 채팅 스트리밍 엔드포인트
 router.include_router(endpoints.chat_stream_router)
-# [어드민] 내부 운영 전용 관리자 엔드포인트 (prefix: /admin)
+# [어드민] 내부 운영 전용 관리자 엔드포인트
 router.include_router(endpoints.admin_router)
 
-# [개인정보] GDPR 삭제권(Right-to-Erasure) 엔드포인트 (prefix: /privacy)
-# NOTE: schedule_audit_log_cleanup()은 FastAPI lifespan 또는 Celery Beat에서 별도 등록 필요합니다.
-# 참조: backend.core.audit_logger.schedule_audit_log_cleanup
+# [개인정보] GDPR 삭제권(Right-to-Erasure) 엔드포인트
+# 참조: backend.core.audit_logger.schedule_audit_log_cleanup (등록 위치: backend/main.py lifespan)
 router.include_router(endpoints.privacy_router)


### PR DESCRIPTION
- **[유지보수성] 인라인 주석의 하드코딩된 라우터 prefix 제거**
  - 기존: 각 `include_router` 주석에 `(prefix: /chat)` 등 실제 라우터 설정을 중복 하드코딩.
  - 수정: prefix 정보는 각 endpoint 파일의 `APIRouter(prefix=...)`가 단일 진실 공급원(SoT)이므로 주석에서 제거.
  - 효과: endpoint 파일에서 prefix가 변경되어도 routes.py 주석이 스테일해지는 위험 제거.

- **[문서 정합성] `schedule_audit_log_cleanup` NOTE 위치 개선**
  - 기존: `include_router` 블록 내부에 NOTE로 위치하여, 실제 등록이 필요한 `lifespan` 컨텍스트(`backend/main.py`)와 괴리.
  - 수정: NOTE 문구를 제거하고, 실제 등록 위치(`backend/main.py lifespan`)를 참조 주석으로 명시하여 미래 편집자가 올바른 위치에서 작업하도록 안내.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1640#pullrequestreview-4591723318)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

라우터 문서화 주석에서 하드코딩된 접두사를 제거하고, 개인정보 보호/감사 로그 관련 안내를 실제 lifespan 등록 위치와 일치하도록 정리했습니다.

개선 사항:
- 인라인 주석에서 중복되고 하드코딩된 라우터 접두사 정보를 제거하여, 단일 진실 공급원(Single Source of Truth)으로서 `APIRouter` 설정에만 의존하도록 합니다.
- 개인정보 보호 라우터 주석을 업데이트하여, 오래된 NOTE 대신 `backend/main.py`의 lifespan 내에 있는 올바른 `schedule_audit_log_cleanup` 등록 위치를 참조하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify router documentation comments by removing hardcoded prefixes and aligning privacy/audit log notes with the actual lifespan registration location.

Enhancements:
- Remove duplicated, hardcoded router prefix information from inline comments to rely on APIRouter configuration as the single source of truth.
- Update privacy router comments to reference the correct schedule_audit_log_cleanup registration in backend/main.py lifespan instead of an outdated NOTE.

</details>