### PR TITLE
📝 docs [#12.3.20] - ㉔ 백엔드 커스텀 예외 계층 Docstring 고도화

### DIFF
--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -1,43 +1,74 @@
 # backend/exceptions.py
 
 """
-커스텀 예외 클래스
-    - Error(오류)를 관리하는 클래스
-    - 구제적으로 에러 처리를 위해 사용하는 카테고리 클래스
+FlowNote MVP - Custom Exception Hierarchy (커스텀 예외 클래스 계층 구조).
+
+[KO] 백엔드 전역에서 사용되는 커스텀 예외 클래스를 정의합니다.
+     구체적인 에러 카테고리를 통해 호출자(API 라우터 등)가 HTTP 상태 코드를 적절히 매핑할 수 있도록 합니다.
+[EN] Defines custom exception classes used globally across the backend.
+     Specific error categories allow callers (e.g., API routers) to map appropriate HTTP status codes.
 """
 
 
 class FlowNoteError(Exception):
-    """FlowNote 기본 에러 정의"""
-
+    """
+    [KO] FlowNote 백엔드 전체에서 사용되는 최상위 기본 예외 클래스.
+         모든 커스텀 예외는 이 클래스를 상속합니다.
+    [EN] Base exception class for the entire FlowNote backend.
+         All custom exceptions inherit from this class.
+    """
 
 
 class FileValidationError(FlowNoteError):
-    """파일 검증 실패 에러
-    - 확장자가 이상하거나 크기가 너무 클 경우"""
-
+    """
+    [KO] 파일 유효성 검증 실패 시 발생하는 예외. (HTTP 400 / 422)
+         - 허용되지 않는 파일 확장자가 업로드된 경우
+         - 파일 크기 제한을 초과한 경우
+    [EN] Raised when file validation fails. (HTTP 400 / 422)
+         - An unsupported file extension is uploaded.
+         - The file size exceeds the allowed limit.
+    """
 
 
 class QueryValidationError(FlowNoteError):
-    """쿼리 검증 실패 에러
-    - 검색창에 너무 짧은 검색어를 입력한 경우
-    - 빈 칸만 입력한 경우"""
-
+    """
+    [KO] 검색 쿼리 유효성 검증 실패 시 발생하는 예외. (HTTP 400)
+         - 검색어가 최소 길이 미만으로 너무 짧은 경우
+         - 공백 문자만으로 구성된 검색어가 입력된 경우
+    [EN] Raised when search query validation fails. (HTTP 400)
+         - The search term is too short (below minimum length).
+         - The input consists of only whitespace characters.
+    """
 
 
 class APIKeyError(FlowNoteError):
-    """API 키 설정 오류 에러
-    - API 키가 잘못되었거나 없는 경우"""
-
+    """
+    [KO] API 키 설정 오류 시 발생하는 예외. (HTTP 500 / 503)
+         - 환경 변수에 API 키가 설정되지 않은 경우
+         - 설정된 API 키가 유효하지 않은 경우
+    [EN] Raised when an API key configuration error is detected. (HTTP 500 / 503)
+         - The API key is not set in environment variables.
+         - The configured API key is invalid or rejected.
+    """
 
 
 class EmbeddingError(FlowNoteError):
-    """임베딩 생성 처리 오류 에러
-    - 임베딩 생성 실패했을 경우"""
-
+    """
+    [KO] 임베딩(Embedding) 생성 처리 중 오류 발생 시 사용하는 예외. (HTTP 502 / 500)
+         - 외부 임베딩 모델 API 호출에 실패한 경우
+         - 임베딩 벡터 생성 결과가 예상과 다른 형식인 경우
+    [EN] Raised when an error occurs during embedding generation. (HTTP 502 / 500)
+         - The external embedding model API call fails.
+         - The resulting embedding vector has an unexpected format.
+    """
 
 
 class SearchError(FlowNoteError):
-    """검색 및 조회 처리 오류 에러
-    - 검색하는 과정에서 문제가 생겼을 경우"""
-
+    """
+    [KO] 검색 및 조회 처리 과정에서 오류 발생 시 사용하는 예외. (HTTP 500)
+         - 벡터 DB(FAISS) 또는 BM25 검색 엔진에서 조회 실패가 발생한 경우
+         - 하이브리드 검색 결과 병합 과정에서 예외가 발생한 경우
+    [EN] Raised when an error occurs during search or retrieval. (HTTP 500)
+         - A retrieval failure occurs in the vector DB (FAISS) or BM25 search engine.
+         - An exception occurs while merging hybrid search results.
+    """


### PR DESCRIPTION
- **[문서화] 커스텀 예외 클래스 한/영 이중 주석 및 가이드 추가**
  - 대상 파일: `backend/exceptions.py`
  - 기존의 단순한 단일 언어(국문) 주석을 `[KO]` / `[EN]` 태그 기반의 구글 스타일 Docstring으로 전면 표준화.
  - `FlowNoteError`, `FileValidationError`, `QueryValidationError`, `APIKeyError`, `EmbeddingError`, `SearchError` 전체 클래스에 적용.

- **[협업 가이드] HTTP 상태 코드 명세 추가**
  - 각 커스텀 예외가 어떤 상황(파일 검증 실패, API 키 오류 등)에서 발생하는지 구체적인 시나리오를 함께 기재.
  - 예외 발생 시 프론트엔드로 반환되어야 할 HTTP 상태 코드(400, 422, 500 등)를 명시하여 프론트/백엔드 협업 시 혼란 방지.

- **[무결성] 비즈니스 로직 유지 및 하드코딩 완전 배제**
  - 예외 클래스의 상속 구조 및 실제 로직은 일절 변경 없이 원형을 유지.
  - 어떠한 개인정보나 시스템 내부 정보도 하드코딩되지 않았음.

🔗 Related: Issue [#1044]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

런타임 동작을 변경하지 않고, 백엔드 커스텀 예외 계층 구조에 대한 문서를 표준화하고 풍부하게 만들어 사용 방식과 HTTP 상태 코드 매핑을 명확히 합니다.

개선사항:
- 모든 핵심 커스텀 예외 클래스에 대해 한/영 이중 언어 docstring을 도입하여 팀 간 더 명확한 협업을 지원합니다.

문서화:
- `FlowNoteError` 및 그로부터 파생된 예외들(파일, 쿼리, API 키, 임베딩, 검색 에러)에 대해, 사용 시나리오와 권장 HTTP 상태 코드를 설명하는 한/영 상세 docstring을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize and enrich documentation for backend custom exception hierarchy to clarify usage and HTTP status mapping without altering runtime behavior.

Enhancements:
- Introduce bilingual (KO/EN) docstrings for all core custom exception classes to support clearer collaboration across teams.

Documentation:
- Add detailed KO/EN docstrings describing scenarios and recommended HTTP status codes for FlowNoteError and its derived exceptions (file, query, API key, embedding, search errors).

</details>