### PR TITLE
📝 docs [#12.3.20] - ⑱: `mcp_config.py` Docstring 고도화 및 환경 변수 명세 추가

### DIFF
--- a/backend/config/mcp_config.py
+++ b/backend/config/mcp_config.py
@@ -1,8 +1,13 @@
 # backend/config/mcp_config.py
 
 """
-MCP (Model Context Protocol) 관련 설정
-외부 도구 연결 설정을 관리합니다.
+MCP (Model Context Protocol) 및 외부 도구 연결 설정 모듈입니다.
+MCP (Model Context Protocol) and external tool connection configuration module.
+
+이 모듈은 Obsidian, Notion 등 외부 도구와의 연동을 위한 환경 변수를
+Pydantic 모델을 통해 검증하고 로드합니다.
+This module validates and loads environment variables for integrating with external tools
+like Obsidian and Notion using Pydantic models.
 """
 
 import os
@@ -12,7 +17,13 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class ObsidianConfig(BaseModel):
-    """Obsidian 연결 설정"""
+    """
+    Obsidian Vault 연결 및 동기화 설정 모델입니다.
+    Obsidian Vault connection and synchronization configuration model.
+
+    환경 변수 `OBSIDIAN_VAULT_PATH`, `OBSIDIAN_SYNC_INTERVAL`, `OBSIDIAN_SYNC_ENABLED`를 통해 구성되며,
+    Vault 경로의 유효성을 런타임에 검사하는 프로퍼티를 제공합니다.
+    """
 
     model_config = ConfigDict(extra="ignore")
 
@@ -29,14 +40,28 @@ class ObsidianConfig(BaseModel):
 
     @property
     def is_valid(self) -> bool:
-        """Vault 경로 유효성 검사"""
+        """
+        현재 설정된 Vault 경로가 유효하고 존재하는지 검사합니다.
+        Validates whether the configured Vault path is valid and exists on the filesystem.
+
+        기능이 비활성화(`enabled=False`)된 경우 항상 True를 반환합니다.
+
+        Returns:
+            bool: 비활성화 상태이거나(True), 경로가 존재할 경우 True. 그렇지 않으면 False.
+        """
         if not self.enabled:
             return True
         return self.vault_path != "" and Path(self.vault_path).exists()
 
 
 class NotionConfig(BaseModel):
-    """Notion 연결 설정 (Phase 5 예정)"""
+    """
+    Notion API 연결 설정 모델입니다 (Phase 5 예정).
+    Notion API connection configuration model (Planned for Phase 5).
+
+    환경 변수 `NOTION_API_KEY`, `NOTION_DATABASE_ID`를 통해 구성됩니다.
+    현재는 비활성화 상태(`enabled=False`)를 기본값으로 갖습니다.
+    """
 
     model_config = ConfigDict(extra="ignore")
 
@@ -48,7 +73,12 @@ class NotionConfig(BaseModel):
 
 
 class MCPConfig(BaseModel):
-    """통합 MCP 설정"""
+    """
+    모든 외부 도구(MCP) 구성을 통합 관리하는 최상위 설정 모델입니다.
+    Top-level configuration model that aggregates all external tool (MCP) settings.
+
+    Obsidian 및 Notion 설정 인스턴스를 포함하며, 전체 초기화 상태를 검증하는 메서드를 제공합니다.
+    """
 
     model_config = ConfigDict(extra="ignore")
 
@@ -56,7 +86,13 @@ class MCPConfig(BaseModel):
     notion: NotionConfig = Field(default_factory=NotionConfig)
 
     def validate_setup(self):
-        """MCP 설정 상태 출력"""
+        """
+        현재 구성된 MCP(외부 도구) 연결 상태를 표준 출력(STDOUT)으로 로깅합니다.
+        Logs the current status of MCP (external tool) configurations to standard output.
+
+        Obsidian의 경우 활성화 여부 및 경로 유효성을 확인하고,
+        Notion의 경우 Phase 5 예정 상태임을 표시합니다.
+        """
         print("\n🔌 MCP Configuration Status:")
         print("=" * 30)
 


### PR DESCRIPTION
- **[문서화] `mcp_config.py` 모듈 및 클래스 Docstring 표준 템플릿 적용**
  - 기존: `"""MCP 관련 설정"""` 등 한 줄짜리 단순 설명만 존재.
  - 수정: `MCPConfig`, `ObsidianConfig`, `NotionConfig` 및 내부 메서드 전체에 한국어 + 영어 병기 Docstring 추가.
  - `ObsidianConfig`: `OBSIDIAN_VAULT_PATH`, `OBSIDIAN_SYNC_INTERVAL` 등 관련된 환경 변수 구성과 `is_valid`의 런타임 검증 로직을 상세히 설명.
  - `NotionConfig`: Phase 5 예정 사항임과 기본값이 비활성화 상태임을 명시.
  - `MCPConfig.validate_setup`: 표준 출력(STDOUT) 로깅의 목적과 각 상태(Ready/Disabled)별 로깅 규칙 설명.

🔗 Related: Issue [#1044]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

MCP 구성 모듈과 그 모델들을 이중 언어(docstring)로 문서화하고, 외부 도구 통합 동작을 명확히 설명합니다.

Documentation:
- MCP 구성에 대한 모듈 수준 문서를 확장하여, 외부 도구용 환경 변수 검증 및 로딩 방식에 대해 설명합니다.
- ObsidianConfig, NotionConfig, MCPConfig에 상세한 이중 언어 docstring을 추가하여 환경 변수, 활성화 상태, 검증 동작을 포함해 문서화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document MCP configuration module and its models with bilingual docstrings and clarified external tool integration behavior.

Documentation:
- Expand module-level documentation for MCP configuration to describe environment variable validation and loading for external tools.
- Add detailed bilingual docstrings to ObsidianConfig, NotionConfig, and MCPConfig, including environment variables, activation status, and validation behavior.

</details>