### PR TITLE
📝 docs & ☘️ refactor [#12.3.20] - ㉒ 관측성 유틸리티 Docstring 표준화 및 Lint 최적화

### DIFF
--- a/backend/utils/observability.py
+++ b/backend/utils/observability.py
@@ -1,4 +1,18 @@
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━
 # backend/utils/observability.py
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+"""
+FlowNote MVP - 관측성(Observability) 및 알림 유틸리티 모듈.
+
+시스템 로그, 예외 이벤트, 임계치 위반 등을 감지하여
+중앙 집중형 이벤트 로깅 및 외부 알림(Discord 등)을 담당합니다.
+
+FlowNote MVP - Observability and Alerting Utilities Module.
+
+Handles centralized event logging and external alerting (e.g., Discord)
+by detecting system logs, exception events, and threshold violations.
+"""
 
 import logging
 import threading
@@ -14,9 +28,15 @@ from backend.config import AlertConfig
 
 class ObsEvent(str, Enum):
     """
-    관측성(Observability) 시스템 전반에서 사용되는 표준 이벤트 이름.
-    자유 형식의 로깅 문자열을 파싱하는 대신, ELK/Datadog 등의 대시보드와 알림 규칙(Rule Engine)이
-    명확한 기준표를 가질 수 있도록 중앙화된 구조를 제공합니다.
+    관측성(Observability) 시스템 전반에서 사용되는 표준 이벤트 이름 정의.
+
+    자유 형식의 로깅 문자열을 파싱하는 대신, ELK/Datadog 등의 대시보드와
+    알림 규칙(Rule Engine)이 명확한 기준표를 가질 수 있도록 중앙화된 구조를 제공합니다.
+
+    Standard event names used across the observability system.
+
+    Provides a centralized structure so that dashboards (like ELK/Datadog)
+    and rule engines have clear references, instead of parsing free-form logs.
     """
 
     FINETUNE_RESERVED_REDIS_KEY_VIOLATION = "reserved_redis_keys_in_extra_fields"
@@ -25,7 +45,12 @@ class ObsEvent(str, Enum):
 class ObsMetaTag(str, Enum):
     """
     관측성 시스템 전반에서 사용되는 메타데이터 플래그 모음.
+
     네임스페이스(meta_)를 부착하여 비즈니스 데이터와 시스템 제어용 데이터를 분리합니다.
+
+    Collection of metadata flags used across the observability system.
+
+    Attaches a namespace (`meta_`) to separate business data from system control data.
     """
 
     INTENTIONAL_WARNING = "meta_intentional_warning"
@@ -33,11 +58,29 @@ class ObsMetaTag(str, Enum):
 
 class DiscordAlertHandler(logging.Handler):
     """
-    [OBS] 태그가 포함된 로그를 감지하여 Discord로 전송하는 커스텀 로깅 핸들러.
-    - 중복 알림 방지(Throttling) 및 비동기 발송 지원.
+    특정 조건의 로그를 Discord 웹훅으로 전송하는 커스텀 로깅 핸들러.
+
+    [OBS] 태그가 포함되거나 ERROR 레벨 이상인 로그를 감지하여 비동기로 전송합니다.
+    중복 알림 방지(Throttling)를 지원합니다.
+
+    Custom logging handler that sends specific logs to a Discord webhook.
+
+    Detects logs with the [OBS] tag or at ERROR level and above, sending them
+    asynchronously. Supports alert deduplication (throttling).
     """
 
     def __init__(self, webhook_url: Optional[str] = None):
+        """
+        DiscordAlertHandler 초기화.
+
+        Initializes the DiscordAlertHandler.
+
+        Args:
+            webhook_url (Optional[str]): 사용할 Discord 웹훅 URL.
+                지정하지 않으면 `AlertConfig.DISCORD_WEBHOOK_URL`을 기본값으로 사용합니다.
+                The Discord webhook URL to use.
+                If not specified, defaults to `AlertConfig.DISCORD_WEBHOOK_URL`.
+        """
         super().__init__()
         self.webhook_url = webhook_url or AlertConfig.DISCORD_WEBHOOK_URL
         self.last_alerts: Dict[str, float] = {}
@@ -50,6 +93,19 @@ class DiscordAlertHandler(logging.Handler):
         )
 
     def emit(self, record: logging.LogRecord):
+        """
+        로깅 레코드를 평가하여 조건에 맞으면 Discord 알림을 트리거합니다.
+
+        중복 알림(Throttling) 및 스레드 동시성을 고려하여 안전하게 처리합니다.
+
+        Evaluates the logging record and triggers a Discord alert if conditions are met.
+
+        Safely handles duplicate alerts (throttling) and thread concurrency.
+
+        Args:
+            record (logging.LogRecord): 평가할 로그 레코드 객체.
+                The log record object to evaluate.
+        """
         # 1. 대상 필터링: [OBS] 태그 체크 또는 ERROR 레벨 이상
         message = self.format(record)
         is_obs = "[OBS]" in message
