### PR TITLE
📝 docs [#12.3.20] - ㊲ 2차 개선 : FAISS 모듈 텍스트 검증 로직 분리 및 주석 압축

### DIFF
--- a/backend/faiss_search.py
+++ b/backend/faiss_search.py
@@ -56,10 +56,8 @@ class FAISSRetriever:
         if value < 1:
             raise ValueError(f"filter_expansion_factor must be >= 1, got {value}")
 
-        # [KO] 타입 체커 오류(Real 형식이 int로 직접 변환되지 않는 문제)를 방지하고,
-        # numpy.float32, Decimal 등 다양한 숫자형 입력을 안전하게 처리하기 위해 float 변환 후 int로 캐스팅합니다.
-        # [EN] To prevent type checker errors (Real not directly convertible to int) and safely handle
-        # various numeric types like np.float32 or Decimal, we cast to float then int.
+        # [KO] numpy.float32 등 다양한 숫자형의 안전한 int 캐스팅을 위해 float를 거침 (타입 체커 오류 방지)
+        # [EN] Cast via float to safely handle numeric types like np.float32 and prevent type errors.
         normalized = int(float(value))
 
         if normalized < 1:
@@ -69,6 +67,21 @@ class FAISSRetriever:
             )
 
         return normalized
+
+    @staticmethod
+    def _validate_content(content: Any) -> str:
+        """
+        [KO] 문서 내용이 텍스트 형식이 되도록 검증 및 변환하는 헬퍼 메서드입니다.
+        [EN] Helper method to validate and convert document content to a string.
+        """
+        if isinstance(content, str):
+            return content
+        if content is None or isinstance(content, (list, dict)):
+            raise TypeError(
+                f"Document content cannot be a structured or None type, got {type(content).__name__}"
+            )
+        # Enum, Path 등 __str__이 유효한 객체는 문자열로 변환 허용
+        return str(content)
 
     def __init__(
         self,
@@ -118,8 +131,8 @@ class FAISSRetriever:
         else:
             embeddings_np = embeddings.astype(np.float32)
 
-        # [KO] FAISS 타입 스텁 오류 무시: add()는 np.ndarray를 정상적으로 받지만, mypy 스텁에서는 인자 매칭(x)이 실패하는 문제가 있습니다.
-        # [EN] Ignore FAISS type stub error: add() accepts np.ndarray correctly at runtime, but mypy stub fails on argument matching (x).
+        # [KO] FAISS mypy 스텁(x 인자 매칭) 오류 무시 (런타임은 정상 동작)
+        # [EN] Ignore FAISS mypy stub error for arg matching
         self.index.add(embeddings_np)  # type: ignore[call-arg]
 
         # 문서 dict 그대로 저장
@@ -169,8 +182,8 @@ class FAISSRetriever:
         query_vector = np.array([query_embedding], dtype=np.float32)
 
         search_k = min(self.index.ntotal, k * expansion if metadata_filter else k)
-        # [KO] FAISS 타입 스텁 오류 무시: search()는 정상 동작하지만, mypy 스텁에서 필요한 인자(k, distances 등)가 누락되었다고 잘못 경고하는 문제가 있습니다.
-        # [EN] Ignore FAISS type stub error: search() works correctly at runtime, but mypy stub incorrectly warns about missing arguments (k, distances, etc).
+        # [KO] FAISS mypy 스텁(누락된 인자 경고) 오류 무시 (런타임은 정상 동작)
+        # [EN] Ignore FAISS mypy stub error for missing args
         distances, indices = self.index.search(query_vector, search_k)  # type: ignore[call-arg]
 
         # 결과 반환 및 필터링
@@ -309,14 +322,8 @@ if __name__ == "__main__":
 
     # 3. 임베딩 생성
     embedding_generator = EmbeddingGenerator()
-    texts = []
-    for doc in docs:
-        content = doc.get("content")
-        if not isinstance(content, str):
-            raise TypeError(
-                f"Document content must be a string, got {type(content).__name__}"
-            )
-        texts.append(content)
+    # 헬퍼 메서드를 통해 안전하게 검증 및 변환
+    texts = [FAISSRetriever._validate_content(doc.get("content")) for doc in docs]
 
     # ✅ 수정: result에서 embeddings 추출!
     result = embedding_generator.generate_embeddings(texts)


### PR DESCRIPTION
- **[설계]**
  - 문서 텍스트(content) 유효성 검사를 `_validate_content()` 헬퍼 메서드로 분리하여 재사용성 확보 및 정책 명시화
- **[호환성]**
  - 텍스트 검증 시 `str` 외에도 `Path`, `Enum` 등 `__str__` 변환이 유효한 객체는 수용
  - `list`, `dict`, `None`은 엄격히 차단하도록 검증 정책 유연화
- **[가독성]**
  - `_normalize_expansion_factor` 및 `FAISS` 타입 스텁 관련 이중 언어(KO/EN) 주석이 코드 가독성을 해치지 않도록 핵심 내용만 1~2줄로 압축
- **[최적화]**
  - 정적 분석(Sourcery) 경고 해소를 위해 테스트 코드의 텍스트 변환 로직을 리스트 컴프리헨션(List Comprehension)으로 간결하게 최적화

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1699#pullrequestreview-4730031248)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

문서 콘텐츠 유효성 검사를 재사용 가능한 헬퍼로 추출하고, FAISS 관련 주석을 더 명확하게 정리했습니다.

New Features:
- 임베딩 생성 전에 문서 콘텐츠를 검증하고 정규화하는 헬퍼 메서드를 도입했습니다.

Enhancements:
- `None` 및 구조화된 타입은 거부하면서, 의미 있는 문자열 표현을 가진 모든 객체를 허용하도록 콘텐츠 타입 처리 방식을 완화했습니다.
- 숫자 정규화와 FAISS mypy 스텁 관련 문제에 대한 이중 언어 주석을 압축하여 코드 가독성을 개선했습니다.

Tests:
- (임베딩 생성 변경 사항에서 암시된 대로) 정적 분석을 더 깔끔하게 하기 위해 리스트 컴프리헨션을 사용해 테스트 측 텍스트 추출 로직을 단순화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract document content validation into a reusable helper and streamline FAISS-related comments for clarity.

New Features:
- Introduce a helper method to validate and normalize document content before embedding generation.

Enhancements:
- Relax content type handling to accept any object with a meaningful string representation while rejecting None and structured types.
- Compress bilingual comments around numeric normalization and FAISS mypy stub issues to improve code readability.

Tests:
- Simplify test-side text extraction logic via list comprehension for cleaner static analysis (as implied by embedding generation changes).

</details>