### PR TITLE
📝 docs [#12.3.20] - ㉟ 1차 개선 : 입력 검증 모듈(validators.py) 명세 가독성 향상

### DIFF
--- a/backend/validators.py
+++ b/backend/validators.py
@@ -47,8 +47,8 @@ class FileValidator:
         [EN] Initialize FileValidator.
 
         Args:
-            max_file_size_mb (int): 허용되는 최대 파일 크기 (단위: MB). 기본값 200. / Maximum allowed file size in megabytes. Defaults to 200.
-            allowed_extensions (Optional[List[str]]): 허용 확장자 목록. 기본값 ['.pdf', '.txt', '.md']. / List of permitted file extensions. Defaults to ['.pdf', '.txt', '.md'].
+            max_file_size_mb: 허용되는 최대 파일 크기 (단위: MB). 기본값 200. / Maximum allowed file size in megabytes. Defaults to 200.
+            allowed_extensions: 허용 확장자 목록. 기본값 ['.pdf', '.txt', '.md']. / List of permitted file extensions. Defaults to ['.pdf', '.txt', '.md'].
         """
         self.max_file_size_mb = max_file_size_mb
         self.max_file_size_bytes = max_file_size_mb * 1024 * 1024
@@ -66,10 +66,11 @@ class FileValidator:
              Fails if the file is empty or exceeds the configured maximum size.
 
         Args:
-            file_path (str): 검증할 파일의 경로 문자열 / Path string of the file to validate
+            file_path: 검증할 파일의 경로 문자열 / Path string of the file to validate
 
         Returns:
-            Tuple[bool, Optional[str]]: (is_valid, error_message) 형태의 튜플. 검증 성공 시 (True, None), 실패 시 (False, 오류 메시지 문자열). / A tuple of (is_valid, error_message). Returns (True, None) on success, (False, error string) on failure.
+            - `(True, None)`: 검증 성공 시 / On success
+            - `(False, str)`: 검증 실패 시 (오류 메시지 포함) / On failure (includes error string)
         """
         try:
             file_size = os.path.getsize(file_path)
@@ -97,10 +98,11 @@ class FileValidator:
              Fails if the extension is not in the list of allowed extensions.
 
         Args:
-            file_path (str): 검증할 파일의 경로 문자열 / Path string of the file to validate
+            file_path: 검증할 파일의 경로 문자열 / Path string of the file to validate
 
         Returns:
-            Tuple[bool, Optional[str]]: (is_valid, error_message) 형태의 튜플. 검증 성공 시 (True, None), 실패 시 (False, 오류 메시지 문자열). / A tuple of (is_valid, error_message). Returns (True, None) on success, (False, error string) on failure.
+            - `(True, None)`: 검증 성공 시 / On success
+            - `(False, str)`: 검증 실패 시 (오류 메시지 포함) / On failure (includes error string)
         """
         ext = Path(file_path).suffix.lower()
 
@@ -121,10 +123,11 @@ class FileValidator:
              Returns immediately on the first failure.
 
         Args:
-            file_path (str): 검증할 파일의 경로 문자열 / Path string of the file to validate
+            file_path: 검증할 파일의 경로 문자열 / Path string of the file to validate
 
         Returns:
-            Tuple[bool, Optional[str]]: (is_valid, error_message) 형태의 튜플. 모든 검증 통과 시 (True, None), 실패 시 (False, 오류 메시지 문자열). / A tuple of (is_valid, error_message). Returns (True, None) if all checks pass, (False, error string) on failure.
+            - `(True, None)`: 모든 검증 통과 시 / If all checks pass
+            - `(False, str)`: 검증 실패 시 (오류 메시지 포함) / On failure (includes error string)
         """
         if not os.path.exists(file_path):
             return False, f"❌ 파일이 존재하지 않습니다: {file_path}"
@@ -154,8 +157,8 @@ class QueryValidator:
         [EN] Initialize QueryValidator.
 
         Args:
-            min_length (int): 허용되는 최소 쿼리 길이 (공백 제거 후 기준). 기본값 2. / Minimum allowed query length (after stripping whitespace). Defaults to 2.
-            max_length (int): 허용되는 최대 쿼리 길이 (공백 제거 후 기준). 기본값 500. / Maximum allowed query length (after stripping whitespace). Defaults to 500.
+            min_length: 허용되는 최소 쿼리 길이 (공백 제거 후 기준). 기본값 2. / Minimum allowed query length (after stripping whitespace). Defaults to 2.
+            max_length: 허용되는 최대 쿼리 길이 (공백 제거 후 기준). 기본값 500. / Maximum allowed query length (after stripping whitespace). Defaults to 500.
         """
         self.min_length = min_length
         self.max_length = max_length
@@ -168,10 +171,11 @@ class QueryValidator:
              Checks for None/empty/whitespace-only string and min/max length in order.
 
         Args:
-            query (str): 검증할 검색 쿼리 문자열 / Search query string to validate
+            query: 검증할 검색 쿼리 문자열 / Search query string to validate
 
         Returns:
-            Tuple[bool, Optional[str]]: (is_valid, error_message) 형태의 튜플. 검증 성공 시 (True, None), 실패 시 (False, 오류 메시지 문자열). / A tuple of (is_valid, error_message). Returns (True, None) on success, (False, error string) on failure.
+            - `(True, None)`: 검증 성공 시 / On success
+            - `(False, str)`: 검증 실패 시 (오류 메시지 포함) / On failure (includes error string)
         """
         if not query or not query.strip():
             return False, "⚠️ 검색어를 입력해주세요."
@@ -212,7 +216,8 @@ class APIKeyValidator:
              Validates the Embedding API key (required) and GPT4O API key (optional) in order.
 
         Returns:
-            Tuple[bool, Optional[str]]: (is_valid, error_message) 형태의 튜플. 모든 검증 통과 시 (True, None), 실패 시 (False, 오류 메시지 문자열). / A tuple of (is_valid, error_message). Returns (True, None) if all checks pass, (False, error string) on failure.
+            - `(True, None)`: 모든 검증 통과 시 / If all checks pass
+            - `(False, str)`: 검증 실패 시 (오류 메시지 포함) / On failure (includes error string)
         """
         embedding_api_key = ModelConfig.EMBEDDING_API_KEY
         embedding_base_url = ModelConfig.EMBEDDING_BASE_URL
@@ -276,7 +281,8 @@ class APIKeyValidator:
              Use this as a simpler alternative to the full validate_api_keys() validation.
 
         Returns:
-            Tuple[bool, Optional[str]]: (is_valid, error_message) 형태의 튜플. 검증 성공 시 (True, None), 실패 시 (False, 오류 메시지 문자열). / A tuple of (is_valid, error_message). Returns (True, None) on success, (False, error string) on failure.
+            - `(True, None)`: 검증 성공 시 / On success
+            - `(False, str)`: 검증 실패 시 (오류 메시지 포함) / On failure (includes error string)
         """
         if not ModelConfig.EMBEDDING_API_KEY:
             return False, "❌ 임베딩 API 키가 설정되지 않았습니다."


### PR DESCRIPTION
- **[반려] Comment 1 (슬래시 vs 문장 분리 통일) 거절**
  - 인라인 파라미터(Args/Returns) 설명에 슬래시(` / `)를 사용하여 KO/EN을 한 줄로 병기하는 것은 수직 공간 낭비를 줄이기 위해 프로젝트 전체(chunking.py 등)에 일관되게 채택된 의도적 컨벤션이므로, 통일성 유지를 위해 반려 처리.

- **[문서화 고도화] 불필요한 타입 중복 제거 및 가독성 개선**
  - Args 섹션에서 이미 함수 시그니처로 제공되는 명시적 타입 힌트(예: `(int)`, `(str)`)를 제거하여, 의미(semantic meaning)에 더 집중할 수 있도록 개선.
  - Returns 섹션의 길고 복잡한 설명을 불릿 포인트(bullet points)로 나누어, 검증 성공 및 실패 케이스를 스캐닝하기 쉽도록 재구성.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1693#pullrequestreview-4722696218)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

검증 유틸리티에 대한 문서를 다듬어, 런타임 동작을 변경하지 않으면서도 매개변수 및 반환 값 설명의 가독성과 일관성을 향상합니다.

Enhancements:
- 함수 시그니처에 의존하도록 `Args` 섹션에서 중복되는 타입 주석을 제거하여 validator의 docstring을 개선합니다.
- validator의 결과를 더 명확히 하기 위해 `Returns` 문서를 성공/실패 케이스에 대한 글머리표 형태로 재구성합니다.

Documentation:
- 더 나은 가독성과 훑어보기 용이성을 위해 `validators.py`에서 매개변수 및 반환 값 설명의 한·영(KO/EN) 병기 내용을 명확히 정리합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine documentation for validation utilities to improve readability and consistency of parameter and return descriptions without changing runtime behavior.

Enhancements:
- Improve validator docstrings by removing redundant type annotations from Args sections and relying on function signatures.
- Restructure Returns documentation into bullet-point success/failure cases to clarify validator outcomes.

Documentation:
- Clarify bilingual (KO/EN) parameter and return descriptions in validators.py for better readability and scanability.

</details>