### PR TITLE
📝 docs [#12.3.20] - ㉝ 3차 개선 : 로그 메시지 품질 강화

### DIFF
--- a/backend/metadata.py
+++ b/backend/metadata.py
@@ -86,14 +86,19 @@ class FileMetadata:
                     self.metadata = loaded
                 else:
                     logger.warning(
-                        "메타데이터 형식 오류: 딕셔너리가 아닙니다. 초기화합니다."
+                        "메타데이터 형식 오류: 딕셔너리가 아닙니다. 초기화합니다. [path=%s]",
+                        self.storage_path,
                     )
                     self.metadata = {}
             except json.JSONDecodeError as e:
-                logger.error("메타데이터 파일 JSON 파싱 실패: %s", e)
+                logger.warning(
+                    "메타데이터 파일 JSON 파싱 실패 (path=%s): %s", self.storage_path, e
+                )
                 self.metadata = {}
             except OSError as e:
-                logger.error("메타데이터 파일 읽기 실패: %s", e)
+                logger.error(
+                    "메타데이터 파일 읽기 실패 (path=%s): %s", self.storage_path, e
+                )
                 self.metadata = {}
         else:
             # [KO] storage_path에 디렉터리 구성 요소가 있을 때만 폴더 생성
@@ -112,7 +117,9 @@ class FileMetadata:
             with open(self.storage_path, "w", encoding="utf-8") as f:
                 json.dump(self.metadata, f, ensure_ascii=False, indent=2)
         except OSError as e:
-            logger.error("메타데이터 파일 저장 실패: %s", e)
+            logger.error(
+                "메타데이터 파일 저장 실패 (path=%s): %s", self.storage_path, e
+            )
 
     def add_file(
         self,


### PR DESCRIPTION
- **[운영성 강화] 모든 로그 메시지에 `storage_path` 컨텍스트 추가**
  - `_load_metadata`와 `_save_metadata`의 모든 로거 호출에 `(path=%s)`와 함께 `self.storage_path`를 인자로 추가.
  - 운영 환경에서 여러 인스턴스가 서로 다른 경로를 사용할 경우, 로그만으로 어느 파일에서 문제가 발생했는지 즉시 파악할 수 있도록 관찰 가능성(Observability) 향상.
  - 파일 경로 정보는 서버 내부 정보로, 사용자 개인정보가 포함되지 않으므로 안전.

- **[로그 레벨 의미화] `json.JSONDecodeError` 핸들러: `error` → `warning` 조정**
  - `JSONDecodeError`는 JSON 파일 손상 등 데이터 수준의 예상 가능한 문제이며, 시스템이 빈 딕셔너리로 graceful하게 복구되므로 즉각 대응이 필요한 `error` 레벨이 과도했음.
  - `warning`으로 낮춰 알람 피로도(alert fatigue)를 줄이고, 진짜 시스템 장애(`OSError` 계열)와 명확하게 구분되도록 로그 레벨 의미론(semantics) 정교화.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1687#pullrequestreview-4695812921)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

스토리지 경로 컨텍스트를 포함해 메타데이터 로깅을 더 명확하고 풍부하게 하고, JSON 파싱 오류에 대한 로그 심각도를 조정합니다.

개선 사항:
- 인스턴스 전반에서 관측 가능성을 높이기 위해 메타데이터 읽기/쓰기 로그 메시지에 `storage_path`를 포함합니다.
- 복구 가능한 상황을 더 잘 반영하고 경고 알림 노이즈를 줄이기 위해 JSON 메타데이터 파싱 실패의 로그 수준을 error에서 warning으로 낮춥니다.
- 문제 진단을 쉽게 하기 위해 경로 컨텍스트를 추가하면서, 메타데이터 읽기/쓰기 중 발생하는 `OSError` 관련 실패에 대해서는 error 수준을 유지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify and enrich metadata logging with storage path context while tuning log severity for JSON parsing errors.

Enhancements:
- Include storage_path in metadata read/write log messages to improve observability across instances.
- Downgrade JSON metadata parsing failures from error to warning to better reflect recoverable conditions and reduce alert noise.
- Retain error severity for OSError-related metadata read/write failures while adding path context for easier diagnosis.

</details>