### PR TITLE
📝 docs [#12.3.20] - ⑱ 2차 개선 : Docstring 한/영 순서 통일 및 줄바꿈 적용

### DIFF
--- a/backend/api/endpoints/__init__.py
+++ b/backend/api/endpoints/__init__.py
@@ -2,14 +2,14 @@
 
 """
 도메인별 FastAPI 라우터 서브모듈을 집계하여 외부로 노출하는 패키지 초기화 모듈입니다.
-Package initializer that aggregates domain-specific FastAPI router sub-modules.
-
 각 서브모듈의 `router` 인스턴스를 `*_router` 별칭으로 노출하여,
 `backend.api.routes` 에서 단일 진입점으로 등록할 수 있게 합니다.
+
+Package initializer that aggregates domain-specific FastAPI router sub-modules.
 Each sub-module's `router` instance is re-exported under a `*_router` alias,
 allowing `backend.api.routes` to register them through a single entry point.
 
-노출되는 라우터:
+노출되는 라우터 (Exported Routers):
     - classify_router   : 분류(Classification) 도메인
     - search_router     : 검색(Search) 도메인
     - metadata_router   : 메타데이터(Metadata) 도메인

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -2,14 +2,14 @@
 
 """
 중앙 집중식 API 라우터 엔트리포인트 모듈입니다.
-Centralized API router entry point module.
-
 이 모듈은 FastAPI 애플리케이션의 모든 하위 도메인 라우터를 단일 `APIRouter` 인스턴스(`router`)로
 통합하여 `prefix="/api"`를 기준으로 마운트합니다.
-This module aggregates all domain-specific sub-routers into a single `APIRouter` instance (`router`)
-mounted under the `/api` prefix.
 
-포함된 도메인 라우터:
+Centralized API router entry point module.
+This module aggregates all domain-specific sub-routers into a single
+`APIRouter` instance (`router`) mounted under the `/api` prefix.
+
+포함된 도메인 라우터 (Included Domain Routers):
     - `/classify` : 분류(Classification) 관련 엔드포인트
     - `/search`   : 검색(Search, 하이브리드 RAG) 관련 엔드포인트
     - `/metadata` : 파일 메타데이터 처리 엔드포인트
@@ -34,10 +34,12 @@ router = APIRouter(prefix="/api")
 async def health_check(locale: str = Depends(get_locale)) -> HealthCheckResponse:
     """
     서버 상태를 확인하는 헬스체크 엔드포인트입니다.
-    Health check endpoint that confirms the server is running and responsive.
-
     클라이언트의 `Accept-Language` 헤더를 기반으로 `get_locale` 의존성을 통해 로케일을 주입받으며,
     다국어(i18n)로 응답 메시지를 반환합니다.
+
+    Health check endpoint that confirms the server is running and responsive.
+    It injects the locale based on the client's `Accept-Language` header
+    via the `get_locale` dependency, returning an i18n response message.
 
     Args:
         locale (str): FastAPI `get_locale` 의존성을 통해 주입된 로케일 코드 (예: 'ko', 'en').

--- a/backend/config/mcp_config.py
+++ b/backend/config/mcp_config.py
@@ -5,7 +5,8 @@ MCP (Model Context Protocol) 및 외부 도구 연결 설정 모듈입니다.
 이 모듈은 Obsidian, Notion 등 외부 도구와의 연동을 위한 환경 변수를 Pydantic 모델을 통해 검증하고 로드합니다.
 
 MCP (Model Context Protocol) and external tool connection configuration module.
-This module validates and loads environment variables for integrating with external tools like Obsidian and Notion using Pydantic models.
+This module validates and loads environment variables for integrating
+with external tools like Obsidian and Notion using Pydantic models.
 """
 
 import os
@@ -21,7 +22,8 @@ class ObsidianConfig(BaseModel):
     Vault 경로의 유효성을 런타임에 검사하는 프로퍼티를 제공합니다.
 
     Obsidian Vault connection and synchronization configuration model.
-    It is configured via environment variables and provides runtime validation for the Vault path.
+    It is configured via environment variables and provides runtime
+    validation for the Vault path.
 
     Attributes:
         vault_path (str): Obsidian Vault의 절대 또는 상대 경로 (기본값: $OBSIDIAN_VAULT_PATH)
@@ -88,7 +90,8 @@ class MCPConfig(BaseModel):
     Obsidian 및 Notion 설정 인스턴스를 포함하며, 전체 초기화 상태를 검증하는 메서드를 제공합니다.
 
     Top-level configuration model that aggregates all external tool (MCP) settings.
-    It includes instances of Obsidian and Notion configs and provides validation for the setup.
+    It includes instances of Obsidian and Notion configs and provides
+    validation for the setup.
 
     Attributes:
         obsidian (ObsidianConfig): Obsidian 동기화 설정 인스턴스
@@ -106,7 +109,8 @@ class MCPConfig(BaseModel):
         Obsidian의 활성화 여부 및 경로 유효성을 확인하고, Notion의 Phase 5 예정 상태를 표시합니다.
 
         Logs the current status of MCP (external tool) configurations to standard output.
-        Checks Obsidian's activation and path validity, and marks Notion as planned for Phase 5.
+        Checks Obsidian's activation and path validity, and marks Notion
+        as planned for Phase 5.
         """
         print("\n🔌 MCP Configuration Status:")
         print("=" * 30)


### PR DESCRIPTION
- **[일관성] Docstring 한/영 순서 및 문단 그룹화 통일**
  - 기존: 파일마다 한/영 혼용 순서가 다르거나 문장 단위로 교차되어 일관성이 부족함.
  - 수정: `mcp_config.py`, `routes.py`, `endpoints/__init__.py` 등 변경된 모든 파일에서 **'한글 설명 문단 -> 영문 설명 문단'** 순서로 엄격하게 통일하여 추후 유지보수와 리뷰 예측 가능성을 극대화함.

- **[가독성] 영문 Docstring Line-length(줄 길이) 제한 준수**
  - 기존: 영문 번역 문장이 100자를 초과하여 GitHub PR diff 환경에서 가로 스크롤(Horizontal scroll)을 유발함.
  - 수정: 기존 PEP 8 기반의 코드 컨벤션에 맞춰 영문 Docstring을 적절한 길이(약 80자 이내)로 Wrap 처리하여 가독성을 획기적으로 개선함.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1643#pullrequestreview-4600985255)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

API 라우팅 및 MCP 구성 모듈에서 이중 언어 도크스트링의 순서를 표준화하고, 영어 설명의 줄 바꿈을 개선합니다.

Documentation:
- 라우팅, 엔드포인트, MCP 구성 모듈 전반에서 도크스트링을 한국어 우선, 그 다음 영어 순서로 정렬합니다.
- 영어 도크스트링 텍스트의 줄 길이를 더 짧게 조정하여 diff와 에디터에서의 가독성을 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize bilingual docstrings order and improve line wrapping for English descriptions in API routing and MCP configuration modules.

Documentation:
- Align Korean-first then English docstring ordering across routing, endpoint, and MCP configuration modules.
- Wrap English docstring text to a shorter line length to improve readability in diffs and editors.

</details>