### PR TITLE
📝 docs [#12.3.20] - ㉛ 1차 개선

### DIFF
--- a/backend/search_history.py
+++ b/backend/search_history.py
@@ -10,6 +10,7 @@
 import json
 import os
 import uuid
+from collections import Counter
 from datetime import datetime
 from typing import Dict, List, Optional
 
@@ -166,6 +167,9 @@ class SearchHistory:
         [KO] 누적된 검색 히스토리를 바탕으로 통계 정보를 계산합니다.
         [EN] Calculates statistical information based on the accumulated search history.
 
+        [KO] 성능 최적화: 가장 많이 검색된 쿼리를 찾을 때 O(n) 복잡도를 가지는 `collections.Counter`를 사용합니다.
+        [EN] Performance optimization: Uses `collections.Counter` with O(n) complexity to find the most common query.
+
         Returns:
             Dict: [KO] 총 검색 횟수, 평균 결과 수, 최다 검색 쿼리를 포함하는 통계 딕셔너리
                   / [EN] Statistics dictionary containing total searches, average results count, and most common query
@@ -182,8 +186,9 @@ class SearchHistory:
         )
 
         # 가장 많이 검색된 쿼리
-        if queries := [h["query"] for h in self.history.values()]:
-            most_common = max(set(queries), key=queries.count)
+        queries = [h["query"] for h in self.history.values()]
+        if queries:  # sourcery skip: use-named-expression
+            most_common = Counter(queries).most_common(1)[0][0]
         else:
             most_common = None
 


### PR DESCRIPTION
- **[성능 최적화] 최다 검색 쿼리 산출 로직 개선 `(O(n²) → `O(n))`**
  - 기존 `max(set(queries), key=queries.count)` 방식이 O(n²) 복잡도를 가져 히스토리가 커질수록 성능이 저하되는 안티 패턴임을 리뷰를 통해 확인.
  - 리뷰어 제안 수용: `collections.Counter`를 도입하여 O(n) 복잡도로 성능을 대폭 개선하고 확장성 확보.
  - 해당 로직 변경 사항을 `get_statistics` 메서드의 Docstring에 성능 최적화 노트로 추가 문서화.

- **[가독성 복원 및 린터 우회] Walrus 연산자 롤백**
  - 린터(Sourcery) 경고 해소를 위해 도입했던 바다코끼리 연산자(`:=`)가 인간의 코드 가독성을 저해한다는 리뷰어 지적 수용.
  - 기계적 린팅보다 팀 내 코드 컨벤션과 가독성을 우선하여, 기존의 명확한 2단계 할당(`queries = ...` 후 `if queries:`) 방식으로 원복.
  - 원복된 위치에 `# sourcery skip: use-named-expression`을 명시하여 향후 린터가 동일한 수정을 강요하지 못하도록 예외 처리.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1677#pullrequestreview-4683693795)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

검색 기록 통계에서 가장 흔한 검색어를 계산하는 방식을 최적화하고, 이에 따른 성능 변화를 문서화합니다.

Bug Fixes:
- 대규모 검색 기록에서 발생하던 이차 시간 복잡도(Quadratic-time) 동작을 피하기 위해, 가장 흔한 검색어 계산 로직을 개선합니다.

Enhancements:
- 왈러스 연산자 기반 구현을 더 명확한 2단계 할당 방식으로 교체하고, 가독성을 유지하기 위해 린터 무시(linter skip) 주석을 추가합니다.
- 성능 최적화에 대한 설명을 위해 `get_statistics`의 docstring에 `collections.Counter` 사용을 문서화합니다.

Documentation:
- 최적화된 O(n) 복잡도의 가장 흔한 검색어 계산 방식을 설명하도록 `get_statistics` docstring을 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize calculation of the most common search query in search history statistics while documenting the performance change.

Bug Fixes:
- Improve the most common query computation to avoid quadratic-time behavior on large search histories.

Enhancements:
- Replace walrus operator-based implementation with a clearer two-step assignment and add a linter skip comment to preserve readability.
- Document the use of collections.Counter in get_statistics docstring as a performance optimization note.

Documentation:
- Update get_statistics docstring to describe the optimized O(n) most-common-query calculation.

</details>