### PR TITLE
📝 docs & 🐛 fix [#12.3.20] - ㉒ 1차 개선 : 관측성 유틸리티 PR 리뷰 반영

### DIFF
--- a/backend/utils/observability.py
+++ b/backend/utils/observability.py
@@ -3,15 +3,10 @@
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 """
-FlowNote MVP - 관측성(Observability) 및 알림 유틸리티 모듈.
+FlowNote MVP - Observability and Alerting Module (관측성 및 알림 유틸리티).
 
-시스템 로그, 예외 이벤트, 임계치 위반 등을 감지하여
-중앙 집중형 이벤트 로깅 및 외부 알림(Discord 등)을 담당합니다.
-
-FlowNote MVP - Observability and Alerting Utilities Module.
-
-Handles centralized event logging and external alerting (e.g., Discord)
-by detecting system logs, exception events, and threshold violations.
+[KO] 시스템 로그, 예외 이벤트 등을 감지하여 중앙 집중형 로깅 및 외부 알림(Discord 등)을 처리합니다.
+[EN] Handles centralized event logging and external alerting (e.g., Discord) by detecting system logs and exception events.
 """
 
 import logging
@@ -28,15 +23,10 @@ from backend.config import AlertConfig
 
 class ObsEvent(str, Enum):
     """
-    관측성(Observability) 시스템 전반에서 사용되는 표준 이벤트 이름 정의.
+    Standard event names for the observability system (표준 관측성 이벤트 이름).
 
-    자유 형식의 로깅 문자열을 파싱하는 대신, ELK/Datadog 등의 대시보드와
-    알림 규칙(Rule Engine)이 명확한 기준표를 가질 수 있도록 중앙화된 구조를 제공합니다.
-
-    Standard event names used across the observability system.
-
-    Provides a centralized structure so that dashboards (like ELK/Datadog)
-    and rule engines have clear references, instead of parsing free-form logs.
+    [KO] 모니터링 대시보드(ELK 등)와 알림 규칙 엔진에서 사용할 수 있도록 중앙화된 이벤트 식별자를 제공합니다.
+    [EN] Provides centralized event identifiers for monitoring dashboards (e.g., ELK) and alert rule engines.
     """
 
     FINETUNE_RESERVED_REDIS_KEY_VIOLATION = "reserved_redis_keys_in_extra_fields"
@@ -44,13 +34,10 @@ class ObsEvent(str, Enum):
 
 class ObsMetaTag(str, Enum):
     """
-    관측성 시스템 전반에서 사용되는 메타데이터 플래그 모음.
+    Metadata flags for the observability system (관측성 메타데이터 태그).
 
-    네임스페이스(meta_)를 부착하여 비즈니스 데이터와 시스템 제어용 데이터를 분리합니다.
-
-    Collection of metadata flags used across the observability system.
-
-    Attaches a namespace (`meta_`) to separate business data from system control data.
+    [KO] `meta_` 네임스페이스를 사용하여 시스템 제어용 데이터를 비즈니스 데이터와 분리합니다.
+    [EN] Uses the `meta_` namespace to separate system control data from business data.
     """
 
     INTENTIONAL_WARNING = "meta_intentional_warning"
@@ -58,28 +45,24 @@ class ObsMetaTag(str, Enum):
 
 class DiscordAlertHandler(logging.Handler):
     """
-    특정 조건의 로그를 Discord 웹훅으로 전송하는 커스텀 로깅 핸들러.
+    Discord Webhook Alert Handler (Discord 알림 전송 핸들러).
 
-    [OBS] 태그가 포함되거나 ERROR 레벨 이상인 로그를 감지하여 비동기로 전송합니다.
-    중복 알림 방지(Throttling)를 지원합니다.
+    [KO] `[OBS]` 태그가 포함되거나 ERROR 레벨 이상인 로그를 감지하여 비동기로 전송합니다.
+    [EN] Detects logs with the `[OBS]` tag or at ERROR level and above, sending them asynchronously.
 
-    Custom logging handler that sends specific logs to a Discord webhook.
-
-    Detects logs with the [OBS] tag or at ERROR level and above, sending them
-    asynchronously. Supports alert deduplication (throttling).
+    Throttling Semantics (알림 제한 규칙):
+    - Key: `f"{levelno}:{formatted_message}"` (Per log level and content).
+    - Window: `throttle_seconds` (Default: AlertConfig.DEFAULT_THROTTLE_SECONDS).
+    - Behavior: Suppresses duplicate alerts within the same time window to prevent spam.
     """
 
     def __init__(self, webhook_url: Optional[str] = None):
         """
-        DiscordAlertHandler 초기화.
-
-        Initializes the DiscordAlertHandler.
+        [KO] 핸들러 및 Throttling 제어 상태를 초기화합니다.
+        [EN] Initializes the handler and its throttling control state.
 
         Args:
-            webhook_url (Optional[str]): 사용할 Discord 웹훅 URL.
-                지정하지 않으면 `AlertConfig.DISCORD_WEBHOOK_URL`을 기본값으로 사용합니다.
-                The Discord webhook URL to use.
-                If not specified, defaults to `AlertConfig.DISCORD_WEBHOOK_URL`.
+            webhook_url: Discord webhook URL. (Default: AlertConfig.DISCORD_WEBHOOK_URL)
         """
         super().__init__()
         self.webhook_url = webhook_url or AlertConfig.DISCORD_WEBHOOK_URL
@@ -94,17 +77,8 @@ class DiscordAlertHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord):
         """
-        로깅 레코드를 평가하여 조건에 맞으면 Discord 알림을 트리거합니다.
-
-        중복 알림(Throttling) 및 스레드 동시성을 고려하여 안전하게 처리합니다.
-
-        Evaluates the logging record and triggers a Discord alert if conditions are met.
-
-        Safely handles duplicate alerts (throttling) and thread concurrency.
-
-        Args:
-            record (logging.LogRecord): 평가할 로그 레코드 객체.
-                The log record object to evaluate.
+        [KO] 로그 레코드를 평가하여 Throttling 규칙 통과 시 Discord 알림을 트리거합니다.
+        [EN] Evaluates the log record and triggers a Discord alert if it passes throttling rules.
         """
         # 1. 대상 필터링: [OBS] 태그 체크 또는 ERROR 레벨 이상
         message = self.format(record)
