### PR TITLE
☘️ refactor [#12.3.20] - ㉖ 11차 개선 : 불변 조건(Invariant) 명시를 통한 조용한 버그(Silent Bug) 방지

### DIFF
--- a/backend/embedding.py
+++ b/backend/embedding.py
@@ -35,6 +35,11 @@ ERROR_MAP: Mapping[Type[Exception], Tuple[str, EmbeddingErrorType]] = (
     )
 )
 
+# 불변 조건(Invariant): _get_error_mapping의 fallback이 항상 일치하도록 보장
+assert (
+    ERROR_MAP.get(APIError) == DEFAULT_API_ERROR
+), "APIError mapping must match DEFAULT_API_ERROR"
+
 
 def _get_error_mapping(exc: Exception) -> Tuple[str, EmbeddingErrorType]:
     """주어진 예외 인스턴스에 가장 적합한 에러 메시지 접두사와 타입을 반환합니다."""


### PR DESCRIPTION
- **[방어적 프로그래밍] 불변 조건(Invariant) Assert 강제**
  - `_get_error_mapping` 함수가 `ERROR_MAP[APIError] == DEFAULT_API_ERROR`라는 가정을 전제로 동작함에 따라, 이 가정이 미래의 코드 수정으로 인해 조용히 깨지는(Silent Bug) 것을 방지하기 위해 명시적인 `assert` 문 추가.
  - 모듈 로드 타임에 `ERROR_MAP.get(APIError) == DEFAULT_API_ERROR`를 강제 검사하여 Fail-Fast 원칙 준수 및 장기적인 유지보수성(Maintainability) 극대화.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1665#pullrequestreview-4646914734)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개선 사항:
- 방어적 프로그래밍과 빠른 오류 감지(fail-fast) 동작을 보장하기 위해, 모듈 로드 시 `ERROR_MAP`의 `APIError`가 항상 `DEFAULT_API_ERROR`에 매핑되는지를 확인하는 어설션을 추가했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Add a module-load-time assertion ensuring APIError in ERROR_MAP always maps to DEFAULT_API_ERROR to uphold defensive programming and fail-fast behavior.

</details>