### PR TITLE
📝 docs [#12.3.20] - ⑱ 1차 개선: 리뷰 반영 (Docstring 포맷팅 및 가독성 개선)

### DIFF
--- a/backend/config/mcp_config.py
+++ b/backend/config/mcp_config.py
@@ -2,12 +2,10 @@
 
 """
 MCP (Model Context Protocol) 및 외부 도구 연결 설정 모듈입니다.
-MCP (Model Context Protocol) and external tool connection configuration module.
+이 모듈은 Obsidian, Notion 등 외부 도구와의 연동을 위한 환경 변수를 Pydantic 모델을 통해 검증하고 로드합니다.
 
-이 모듈은 Obsidian, Notion 등 외부 도구와의 연동을 위한 환경 변수를
-Pydantic 모델을 통해 검증하고 로드합니다.
-This module validates and loads environment variables for integrating with external tools
-like Obsidian and Notion using Pydantic models.
+MCP (Model Context Protocol) and external tool connection configuration module.
+This module validates and loads environment variables for integrating with external tools like Obsidian and Notion using Pydantic models.
 """
 
 import os
@@ -19,10 +17,16 @@ from pydantic import BaseModel, ConfigDict, Field
 class ObsidianConfig(BaseModel):
     """
     Obsidian Vault 연결 및 동기화 설정 모델입니다.
-    Obsidian Vault connection and synchronization configuration model.
-
     환경 변수 `OBSIDIAN_VAULT_PATH`, `OBSIDIAN_SYNC_INTERVAL`, `OBSIDIAN_SYNC_ENABLED`를 통해 구성되며,
     Vault 경로의 유효성을 런타임에 검사하는 프로퍼티를 제공합니다.
+
+    Obsidian Vault connection and synchronization configuration model.
+    It is configured via environment variables and provides runtime validation for the Vault path.
+
+    Attributes:
+        vault_path (str): Obsidian Vault의 절대 또는 상대 경로 (기본값: $OBSIDIAN_VAULT_PATH)
+        sync_interval (int): 동기화 주기(초) (기본값: $OBSIDIAN_SYNC_INTERVAL 또는 300)
+        enabled (bool): Obsidian 동기화 활성화 여부 (기본값: $OBSIDIAN_SYNC_ENABLED 또는 True)
     """
 
     model_config = ConfigDict(extra="ignore")
@@ -42,12 +46,13 @@ class ObsidianConfig(BaseModel):
     def is_valid(self) -> bool:
         """
         현재 설정된 Vault 경로가 유효하고 존재하는지 검사합니다.
-        Validates whether the configured Vault path is valid and exists on the filesystem.
-
         기능이 비활성화(`enabled=False`)된 경우 항상 True를 반환합니다.
 
+        Validates whether the configured Vault path is valid and exists on the filesystem.
+        Always returns True if the feature is disabled.
+
         Returns:
-            bool: 비활성화 상태이거나(True), 경로가 존재할 경우 True. 그렇지 않으면 False.
+            bool: 비활성화 상태이거나 경로가 존재할 경우 True, 그렇지 않으면 False.
         """
         if not self.enabled:
             return True
@@ -57,10 +62,15 @@ class ObsidianConfig(BaseModel):
 class NotionConfig(BaseModel):
     """
     Notion API 연결 설정 모델입니다 (Phase 5 예정).
-    Notion API connection configuration model (Planned for Phase 5).
+    환경 변수 `NOTION_API_KEY`, `NOTION_DATABASE_ID`를 통해 구성되며, 현재는 비활성화 상태를 기본값으로 갖습니다.
 
-    환경 변수 `NOTION_API_KEY`, `NOTION_DATABASE_ID`를 통해 구성됩니다.
-    현재는 비활성화 상태(`enabled=False`)를 기본값으로 갖습니다.
+    Notion API connection configuration model (Planned for Phase 5).
+    Configured via environment variables and disabled by default.
+
+    Attributes:
+        api_key (str): Notion API 연동 토큰 (기본값: $NOTION_API_KEY)
+        database_id (str): 대상 Notion 데이터베이스 ID (기본값: $NOTION_DATABASE_ID)
+        enabled (bool): Notion 연동 활성화 여부 (기본값: False)
     """
 
     model_config = ConfigDict(extra="ignore")
@@ -75,9 +85,14 @@ class NotionConfig(BaseModel):
 class MCPConfig(BaseModel):
     """
     모든 외부 도구(MCP) 구성을 통합 관리하는 최상위 설정 모델입니다.
-    Top-level configuration model that aggregates all external tool (MCP) settings.
-
     Obsidian 및 Notion 설정 인스턴스를 포함하며, 전체 초기화 상태를 검증하는 메서드를 제공합니다.
+
+    Top-level configuration model that aggregates all external tool (MCP) settings.
+    It includes instances of Obsidian and Notion configs and provides validation for the setup.
+
+    Attributes:
+        obsidian (ObsidianConfig): Obsidian 동기화 설정 인스턴스
+        notion (NotionConfig): Notion 연동 설정 인스턴스
     """
 
     model_config = ConfigDict(extra="ignore")
@@ -88,10 +103,10 @@ class MCPConfig(BaseModel):
     def validate_setup(self):
         """
         현재 구성된 MCP(외부 도구) 연결 상태를 표준 출력(STDOUT)으로 로깅합니다.
-        Logs the current status of MCP (external tool) configurations to standard output.
+        Obsidian의 활성화 여부 및 경로 유효성을 확인하고, Notion의 Phase 5 예정 상태를 표시합니다.
 
-        Obsidian의 경우 활성화 여부 및 경로 유효성을 확인하고,
-        Notion의 경우 Phase 5 예정 상태임을 표시합니다.
+        Logs the current status of MCP (external tool) configurations to standard output.
+        Checks Obsidian's activation and path validity, and marks Notion as planned for Phase 5.
         """
         print("\n🔌 MCP Configuration Status:")
         print("=" * 30)


### PR DESCRIPTION
- **[가독성] 한/영 Docstring 분리 및 Google Style 일관성 확보**
  - 기존: 한글 문장과 영어 문장이 교차(Interleaved) 배치되거나 마크다운 구분자로 어색하게 분리되어 가독성 저하.
  - 수정: 자연스러운 문단 분리(빈 줄)로 한/영 설명을 그룹화하고, Google Docstring Style(`Attributes:`, `Returns:`)을 모듈 전체에 일관되게 적용하여 자동 문서화 도구 호환성 향상.

- **[문서 정합성] NotionConfig 필드 명세 명확화**
  - 기존: Docstring에 환경변수는 명시되었으나, 실제 Pydantic 필드(`api_key`, `database_id`, `enabled`)와의 매핑 관계가 모호함.
  - 수정: `Attributes:` 섹션에 각 필드명과 환경변수, 기본값의 관계를 1:1로 명시하여 diff 환경에서도 리뷰어가 필드와 설정을 직관적으로 파악할 수 있도록 개선.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1642#pullrequestreview-4600930991)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

MCP 구성 모델에 대한 문서 가독성과 일관성을 개선합니다.

문서:
- MCP, ObsidianConfig, NotionConfig, MCPConfig에 대한 모듈 및 클래스 수준의 docstring을 한국어와 영어로 명확하게 정리합니다.
- Google 스타일의 일관된 docstring 형식을 사용하여 Obsidian, Notion, MCP 구성 필드의 속성과 기본 동작을 문서화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve documentation readability and consistency for MCP configuration models.

Documentation:
- Clarify module- and class-level docstrings for MCP, ObsidianConfig, NotionConfig, and MCPConfig in both Korean and English.
- Document attributes and default behaviors for Obsidian, Notion, and MCP configuration fields using a consistent Google-style docstring format.

</details>