### PR TITLE
📝 docs [#12.3.20] - ㉞ 1차 개선 : 헬퍼 메서드 Docstring 보강

### DIFF
--- a/backend/chunking.py
+++ b/backend/chunking.py
@@ -104,7 +104,9 @@ class TextChunker:
     def _log_invalid_int_attr(self, val: Any, attr_name: str, is_private: bool) -> None:
         """
         [KO] 유효하지 않은 정수형 속성 값을 안전하게 로깅합니다.
+             긴 문자열 값으로 인한 로그 비대화를 막기 위해 `MAX_INVALID_VALUE_REPR_LEN`(기본 100자) 기준으로 값을 생략(truncation) 처리합니다.
         [EN] Safely logs an invalid integer attribute value.
+             To prevent log bloat from long string values, the value is truncated based on `MAX_INVALID_VALUE_REPR_LEN` (default 100 chars).
 
         Args:
             val (Any): 유효하지 않은 속성 값 / The invalid attribute value
@@ -132,7 +134,9 @@ class TextChunker:
     def _log_missing_splitter_attr(self, attr_name: str, private_attr: str) -> None:
         """
         [KO] 스플리터에 필요한 속성이 없을 경우 중복을 방지하여 로깅합니다.
+             `(splitter_id, splitter_type, attr_name, private_attr)` 튜플을 중복 제거 키(deduplication key)로 사용하여, 동일 인스턴스의 동일 속성에 대한 반복적인 로깅을 억제합니다.
         [EN] Logs a missing attribute on the splitter while preventing duplicate logs.
+             Uses a tuple of `(splitter_id, splitter_type, attr_name, private_attr)` as a deduplication key to suppress repeated logging for the same attribute on the same instance.
 
         Args:
             attr_name (str): 찾지 못한 공개 속성 이름 / The public attribute name that was not found


### PR DESCRIPTION
- **[문서화 고도화] 로깅 헬퍼 메서드 부작용(Side-effect) 설명 추가**
  - `_log_invalid_int_attr`: 긴 문자열로 인한 로그 비대화를 막기 위해 `MAX_INVALID_VALUE_REPR_LEN` 기준으로 생략(truncation) 처리됨을 명시하여, 운영 중 일부 값이 잘려 보이는 현상이 의도된 것임을 문서화.
  - `_log_missing_splitter_attr`: 튜플 기반의 중복 제거 키(deduplication key)를 사용하여 동일 인스턴스의 동일 속성에 대한 로깅을 억제한다는 내부 메커니즘을 명확히 기재.

- **[반려] Comment 1 (슬래시 vs 문장 분리 통일) 거절**
  - 주요 설명(Description)은 `[KO]`와 `[EN]`을 줄바꿈(newline)으로 분리하고, 인라인 파라미터(Args/Returns)는 슬래시(` / `)로 구분하는 것은 프로젝트 전체(예: metadata.py, embedding.py 등)에 일관되게 적용 중인 의도적 컨벤션임을 리뷰어에게 영어 코멘트로 소명하고 반려 처리.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1691#pullrequestreview-4713335428)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

잘못되었거나 누락된 splitter 속성에 대한 로깅 헬퍼의 문서화된 동작을 명확히 하여, 그 부수 효과 및 중복 제거(deduplication) 동작을 더 잘 설명합니다.

Documentation:
- 로깅에서 잘못된 정수 속성 값이 너무 길 경우 잘리는(truncation) 동작을 문서화하여, 로그에서 의도적으로 값이 짧게 표시되는 이유를 설명합니다.
- 동일 인스턴스에서 누락된 splitter 속성에 대해 반복되는 로그를 억제하기 위해 사용되는 중복 제거 키(deduplication key)를 문서화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the documented behavior of logging helpers for invalid and missing splitter attributes to better explain their side effects and deduplication behavior.

Documentation:
- Document truncation behavior for long invalid integer attribute values in logging to explain intentional value shortening in logs.
- Document the deduplication key used to suppress repeated logs for missing splitter attributes on the same instance.

</details>