### PR TITLE
📝 docs [#12.3.20] - ⑲ `.env.example` 전면 최신화 및 환경 변수 주석 보강

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,39 +1,316 @@
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# FlowNote Environment Variables Template
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# FlowNote MVP — Environment Variables Template (.env.example)
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# ⚠️  이 파일은 .env 파일의 템플릿입니다. 실제 API 키·비밀 값은
+#     절대 이 파일에 기입하지 마세요. .env 파일에만 기입하고 .gitignore로 보호하세요.
+#
+# ⚠️  This is a template for your .env file. NEVER commit actual secrets
+#     (API keys, tokens, personal paths) here. Fill them in your local .env,
+#     which must be protected by .gitignore.
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-# --- Server Configuration ---
+
+# ─────────────────────────────────────────────────────────────────────
+# 1. Server Configuration — 서버 기본 설정
+# ─────────────────────────────────────────────────────────────────────
+
+# 서버 리슨 포트 (기본값: 8000 / 허용 범위: 1024~65535)
+# Server listening port (default: 8000 / range: 1024~65535)
 PORT=8000
+
+# Gunicorn 워커 프로세스 수 (기본값: 2 / 권장: CPU 코어 수 × 2 + 1)
+# Number of Gunicorn worker processes (default: 2 / recommended: CPU cores × 2 + 1)
 WEB_CONCURRENCY=2
+
+# 실행 환경 — 허용값: production | development | test
+# Runtime environment — allowed: production | development | test
 ENVIRONMENT=production
 
-# --- OpenAI API Configuration ---
 
-# GPT-4o (High Performance)
+# ─────────────────────────────────────────────────────────────────────
+# 2. OpenAI-compatible Models — OpenAI 호환 AI 모델 설정
+# ─────────────────────────────────────────────────────────────────────
+
+# GPT-4o (고성능 채팅 — High-performance chat)
 GPT4O_API_KEY=sk-...
 GPT4O_BASE_URL=https://api.openai.com/v1
 GPT4O_MODEL=gpt-4o
 
-# GPT-4o-mini (Fast & Cost-effective) - Main Model
+# GPT-4o-mini ⭐ 기본 주력 모델 (빠르고 저렴 — Fast & cost-effective, main model)
 GPT4O_MINI_API_KEY=sk-...
 GPT4O_MINI_BASE_URL=https://api.openai.com/v1
 GPT4O_MINI_MODEL=gpt-4o-mini
 
-# GPT-4.1 (Vision)
+# GPT-4.1 (비전/멀티모달 전용 — For vision/multimodal tasks)
 GPT41_API_KEY=sk-...
 GPT41_BASE_URL=https://api.openai.com/v1
 GPT41_MODEL=gpt-4-turbo
 
-# Embedding (Vector Search)
+# Embedding Small ⭐ FAISS 벡터 검색 기본 모델 (기본 임베딩 — Default embedding)
 EMBEDDING_API_KEY=sk-...
 EMBEDDING_BASE_URL=https://api.openai.com/v1
 EMBEDDING_MODEL=text-embedding-3-small
 
-# --- Anthropic Configuration (Optional) ---
+# Embedding Large (고정밀 임베딩 — High-precision embedding, optional)
+EMBEDDING_LARGE_API_KEY=sk-...
+EMBEDDING_LARGE_BASE_URL=https://api.openai.com/v1
+EMBEDDING_LARGE_MODEL=text-embedding-3-large
+
+
+# ─────────────────────────────────────────────────────────────────────
+# 3. Anthropic Models — Anthropic 모델 설정 (OpenAI 호환 API)
+# ─────────────────────────────────────────────────────────────────────
+
+# Claude 4 Sonnet
 CLAUDE_4_SONNET_API_KEY=sk-ant-...
 CLAUDE_4_SONNET_BASE_URL=https://api.anthropic.com/v1
 CLAUDE_4_SONNET_MODEL=claude-3-sonnet-20240229
 
+# Claude 3.5 Haiku (빠른 응답 — Fast response)
 CLAUDE_35_HAIKU_API_KEY=sk-ant-...
 CLAUDE_35_HAIKU_BASE_URL=https://api.anthropic.com/v1
 CLAUDE_35_HAIKU_MODEL=claude-3-haiku-20240307
+
+# Claude 4.5 Sonnet (선택 사항 — Optional)
+CLAUDE_45_SONNET_API_KEY=sk-ant-...
+CLAUDE_45_SONNET_BASE_URL=https://api.anthropic.com/v1
+CLAUDE_45_SONNET_MODEL=anthropic/claude-sonnet-4-5
+
+# Claude 4.5 Haiku (선택 사항 — Optional)
+CLAUDE_45_HAIKU_API_KEY=sk-ant-...
+CLAUDE_45_HAIKU_BASE_URL=https://api.anthropic.com/v1
+CLAUDE_45_HAIKU_MODEL=anthropic/claude-haiku-4-5
+
+# Claude 4.5 Opus (선택 사항 — Optional)
+CLAUDE_45_OPUS_API_KEY=sk-ant-...
+CLAUDE_45_OPUS_BASE_URL=https://api.anthropic.com/v1
+CLAUDE_45_OPUS_MODEL=anthropic/claude-opus-4-5
+
+
+# ─────────────────────────────────────────────────────────────────────
+# 4. Google Gemini Models — Gemini 모델 설정 (OpenAI 호환 API, 선택 사항)
+# ─────────────────────────────────────────────────────────────────────
+
+# Gemini 2.5 Pro (선택 사항 — Optional)
+GEMINI_25_PRO_API_KEY=...
+GEMINI_25_PRO_BASE_URL=https://generativelanguage.googleapis.com/v1beta
+GEMINI_25_PRO_MODEL=gemini-2.5-pro
+
+# Gemini 3 Pro (선택 사항 — Optional)
+GEMINI_3_PRO_API_KEY=...
+GEMINI_3_PRO_BASE_URL=https://generativelanguage.googleapis.com/v1beta
+GEMINI_3_PRO_MODEL=gemini-3-pro-preview
+
+
+# ─────────────────────────────────────────────────────────────────────
+# 5. Custom Proxy Settings — 커스텀 프록시 설정 (선택 사항)
+# ─────────────────────────────────────────────────────────────────────
+
+# 프록시 디버그 모드 — 허용값: true | false (기본값: false)
+# Proxy debug mode — allowed: true | false (default: false)
+PROXY_DEBUG=false
+
+# 프록시 API 요청 타임아웃 (초 단위 / 기본값: 120 / 범위: 1 이상)
+# Proxy request timeout in seconds (default: 120 / range: 1+)
+PROXY_TIMEOUT=120
+
+# 주 모델 실패 시 사용할 폴백 모델 이름 (Fallback model when primary fails)
+PROXY_FALLBACK_MODEL=gpt-4o-mini
+
+
+# ─────────────────────────────────────────────────────────────────────
+# 6. Infrastructure — 인프라 설정
+# ─────────────────────────────────────────────────────────────────────
+
+# Redis 연결 URL — LangGraph 체크포인터·세션·Celery Broker 공용
+# Redis connection URL (shared by LangGraph checkpointer, sessions, and Celery)
+REDIS_URL=redis://localhost:6379
+
+# Celery Broker URL (기본값: Redis / Default: Redis)
+CELERY_BROKER_URL=redis://localhost:6379/0
+
+# Celery 결과 Backend URL (기본값: Redis)
+# Celery result backend URL (default: Redis)
+CELERY_RESULT_BACKEND=redis://localhost:6379/0
+
+
+# ─────────────────────────────────────────────────────────────────────
+# 7. Admin & Alerting — 관리자 및 알림 설정
+# ─────────────────────────────────────────────────────────────────────
+
+# 어드민 API 접근 키 — 미설정 시 어드민 엔드포인트 전체 비활성화
+# Admin API access key (all admin endpoints disabled if unset)
+ADMIN_API_KEY=your-secure-admin-api-key-here
+
+# Discord Webhook URL — 시스템 에러 알림용 (선택 사항 / Optional)
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/your-webhook-id/your-webhook-token
+
+
+# ─────────────────────────────────────────────────────────────────────
+# 8. External Search — 외부 검색 API
+# ─────────────────────────────────────────────────────────────────────
+
+# Tavily 웹 검색 API 키 — 에이전트 웹 검색 도구에 필요 (선택 사항 / Optional)
+# Tavily web search API key — required for agent web search tool (optional)
+TAVILY_API_KEY=tvly-...
+
+
+# ─────────────────────────────────────────────────────────────────────
+# 9. MCP (Model Context Protocol) — 외부 도구 연동 설정
+# ─────────────────────────────────────────────────────────────────────
+
+# --- Obsidian ---
+# Obsidian Vault 절대 경로 (비어있으면 Obsidian 연동 비활성화)
+# Absolute path to your Obsidian Vault (leave empty to disable sync)
+OBSIDIAN_VAULT_PATH=/path/to/your/obsidian/vault
+
+# Obsidian 동기화 주기 (초 단위 / 기본값: 300 / 범위: 1 이상)
+# Obsidian sync interval in seconds (default: 300 / range: 1+)
+OBSIDIAN_SYNC_INTERVAL=300
+
+# Obsidian 동기화 활성화 여부 — 허용값: true | false (기본값: true)
+# Enable Obsidian sync — allowed: true | false (default: true)
+OBSIDIAN_SYNC_ENABLED=true
+
+# --- Notion (Phase 5 예정 / Planned — disabled by default) ---
+# Notion API 통합 토큰 (Phase 5 예정 — 현재 비활성화)
+# Notion API integration token (Phase 5 planned — currently disabled)
+NOTION_API_KEY=secret_...
+
+# Notion 대상 데이터베이스 ID (Phase 5 예정 — 현재 비활성화)
+# Target Notion database ID (Phase 5 planned — currently disabled)
+NOTION_DATABASE_ID=
+
+
+# ─────────────────────────────────────────────────────────────────────
+# 10. WebSocket Configuration — WebSocket 설정
+# ─────────────────────────────────────────────────────────────────────
+
+# 메시지 압축 적용 임계값 (바이트 / 기본값: 1024 / 범위: 1 이상)
+# Message compression threshold in bytes (default: 1024 / range: 1+)
+WS_COMPRESSION_THRESHOLD=1024
+
+# TPS 계산용 최대 샘플 수 (기본값: 100 / 범위: 1~1000)
+# Max sample count for TPS calculation (default: 100 / range: 1~1000)
+WS_METRICS_MAX_TPS=100
+
+# TPS 계산 시간 윈도우 (초 / 기본값: 60 / 범위: 1~3600)
+# Time window for TPS calculation in seconds (default: 60 / range: 1~3600)
+WS_METRICS_WINDOW_SECONDS=60
+
+
+# ─────────────────────────────────────────────────────────────────────
+# 11. Privacy & GDPR — 개인정보 보호 및 GDPR 설정
+# ─────────────────────────────────────────────────────────────────────
+
+# Vacuum 스케줄 Cron 표현식 (기본값: 비어있음 — 수동 실행만 / empty = manual only)
+# Cron expression for automated vacuum scheduling (e.g. "0 2 * * *" = daily at 2 AM)
+VACUUM_SCHEDULE_CRON=
+
+# Vacuum 누적 삭제 임계값 — 해당 건수 이상 시 자동 Vacuum 실행
+# (기본값: 1000 / 범위: 1~100,000)
+# Cumulative deletion threshold to trigger auto-vacuum (default: 1000 / range: 1~100,000)
+VACUUM_BATCH_THRESHOLD=1000
+
+# PBKDF2 반복 횟수 — 높을수록 보안 강화, 처리 속도 저하
+# (기본값: 600000 / NIST SP 800-132 권장: 600,000 이상)
+# PBKDF2 iteration count — higher = more secure but slower
+# (default: 600000 / NIST SP 800-132 recommendation: 600,000+)
+PBKDF2_ITERATIONS=600000
+
+# PBKDF2 해시 알고리즘 — 허용값: sha256 | sha512 (기본값: sha256)
+# PBKDF2 hash algorithm — allowed: sha256 | sha512 (default: sha256)
+PBKDF2_HASH_NAME=sha256
+
+# PBKDF2 파생 키 길이 (바이트 / 기본값: 32 / 범위: 16~64)
+# PBKDF2 derived key length in bytes (default: 32 / range: 16~64)
+PBKDF2_KEY_LENGTH_BYTES=32
+
+# PBKDF2 Salt 길이 (바이트 / 기본값: 32 / 범위: 16~64)
+# PBKDF2 salt length in bytes (default: 32 / range: 16~64 per NIST SP 800-132 §5.1)
+PBKDF2_SALT_LENGTH_BYTES=32
+
+# PBKDF2 키 버전 — 키 순환(Key Rotation) 시 1씩 증가
+# (기본값: 1 / 범위: 1 이상 / N-1까지 과도기 허용, N-2 이하 폐기 대상)
+# PBKDF2 key version for key rotation (default: 1 / range: 1+, increment on each rotation)
+PBKDF2_KEY_VERSION=1
+
+# 개인정보 로그 항목당 최대 문자 수 (기본값: 4096 / 범위: 64~1,048,576)
+# Max character length per privacy log field (default: 4096 / range: 64~1,048,576)
+PRIVACY_LOG_FIELD_MAX_LENGTH=4096
+
+
+# ─────────────────────────────────────────────────────────────────────
+# 12. RAG & Search — 검색 및 RAG 설정
+# ─────────────────────────────────────────────────────────────────────
+
+# RAG 쿼리당 최대 검색 문서 수 (기본값: 10 / 범위: 1 이상)
+# Max number of documents retrieved per RAG query (default: 10 / range: 1+)
+RAG_MAX_DOCS=10
+
+# RAG 문서 1개당 최대 문자 수 (기본값: 2000 / 범위: 1 이상)
+# Max characters per document in RAG context (default: 2000 / range: 1+)
+RAG_MAX_DOC_CHARS=2000
+
+# RAG 컨텍스트 총 최대 문자 수 (기본값: 16000 / 범위: 1 이상)
+# Max total characters in RAG context window (default: 16000 / range: 1+)
+RAG_MAX_TOTAL_CHARS=16000
+
+# 검색 히스토리 로깅 타임아웃 (초 / 기본값: 3.0 / 범위: 0.1 이상)
+# Timeout for search history logging in seconds (default: 3.0 / range: 0.1+)
+SEARCH_HISTORY_LOG_TIMEOUT=3.0
+
+# 하이브리드 검색 — 개인화 인덱스 가중치 (기본값: 0.6 / 범위: 0.0~1.0)
+# Hybrid search — personalized index weight (default: 0.6 / range: 0.0~1.0)
+# Note: 두 가중치 합은 런타임에 자동 정규화됩니다 (auto-normalized to 1.0 at runtime)
+PERSONALIZED_INDEX_WEIGHT=0.6
+
+# 하이브리드 검색 — 전역 인덱스 가중치 (기본값: 0.4 / 범위: 0.0~1.0)
+# Hybrid search — global index weight (default: 0.4 / range: 0.0~1.0)
+GLOBAL_INDEX_WEIGHT=0.4
+
+
+# ─────────────────────────────────────────────────────────────────────
+# 13. Fine-tuning — 파인튜닝 설정 (선택 사항 / Optional)
+# ─────────────────────────────────────────────────────────────────────
+
+# Redis Job 상태 키 프리픽스 (기본값: v9:finetune:job:)
+# Redis key prefix for fine-tuning job state (default: v9:finetune:job:)
+FINETUNE_REDIS_KEY_PREFIX=v9:finetune:job:
+
+# 현재 운영 중인 파인튜닝 모델 ID 추적 Redis 키 (기본값: v9:finetune:current_model_id)
+# Redis key tracking the currently active fine-tuned model ID
+FINETUNE_ACTIVE_MODEL_KEY=v9:finetune:current_model_id
+
+# 파인튜닝 JSONL 데이터 저장 디렉터리 (기본값: {project_root}/data/golden_dataset)
+# Directory for fine-tuning JSONL data (default: {project_root}/data/golden_dataset)
+# FINETUNE_DATA_DIR=/custom/path/to/golden_dataset
+
+# Job 완료 여부 폴링 간격 (초 / 기본값: 30 / 범위: 5 이상)
+# Polling interval for fine-tuning job status (seconds / default: 30 / range: 5+)
+FINETUNE_POLL_INTERVAL_SECS=30
+
+# Job 완료 대기 최대 시간 (초 / 기본값: 7200 = 2시간 / 범위: 600 이상)
+# Max wait time for fine-tuning job completion (seconds / default: 7200=2h / range: 600+)
+FINETUNE_POLL_TIMEOUT_SECS=7200
+
+# Redis Job 상태 보관 TTL (초 / 기본값: 604800 = 7일 / 범위: 86400 이상)
+# TTL for fine-tuning job state in Redis (seconds / default: 604800=7days / range: 86400+)
+FINETUNE_REDIS_TTL_SECS=604800
+
+# 파인튜닝 Job 생성 시 사용할 기반 모델 (기본값: gpt-4o-mini-2024-07-18)
+# Base model for fine-tuning jobs (default: gpt-4o-mini-2024-07-18)
+FINETUNE_BASE_MODEL=gpt-4o-mini-2024-07-18
+
+
+# ─────────────────────────────────────────────────────────────────────
+# 14. Evaluation — 평가 설정 (선택 사항 / Optional)
+# ─────────────────────────────────────────────────────────────────────
+
+# 평가 리포트 Redis SCAN 최대 반복 횟수 (기본값: 100 / 범위: 1 이상)
+# Max Redis SCAN iterations for evaluation reports (default: 100 / range: 1+)
+EVAL_REPORT_MAX_SCAN_ITERATIONS=100
+
+# 평가 리포트 SCAN 1회당 조회 키 개수 (기본값: 500 / 범위: 1 이상)
+# Number of keys per Redis SCAN call for evaluation reports (default: 500 / range: 1+)
+EVAL_REPORT_SCAN_BATCH_SIZE=500


### PR DESCRIPTION
- **[누락 변수 추가] 코드베이스 전수 스캔으로 미반영 환경 변수 40개 이상 추가**
  - 기존: 40줄, 주요 AI 모델 API 키 위주의 최소한의 템플릿.
  - 수정: 316줄, 14개 카테고리로 구조화하여 서버·모델·인프라·MCP·개인정보보호·RAG· 파인튜닝·평가 설정 등 코드베이스에서 실제 사용되는 모든 환경 변수를 망라.

- **[문서화] 각 환경 변수에 한/영 이중 주석·기본값·허용 범위 명시**
  - 신규 추가: EMBEDDING_LARGE_*, CLAUDE_45_*, GEMINI_*, PROXY_*, CELERY_*, ADMIN_API_KEY, DISCORD_WEBHOOK_URL, TAVILY_API_KEY, OBSIDIAN_SYNC_INTERVAL, OBSIDIAN_SYNC_ENABLED, NOTION_*, WS_COMPRESSION_THRESHOLD, WS_METRICS_*, VACUUM_*, PBKDF2_*, PRIVACY_LOG_FIELD_MAX_LENGTH, RAG_*, SEARCH_HISTORY_LOG_TIMEOUT, *_INDEX_WEIGHT, FINETUNE_*, EVAL_REPORT_*
  - 실제 코드(privacy_service.py 등)에서 검증된 정확한 범위값을 주석에 반영.

- **[보안] 하드코딩 금지 원칙 엄수 / No-hardcoding & Privacy-first**
  - OBSIDIAN_VAULT_PATH에 실제 경로 대신 플레이스홀더(/path/to/your/obsidian/vault) 사용.
  - 모든 API 키 필드를 `sk-...` / `sk-ant-...` / `tvly-...` 형식으로만 표기.
  - 파일 최상단에 실제 비밀값 기입 금지 경고 문구(한/영) 추가.

🔗 Related:
- Issue [#1044]
- Obsidian/Notion 설정 참조

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

예시 환경 구성 파일을 확장하고 완전히 문서화하여, 코드베이스 전반에서 사용되는 모든 환경 변수를 구조화된 카테고리와 강화된 보안 지침과 함께 다루도록 합니다.

Documentation:
- `.env.example`를 수정하여 현재 사용 중인 모든 환경 변수를 카테고리별로 정리하고, 이중언어 주석, 기본값, 허용 값 범위를 포함합니다.
- 코드베이스에서 실제로 사용되는 내용을 기반으로 `.env.example` 내 개인정보 관련 설정 및 RAG/파인튜닝/평가 설정을 명확히 합니다.
- 실제 비밀 값을 템플릿에 저장하지 않도록 `.env.example`에 하드코딩 금지 및 API 키 형식에 대한 명시적인 안내를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expand and fully document the example environment configuration file to cover all environment variables used across the codebase with structured categories and stronger security guidance.

Documentation:
- Revise .env.example to include all current environment variables organized by category with bilingual comments, defaults, and allowed value ranges.
- Clarify privacy-related and RAG/finetuning/evaluation settings in .env.example based on actual usage in the codebase.
- Add explicit no-hardcoding and API key formatting guidance to .env.example to discourage storing real secrets in the template.

</details>