### PR TITLE
📝 docs [#12.3.20] - ㉜ 1차 개선 : `backend/embedding.py` 반환 타입 명시(TypedDict 도입)

### DIFF
--- a/backend/embedding.py
+++ b/backend/embedding.py
@@ -11,7 +11,7 @@
 """
 
 import types
-from typing import Any, Dict, List, Mapping, Tuple, Type
+from typing import List, Mapping, Tuple, Type, TypedDict
 
 from openai import APIConnectionError, APIError, APITimeoutError, RateLimitError
 
@@ -24,6 +24,18 @@ from backend.utils import count_tokens, estimate_cost
 # [KO] API 오류 발생 시 반환할 기본 메시지와 에러 타입
 # [EN] Default message and error type returned upon API error
 DEFAULT_API_ERROR: Tuple[str, EmbeddingErrorType] = ("Embedding API error", "api_error")
+
+
+class EmbeddingResult(TypedDict):
+    """
+    [KO] 임베딩 생성 결과 반환 타입
+    [EN] Return type for embedding generation results
+    """
+
+    embeddings: List[List[float]]
+    tokens: int
+    cost: float
+
 
 # 예외 클래스에 따른 에러 메시지 접두사와 관측성 타입을 매핑하는 모듈 상수
 # 런타임 불변성을 보장하기 위해 MappingProxyType 사용
@@ -97,7 +109,7 @@ class EmbeddingGenerator:
             model_name.split("/")[-1], 0.02 / 1_000_000
         )  # ?
 
-    def generate_embeddings(self, texts: List[str]) -> Dict[str, Any]:
+    def generate_embeddings(self, texts: List[str]) -> EmbeddingResult:
         """
         [KO] 텍스트 리스트에 대한 임베딩 벡터를 생성하고 비용 및 토큰 수를 반환합니다.
         [EN] Generates embedding vectors for a list of texts and returns cost and token metrics.
@@ -107,7 +119,7 @@ class EmbeddingGenerator:
                                / [EN] List of text chunks to convert into embeddings.
 
         Returns:
-            Dict[str, Any]: [KO] 임베딩 벡터 리스트, 총 사용 토큰 수, 예상 비용을 포함한 딕셔너리
+            EmbeddingResult: [KO] 임베딩 벡터 리스트, 총 사용 토큰 수, 예상 비용을 포함한 딕셔너리
                             / [EN] Dictionary containing embedding vectors, total token count, and estimated cost.
 
         Raises:


### PR DESCRIPTION
- **[반환 타입 고도화] `EmbeddingResult` TypedDict 도입**
  - 기존에 `Dict[str, Any]`로 모호하게 선언되었던 `generate_embeddings`의 반환 타입을 명확히 하기 위해 `EmbeddingResult` TypedDict를 정의.
  - 이를 통해 반환되는 딕셔너리의 구조(`embeddings: List[List[float]]`, `tokens: int`, `cost: float`)를 API 계약(Contract) 수준에서 강제하고, 호출부의 가독성 및 타입 안정성을 대폭 향상시킴.

- **[반려] Docstring 다국어 분리 제안 거절**
  - 인라인 `[KO]/`[EN]` 병기는 프로젝트 전역 표준 컨벤션이므로, i18n 헬퍼로 분리하라는 리뷰어의 제안은 의도적으로 반영하지 않음.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1683#pullrequestreview-4695211176)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

백엔드 임베딩 모듈에서 임베딩 생성 결과를 포함하는 구조화된 반환 타입을 지정합니다.

Enhancements:
- `generate_embeddings`가 반환하는 임베딩, 토큰 수, 비용 필드를 정형화하는 `EmbeddingResult` TypedDict를 도입합니다.
- 더 명확한 API 계약과 타입 안정성을 위해 `generate_embeddings`의 시그니처와 docstring에 `EmbeddingResult` 타입을 사용하도록 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Specify a structured return type for embedding generation results in the backend embedding module.

Enhancements:
- Introduce an EmbeddingResult TypedDict that formalizes the embeddings, token count, and cost fields returned by generate_embeddings.
- Update generate_embeddings to use the EmbeddingResult type in its signature and docstring for clearer API contracts and type safety.

</details>