### PR TITLE
☘️ refactor [#12.3.20] - ㉘ 1차 개선 : `Type Safety` 및 명시적 문자열 변환 처리

### DIFF
--- a/backend/data_manager.py
+++ b/backend/data_manager.py
@@ -13,7 +13,7 @@ import csv
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 
 class DataManager:
@@ -89,11 +89,13 @@ class DataManager:
                 )
 
     @staticmethod
-    def _join_list(data) -> str:
+    def _join_list(data: Optional[Union[str, List[str]]]) -> str:
         """
         [KO] 리스트 데이터를 쉼표(,)로 연결된 문자열로 변환합니다.
         [EN] Converts list data to a comma-separated string.
         """
+        if data is None:
+            return ""
         if isinstance(data, str):
             return data
         return ", ".join(data) if isinstance(data, list) else ""
@@ -375,7 +377,7 @@ def save_json_log(
     file_name: str,
     category: str,
     confidence: float,
-    snapshot_id: str,
+    snapshot_id: Union[str, int],
     conflict_detected: bool,
     requires_review: bool,
     keyword_tags: list,
@@ -393,7 +395,7 @@ def save_json_log(
         file_name (str): 처리된 파일명 / Processed file name
         category (str): 결정된 카테고리 / Determined category
         confidence (float): 예측 신뢰도 / Prediction confidence
-        snapshot_id (str): 스냅샷 ID / Snapshot ID
+        snapshot_id (Union[str, int]): 스냅샷 ID / Snapshot ID
         conflict_detected (bool): 충돌 감지 여부 / Whether a conflict was detected
         requires_review (bool): 검토 필요 여부 / Whether review is required
         keyword_tags (list): 키워드 태그 리스트 / List of keyword tags
@@ -429,7 +431,7 @@ def save_json_log(
         "file_name": file_name,
         "category": category,
         "confidence": confidence,
-        "snapshot_id": snapshot_id,
+        "snapshot_id": str(snapshot_id),
         "conflict_detected": conflict_detected,
         "requires_review": requires_review,
         "keyword_tags": keyword_tags,


### PR DESCRIPTION
- **[Type Safety]**
  - `_join_list` 파라미터에 Optional[Union[str, List[str]]] 타입 힌트 명시 및 None 사전 방어 로직 추가
- **[Data Validation]**
  - `save_json_log` 내 `snapshot_id` 해시 기록 시, 외부의 비문자열 주입에 대비한 명시적 str() 캐스팅 적용
- **[Linter Fix]**
  - 내부 검토를 통해 `snapshot_id` 파라미터 타입을 Union[str, int]로 확장하여 불필요한 캐스팅(Unnecessary cast) 경고 해결

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1670#pullrequestreview-4665474860)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

DataManager에서 로그 처리의 타입 안정성과 데이터 검증을 개선했습니다.

개선 사항:
- `_join_list`에서 리스트를 문자열로 변환할 때 명시적인 타입 힌트와 `None` 처리 로직을 추가했습니다.
- JSON 로그에서 일관된 문자열 직렬화를 보장하면서, `snapshot_id`를 문자열 또는 정수 형태로 모두 받을 수 있도록 허용했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve type safety and data validation for log handling in DataManager.

Enhancements:
- Add explicit type hints and None handling for list-to-string conversion in _join_list.
- Allow snapshot_id to be provided as either string or integer while ensuring consistent string serialization in JSON logs.

</details>