### PR TITLE
📝 docs [#12.3.20] - ㉝ 2차 개선 : 로깅 표준화 및 구체적 예외 처리

### DIFF
--- a/backend/metadata.py
+++ b/backend/metadata.py
@@ -13,10 +13,13 @@
 """
 
 import json
+import logging
 import os
 import uuid
 from datetime import datetime
 from typing import Dict, List, Optional, TypedDict
+
+logger = logging.getLogger(__name__)
 
 
 class FileMetadataRecord(TypedDict):
@@ -82,10 +85,15 @@ class FileMetadata:
                 if isinstance(loaded, dict):
                     self.metadata = loaded
                 else:
-                    print("메타데이터 형식 오류: 딕셔너리가 아닙니다. 초기화합니다.")
+                    logger.warning(
+                        "메타데이터 형식 오류: 딕셔너리가 아닙니다. 초기화합니다."
+                    )
                     self.metadata = {}
-            except Exception as e:
-                print(f"메타데이터 로드 실패: {e}")
+            except json.JSONDecodeError as e:
+                logger.error("메타데이터 파일 JSON 파싱 실패: %s", e)
+                self.metadata = {}
+            except OSError as e:
+                logger.error("메타데이터 파일 읽기 실패: %s", e)
                 self.metadata = {}
         else:
             # [KO] storage_path에 디렉터리 구성 요소가 있을 때만 폴더 생성
@@ -103,8 +111,8 @@ class FileMetadata:
         try:
             with open(self.storage_path, "w", encoding="utf-8") as f:
                 json.dump(self.metadata, f, ensure_ascii=False, indent=2)
-        except Exception as e:
-            print(f"메타데이터 저장 실패: {e}")
+        except OSError as e:
+            logger.error("메타데이터 파일 저장 실패: %s", e)
 
     def add_file(
         self,


### PR DESCRIPTION
- **[로깅 표준화] `print` → `logger` 교체**
  - 프로젝트 전체 표준인 `logging.getLogger(__name__)` 패턴을 도입하여 `logger` 모듈 상수를 추가.
  - `_load_metadata`와 `_save_metadata`에 산재해 있던 `print()` 호출을 모두 `logger.warning()` / `logger.error()`로 교체하여 로그 레벨 구분 및 중앙 집중식 로그 관리 가능하도록 개선.
  - 로그 메시지를 f-string 대신 `%s` 포맷으로 전환하여 로깅 모범 사례(lazy evaluation) 준수.

- **[안전성 강화] `except Exception` → 구체적 예외 분리**
  - `_load_metadata`의 포괄적인 `except Exception`을 의미별로 분리:
    - `json.JSONDecodeError`: JSON 파싱 실패 (파일 내용 손상)
    - `OSError`: 파일 시스템 접근 실패 (권한 오류, 잠김 등)
  - `_save_metadata`의 포괄적인 `except Exception`도 `OSError`로 구체화.
  - 이를 통해 예상하지 못한 예외(예: `TypeError`)가 조용히 마스킹(swallowing)되는 위험 제거.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1686#pullrequestreview-4695740566)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

메타데이터 로깅을 표준화하고 메타데이터 로드/저장 작업에 대한 예외 처리를 강화합니다.

버그 수정:
- 메타데이터 로드/저장 중 발생하는 예상치 못한 예외가 조용히 무시되지 않도록, 구체적인 예외 타입을 사용합니다.

향상 사항:
- 메타데이터 처리 과정의 `print` 기반 진단을 모듈 수준의 구조화된 로깅과 적절한 로그 레벨로 대체합니다.
- 메타데이터 파일을 읽고 쓰는 과정에서 JSON 파싱 및 파일 시스템 오류에 대한 에러 처리 방식을 명확히 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize metadata logging and tighten exception handling for metadata load/save operations.

Bug Fixes:
- Prevent unexpected exceptions during metadata load/save from being silently swallowed by using specific exception types.

Enhancements:
- Replace print-based diagnostics in metadata handling with module-level structured logging and appropriate log levels.
- Clarify error handling for JSON parsing and filesystem failures when reading and writing metadata files.

</details>