### PR TITLE
📝 docs [#12.3.20] - ⑳ Celery 백그라운드 워커 진입점 및 설정 모듈 Docstring 고도화

### DIFF
--- a/backend/celery_app/celery.py
+++ b/backend/celery_app/celery.py
@@ -1,59 +1,75 @@
-# backend/celery_app/celery.py
+"""
+Celery 애플리케이션 및 스케줄러(Beat) 진입점.
+
+이 모듈은 FlowNote MVP의 백그라운드 작업을 조율하는 메인 Celery 앱 인스턴스를 생성하고,
+주기적인 백그라운드 태스크(Beat Schedule)를 정의합니다. 설정은 `CeleryConfig`에서 로드하며,
+`tasks` 패키지 내의 태스크들을 자동으로 검색하여 등록합니다.
+
+Entry point for the Celery application and scheduler (Beat).
+
+This module creates the main Celery app instance orchestrating background tasks
+for FlowNote MVP, and defines periodic background tasks (Beat Schedule). It loads
+configurations from `CeleryConfig` and automatically discovers and registers tasks
+from the `tasks` package.
+"""
 
 from celery import Celery
 from celery.schedules import crontab
 
 from backend.celery_app.config import CeleryConfig
 
-# Celery App 초기화
+# Celery App 인스턴스 초기화
+# Initialize the Celery App instance
 app = Celery("flownote")
 
-# 설정 로드
+# CeleryConfig 클래스 기반 설정 적용
+# Apply configurations based on the CeleryConfig class
 app.config_from_object(CeleryConfig)
 
 # 태스크 자동 발견 (Auto-discover Tasks)
-# 'backend.celery_app' 앱 내의 tasks 모듈(패키지)을 자동으로 찾아 로드합니다.
-# backend/celery_app/tasks/__init__.py에서 명시적으로 임포트된 태스크들이 등록됩니다.
+# 'backend.celery_app.tasks.__init__.py'에서 명시적으로 임포트된 태스크들을 로드합니다.
+# Automatically discover and load tasks explicitly imported in 'backend.celery_app.tasks.__init__.py'.
 app.autodiscover_tasks(["backend.celery_app"])
 
 # Beat Schedule 정의
+# Define the Beat Schedule for periodic tasks
 app.conf.beat_schedule = {
-    # 1. 재분류 (Daily - 매일 자정)
+    # 1. 재분류 (매일 자정) / Reclassification (Daily at Midnight)
     "daily-reclassification": {
         "task": "backend.celery_app.tasks.reclassification.daily_reclassify_tasks",
         "schedule": crontab(hour=0, minute=0),
     },
-    # 2. 재분류 심화 (Weekly - 매주 일요일 새벽 2시)
+    # 2. 심층 재분류 (매주 일요일 새벽 2시) / Deep Reclassification (Weekly on Sunday at 2 AM)
     "weekly-reclassification": {
         "task": "backend.celery_app.tasks.reclassification.weekly_reclassify_tasks",
         "schedule": crontab(hour=2, minute=0, day_of_week=0),
     },
-    # 3. 자동 아카이브 (Daily - 매일 새벽 3시)
+    # 3. 자동 아카이브 (매일 새벽 3시) / Auto Archiving (Daily at 3 AM)
     "daily-archiving": {
         "task": "backend.celery_app.tasks.archiving.auto_archive_tasks",
         "schedule": crontab(hour=3, minute=0),
     },
-    # 4. 주간 리포트 (Weekly - 매주 월요일 아침 9시)
+    # 4. 주간 리포트 생성 (매주 월요일 아침 9시) / Weekly Report Generation (Weekly on Monday at 9 AM)
     "weekly-report": {
         "task": "backend.celery_app.tasks.reporting.generate_weekly_report",
         "schedule": crontab(hour=9, minute=0, day_of_week=1),
     },
-    # 5. 월간 리포트 (Monthly - 매월 1일 아침 9시)
+    # 5. 월간 리포트 생성 (매월 1일 아침 9시) / Monthly Report Generation (Monthly on the 1st at 9 AM)
     "monthly-report": {
         "task": "backend.celery_app.tasks.reporting.generate_monthly_report",
         "schedule": crontab(hour=9, minute=0, day_of_month="1"),
     },
-    # 6. 동기화 상태 모니터링 (Hourly - 매시간 정각)
+    # 6. 동기화 상태 모니터링 (매시간 정각) / Sync Status Monitoring (Hourly on the hour)
     "monitor-sync-status": {
         "task": "backend.celery_app.tasks.monitoring.check_sync_status",
         "schedule": crontab(minute=0),
     },
-    # 7. 로그 및 임시 파일 정리 (Weekly - 매주 일요일 새벽 4시)
+    # 7. 로그 및 임시 파일 정리 (매주 일요일 새벽 4시) / Cleanup Logs and Temp Files (Weekly on Sunday at 4 AM)
     "cleanup-logs": {
         "task": "backend.celery_app.tasks.maintenance.cleanup_old_logs",
         "schedule": crontab(hour=4, minute=0, day_of_week=0),
     },
-    # 8. 고립 노트 스캔 (Daily - 매일 새벽 5시)
+    # 8. 고립된 노트 스캔 (매일 새벽 5시) / Orphan Notes Scan (Daily at 5 AM)
     "daily-orphan-notes-scan": {
         "task": "backend.celery_app.tasks.graph.detect_orphan_notes_for_all_users",
         "schedule": crontab(hour=5, minute=0),

--- a/backend/celery_app/config.py
+++ b/backend/celery_app/config.py
@@ -1,28 +1,69 @@
-# backend/celery_app/config.py
+"""
+Celery 백그라운드 워커 설정 모듈.
+
+이 모듈은 FlowNote MVP의 백그라운드 태스크 처리를 위한 Celery 구성을 정의합니다.
+Redis를 메시지 브로커 및 결과 저장소로 활용하며, 워커 동작(Prefetch, Max Tasks)을 최적화합니다.
+
+Configuration module for the Celery background worker.
+
+This module defines the Celery configuration for background task processing in FlowNote MVP.
+It utilizes Redis as both the message broker and result backend, and optimizes worker behavior.
+"""
 
 import os
 
 
 class CeleryConfig:
-    # Broker & Backend Settings
-    # RabbitMQ를 사용하지 않고 Redis를 Broker와 Backend로 모두 사용합니다.
+    """
+    Celery 워커 기본 설정 클래스.
+
+    브로커 URL, 직렬화 방식, 워커의 메모리 누수 방지 등 핵심 설정을 관리합니다.
+
+    Base configuration class for the Celery worker.
+
+    Manages core settings such as broker URL, serialization methods, and
+    worker memory leak prevention.
+
+    Attributes:
+        broker_url (str): 메시지 브로커 연결 URL (기본값: Redis).
+            Message broker connection URL (default: Redis).
+        result_backend (str): 태스크 결과 저장소 연결 URL (기본값: Redis).
+            Task result backend connection URL (default: Redis).
+        timezone (str): 워커 및 스케줄러 시간대 (기본값: Asia/Seoul).
+            Timezone for the worker and scheduler (default: Asia/Seoul).
+        enable_utc (bool): UTC 사용 여부 (기본값: False).
+            Whether to enable UTC (default: False).
+        task_serializer (str): 태스크 페이로드 직렬화 포맷 (기본값: json).
+            Task payload serialization format (default: json).
+        result_serializer (str): 결과 페이로드 직렬화 포맷 (기본값: json).
+            Result payload serialization format (default: json).
+        accept_content (list[str]): 허용되는 직렬화 콘텐츠 타입.
+            Allowed serialization content types.
+        worker_prefetch_multiplier (int): 워커가 한 번에 미리 가져올 태스크 수.
+            1로 설정하여 태스크를 워커 간 공정하게 분배합니다.
+            Number of tasks a worker prefetches at a time.
+            Set to 1 to distribute tasks fairly among workers.
+        worker_max_tasks_per_child (int): 프로세스 재시작 전 처리할 최대 태스크 수.
+            메모리 누수를 방지하기 위해 50으로 제한합니다.
+            Maximum number of tasks processed before restarting the process.
+            Limited to 50 to prevent memory leaks.
+        worker_hijack_root_logger (bool): Celery가 루트 로거를 가로채는지 여부.
+            기존 로깅 설정을 유지하기 위해 False로 설정합니다.
+            Whether Celery hijacks the root logger.
+            Set to False to preserve existing logging configurations.
+    """
+
     broker_url = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
     result_backend = os.getenv("CELERY_RESULT_BACKEND", "redis://localhost:6379/0")
 
-    # Timezone Setting (KST)
     timezone = "Asia/Seoul"
     enable_utc = False
 
-    # Task & Result Serialization
     task_serializer = "json"
     result_serializer = "json"
     accept_content = ["json"]
 
-    # Worker Settings
-    # Prefetch Multiplier: 한 번에 가져올 태스크 수 (1로 설정하여 공정하게 분배)
     worker_prefetch_multiplier = 1
-    # Max Tasks Per Child: 메모리 누수 방지를 위해 일정 작업 후 워커 프로세스 재시작
     worker_max_tasks_per_child = 50
 
-    # Logging
     worker_hijack_root_logger = False


### PR DESCRIPTION
- **[문서화] 백그라운드 태스크 메인 설정(CeleryConfig) 명세 보강**
  - 기존: 단순 인라인 주석(국문) 위주의 설정 클래스.
  - 수정: `backend/celery_app/config.py`에 모듈 및 `CeleryConfig` 클래스 레벨 Docstring 추가.
  - `worker_prefetch_multiplier`, `worker_max_tasks_per_child` 등 메모리 누수 방지와 최적화를 위한 핵심 파라미터의 역할을 한/영 이중 주석으로 상세히 설명(Google Style).

- **[가독성] Beat Schedule 스케줄러 진입점 주석 체계화**
  - `backend/celery_app/celery.py` 모듈 상단에 전체적인 앱 및 스케줄러의 역할을 설명하는 한/영 Docstring 추가.
  - `daily-reclassification`, `weekly-report`, `cleanup-logs` 등 8개의 정기 배치 태스크 항목에 대해 한/영 분리 병기 방식(예: `재분류 (매일 자정) / Reclassification (Daily at Midnight)`)을 일관되게 적용하여 스크롤 및 유지보수 편의성 증대.

- **[보안/무결성] 하드코딩 금지 원칙 준수**
  - 기존에 환경 변수로 파싱하던 로직(`os.getenv`)을 완벽하게 보존하여, 설정 로딩 메커니즘을 변경하지 않고 안전하게 문서화만 진행.

🔗 Related: Issue [#1044]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

FlowNote MVP를 위한 Celery 백그라운드 워커 설정 및 스케줄러 엔트리포인트를 문서화하고 명확히 합니다.

Documentation:
- Celery 워커 설정, 핵심 파라미터, 그리고 신뢰성 및 메모리 사용량에 미치는 영향을 설명하는 모듈 및 클래스 수준의 이중 언어(한영) docstring을 추가합니다.
- Celery 애플리케이션과 Beat 스케줄러 엔트리포인트에 대해, 설정이 어떻게 로드되고 태스크가 어떻게 발견되는지에 대한 내용을 한국어와 영어로 문서화합니다.
- 모든 주기적 Beat 스케줄 태스크에 대해, 그 목적과 실행 주기를 설명하는 이중 언어(한영) 주석을 표준화하고 명확하게 정리합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document and clarify the Celery background worker configuration and scheduler entrypoint for FlowNote MVP.

Documentation:
- Add bilingual module- and class-level docstrings describing the Celery worker configuration, core parameters, and their impact on reliability and memory usage.
- Document the Celery application and Beat scheduler entrypoint, including how configurations are loaded and tasks are discovered, in both Korean and English.
- Standardize and clarify bilingual comments for all periodic Beat schedule tasks, describing their purpose and run cadence.

</details>