### PR TITLE
☘️ refactor [#12.3.20] - ㉖ 3차 개선 : 예외 타입 Literal 강제 및 Lookup Table 패턴 도입

### DIFF
--- a/backend/embedding.py
+++ b/backend/embedding.py
@@ -15,7 +15,7 @@ from openai import APIConnectionError, APIError, APITimeoutError, RateLimitError
 
 # from backend.config import get_embedding_model, EMBEDDING_MODEL, EMBEDDING_COSTS
 from backend.config import EMBEDDING_COSTS, EMBEDDING_MODEL, ModelConfig
-from backend.exceptions import EmbeddingError
+from backend.exceptions import EmbeddingError, EmbeddingErrorType
 from backend.utils import count_tokens, estimate_cost
 
 
@@ -71,26 +71,26 @@ class EmbeddingGenerator:
             # [NOTE] 이곳에서 통신 실패, Rate Limit 초과 등 외부 API 장애가 발생할 수 있습니다.
             # OpenAI SDK 전용 예외(APIError 계열)만 래핑하여, 내부 코드 버그(TypeError 등)가 마스킹되지 않도록 합니다.
             response = self.client.embeddings.create(model=self.model_name, input=texts)
-        except APITimeoutError as e:
-            # 타임아웃: 요청이 응답 대기 시간 초과
-            raise EmbeddingError(
-                f"Embedding API call timed out: {str(e)}", error_type="timeout"
-            ) from e
-        except APIConnectionError as e:
-            # 네트워크 연결 실패 (DNS 오류, 소켓 오류 등)
-            raise EmbeddingError(
-                f"Embedding API connection error: {str(e)}", error_type="connection"
-            ) from e
-        except RateLimitError as e:
-            # 요청 횟수 초과 (Rate Limit)
-            raise EmbeddingError(
-                f"Embedding API rate limit exceeded: {str(e)}", error_type="rate_limit"
-            ) from e
-        except APIError as e:
-            # 그 외 OpenAI API 계열 오류 (4xx/5xx HTTP 상태 코드 등)
-            raise EmbeddingError(
-                f"Embedding API error: {str(e)}", error_type="api_error"
-            ) from e
+        except (APITimeoutError, APIConnectionError, RateLimitError, APIError) as e:
+            # 예외 클래스에 따른 에러 메시지 접두사와 관측성 타입을 매핑합니다.
+            error_map = {
+                APITimeoutError: ("Embedding API call timed out", "timeout"),
+                APIConnectionError: ("Embedding API connection error", "connection"),
+                RateLimitError: ("Embedding API rate limit exceeded", "rate_limit"),
+                APIError: ("Embedding API error", "api_error"),
+            }
+
+            msg_prefix = "Embedding API error"
+            err_type: EmbeddingErrorType = "api_error"
+
+            # 매핑 테이블에서 구체적인 예외 타입을 순서대로 확인합니다.
+            for exc_class, (prefix, type_str) in error_map.items():
+                if isinstance(e, exc_class):
+                    msg_prefix = prefix
+                    err_type = type_str  # type: ignore
+                    break
+
+            raise EmbeddingError(f"{msg_prefix}: {str(e)}", error_type=err_type) from e
 
         embeddings = [item.embedding for item in response.data]
 

--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -10,6 +10,8 @@ FlowNote MVP - Custom Exception Hierarchy (커스텀 예외 클래스 계층 구
      based on the specific exception type as documented below.
 """
 
+from typing import Literal
+
 
 class FlowNoteError(Exception):
     """
@@ -60,6 +62,9 @@ class APIKeyError(FlowNoteError):
     """
 
 
+EmbeddingErrorType = Literal["timeout", "connection", "rate_limit", "api_error"]
+
+
 class EmbeddingError(FlowNoteError):
     """
     [KO] 임베딩(Embedding) 생성 처리 중 오류 발생 시 사용하는 예외. → HTTP 502 (Bad Gateway)
@@ -68,7 +73,7 @@ class EmbeddingError(FlowNoteError):
          - 임베딩 벡터 생성 결과가 예상과 다른 형식인 경우
 
          `error_type` 필드를 통해 장애 원인을 분류하여 관측성(Observability)을 제공합니다.
-         (예: "timeout", "connection", "api_error")
+         (예: "timeout", "connection", "rate_limit", "api_error")
 
     [EN] Raised when an error occurs during embedding generation. → HTTP 502 (Bad Gateway)
          Use when the server fails to receive a valid response from an external embedding service.
@@ -76,10 +81,10 @@ class EmbeddingError(FlowNoteError):
          - The resulting embedding vector has an unexpected format.
 
          The `error_type` field classifies the failure cause for improved observability.
-         (e.g., "timeout", "connection", "api_error")
+         (e.g., "timeout", "connection", "rate_limit", "api_error")
     """
 
-    def __init__(self, message: str = "", error_type: str = "api_error"):
+    def __init__(self, message: str = "", error_type: EmbeddingErrorType = "api_error"):
         super().__init__(message)
         self.error_type = error_type
 


### PR DESCRIPTION
- **[타이핑] error_type 필드를 Literal로 엄격하게 제한**
  - `backend/exceptions.py`에 `EmbeddingErrorType = Literal["timeout", "connection", "rate_limit", "api_error"]`를 도입.
  - 자유 형식의 `str` 대신 고정된 값의 집합을 강제하여 다운스트림 시스템 및 정적 분석 도구(Mypy/IDE)에서 발생할 수 있는 오타 버그를 컴파일 시점에 차단.
  - 리뷰어 지적에 따라 주석 내 `error_type` 예시에도 누락되었던 `"rate_limit"` 카테고리 추가로 문서 일치화.

- **[리팩토링] 예외 매핑 Lookup Table 도입으로 중복 최소화**
  - `backend/embedding.py` 내부의 4중 `except` 블록에서 반복되던 `raise EmbeddingError(...)` 패턴 제거.
  - 예외 클래스(`APITimeoutError`, `RateLimitError` 등)를 키(Key)로 하는 `error_map` 딕셔너리를 선언.
  - `isinstance`를 통한 동적 매핑으로 코드를 획기적으로 단순화하고(DRY 원칙), 새로운 예외 타입이 추가되더라도 대응이 용이하도록 아키텍처 개선.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1657#pullrequestreview-4646533931)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

타입이 지정된 에러 카테고리를 강제하고 외부 API 예외 매핑을 통합함으로써 임베딩 에러 처리 방식을 개선합니다.

개선 사항:
- 더 안전하고 분석 가능한 에러 분류를 위해 `EmbeddingError.error_type`을 `Literal` 기반의 `EmbeddingErrorType`으로 제한합니다.
- SDK 예외에서 에러 메시지 및 에러 타입으로의 매핑을 수행하는 조회 테이블 기반 방식으로 교체하여, 중복된 임베딩 API 예외 처리 분기를 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine embedding error handling by enforcing a typed error category and consolidating external API exception mapping.

Enhancements:
- Constrain EmbeddingError.error_type to a Literal-based EmbeddingErrorType for safer, analyzable error categorization.
- Replace duplicated embedding API exception branches with a lookup-table driven mapping from SDK exceptions to error messages and error types.

</details>