### PR TITLE
☘️ refactor [#12.3.20] - ㉖ 7차 개선 : 하드코딩 제거 및 Single Source of Truth 달성

### DIFF
--- a/backend/embedding.py
+++ b/backend/embedding.py
@@ -10,7 +10,7 @@ FlowNote MVP - Embedding Generator Module (임베딩 생성).
 """
 
 import types
-from typing import Any, Dict, List, Mapping, Tuple, Type, cast
+from typing import Any, Dict, List, Mapping, Tuple, Type
 
 from openai import APIConnectionError, APIError, APITimeoutError, RateLimitError
 
@@ -37,7 +37,7 @@ def _get_error_mapping(exc: Exception) -> Tuple[str, EmbeddingErrorType]:
     """주어진 예외 인스턴스에 가장 적합한 에러 메시지 접두사와 타입을 반환합니다."""
     return next(
         (v for k, v in ERROR_MAP.items() if isinstance(exc, k)),
-        ("Embedding API error", cast(EmbeddingErrorType, "api_error")),
+        ERROR_MAP[APIError],
     )
 
 


### PR DESCRIPTION
**[DRY 원칙] 기본값 하드코딩 제거**
  - `_get_error_mapping` 헬퍼 함수 내 `next(...)`의 fallback 기본값으로 사용되던 하드코딩 튜플을 삭제.
  - 대신 `ERROR_MAP[APIError]`를 참조하도록 수정하여, 에러 메시지가 변경되더라도 단일 출처(Single Source of Truth)에서만 관리되도록 일관성 보장.

- **[리팩토링] 불필요한 의존성 제거**
  - 하드코딩 튜플이 사라짐에 따라 린트 우회를 위해 임시로 사용하던 `cast` 함수 호출 제거.
  - `typing` 모듈에서 `cast` 임포트 구문을 완전히 삭제하여 의존성 다이어트 진행.
  - 포맷터(black) 실패 방지를 위해 전체 파일 재정렬 완료.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1661#pullrequestreview-4646716897)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

임베딩 오류 처리를 리팩터링하여 하드코딩된 기본값을 제거하고, 단일 공유 오류 매핑 소스에 의존하도록 개선했습니다.

개선 사항:
- 임베딩 오류 매핑 헬퍼가 하드코딩된 기본 튜플 대신 중앙 `ERROR_MAP`의 `APIError` 항목을 사용하도록 업데이트하여, 기본 임베딩 API 오류에 대한 단일 신뢰 소스를 보장했습니다.
- 하드코딩된 기본 튜플이 더 이상 필요하지 않으므로 사용되지 않는 `typing.cast` 의존성을 제거했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor embedding error handling to remove hardcoded defaults and rely on a single shared error mapping source.

Enhancements:
- Update the embedding error mapping helper to use the central ERROR_MAP entry for APIError instead of a hardcoded fallback tuple, ensuring a single source of truth for default embedding API errors.
- Remove the unused typing.cast dependency now that the hardcoded fallback tuple is no longer needed.

</details>