### PR TITLE
📝 docs [#12.3.20] - ㊱ 데이터 내보내기 모듈(export.py) 명세 표준화

### DIFF
--- a/backend/export.py
+++ b/backend/export.py
@@ -29,33 +29,25 @@ class MarkdownExporter:
     """
 
     def __init__(self):
-        pass
+        """
+        [KO] MarkdownExporter를 초기화합니다.
+        [EN] Initialize MarkdownExporter.
+        """
 
     def export_search_results(
         self, query: str, results: List[SearchResult], include_metadata: bool = True
     ) -> str:
         """
-        [KO]
-        검색 결과 리스트를 마크다운 형식의 문자열로 변환합니다.
+        [KO] 검색 결과 리스트를 마크다운 형식의 문자열로 변환합니다.
+        [EN] Converts a list of search results into a Markdown formatted string.
 
         Args:
-            query: 사용자가 입력한 원본 검색 쿼리.
-            results: 검색 엔진으로부터 반환된 TypedDict 기반 결과 리스트.
-            include_metadata: 문서 출처, 청크 번호 등 메타데이터 포함 여부 (기본값 True).
+            query: 사용자가 입력한 원본 검색 쿼리 / The original search query entered by the user
+            results: 검색 엔진으로부터 반환된 TypedDict 기반 결과 리스트 / List of result dictionaries matching the SearchResult TypedDict
+            include_metadata: 문서 출처, 청크 번호 등 메타데이터 포함 여부 (기본값 True) / Whether to include metadata such as source and chunk index (default True)
 
         Returns:
-            포맷팅이 완료된 마크다운 문자열.
-
-        [EN]
-        Converts a list of search results into a Markdown formatted string.
-
-        Args:
-            query: The original search query entered by the user.
-            results: List of result dictionaries matching the SearchResult TypedDict.
-            include_metadata: Whether to include metadata such as source and chunk index (default True).
-
-        Returns:
-            The fully formatted Markdown string.
+            포맷팅이 완료된 마크다운 문자열 / The fully formatted Markdown string
         """
 
         # 시간


### PR DESCRIPTION
- 마크다운 내보내기 모듈(`MarkdownExporter`)의 초기화 및 텍스트 변환 메서드에 대하여 프로젝트 표준(Google Style, [KO]/[EN] 병기) Docstring 적용
- 기존에 길게 분리되어 있던 설명을 압축하고 인라인 슬래시(` / `) 방식으로 통일하여 코드 가독성 향상

🔗 Related: Issue [#1044]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

프로젝트 문서화 규칙에 맞춰 MarkdownExporter 모듈의 독스트링을 표준화합니다.

Documentation:
- Google 스타일을 따르는 한·영(한국어/영어) 병기 형식으로 `MarkdownExporter` 이니셜라이저 독스트링을 업데이트합니다.
- 가독성을 높이기 위해 `export_search_results` 독스트링과 파라미터 설명을 하나의 통합된 한·영(한국어/영어) 인라인 형식으로 축약·정렬합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize docstrings for the MarkdownExporter module in line with project documentation conventions.

Documentation:
- Update MarkdownExporter initializer docstring to bilingual KO/EN format following Google Style.
- Condense and align export_search_results docstrings and parameter descriptions into a unified bilingual KO/EN inline format for improved readability.

</details>