### PR TITLE
📝 docs [#12.3.20] - ㉔ 1차 개선 : 커스텀 예외 HTTP 코드 확정 및 구현 결합 제거

### DIFF
--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -4,9 +4,10 @@
 FlowNote MVP - Custom Exception Hierarchy (커스텀 예외 클래스 계층 구조).
 
 [KO] 백엔드 전역에서 사용되는 커스텀 예외 클래스를 정의합니다.
-     구체적인 에러 카테고리를 통해 호출자(API 라우터 등)가 HTTP 상태 코드를 적절히 매핑할 수 있도록 합니다.
+     호출자(API 라우터 등)는 각 예외 타입에 따라 아래에 명시된 HTTP 상태 코드를 결정론적으로 매핑해야 합니다.
 [EN] Defines custom exception classes used globally across the backend.
-     Specific error categories allow callers (e.g., API routers) to map appropriate HTTP status codes.
+     Callers (e.g., API routers) should deterministically map HTTP status codes
+     based on the specific exception type as documented below.
 """
 
 
@@ -21,10 +22,12 @@ class FlowNoteError(Exception):
 
 class FileValidationError(FlowNoteError):
     """
-    [KO] 파일 유효성 검증 실패 시 발생하는 예외. (HTTP 400 / 422)
+    [KO] 파일 유효성 검증 실패 시 발생하는 예외. → HTTP 422 (Unprocessable Entity)
+         입력 파일 자체는 수신되었으나, 의미론적 검증 규칙을 통과하지 못한 경우에 사용합니다.
          - 허용되지 않는 파일 확장자가 업로드된 경우
          - 파일 크기 제한을 초과한 경우
-    [EN] Raised when file validation fails. (HTTP 400 / 422)
+    [EN] Raised when file validation fails. → HTTP 422 (Unprocessable Entity)
+         Use when the file is received but fails semantic validation rules.
          - An unsupported file extension is uploaded.
          - The file size exceeds the allowed limit.
     """
@@ -32,10 +35,12 @@ class FileValidationError(FlowNoteError):
 
 class QueryValidationError(FlowNoteError):
     """
-    [KO] 검색 쿼리 유효성 검증 실패 시 발생하는 예외. (HTTP 400)
+    [KO] 검색 쿼리 유효성 검증 실패 시 발생하는 예외. → HTTP 400 (Bad Request)
+         클라이언트가 잘못된 형식의 요청 데이터를 전송한 경우에 사용합니다.
          - 검색어가 최소 길이 미만으로 너무 짧은 경우
          - 공백 문자만으로 구성된 검색어가 입력된 경우
-    [EN] Raised when search query validation fails. (HTTP 400)
+    [EN] Raised when search query validation fails. → HTTP 400 (Bad Request)
+         Use when the client sends a malformed or invalid request payload.
          - The search term is too short (below minimum length).
          - The input consists of only whitespace characters.
     """
@@ -43,10 +48,13 @@ class QueryValidationError(FlowNoteError):
 
 class APIKeyError(FlowNoteError):
     """
-    [KO] API 키 설정 오류 시 발생하는 예외. (HTTP 500 / 503)
+    [KO] API 키 설정 오류 시 발생하는 예외. → HTTP 503 (Service Unavailable)
+         서버가 외부 서비스에 연결할 수 없는 구성 문제로, 클라이언트 요청 자체의 잘못이 아닌 경우에 사용합니다.
          - 환경 변수에 API 키가 설정되지 않은 경우
          - 설정된 API 키가 유효하지 않은 경우
-    [EN] Raised when an API key configuration error is detected. (HTTP 500 / 503)
+    [EN] Raised when an API key configuration error is detected. → HTTP 503 (Service Unavailable)
+         Use when a server-side configuration issue prevents connection to an external service,
+         not due to a client-side error.
          - The API key is not set in environment variables.
          - The configured API key is invalid or rejected.
     """
@@ -54,10 +62,12 @@ class APIKeyError(FlowNoteError):
 
 class EmbeddingError(FlowNoteError):
     """
-    [KO] 임베딩(Embedding) 생성 처리 중 오류 발생 시 사용하는 예외. (HTTP 502 / 500)
+    [KO] 임베딩(Embedding) 생성 처리 중 오류 발생 시 사용하는 예외. → HTTP 502 (Bad Gateway)
+         외부 임베딩 서비스로부터 유효한 응답을 받지 못한 경우에 사용합니다.
          - 외부 임베딩 모델 API 호출에 실패한 경우
          - 임베딩 벡터 생성 결과가 예상과 다른 형식인 경우
-    [EN] Raised when an error occurs during embedding generation. (HTTP 502 / 500)
+    [EN] Raised when an error occurs during embedding generation. → HTTP 502 (Bad Gateway)
+         Use when the server fails to receive a valid response from an external embedding service.
          - The external embedding model API call fails.
          - The resulting embedding vector has an unexpected format.
     """
@@ -65,10 +75,12 @@ class EmbeddingError(FlowNoteError):
 
 class SearchError(FlowNoteError):
     """
-    [KO] 검색 및 조회 처리 과정에서 오류 발생 시 사용하는 예외. (HTTP 500)
-         - 벡터 DB(FAISS) 또는 BM25 검색 엔진에서 조회 실패가 발생한 경우
-         - 하이브리드 검색 결과 병합 과정에서 예외가 발생한 경우
-    [EN] Raised when an error occurs during search or retrieval. (HTTP 500)
-         - A retrieval failure occurs in the vector DB (FAISS) or BM25 search engine.
-         - An exception occurs while merging hybrid search results.
+    [KO] 검색 및 조회 처리 과정에서 오류 발생 시 사용하는 예외. → HTTP 500 (Internal Server Error)
+         서버 내부의 검색 파이프라인에서 예기치 않은 오류가 발생한 경우에 사용합니다.
+         - 벡터 검색 인덱스 또는 텍스트 검색 엔진에서 조회 실패가 발생한 경우
+         - 복합 검색 결과 병합 과정에서 예외가 발생한 경우
+    [EN] Raised when an error occurs during search or retrieval. → HTTP 500 (Internal Server Error)
+         Use when an unexpected failure occurs in the server-side search pipeline.
+         - A retrieval failure occurs in the vector search index or text search engine.
+         - An exception occurs while merging combined search results.
     """


### PR DESCRIPTION
- **[문서화] HTTP 상태 코드 매핑 결정론적 단일화**
  - 리뷰어의 피드백을 수용하여 각 예외마다 복수로 나열되어 모호했던 HTTP 코드(예: 400/422, 500/503)를 예외의 의미에 맞는 단일 코드로 확정하고, 그 선택 근거를 간략히 Docstring에 명시.
  - `FileValidationError` → 422: 의미론적 검증 실패 (수신은 성공)
  - `APIKeyError` → 503: 서버 구성 오류 (클라이언트 잘못 아님)
  - `EmbeddingError` → 502: 외부 서비스 응답 실패 (Bad Gateway)

- **[가독성] SearchError 구현체 종속 표현 제거**
  - 기존에 FAISS, BM25 등 특정 검색 엔진 구현체 이름이 예외 Docstring에 포함되어 있어, 추후 기술 교체 시 예외 정의 자체가 오염될 위험이 있었음.
  - 이를 `벡터 검색 인덱스` / `텍스트 검색 엔진` 등 구현 독립적(Implementation-agnostic)인 일반 용어로 대체.

- **[무결성] 예외 클래스 로직 및 하드코딩 원칙 준수**
  - 예외 상속 구조 및 실제 코드는 일절 변경 없이 원형을 유지.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1652#pullrequestreview-4632277911)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

백엔드 커스텀 예외에 대한 결정적(일관된) HTTP 상태 코드 매핑을 문서화하고, 의도된 사용 의미를 명확히 합니다.

문서화:
- 각 에러 타입에 대해 단일하고 타당한 HTTP 상태 코드를 명시하고, 각 코드가 언제 사용되어야 하는지 설명하도록 예외의 docstring을 업데이트합니다.
- 검색 관련 예외 문서를 특정 검색 엔진에 종속되지 않고 구현에 구애받지 않는(implementation-agnostic) 방식으로 일반화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document deterministic HTTP status code mappings for backend custom exceptions and clarify their intended usage semantics.

Documentation:
- Update exception docstrings to specify single, well-justified HTTP status codes for each error type and explain when each should be used.
- Generalize search-related exception documentation to be implementation-agnostic rather than tied to specific search engines.

</details>