### PR TITLE
📝 docs [#12.3.20] - ㉖ 임베딩 제너레이터 Docstring 표준화 및 예외 처리 래핑

### DIFF
--- a/backend/embedding.py
+++ b/backend/embedding.py
@@ -3,20 +3,25 @@
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 """
-FlowNote MVP - 임베딩 생성
+FlowNote MVP - Embedding Generator Module (임베딩 생성).
+
+[KO] 텍스트 청크를 입력받아 외부 API(OpenAI 등)를 호출하여 임베딩 벡터로 변환하는 모듈입니다.
+[EN] Provides a class that takes text chunks and calls external APIs to convert them into embedding vectors.
 """
 
+from typing import Any, Dict, List
+
 # from backend.config import get_embedding_model, EMBEDDING_MODEL, EMBEDDING_COSTS
-from backend.config import (
-    EMBEDDING_COSTS,
-    EMBEDDING_MODEL,
-    ModelConfig,
-)
+from backend.config import EMBEDDING_COSTS, EMBEDDING_MODEL, ModelConfig
+from backend.exceptions import EmbeddingError
 from backend.utils import count_tokens, estimate_cost
 
 
 class EmbeddingGenerator:
-    """임베딩 생성 클래스"""
+    """
+    [KO] 임베딩 생성을 담당하는 제너레이터 클래스.
+    [EN] Generator class responsible for creating embeddings.
+    """
 
     def __init__(self, model_name: str = EMBEDDING_MODEL):
         self.model_name = model_name
@@ -26,8 +31,32 @@ class EmbeddingGenerator:
             model_name.split("/")[-1], 0.02 / 1_000_000
         )  # ?
 
-    def generate_embeddings(self, texts: list[str]) -> dict:
-        """텍스트 리스트에 대한 임베딩 생성"""
+    def generate_embeddings(self, texts: List[str]) -> Dict[str, Any]:
+        """
+        [KO]
+        텍스트 리스트에 대한 임베딩 벡터를 생성하고 비용 및 토큰 수를 반환합니다.
+
+        Args:
+            texts: 임베딩으로 변환할 텍스트 청크 리스트.
+
+        Returns:
+            임베딩 벡터 리스트, 총 사용 토큰 수, 예상 비용을 포함한 딕셔너리.
+
+        Raises:
+            EmbeddingError: 외부 임베딩 모델 API 호출에 실패한 경우 (HTTP 502 매핑 대상).
+
+        [EN]
+        Generates embedding vectors for a list of texts and returns cost and token metrics.
+
+        Args:
+            texts: List of text chunks to convert into embeddings.
+
+        Returns:
+            Dictionary containing embedding vectors, total token count, and estimated cost.
+
+        Raises:
+            EmbeddingError: If the external embedding model API call fails (mapped to HTTP 502).
+        """
         if not texts:
             return {"embeddings": [], "tokens": 0, "cost": 0.0}
 
@@ -35,8 +64,15 @@ class EmbeddingGenerator:
         total_tokens = sum(count_tokens(text) for text in texts)
         estimated_cost = estimate_cost(total_tokens, self.cost_per_token)
 
-        # 임베딩 생성
-        response = self.client.embeddings.create(model=self.model_name, input=texts)
+        try:
+            # 임베딩 생성 API 호출
+            # [NOTE] 이곳에서 통신 실패, Rate Limit 초과 등 외부 API 장애가 발생할 수 있습니다.
+            # 클라이언트 잘못이 아닌 외부 연동 문제이므로 EmbeddingError(502 Bad Gateway)로 래핑하여 전달합니다.
+            response = self.client.embeddings.create(model=self.model_name, input=texts)
+        except Exception as e:
+            raise EmbeddingError(
+                f"External API call failed during embedding generation: {str(e)}"
+            ) from e
 
         embeddings = [item.embedding for item in response.data]
 
@@ -63,7 +99,7 @@ if __name__ == "__main__":
 
     result = generator.generate_embeddings(test_texts)
 
-    print(f"✅ 임베딩 완료!")
+    print("✅ 임베딩 완료!")
     print(f"   - 청크 수: {len(result['embeddings'])}")
     print(f"   - 토큰 수: {result['tokens']}")
     print(f"   - 예상 비용: ${result['cost']:.6f}")
@@ -76,7 +112,7 @@ if __name__ == "__main__":
 
     - 실행 방법_1: 프로젝트 루트에서 실행 시
         python -m backend.embedding
-    
+
     - 실행 방법_2:
         python -m backend.faiss_search
 
@@ -114,7 +150,7 @@ if __name__ == "__main__":
 """
 
 
-"""result_4 - 클래스형 + 함수형 config.py 수정 후 
+"""result_4 - 클래스형 + 함수형 config.py 수정 후
 
     ==================================================
     임베딩 테스트


### PR DESCRIPTION
- **[문서화] 임베딩 모듈 한/영 이중 주석 및 가독성 최적화**
  - 기존 주석을 `[KO]` / `[EN]` 섹션으로 완전히 분리하여 다국어 사용자의 가독성을 극대화하는 최신 코드 리뷰 룰(PR #1654 참고) 완벽 적용.
  - `generate_embeddings` 함수에 **Google Style (Args, Returns, Raises 명시)** 적용.

- **[리팩토링] `EmbeddingError` 발생 시점 명세화 및 예외 래핑**
  - 외부 임베딩 모델 API(OpenAI 등)를 호출하는 로직을 `try-except` 블록으로 보호.
  - 단순 `Exception`이 아닌 전역 커스텀 예외인 `EmbeddingError(HTTP 502)`로 명확하게 래핑하여, API 라우터가 장애 원인을 정확히 식별할 수 있도록 견고함(Robustness) 향상.
  - 테스트 블록 내 불필요한 f-string 사용에 대한 Sourcery Lint 경고 사전 해결.

- **[무결성] 비즈니스 로직 유지 및 하드코딩 완전 배제**
  - 임베딩 생성 및 토큰/비용 계산 로직은 변경 없이 원형 유지.
  - 어떠한 API Key나 민감한 구성 정보도 소스 코드에 하드코딩되지 않았음을 재차 검증.

🔗 Related: Issue [#1044]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

임베딩 생성기 모듈의 문서를 표준화하고, 외부 API 실패를 커스텀 임베딩 에러로 래핑합니다.

Enhancements:
- 임베딩 생성기에 대해 KO/EN 이중 언어 모듈 및 클래스 독스트링을 추가하고, `generate_embeddings`에 Google 스타일 문서 양식을 적용합니다.
- `generate_embeddings`의 입력과 반환 메타데이터에 대해 정밀한 타입 힌트를 추가합니다.
- 외부 임베딩 API 호출을 감싸던 일반적인 예외 처리를 `EmbeddingError`로 교체하여 상위 단계의 실패를 더 잘 드러나게 합니다.

Tests:
- 불필요한 f-string을 사용하던 `print` 문을 정리하여 임베딩 테스트 하네스 출력 내용을 깔끔하게 정리합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize the embedding generator module’s documentation and wrap external API failures in a custom embedding error.

Enhancements:
- Add bilingual (KO/EN) module and class docstrings for the embedding generator and adopt Google-style documentation for generate_embeddings.
- Annotate generate_embeddings with precise typing for inputs and returned metadata.
- Replace generic exception handling around external embedding API calls with EmbeddingError to better surface upstream failures.

Tests:
- Tidy the embedding test harness output by removing unnecessary f-string usage in a print statement.

</details>