### PR TITLE
📝 docs [#12.3.20] - ㉕ 마크다운 내보내기 모듈 Docstring 전면 표준화 및 Lint 최적화

### DIFF
--- a/backend/export.py
+++ b/backend/export.py
@@ -8,7 +8,18 @@ FlowNote MVP - Markdown Exporter Module (마크다운 내보내기).
 """
 
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, NotRequired, TypedDict
+
+
+class SearchResult(TypedDict):
+    """
+    [KO] 검색 결과 항목의 타입 힌트를 위한 정적 타입 정의.
+    [EN] Static type definition for a search result item.
+    """
+
+    content: NotRequired[str]
+    score: NotRequired[float]
+    metadata: NotRequired[Dict[str, Any]]
 
 
 class MarkdownExporter:
@@ -21,20 +32,30 @@ class MarkdownExporter:
         pass
 
     def export_search_results(
-        self, query: str, results: List[Dict[str, Any]], include_metadata: bool = True
+        self, query: str, results: List[SearchResult], include_metadata: bool = True
     ) -> str:
         """
-        [KO] 검색 결과 리스트를 마크다운 형식의 문자열로 변환합니다.
-        [EN] Converts a list of search results into a Markdown formatted string.
+        [KO]
+        검색 결과 리스트를 마크다운 형식의 문자열로 변환합니다.
 
         Args:
-            query: [KO] 사용자가 입력한 원본 검색 쿼리. [EN] The original search query entered by the user.
-            results: [KO] 검색 엔진으로부터 반환된 결과 딕셔너리 리스트. [EN] List of result dictionaries returned from the search engine.
-            include_metadata: [KO] 문서 출처, 청크 번호 등 메타데이터 포함 여부 (기본값 True). [EN] Whether to include metadata such as source and chunk index (default True).
+            query: 사용자가 입력한 원본 검색 쿼리.
+            results: 검색 엔진으로부터 반환된 TypedDict 기반 결과 리스트.
+            include_metadata: 문서 출처, 청크 번호 등 메타데이터 포함 여부 (기본값 True).
 
         Returns:
-            [KO] 포맷팅이 완료된 마크다운 문자열.
-            [EN] The fully formatted Markdown string.
+            포맷팅이 완료된 마크다운 문자열.
+
+        [EN]
+        Converts a list of search results into a Markdown formatted string.
+
+        Args:
+            query: The original search query entered by the user.
+            results: List of result dictionaries matching the SearchResult TypedDict.
+            include_metadata: Whether to include metadata such as source and chunk index (default True).
+
+        Returns:
+            The fully formatted Markdown string.
         """
 
         # 시간

--- a/backend/export.py
+++ b/backend/export.py
@@ -1,32 +1,40 @@
 # backend/export.py
 
 """
-FlowNote MVP - 마크다운 내보내기
+FlowNote MVP - Markdown Exporter Module (마크다운 내보내기).
+
+[KO] RAG 검색 결과나 노트 데이터를 마크다운(Markdown) 포맷 등 외부 파일 형식으로 내보내는 유틸리티 모듈입니다.
+[EN] Utility module for exporting RAG search results or note data into external file formats like Markdown.
 """
 
 from datetime import datetime
-from typing import Dict, List
+from typing import Any, Dict, List
 
 
 class MarkdownExporter:
-    """검색 결과를 마크다운으로 변환"""
+    """
+    [KO] 검색 결과를 마크다운(Markdown) 문자열로 변환하는 클래스.
+    [EN] Class to convert search results into Markdown formatted strings.
+    """
 
     def __init__(self):
         pass
 
     def export_search_results(
-        self, query: str, results: List[Dict], include_metadata: bool = True
+        self, query: str, results: List[Dict[str, Any]], include_metadata: bool = True
     ) -> str:
         """
-        검색 결과를 마크다운 형식으로 변환
+        [KO] 검색 결과 리스트를 마크다운 형식의 문자열로 변환합니다.
+        [EN] Converts a list of search results into a Markdown formatted string.
 
         Args:
-            query: 검색 쿼리
-            results: 검색 결과 리스트
-            include_metadata: 메타데이터 포함 여부
+            query: [KO] 사용자가 입력한 원본 검색 쿼리. [EN] The original search query entered by the user.
+            results: [KO] 검색 엔진으로부터 반환된 결과 딕셔너리 리스트. [EN] List of result dictionaries returned from the search engine.
+            include_metadata: [KO] 문서 출처, 청크 번호 등 메타데이터 포함 여부 (기본값 True). [EN] Whether to include metadata such as source and chunk index (default True).
 
         Returns:
-            마크다운 문자열
+            [KO] 포맷팅이 완료된 마크다운 문자열.
+            [EN] The fully formatted Markdown string.
         """
 
         # 시간
@@ -53,8 +61,7 @@ class MarkdownExporter:
 
             # 메타데이터
             if include_metadata:
-                metadata = result.get("metadata", {})
-                if metadata:
+                if metadata := result.get("metadata", {}):
                     md += f"### 메타데이터\n\n"
                     md += f"- **출처**: {metadata.get('source', 'N/A')}\n"
                     md += f"- **청크 번호**: {metadata.get('chunk_index', 'N/A')}\n"


### PR DESCRIPTION
- **[문서화] 마크다운 내보내기 유틸리티 한/영 이중 주석 적용**
  - 기존의 단일 언어(국문) 주석들을 `[KO]` / `[EN]` 태그 기반의 모듈 및 클래스 Docstring으로 표준화하여, RAG 검색 결과 내보내기 로직의 역할을 명확히 기술.
  - `export_search_results` 메서드에 **Google Style (Args, Returns 명시)**을 적용하여 매개변수에 대한 설명을 국/영문으로 병기.

- **[타이핑] 딕셔너리 리스트 타입 힌트 구체화**
  - 정적 타입 분석기 및 Lint 도구의 정확도 향상을 위해 모호했던 `List[Dict]` 타입을 `List[Dict[str, Any]]`로 엄격하게 수정.

- **[리팩토링] Sourcery Lint 권고사항 반영 (바다코끼리 연산자 활용)**
  - `export_search_results` 내부에서 메타데이터를 파싱할 때, 변수 할당과 조건 검사가 분리되어 있던 코드를 파이썬 3.8+ Named Expression(`:=`)을 활용하여 한 줄(`if metadata := result.get("metadata", {}):`)로 결합, 가독성 향상.

- **[무결성] 비즈니스 로직 유지 및 하드코딩 완전 배제**
  - 마크다운 문자열 조합 등 핵심 포맷팅 로직은 어떠한 변경 없이 그대로 유지.
  - 민감한 설정값이나 개인 경로가 소스 코드 내에 포함되지 않았음을 교차 검증 완료.

🔗 Related: Issue [#1044]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Markdown 내보내기 모듈의 문서를 표준화하고, 검색 결과 내보내기 기능에서 타입과 메타데이터 처리 방식을 강화했습니다.

Enhancements:
- Markdown 내보내기 기능에서 Google 스타일 섹션을 사용하는 한·영(docstring)을 추가하여 모듈과 클래스의 목적을 명확히 했습니다.
- 더 엄격한 정적 분석을 위해 검색 결과에 대한 타입 힌트를 `List[Dict[str, Any]]`로 정제했습니다.
- 비즈니스 로직을 유지하면서도, `export_search_results`에서 명명된 표현식을 사용하여 메타데이터 파싱을 단순화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize the Markdown export module documentation and tighten typing and metadata handling in the search results exporter.

Enhancements:
- Clarify module and class purpose with bilingual (KO/EN) docstrings using Google-style sections in the Markdown exporter.
- Refine type hints for search results to use List[Dict[str, Any]] for stricter static analysis.
- Simplify metadata parsing in export_search_results using a named expression while preserving business logic.

</details>