@@ -115,13 +89,11 @@ class DiscordAlertHandler(logging.Handler):
             return
 
         # 2. 알림 임계값(Throttling) 체크 (포맷이 적용된 최종 메시지 기준)
-        # record.msg 대신 getMessage()를 사용하여 파라미터가 포맷팅된 실제 내용을 기준으로 필터링
         alert_key = f"{record.levelno}:{record.getMessage()}"
         current_time = time.monotonic()
 
-        # [Fix] 동시 접속(Concurrent logging) 시 last_alerts 딕셔너리 Race Condition 방어
         with self._lock:
-            # [Fix] 메모리 누수 방지(Eviction Strategy): 저장된 키가 1000개를 초과하면 만료된 데이터 정리
+            # 메모리 누수 방지(Eviction Strategy)
             if len(self.last_alerts) > 1000:
                 stale_keys = [
                     k
@@ -136,28 +108,17 @@ class DiscordAlertHandler(logging.Handler):
                 and current_time - self.last_alerts[alert_key] < self.throttle_seconds
             ):
                 return
+
             # 3. 알림 발송 시간 갱신
             self.last_alerts[alert_key] = current_time
 
-        # [Fix] 에러 폭주 시 과도한 스레드 생성을 막기 위해 ThreadPoolExecutor 사용
+        # 에러 폭주 시 과도한 스레드 생성을 막기 위해 ThreadPoolExecutor 사용
         self._executor.submit(self._send_discord_alert, message, record)
 
     def _send_discord_alert(self, formatted_message: str, record: logging.LogRecord):
         """
-        실제로 HTTP 요청을 통해 Discord 웹훅에 메시지를 전송합니다.
-
-        로그 레벨에 따라 색상을 다르게 표시하며 예외(Stack Trace) 정보가 있다면 첨부합니다.
-
-        Actually sends the message to the Discord webhook via HTTP request.
-
-        Displays different colors based on the log level and attaches
-        exception (Stack Trace) information if available.
-
-        Args:
-            formatted_message (str): 텍스트 포맷팅이 완료된 최종 로그 문자열.
-                The final log string with text formatting applied.
-            record (logging.LogRecord): 원본 로그 레코드 (레벨 및 시간 참조용).
-                The original log record (used for level and timestamp reference).
+        [KO] HTTP 통신을 통해 구성된 Embed 데이터를 Discord 웹훅으로 전송합니다.
+        [EN] Sends the constructed Embed data to the Discord webhook via HTTP request.
         """
         if not self.webhook_url:
             return
