### PR TITLE
☘️ refactor [#12.3.20] - ㉖ 12차 개선 : Production 환경 최적화(-O)에 대비한 명시적 Invariant 검증

### DIFF
--- a/backend/embedding.py
+++ b/backend/embedding.py
@@ -36,9 +36,9 @@ ERROR_MAP: Mapping[Type[Exception], Tuple[str, EmbeddingErrorType]] = (
 )
 
 # 불변 조건(Invariant): _get_error_mapping의 fallback이 항상 일치하도록 보장
-assert (
-    ERROR_MAP.get(APIError) == DEFAULT_API_ERROR
-), "APIError mapping must match DEFAULT_API_ERROR"
+# (python -O 환경에서도 안전하게 검증되도록 assert 대신 명시적 예외 발생)
+if ERROR_MAP.get(APIError) != DEFAULT_API_ERROR:
+    raise RuntimeError("APIError mapping must match DEFAULT_API_ERROR")
 
 
 def _get_error_mapping(exc: Exception) -> Tuple[str, EmbeddingErrorType]:

--- a/backend/embedding.py
+++ b/backend/embedding.py
@@ -16,7 +16,7 @@ from openai import APIConnectionError, APIError, APITimeoutError, RateLimitError
 
 # from backend.config import get_embedding_model, EMBEDDING_MODEL, EMBEDDING_COSTS
 from backend.config import EMBEDDING_COSTS, EMBEDDING_MODEL, ModelConfig
-from backend.exceptions import EmbeddingError, EmbeddingErrorType
+from backend.exceptions import ConfigurationError, EmbeddingError, EmbeddingErrorType
 from backend.utils import count_tokens, estimate_cost
 
 # 기본 예외 튜플 (Single Source of Truth)
@@ -35,10 +35,14 @@ ERROR_MAP: Mapping[Type[Exception], Tuple[str, EmbeddingErrorType]] = (
     )
 )
 
-# 불변 조건(Invariant): _get_error_mapping의 fallback이 항상 일치하도록 보장
-# (python -O 환경에서도 안전하게 검증되도록 assert 대신 명시적 예외 발생)
-if ERROR_MAP.get(APIError) != DEFAULT_API_ERROR:
-    raise RuntimeError("APIError mapping must match DEFAULT_API_ERROR")
+
+def _verify_invariants() -> None:
+    """
+    [KO] 모듈 내 불변 조건(Invariant)을 검증하는 부트스트랩 함수입니다.
+         런타임에 안전한지 초기화 단계에서 명시적으로 확인합니다.
+    """
+    if ERROR_MAP.get(APIError) != DEFAULT_API_ERROR:
+        raise ConfigurationError("APIError mapping must match DEFAULT_API_ERROR")
 
 
 def _get_error_mapping(exc: Exception) -> Tuple[str, EmbeddingErrorType]:
@@ -56,6 +60,7 @@ class EmbeddingGenerator:
     """
 
     def __init__(self, model_name: str = EMBEDDING_MODEL):
+        _verify_invariants()
         self.model_name = model_name
         # self.client = get_embedding_model(model_name)
         self.client = ModelConfig.get_embedding_model(model_name)

--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -62,6 +62,15 @@ class APIKeyError(FlowNoteError):
     """
 
 
+class ConfigurationError(FlowNoteError):
+    """
+    [KO] 서버 구동 또는 모듈 초기화 시 구성이나 불변 조건(Invariant) 위배가 감지될 때 발생하는 예외. → HTTP 500 (Internal Server Error)
+         잘못된 하드코딩 매핑, 누락된 필수 시스템 설정 등 개발/운영 환경의 구조적 결함 시 발생합니다.
+    [EN] Raised when a structural configuration or invariant violation is detected. → HTTP 500 (Internal Server Error)
+         Used for invalid hardcoded mappings or missing essential system configurations.
+    """
+
+
 EmbeddingErrorType = Literal["timeout", "connection", "rate_limit", "api_error"]
 
 


### PR DESCRIPTION
- **[버그 리스크 제거] assert 구문 의존성 탈피**
  - 파이썬을 최적화 모드(`-O` 플래그)로 실행할 경우 `assert` 문이 무시되어 불변 조건(Invariant) 검증이 누락되는 치명적 버그 리스크 해결.
  - 기존 `assert` 문을 `if ERROR_MAP.get(APIError) != DEFAULT_API_ERROR:` 구문으로 대체.

- **[프로덕션 안전성] 명시적 런타임 예외 발생**
  - 조건 위배 시 `AssertionError` 대신 프로덕션 환경에서도 반드시 동작하는 `RuntimeError`를 명시적으로 던지도록(raise) 변경.
  - 개발, 테스트, 운영(Production) 등 어떠한 파이썬 런타임 환경에서도 단일 출처(Single Source of Truth) 원칙이 무너지지 않도록 완벽한 런타임 방어(Defensive Programming) 달성.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1666#pullrequestreview-4646958155)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

API 에러 매핑에 대한 불변 조건(invariant) 검사를 `assert` 기반 방식에서 명시적인 런타임 검사로 교체하여, 최적화 모드(-O)로 실행되는 Python 환경에서도 항상 강제되도록 합니다.

Bug Fixes:
- `assert`를 런타임 조건으로 교체하여, Python이 -O 최적화 플래그와 함께 실행될 때 API 에러 매핑에 대한 불변 조건 검사가 건너뛰어지는 문제를 방지합니다.

Enhancements:
- API 에러 매핑 불변 조건이 위반될 경우, `AssertionError` 대신 `RuntimeError`를 발생시키도록 하여 모든 런타임 환경에서 일관된 동작을 보장합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace assert-based invariant checking for API error mapping with an explicit runtime check to ensure it is enforced in optimized (-O) Python environments.

Bug Fixes:
- Prevent invariant checks for API error mapping from being skipped when Python runs with the -O optimization flag by replacing assert with a runtime condition.

Enhancements:
- Raise a RuntimeError instead of AssertionError when the API error mapping invariant is violated to ensure consistent behavior across all runtime environments.

</details>