### PR TITLE
☘️ refactor [#12.3.20] - ㉖ 9차 개선 : 공통 상수 추출을 통한 하드코딩 완전 제거 및 타입 안전성 확보

### DIFF
--- a/backend/embedding.py
+++ b/backend/embedding.py
@@ -10,7 +10,7 @@ FlowNote MVP - Embedding Generator Module (임베딩 생성).
 """
 
 import types
-from typing import Any, Dict, List, Mapping, Tuple, Type, cast
+from typing import Any, Dict, List, Mapping, Tuple, Type
 
 from openai import APIConnectionError, APIError, APITimeoutError, RateLimitError
 
@@ -18,6 +18,9 @@ from openai import APIConnectionError, APIError, APITimeoutError, RateLimitError
 from backend.config import EMBEDDING_COSTS, EMBEDDING_MODEL, ModelConfig
 from backend.exceptions import EmbeddingError, EmbeddingErrorType
 from backend.utils import count_tokens, estimate_cost
+
+# 기본 예외 튜플 (Single Source of Truth)
+DEFAULT_API_ERROR: Tuple[str, EmbeddingErrorType] = ("Embedding API error", "api_error")
 
 # 예외 클래스에 따른 에러 메시지 접두사와 관측성 타입을 매핑하는 모듈 상수
 # 런타임 불변성을 보장하기 위해 MappingProxyType 사용
@@ -27,7 +30,7 @@ ERROR_MAP: Mapping[Type[Exception], Tuple[str, EmbeddingErrorType]] = (
             APITimeoutError: ("Embedding API call timed out", "timeout"),
             APIConnectionError: ("Embedding API connection error", "connection"),
             RateLimitError: ("Embedding API rate limit exceeded", "rate_limit"),
-            APIError: ("Embedding API error", "api_error"),
+            APIError: DEFAULT_API_ERROR,
         }
     )
 )
@@ -37,9 +40,7 @@ def _get_error_mapping(exc: Exception) -> Tuple[str, EmbeddingErrorType]:
     """주어진 예외 인스턴스에 가장 적합한 에러 메시지 접두사와 타입을 반환합니다."""
     return next(
         (v for k, v in ERROR_MAP.items() if isinstance(exc, k)),
-        ERROR_MAP.get(
-            APIError, ("Embedding API error", cast(EmbeddingErrorType, "api_error"))
-        ),
+        ERROR_MAP.get(APIError, DEFAULT_API_ERROR),
     )
 
 


### PR DESCRIPTION
- **[DRY 원칙] 공통 상수(DEFAULT_API_ERROR) 추출**
  - 예외 처리 fallback과 `ERROR_MAP` 내부에서 중복 사용되던 튜플을 `DEFAULT_API_ERROR` 상수로 분리.
  - 이를 통해 문자열 하드코딩 중복을 완벽히 제거하고 단일 출처(Single Source of Truth) 달성.

- **[타입 안전성] 강제 형변환(cast) 제거**
  - 상수에 명시적인 `Tuple[str, EmbeddingErrorType]` 타입 힌트를 적용.
  - 정적 타입 분석기(IDE/Mypy) 우회를 위해 사용하던 `cast` 함수를 제거하여, 소스 레벨에서 자연스럽고 엄격한 타입 체킹이 이루어지도록 아키텍처 고도화.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1663#pullrequestreview-4646841709)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

향상 사항:
- 형식화된 `DEFAULT_API_ERROR` 상수를 도입하고 폴백 경로에서 불필요한 캐스팅 사용을 제거하여, 임베딩 오류 처리의 타입 안전성을 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Improve type safety of embedding error handling by introducing a typed DEFAULT_API_ERROR constant and removing unnecessary cast usage in the fallback path.

</details>