### PR TITLE
🐛 fix [#12.3.20] - ㉗ 1차 개선 : 해당 파일 이중 언어 표준화 및 로직 개선

### DIFF
--- a/backend/validators.py
+++ b/backend/validators.py
@@ -133,8 +133,11 @@ class FileValidator:
         if not os.path.exists(file_path):
             return False, f"❌ 파일이 존재하지 않습니다: {file_path}"
 
-        ext_result = self.validate_extension(file_path)
-        return self.validate_file_size(file_path) if ext_result[0] else ext_result
+        valid, error = self.validate_extension(file_path)
+        if valid:
+            valid, error = self.validate_file_size(file_path)
+
+        return valid, error
 
 
 class QueryValidator:
@@ -164,24 +167,18 @@ class QueryValidator:
     def validate_query(self, query: str) -> Tuple[bool, Optional[str]]:
         """
         [KO] 검색 쿼리를 검증합니다.
-             None/빈 문자열, 공백 전용 문자열, 최소/최대 길이 조건을 순서대로 확인합니다.
+             None/빈 문자열/공백 전용 문자열 및 최소/최대 길이 조건을 순서대로 확인합니다.
              query(str): 검증할 검색 쿼리 문자열.
              반환값(Tuple[bool, Optional[str]]): (is_valid, error_message) 형태의 튜플.
              검증 성공 시 (True, None), 실패 시 (False, 오류 메시지 문자열).
         [EN] Validates a search query.
-             Checks for None/empty string, whitespace-only string, and min/max length in order.
+             Checks for None/empty/whitespace-only string and min/max length in order.
              query(str): Search query string to validate.
              Returns(Tuple[bool, Optional[str]]): A tuple of (is_valid, error_message).
              Returns (True, None) on success, (False, error string) on failure.
         """
         if not query or not query.strip():
             return False, "⚠️ 검색어를 입력해주세요."
-
-        if query.isspace():
-            return (
-                False,
-                "⚠️ 검색어는 공백만으로 구성될 수 없습니다.",
-            )
 
         query_length = len(query.strip())
 


### PR DESCRIPTION
- **[코드 품질 및 리뷰 반영]**
  - validate_extension(): `if not` → `if in early-return` 패턴 재구성.
  - validate_file():
    - 리뷰어 권고 100% 반영: 가독성을 위해 튜플 인덱싱 대신 명시적 언패킹(valid, error = ...) 복원.
    - 정적 분석기(Sourcery) 충돌 우아하게 해결: 억지 삼항 연산자 요구 및 임시 skip 주석을 모두 배제하고, 단일 return 구조(Single Exit Point)로 제어 흐름을 재설계하여 가독성과 무결성을 동시 확보.
  - validate_query():
    - not query.strip()에 의해 중복 처리되는 도달 불가(dead code)인 query.isspace() 분기 조건 제거.
    - 빈/공백 쿼리를 단일 분기로 통합.
  - validate_embedding_api(): 중간 변수 할당 제거, ModelConfig 속성 직접 참조.
  - validate_file_size(): except Exception → except OSError 구체화.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1668#pullrequestreview-4655501684)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

파일 및 쿼리 검증 로직을 다듬어 제어 흐름을 더 명확하게 하고 중복 검사를 제거했습니다.

개선 사항:
- 확장자 검증 결과를 명시적으로 언패킹하고, 이후의 파일 크기 검증에서 이를 재사용하여 파일 검증을 단순화했습니다.
- 빈 입력 및 공백만 있는 입력에 대한 쿼리 검증을 하나의 분기로 통합하고, 양언어(docstring) 주석을 일관되도록 업데이트했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine file and query validation logic for clearer control flow and de-duplicated checks.

Enhancements:
- Simplify file validation by explicitly unpacking extension validation results and reusing them through subsequent size validation.
- Consolidate query validation for empty and whitespace-only inputs into a single branch while updating bilingual docstrings for consistency.

</details>