### PR TITLE
🐛 fix [#12.3.20] - ㉖ 2차 개선 : OpenAI SDK 전용 예외로 세분화 및 EmbeddingError 관측성 강화

### DIFF
--- a/backend/embedding.py
+++ b/backend/embedding.py
@@ -11,7 +11,7 @@ FlowNote MVP - Embedding Generator Module (임베딩 생성).
 
 from typing import Any, Dict, List
 
-from openai import OpenAIError
+from openai import APIConnectionError, APIError, APITimeoutError, RateLimitError
 
 # from backend.config import get_embedding_model, EMBEDDING_MODEL, EMBEDDING_COSTS
 from backend.config import EMBEDDING_COSTS, EMBEDDING_MODEL, ModelConfig
@@ -69,13 +69,27 @@ class EmbeddingGenerator:
         try:
             # 임베딩 생성 API 호출
             # [NOTE] 이곳에서 통신 실패, Rate Limit 초과 등 외부 API 장애가 발생할 수 있습니다.
-            # 클라이언트 잘못이 아닌 외부 연동 문제이므로 EmbeddingError(502 Bad Gateway)로 래핑하여 전달합니다.
+            # OpenAI SDK 전용 예외(APIError 계열)만 래핑하여, 내부 코드 버그(TypeError 등)가 마스킹되지 않도록 합니다.
             response = self.client.embeddings.create(model=self.model_name, input=texts)
-        except (TimeoutError, ConnectionError, OpenAIError) as e:
-            # 외부 통신/네트워크 계열 예외만 EmbeddingError로 래핑합니다.
-            # 클라이언트 사용상의 버그(예: TypeError, AttributeError 등)는 그대로 전파되어 디버깅 가능하도록 둡니다.
+        except APITimeoutError as e:
+            # 타임아웃: 요청이 응답 대기 시간 초과
             raise EmbeddingError(
-                f"External API call failed during embedding generation: {str(e)}"
+                f"Embedding API call timed out: {str(e)}", error_type="timeout"
+            ) from e
+        except APIConnectionError as e:
+            # 네트워크 연결 실패 (DNS 오류, 소켓 오류 등)
+            raise EmbeddingError(
+                f"Embedding API connection error: {str(e)}", error_type="connection"
+            ) from e
+        except RateLimitError as e:
+            # 요청 횟수 초과 (Rate Limit)
+            raise EmbeddingError(
+                f"Embedding API rate limit exceeded: {str(e)}", error_type="rate_limit"
+            ) from e
+        except APIError as e:
+            # 그 외 OpenAI API 계열 오류 (4xx/5xx HTTP 상태 코드 등)
+            raise EmbeddingError(
+                f"Embedding API error: {str(e)}", error_type="api_error"
             ) from e
 
         embeddings = [item.embedding for item in response.data]

--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -66,11 +66,22 @@ class EmbeddingError(FlowNoteError):
          외부 임베딩 서비스로부터 유효한 응답을 받지 못한 경우에 사용합니다.
          - 외부 임베딩 모델 API 호출에 실패한 경우
          - 임베딩 벡터 생성 결과가 예상과 다른 형식인 경우
+
+         `error_type` 필드를 통해 장애 원인을 분류하여 관측성(Observability)을 제공합니다.
+         (예: "timeout", "connection", "api_error")
+
     [EN] Raised when an error occurs during embedding generation. → HTTP 502 (Bad Gateway)
          Use when the server fails to receive a valid response from an external embedding service.
          - The external embedding model API call fails.
          - The resulting embedding vector has an unexpected format.
+
+         The `error_type` field classifies the failure cause for improved observability.
+         (e.g., "timeout", "connection", "api_error")
     """
+
+    def __init__(self, message: str = "", error_type: str = "api_error"):
+        super().__init__(message)
+        self.error_type = error_type
 
 
 class SearchError(FlowNoteError):


### PR DESCRIPTION
- **[버그 방지] 광범위 내장 예외 제거, OpenAI SDK 전용 예외 계층으로 교체**
  - 리뷰어의 2차 피드백을 수용하여 1차 개선의 `TimeoutError`, `ConnectionError`(파이썬 내장)도 제거.
  - 대신 OpenAI SDK 고유 예외인 `APITimeoutError`, `APIConnectionError`, `RateLimitError`, `APIError`만 정밀 캐치하여 내부 프로그래밍 버그가 외부 장애로 둔갑하는 위험을 완전히 차단.

- **[관측성] EmbeddingError 장애 원인 분류 메타데이터 추가**
  - `backend/exceptions.py`의 `EmbeddingError` 클래스에 `error_type` 파라미터 추가 (기본값: `"api_error"`).
  - 실제 발생 예외 종류에 따라 `"timeout"`, `"connection"`, `"rate_limit"`, `"api_error"` 중 하나를 결정론적으로 전달.
  - API 라우터 및 모니터링 도구가 장애 원인을 정확히 분류하여 재시도, 알림, 로그 등 차등 처리를 할 수 있는 기반 마련.

- **[무결성] 비즈니스 로직 유지 및 하드코딩 완전 배제**
  - 임베딩 생성 핵심 로직 및 토큰/비용 계산은 변경 없이 유지.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1656#pullrequestreview-4646461188)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

임베딩 오류 처리를 OpenAI SDK 전용 예외를 사용하도록 개선하고, 임베딩 실패에 대한 관측 가능성을 향상했습니다.

버그 수정:
- OpenAI SDK의 API 오류 타입만 래핑함으로써, 내부 프로그래밍 오류가 외부 임베딩 API 실패로 잘못 표시되는 문제를 방지했습니다.

개선 사항:
- 임베딩 실패를 타임아웃, 연결, 레이트 리밋, 일반 API 오류 카테고리로 분류하기 위해 `EmbeddingError`에 새로운 `error_type` 필드를 추가하여, 관측 가능성과 후속 처리(다운스트림 처리)를 개선했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine embedding error handling to use OpenAI SDK-specific exceptions and enhance observability of embedding failures.

Bug Fixes:
- Prevent internal programming errors from being masked as external embedding API failures by only wrapping OpenAI SDK API error types.

Enhancements:
- Classify embedding failures into timeout, connection, rate limit, and generic API error categories using a new error_type field on EmbeddingError for better observability and downstream handling.

</details>