### PR TITLE
📝 docs [#12.3.20] - ㊲ 1차 개선 : FAISS 모듈 타입 캐스팅 주석 보강 및 검증 로직 추가

### DIFF
--- a/backend/faiss_search.py
+++ b/backend/faiss_search.py
@@ -56,7 +56,10 @@ class FAISSRetriever:
         if value < 1:
             raise ValueError(f"filter_expansion_factor must be >= 1, got {value}")
 
-        # 타입 체커를 만족시키기 위해 float로 변환 후 int로 캐스팅
+        # [KO] 타입 체커 오류(Real 형식이 int로 직접 변환되지 않는 문제)를 방지하고,
+        # numpy.float32, Decimal 등 다양한 숫자형 입력을 안전하게 처리하기 위해 float 변환 후 int로 캐스팅합니다.
+        # [EN] To prevent type checker errors (Real not directly convertible to int) and safely handle
+        # various numeric types like np.float32 or Decimal, we cast to float then int.
         normalized = int(float(value))
 
         if normalized < 1:
@@ -115,7 +118,8 @@ class FAISSRetriever:
         else:
             embeddings_np = embeddings.astype(np.float32)
 
-        # FAISS 인덱스에 추가 (타입 스텁 오류 무시)
+        # [KO] FAISS 타입 스텁 오류 무시: add()는 np.ndarray를 정상적으로 받지만, mypy 스텁에서는 인자 매칭(x)이 실패하는 문제가 있습니다.
+        # [EN] Ignore FAISS type stub error: add() accepts np.ndarray correctly at runtime, but mypy stub fails on argument matching (x).
         self.index.add(embeddings_np)  # type: ignore[call-arg]
 
         # 문서 dict 그대로 저장
@@ -165,7 +169,8 @@ class FAISSRetriever:
         query_vector = np.array([query_embedding], dtype=np.float32)
 
         search_k = min(self.index.ntotal, k * expansion if metadata_filter else k)
-        # FAISS 타입 스텁 오류 무시
+        # [KO] FAISS 타입 스텁 오류 무시: search()는 정상 동작하지만, mypy 스텁에서 필요한 인자(k, distances 등)가 누락되었다고 잘못 경고하는 문제가 있습니다.
+        # [EN] Ignore FAISS type stub error: search() works correctly at runtime, but mypy stub incorrectly warns about missing arguments (k, distances, etc).
         distances, indices = self.index.search(query_vector, search_k)  # type: ignore[call-arg]
 
         # 결과 반환 및 필터링
@@ -304,7 +309,14 @@ if __name__ == "__main__":
 
     # 3. 임베딩 생성
     embedding_generator = EmbeddingGenerator()
-    texts = [str(doc["content"]) for doc in docs]
+    texts = []
+    for doc in docs:
+        content = doc.get("content")
+        if not isinstance(content, str):
+            raise TypeError(
+                f"Document content must be a string, got {type(content).__name__}"
+            )
+        texts.append(content)
 
     # ✅ 수정: result에서 embeddings 추출!
     result = embedding_generator.generate_embeddings(texts)


### PR DESCRIPTION
- **[안정성]**
  - `_normalize_expansion_factor()`의 int(float()) 이중 캐스팅 이유
    - 다양한 숫자형 타입 지원 및 회귀 방지)를 주석으로 명시
  - 테스트 코드의 문서 content 임베딩 시, 암묵적 str() 강제 변환을 제거하고 isinstance() 기반의 명시적 타입 검증(Fail-Fast) 로직으로 교체하여 예기치 않은 데이터 오염 사전 차단

- **[유지보수성]**
  - `FAISS add()` 및 `search()` 메서드의 `# type: ignore[call-arg]` 사용 사유(mypy 타입 스텁 불일치)를 주석으로 기록하여 추후 제거 가능 시점 안내

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1698#pullrequestreview-4730008468)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

FAISS 인덱스 사용 방식과 형변환 동작을 명확히 하고, 임베딩 생성 전에 문서 콘텐츠에 대한 검증을 강화합니다.

Bug Fixes:
- 잘못된 데이터에 대해 빠르게 실패하도록, 임베딩 생성 시 문서 콘텐츠가 문자열 타입인지 명시적으로 검증하는 로직을 추가했습니다.

Enhancements:
- 다양한 숫자 입력 타입을 지원하고 타입 체커 문제를 피하기 위해, 확장 계수(expansion factors)에 대한 float→int 정규화의 근거를 문서화했습니다.
- 향후 유지보수를 돕기 위해, FAISS `add()` 및 `search()` 호출 시 mypy 타입 스텁의 call-arg 오류를 무시하는 이유를 명확히 설명했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify FAISS index usage and type casting behavior while tightening validation of document contents before embedding generation.

Bug Fixes:
- Add explicit string type validation for document content during embedding generation to fail fast on invalid data.

Enhancements:
- Document the rationale for float-to-int normalization of expansion factors to support diverse numeric input types and avoid type checker issues.
- Clarify the reasons for ignoring mypy type stub call-arg errors on FAISS add() and search() to aid future maintenance.

</details>