@@ -215,13 +176,8 @@ class DiscordAlertHandler(logging.Handler):
 
     def close(self):
         """
-        로깅 시스템 종료 시 ThreadPoolExecutor의 자원을 안전하게 회수합니다 (Shutdown Hook).
-
-        대기 중인 알림 전송 태스크가 완료될 때까지 대기(Best-effort)합니다.
-
-        Safely reclaims ThreadPoolExecutor resources upon logging system shutdown.
-
-        Waits on a best-effort basis for pending alert tasks to complete.
+        [KO] 로깅 시스템 종료 시 ThreadPool 자원을 회수하며(Shutdown Hook), 부모 핸들러의 close()를 호출합니다.
+        [EN] Reclaims ThreadPool resources on system shutdown and calls the parent handler's close().
         """
         if hasattr(self, "_executor"):
             # 최대한 생성된 알림 전송 태스크가 완료되도록 대기 (Best-effort delivery)


### PR DESCRIPTION
- **[문서화] Docstring 가독성 극대화 및 통합**
  - 리뷰어의 피드백을 적극 수용하여 장황하고 중복되던 한/영 이중 주석을 `[KO]` / `[EN]` 태그 기반의 단일 문단으로 압축하여 동기화 이탈(Drift) 위험 제거.
  - `DiscordAlertHandler.emit` 등 여러 곳에 흩어져 있던 Throttling(알림 제한 규칙) 동작 설명을 클래스 수준(Class-level)의 Docstring 단일 공간으로 통합하여 유지보수성 극대화.

- **[버그 방어] `logging.Handler` 생명주기 완벽 준수**
  - `close(self)` 메서드에서 스레드풀 `shutdown` 완료 직후 부모 클래스의 `super().close()`가 정상적으로 호출됨을 재검증.
  - 부모 클래스의 리소스 해제(Cleanup) 로직 누락에 대한 리뷰어의 우려를 불식시키기 위해, 해당 메서드의 주석에 부모 핸들러 호출 사실을 명확히 기재함.

- **[무결성] 하드코딩 완전 배제**
  - 웹훅 URL 등 민감한 개인정보/환경변수를 코드에 일절 하드코딩하지 않고 기존 `AlertConfig` 연동 방식을 그대로 유지함.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1648#pullrequestreview-4626983460)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

관측 가능성(observability) 및 경고 처리기(alerting handler) 문서를 개선하고 라이프사이클 동작을 명확히 합니다.

Documentation:
- 관측 가능성 유틸리티에 대한 모듈 및 클래스 docstring을 이중 언어 형태에서 KO/EN 태그가 포함된 단일 블록으로 통합합니다.
- Discord 경고 로깅 핸들러의 throttling 동작 방식과 종료(shutdown) 동작을 문서화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve observability and alerting handler documentation and clarify lifecycle behavior.

Documentation:
- Consolidate bilingual module and class docstrings into single KO/EN-tagged blocks for observability utilities.
- Document throttling semantics and shutdown behavior for the Discord alert logging handler.

</details>