### PR TITLE
📝 docs [#12.3.20] - ㉛ 5차 개선 : `TypedDict` 적용 및 센티널 값 복원

### DIFF
--- a/backend/search_history.py
+++ b/backend/search_history.py
@@ -12,7 +12,18 @@ import os
 import uuid
 from collections import Counter
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, TypedDict
+
+
+class SearchStatistics(TypedDict):
+    """
+    [KO] 검색 통계 반환 타입
+    [EN] Return type for search statistics
+    """
+
+    total_searches: int
+    avg_results: float
+    most_common_query: Optional[str]
 
 
 class SearchHistory:
@@ -162,7 +173,7 @@ class SearchHistory:
         self.history = {}
         self._save_history()
 
-    def get_statistics(self) -> Dict:
+    def get_statistics(self) -> SearchStatistics:
         """
         [KO] 누적된 검색 히스토리를 바탕으로 통계 정보를 계산합니다.
         [EN] Calculates statistical information based on the accumulated search history.
@@ -171,11 +182,11 @@ class SearchHistory:
         [EN] Performance optimization: Uses `collections.Counter` with O(n) complexity to find the most common query.
 
         Returns:
-            Dict: [KO] 총 검색 횟수, 평균 결과 수, 최다 검색 쿼리를 포함하는 통계 딕셔너리
-                  / [EN] Statistics dictionary containing total searches, average results count, and most common query
+            SearchStatistics: [KO] 총 검색 횟수, 평균 결과 수, 최다 검색 쿼리를 포함하는 통계 딕셔너리
+                              / [EN] Statistics dictionary containing total searches, average results count, and most common query
         """
         if not self.history:
-            return {"total_searches": 0, "avg_results": 0, "most_common_query": ""}
+            return {"total_searches": 0, "avg_results": 0.0, "most_common_query": None}
 
         # 전체 검색 수
         total_searches = len(self.history)
@@ -188,7 +199,7 @@ class SearchHistory:
         # 가장 많이 검색된 쿼리 (메모리 최적화: 제너레이터 사용)
         query_counts = Counter(h["query"] for h in self.history.values())
         top_queries = query_counts.most_common(1)
-        most_common = top_queries[0][0] if top_queries else ""
+        most_common = top_queries[0][0] if top_queries else None
 
         return {
             "total_searches": total_searches,


### PR DESCRIPTION
- **[타입 시스템 고도화] `TypedDict` 도입**
  - 기존에 막연하게 `→ Dict`로 반환하던 `get_statistics` 메서드에 `SearchStatistics`라는 `TypedDict`를 새롭게 정의하여 적용.
  - 이를 통해 각 반환 필드의 타입(`total_searches: int`, `avg_results: float`, `most_common_query: Optional[str]`)이 정적 분석 단계부터 엄격하게 검증 및 보장됨.

- **[의미론적 명확성] `None` 센티널 값 복원**
  - 이전 4차 개선에서 도입했던 `""`(빈 문자열) 폴백 로직이 '데이터 없음'과 '실제 빈 문자열 검색' 간의 의미적 혼동(Semantic Confusion)을 초래할 수 있다는 리뷰어 지적 수용.
  - 명시적인 센티널 값인 `None`으로 롤백하고, 이를 `SearchStatistics`의 `Optional[str]` 타입 힌트와 결합하여 호출부의 안전성을 구조적으로 완벽히 확보함.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1681#pullrequestreview-4683840468)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

검색 기록 통계를 위한 타입 지정된 `SearchStatistics` 반환 구조를 정의하고, 빈 문자열 대신 `None`을 사용하여 누락된 쿼리의 의미를 명확히 합니다.

New Features:
- 검색 통계를 위한 구조화된 반환 타입을 정의하기 위해 `SearchStatistics` TypedDict를 도입합니다.

Bug Fixes:
- 빈 문자열 쿼리와 구분하기 위해 `most_common_query`가 존재하지 않을 때를 나타내는 센티널 값으로 `None`을 다시 사용하도록 복원합니다.

Enhancements:
- `get_statistics`에 대한 타입 힌트를 강화하고, `avg_results`에 대해 더 정밀한 숫자 기본값을 포함하도록 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Define a typed SearchStatistics return structure for search history statistics and clarify the semantics of missing queries by using None instead of an empty string.

New Features:
- Introduce a SearchStatistics TypedDict to define the structured return type for search statistics.

Bug Fixes:
- Restore None as the sentinel value for missing most_common_query to distinguish it from an empty-string query.

Enhancements:
- Tighten type hints for get_statistics, including more precise numeric defaults for avg_results.

</details>