### PR TITLE
🐛 fix [#12.3.20] - ㉖ 1차 개선 : 임베딩 예외 처리 안티패턴 수정 (버그 마스킹 방지)

### DIFF
--- a/backend/embedding.py
+++ b/backend/embedding.py
@@ -11,6 +11,8 @@ FlowNote MVP - Embedding Generator Module (임베딩 생성).
 
 from typing import Any, Dict, List
 
+from openai import OpenAIError
+
 # from backend.config import get_embedding_model, EMBEDDING_MODEL, EMBEDDING_COSTS
 from backend.config import EMBEDDING_COSTS, EMBEDDING_MODEL, ModelConfig
 from backend.exceptions import EmbeddingError
@@ -69,7 +71,9 @@ class EmbeddingGenerator:
             # [NOTE] 이곳에서 통신 실패, Rate Limit 초과 등 외부 API 장애가 발생할 수 있습니다.
             # 클라이언트 잘못이 아닌 외부 연동 문제이므로 EmbeddingError(502 Bad Gateway)로 래핑하여 전달합니다.
             response = self.client.embeddings.create(model=self.model_name, input=texts)
-        except Exception as e:
+        except (TimeoutError, ConnectionError, OpenAIError) as e:
+            # 외부 통신/네트워크 계열 예외만 EmbeddingError로 래핑합니다.
+            # 클라이언트 사용상의 버그(예: TypeError, AttributeError 등)는 그대로 전파되어 디버깅 가능하도록 둡니다.
             raise EmbeddingError(
                 f"External API call failed during embedding generation: {str(e)}"
             ) from e


### PR DESCRIPTION
- **[버그 방지] 광범위한 예외 캐치(Exception) 패턴 제거**
  - 리뷰어의 피드백을 수용하여, `generate_embeddings` 내부의 API 호출부 예외 처리 방식을 개선.
  - 기존 광범위한 `Exception` 캐치로 인해 내부 프로그래밍 오류(`TypeError`, `AttributeError` 등)가 외부 연동 장애(HTTP 502)로 잘못 둔갑하여 버그가 숨겨지는(Bug Masking) 리스크를 원천 차단함.

- **[리팩토링] 외부 네트워크 특정 예외만 선별적 래핑**
  - `openai.OpenAIError` 및 내장 `TimeoutError`, `ConnectionError`만 선별적으로 캐치하여 `EmbeddingError`로 래핑하도록 수정.
  - 순수 내부 코드 결함은 상위로 그대로 전파(Propagate)되어 즉각적인 디버깅이 가능하도록 구조 개선.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1655#pullrequestreview-4646426825)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

내부 버그가 가려지는 것을 방지하기 위해, 임베딩 API 오류 처리를 네트워크 관련 오류로만 제한합니다.

버그 수정:
- 임베딩 생성 과정에서 모든 예외를 포착하여 외부 API 실패로 재던지는 방식은 더 이상 사용하지 않음으로써, 내부 프로그래밍 오류가 마스킹되는 것을 방지합니다.

개선 사항:
- 임베딩 생성 시 예외 래핑을 특정 네트워크 오류와 OpenAI 클라이언트 오류로만 제한하여, 네트워크와 무관한 문제는 그대로 전파되도록 함으로써 디버깅을 더 쉽게 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restrict embedding API error handling to network-related errors to avoid masking internal bugs.

Bug Fixes:
- Prevent masking of internal programming errors by no longer catching all exceptions in embedding generation and rethrowing them as external API failures.

Enhancements:
- Limit exception wrapping in embedding generation to specific network and OpenAI client errors, allowing non-network issues to propagate for easier debugging.

</details>