@@ -75,9 +131,11 @@ class DiscordAlertHandler(logging.Handler):
                 for k in stale_keys:
                     del self.last_alerts[k]
 
-            if alert_key in self.last_alerts:
-                if current_time - self.last_alerts[alert_key] < self.throttle_seconds:
-                    return
+            if (
+                alert_key in self.last_alerts
+                and current_time - self.last_alerts[alert_key] < self.throttle_seconds
+            ):
+                return
             # 3. 알림 발송 시간 갱신
             self.last_alerts[alert_key] = current_time
 
@@ -85,6 +143,22 @@ class DiscordAlertHandler(logging.Handler):
         self._executor.submit(self._send_discord_alert, message, record)
 
     def _send_discord_alert(self, formatted_message: str, record: logging.LogRecord):
+        """
+        실제로 HTTP 요청을 통해 Discord 웹훅에 메시지를 전송합니다.
+
+        로그 레벨에 따라 색상을 다르게 표시하며 예외(Stack Trace) 정보가 있다면 첨부합니다.
+
+        Actually sends the message to the Discord webhook via HTTP request.
+
+        Displays different colors based on the log level and attaches
+        exception (Stack Trace) information if available.
+
+        Args:
+            formatted_message (str): 텍스트 포맷팅이 완료된 최종 로그 문자열.
+                The final log string with text formatting applied.
+            record (logging.LogRecord): 원본 로그 레코드 (레벨 및 시간 참조용).
+                The original log record (used for level and timestamp reference).
+        """
         if not self.webhook_url:
             return
 
@@ -140,7 +214,15 @@ class DiscordAlertHandler(logging.Handler):
             print(f"Error in DiscordAlertHandler: {e}")
 
     def close(self):
-        """로깅 시스템 종료 시 ThreadPoolExecutor의 자원을 안전하게 회수(Shutdown Hook)합니다."""
+        """
+        로깅 시스템 종료 시 ThreadPoolExecutor의 자원을 안전하게 회수합니다 (Shutdown Hook).
+
+        대기 중인 알림 전송 태스크가 완료될 때까지 대기(Best-effort)합니다.
+
+        Safely reclaims ThreadPoolExecutor resources upon logging system shutdown.
+
+        Waits on a best-effort basis for pending alert tasks to complete.
+        """
         if hasattr(self, "_executor"):
             # 최대한 생성된 알림 전송 태스크가 완료되도록 대기 (Best-effort delivery)
             self._executor.shutdown(wait=True)


### PR DESCRIPTION
- **[문서화] 관측성 및 알림 유틸리티 한/영 이중 주석 적용**
  - 대상 파일: `backend/utils/observability.py`
  - 기존의 단일 언어 및 불규칙한 주석들을 **Google Style (Args, Returns 명시)** 형식의 상세 Docstring으로 고도화.
  - `ObsEvent`, `ObsMetaTag`와 같은 핵심 Enum 클래스와, `DiscordAlertHandler`의 생명 주기(init, emit, _send_discord_alert, close) 전반에 걸쳐 동작 원리와 임계값(Throttling) 방어, 멀티스레드 동시성(Race Condition) 제어 로직을 명확히 문서화함.

- **[가독성] 국/영 병기 규칙 및 모듈 문서화 준수**
  - 모듈 최상단에 시스템 이벤트 감지 및 중앙 집중형 외부 알림(Discord) 역할을 담당함을 나타내는 설명 추가.
  - 각 클래스와 함수의 Docstring을 철저히 `[국문 설명] → [영문 설명] → Args → Returns` 순서로 통일.

- **[리팩토링] Sourcery Lint 권고사항 반영 (조건문 병합)**
  - `DiscordAlertHandler.emit` 내부의 Throttling 검사 로직에서 불필요하게 중첩된 if 블록을 단일 `and` 연산으로 병합(Merge nested if conditions)하여 코드 가독성 향상.

- **[보안/무결성] 비즈니스 로직 유지 및 하드코딩 금지**
  - 어떠한 웹훅 URL(DISCORD_WEBHOOK_URL)이나 민감한 API 정보도 코드 내에 하드코딩되지 않았음.

🔗 Related: Issue [#1044]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

관측(Observability) 유틸리티 문서를 표준화하고 Discord 알림 핸들러의 스로틀링(throttling) 로직을 개선합니다.

Enhancements:
- DiscordAlertHandler 및 관련 enum의 동작 방식과 라이프사이클을 명확히 하고, 가독성을 높이기 위해 스로틀링 조건을 단순화했습니다.

Documentation:
- 관측(Observability) 유틸리티에 한국어와 영어로 된 모듈 및 클래스 레벨의 이중 언어(docstring)를 추가하고, 한국어/영어 설명에 일관된 구조를 적용했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize observability utility documentation and refine Discord alert handler throttling logic.

Enhancements:
- Clarify behavior and lifecycle of DiscordAlertHandler and related enums, and simplify its throttling condition for improved readability.

Documentation:
- Add bilingual module- and class-level docstrings to observability utilities following a consistent structure for Korean and English descriptions.

</details>