### PR TITLE
🐛 fix [#12.3.20] - ㉘ 2차 개선 : `_join_list` 예외 처리 강화 및 `snapshot_id` 린터 경고 해결

### DIFF
--- a/backend/data_manager.py
+++ b/backend/data_manager.py
@@ -98,7 +98,10 @@ class DataManager:
             return ""
         if isinstance(data, str):
             return data
-        return ", ".join(data) if isinstance(data, list) else ""
+        if isinstance(data, list):
+            return ", ".join(data)
+
+        raise TypeError(f"Unsupported data type for _join_list: {type(data)}")
 
     # =====================
     # 👤 사용자 프로필 관리
@@ -377,7 +380,7 @@ def save_json_log(
     file_name: str,
     category: str,
     confidence: float,
-    snapshot_id: Union[str, int],
+    snapshot_id: str,
     conflict_detected: bool,
     requires_review: bool,
     keyword_tags: list,
@@ -395,7 +398,7 @@ def save_json_log(
         file_name (str): 처리된 파일명 / Processed file name
         category (str): 결정된 카테고리 / Determined category
         confidence (float): 예측 신뢰도 / Prediction confidence
-        snapshot_id (Union[str, int]): 스냅샷 ID / Snapshot ID
+        snapshot_id (str): 스냅샷 ID (숫자인 경우 호출자가 str로 변환하여 전달해야 함) / Snapshot ID
         conflict_detected (bool): 충돌 감지 여부 / Whether a conflict was detected
         requires_review (bool): 검토 필요 여부 / Whether review is required
         keyword_tags (list): 키워드 태그 리스트 / List of keyword tags
@@ -431,7 +434,7 @@ def save_json_log(
         "file_name": file_name,
         "category": category,
         "confidence": confidence,
-        "snapshot_id": str(snapshot_id),
+        "snapshot_id": snapshot_id,
         "conflict_detected": conflict_detected,
         "requires_review": requires_review,
         "keyword_tags": keyword_tags,


### PR DESCRIPTION
- **[안전성 강화] `_join_list` 미지원 타입 `Fail-Fast` 적용**
  - 리뷰어 피드백 수용: None이나 문자열/리스트가 아닌 예상치 못한 값(객체, 정수 등)이 들어올 경우 조용히 빈 문자열을 반환(Silent Bug)하지 않도록 구조 개선.
  - 지원하지 않는 타입은 명시적으로 TypeError를 발생시키도록 변경하여, 런타임 오류 추적과 데이터 정합성(Type Safety)을 극대화.

- **[코드 품질] `snapshot_id` 타입 단일화 및 `Linter` 충돌 해결**
  - `save_json_log`의 파라미터를 다시 `snapshot_id`: str로 좁히고, 숫자형 등은 호출자(Caller) 측에서 변환하여 전달하도록 Docstring 계약 명시(데이터 직렬화 책임 분리).
  - 이에 따라 내부 딕셔너리 생성 로직에 남아있던 불필요한 str() 캐스팅을 제거하여, Sourcery 및 Pyrefly 정적 분석 경고(Unnecessary cast)를 완전히 해소.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1671#pullrequestreview-4665565062)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

리스트 조인에서 타입 안정성을 강화하고 JSON 로그 저장 시 스냅샷 ID 처리 방식을 표준화합니다.

버그 수정:
- 지원되지 않는 입력 타입에 대해 `_join_list`가 빈 문자열을 조용히 반환하는 대신 `TypeError`를 발생하도록 합니다.
- `save_json_log`이 문자열 타입의 `snapshot_id`만 받도록 제한하고, 필요한 변환은 호출 측에서 수행해야 함을 문서에 명시합니다.

개선 사항:
- 정적 분석 경고를 해결하기 위해 JSON 로그 엔트리에 `snapshot_id`를 저장할 때 불필요한 문자열 캐스팅을 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen type safety in list joining and standardize snapshot ID handling in JSON log saving.

Bug Fixes:
- Ensure `_join_list` raises a `TypeError` for unsupported input types instead of silently returning an empty string.
- Restrict `save_json_log` to accept `snapshot_id` as a string and update documentation to require callers to perform any necessary conversions.

Enhancements:
- Remove unnecessary string casting when storing `snapshot_id` in JSON log entries to resolve static analysis warnings.

</details>