### PR TITLE
📝 docs [#12.3.20] - ㉝ 4차 개선 : 구조화된 로깅(extra=) 적용

### DIFF
--- a/backend/metadata.py
+++ b/backend/metadata.py
@@ -86,18 +86,22 @@ class FileMetadata:
                     self.metadata = loaded
                 else:
                     logger.warning(
-                        "메타데이터 형식 오류: 딕셔너리가 아닙니다. 초기화합니다. [path=%s]",
-                        self.storage_path,
+                        "메타데이터 형식 오류: 딕셔너리가 아닙니다. 초기화합니다.",
+                        extra={"storage_path": self.storage_path},
                     )
                     self.metadata = {}
             except json.JSONDecodeError as e:
                 logger.warning(
-                    "메타데이터 파일 JSON 파싱 실패 (path=%s): %s", self.storage_path, e
+                    "메타데이터 파일 JSON 파싱 실패: %s",
+                    e,
+                    extra={"storage_path": self.storage_path},
                 )
                 self.metadata = {}
             except OSError as e:
                 logger.error(
-                    "메타데이터 파일 읽기 실패 (path=%s): %s", self.storage_path, e
+                    "메타데이터 파일 읽기 실패: %s",
+                    e,
+                    extra={"storage_path": self.storage_path},
                 )
                 self.metadata = {}
         else:
@@ -118,7 +122,9 @@ class FileMetadata:
                 json.dump(self.metadata, f, ensure_ascii=False, indent=2)
         except OSError as e:
             logger.error(
-                "메타데이터 파일 저장 실패 (path=%s): %s", self.storage_path, e
+                "메타데이터 파일 저장 실패: %s",
+                e,
+                extra={"storage_path": self.storage_path},
             )
 
     def add_file(


### PR DESCRIPTION
- **[로깅 고도화] 인라인 경로 문자열 → 구조화된 `extra=` 딕셔너리로 전환**
  - 기존에 로그 메시지 문자열 내에 `(path=%s)` 형식으로 삽입하던 `storage_path` 정보를, 프로젝트 표준 패턴인 `extra={"storage_path": self.storage_path}`로 분리.
  - 이를 통해 Elasticsearch, Datadog, CloudWatch 등 구조화된 로그 처리 시스템에서 `storage_path` 필드를 기준으로 필터링·집계가 가능해져 관찰 가능성(Observability) 대폭 향상.
  - `_load_metadata`의 3개 핸들러(형식 오류 / `JSONDecodeError` / `OSError`)와 `_save_metadata`의 `OSError` 핸들러, 총 4개 로거 호출에 일관되게 적용.
  - 프로젝트 내 `services/`, `celery_app/tasks/` 등 기존 모듈들의 `extra=` 활용 패턴과 완전히 동일한 방식으로 통일.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1688#pullrequestreview-4695853198)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개선 사항:
- 메타데이터 로그 메시지에서 인라인 스토리지 경로 포매팅을 제거하고, 기존 로깅 규칙과의 일관성과 관측 가능성을 높이기 위해 `extra={"storage_path": ...}` 형태의 구조화된 필드를 사용하도록 변경했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace inline storage path formatting in metadata log messages with structured extra={"storage_path": ...} for better observability and consistency with existing logging conventions.

</details>