### PR TITLE
📝 docs [#12.3.20] - ㉝ 1차 개선 : `backend/metadata.py` 방어적 로딩 및 일관성 강화

### DIFF
--- a/backend/metadata.py
+++ b/backend/metadata.py
@@ -76,13 +76,23 @@ class FileMetadata:
         if os.path.exists(self.storage_path):
             try:
                 with open(self.storage_path, "r", encoding="utf-8") as f:
-                    self.metadata = json.load(f)
+                    loaded = json.load(f)
+                # [KO] json.load 결과가 dict인지 경량 검증 (손상된 파일 대비)
+                # [EN] Lightweight validation to ensure json.load result is a dict (guards against corrupted files)
+                if isinstance(loaded, dict):
+                    self.metadata = loaded
+                else:
+                    print("메타데이터 형식 오류: 딕셔너리가 아닙니다. 초기화합니다.")
+                    self.metadata = {}
             except Exception as e:
                 print(f"메타데이터 로드 실패: {e}")
                 self.metadata = {}
         else:
-            # data 폴더 생성
-            os.makedirs(os.path.dirname(self.storage_path), exist_ok=True)
+            # [KO] storage_path에 디렉터리 구성 요소가 있을 때만 폴더 생성
+            # [EN] Only create directory if storage_path contains a directory component
+            storage_dir = os.path.dirname(self.storage_path)
+            if storage_dir:
+                os.makedirs(storage_dir, exist_ok=True)
             self.metadata = {}
 
     def _save_metadata(self) -> None:
@@ -212,7 +222,7 @@ class FileMetadata:
 
         total_chunks = sum(m["chunk_count"] for m in self.metadata.values())
         total_size = sum(m["file_size"] for m in self.metadata.values())
-        models = list({m["embedding_model"] for m in self.metadata.values()})
+        models = sorted({m["embedding_model"] for m in self.metadata.values()})
 
         return {
             "total_files": len(self.metadata),


### PR DESCRIPTION
- **[버그 픽스] `os.makedirs` 빈 문자열 오류 방어**
  - `storage_path`가 `"metadata.json"`처럼 디렉터리 구성 요소가 없는 경우, `os.path.dirname()`이 빈 문자열을 반환하여 `FileNotFoundError`가 발생하는 실제 버그 수정.
  - `storage_dir` 변수를 먼저 계산하고, 비어 있지 않을 때만 `os.makedirs`를 호출하도록 가드 추가.

- **[안정성 강화] `json.load` 결과에 경량 타입 검증 추가**
  - `TypedDict`를 도입했음에도 런타임 시점에서 JSON 파일이 손상되거나 형식이 올바르지 않을 경우 (예: 리스트가 저장된 경우) `self.metadata`가 `dict`가 아닌 상태로 로드될 수 있는 문제 방어.
  - `isinstance(loaded, dict)` 검증을 추가하고, 형식 오류 시 안전하게 빈 상태로 초기화.

- **[일관성 강화] `models_used` 정렬된 리스트로 반환**
  - `get_statistics`에서 집합(set)으로 중복을 제거한 모델 목록의 순서가 파이썬 실행 환경에 따라 비결정적으로 달라질 수 있는 문제 해결.
  - `sorted()`를 적용하여 API 응답 및 로그에서 항상 일관된 알파벳 순서로 반환되도록 수정.

- **[검토 후 반려] Sourcery walrus 연산자 제안 거절**
  - Sourcery가 93~94번 줄(`storage_dir` 변수 분리 패턴)을 walrus 연산자로 합치도록 제안했으나, 해당 변경 시 `[KO]/[EN]` 이중 언어 설명 주석이 삭제되므로 프로젝트 컨벤션 준수를 위해 의도적으로 반려.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1685#pullrequestreview-4695669318)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

메타데이터 로딩과 통계 보고의 안정성과 일관성을 개선합니다.

버그 수정:
- 저장 경로에 디렉터리 구성 요소가 있을 때만 메타데이터 디렉터리를 생성하여 `FileNotFoundError`를 방지합니다.
- JSON 내용이 딕셔너리가 아닐 경우 메타데이터를 재설정하여 손상되었거나 잘못된 메타데이터 파일에 대비합니다.

개선 사항:
- 메타데이터 통계에서 보고되는 임베딩 모델 목록이 결정론적인 정렬 순서로 반환되도록 보장합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve robustness and consistency of metadata loading and statistics reporting.

Bug Fixes:
- Prevent FileNotFoundError by only creating the metadata directory when the storage path has a directory component.
- Guard against corrupted or invalid metadata files by resetting metadata when the JSON content is not a dictionary.

Enhancements:
- Ensure reported embedding models list is returned in a deterministic sorted order in metadata statistics.

</details>