### PR TITLE
📝 docs & 🐛 fix [#12.3.20] - ㉒ 2차 개선 : 관측성 유틸리티 PR 리뷰 반영

### DIFF
--- a/backend/utils/observability.py
+++ b/backend/utils/observability.py
@@ -51,7 +51,7 @@ class DiscordAlertHandler(logging.Handler):
     [EN] Detects logs with the `[OBS]` tag or at ERROR level and above, sending them asynchronously.
 
     Throttling Semantics (알림 제한 규칙):
-    - Key: `f"{levelno}:{formatted_message}"` (Per log level and content).
+    - Key: `f"{record.levelno}:{record.getMessage()}"` (Per log level and unformatted content).
     - Window: `throttle_seconds` (Default: AlertConfig.DEFAULT_THROTTLE_SECONDS).
     - Behavior: Suppresses duplicate alerts within the same time window to prevent spam.
     """
@@ -88,7 +88,9 @@ class DiscordAlertHandler(logging.Handler):
         if not (is_obs or is_critical):
             return
 
-        # 2. 알림 임계값(Throttling) 체크 (포맷이 적용된 최종 메시지 기준)
+        # 2. 알림 임계값(Throttling) 체크
+        # record.msg 대신 getMessage()를 사용하여 파라미터가 포맷팅된 내용 기준으로 필터링
+        # (formatted_message를 쓰면 타임스탬프 등 가변 데이터 때문에 중복 제거가 안됨)
         alert_key = f"{record.levelno}:{record.getMessage()}"
         current_time = time.monotonic()
 


### PR DESCRIPTION
- **[문서화] Throttling 동작 명세와 실제 로직 불일치 해소**
  - 리뷰어의 2차 피드백을 수용하여, `DiscordAlertHandler` 클래스의 Docstring 중 Throttling Key 명세를 실제 구현체와 완벽히 동일한 `f"{record.levelno}:{record.getMessage()}"`로 정정.
  - `formatted_message` 대신 `getMessage()`를 사용하는 기술적 이유(타임스탬프 등 가변 데이터 포함에 의한 중복 제거 실패 방어)를 `emit` 메서드 내 인라인 주석으로 복구하여 미래 유지보수 담당자의 혼동을 원천 차단.

- **[무결성] 비즈니스 로직 유지 및 하드코딩 완전 배제**
  - 실제 동작하는 Throttling 및 Discord 발송 로직은 훼손 없이 원형을 유지.
  - 어떠한 웹훅 URL이나 민감한 환경 변수도 하드코딩되지 않았음을 재차 검증.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1649#pullrequestreview-4627008928)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

DiscordAlertHandler의 실제 구현과 스로틀링(throttling) 관련 문서를 정렬하고, 스로틀링 로직에서 포맷되지 않은 로그 메시지를 사용하는 이유를 명확히 합니다.

Enhancements:
- 중복 억제를 효과적으로 보장하기 위해 스로틀링이 포맷된 메시지가 아닌 `record.getMessage()`를 사용하는 이유를 설명하는 인라인 주석을 복원하고 명확히 합니다.

Documentation:
- 구현된 `record.levelno:getMessage()` 동작에 맞도록 DiscordAlertHandler 스로틀링 키 문서를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align throttling documentation for DiscordAlertHandler with the actual implementation and clarify the rationale for using unformatted log messages in throttling logic.

Enhancements:
- Restore and clarify inline comments explaining why throttling uses `record.getMessage()` instead of formatted messages to ensure effective duplicate suppression.

Documentation:
- Update DiscordAlertHandler throttling key documentation to match the implemented `record.levelno:getMessage()` behavior.

</details>