### PR TITLE
📝 docs [#12.3.20] - ㊲ 3차 개선 : FAISS 모듈 동적 바인딩 및 비스칼라 데이터 검증 정책 강화

### DIFF
--- a/backend/faiss_search.py
+++ b/backend/faiss_search.py
@@ -18,6 +18,7 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
 import numbers
+from collections import abc
 from typing import Any, Dict, List, Optional, Union
 
 import faiss
@@ -71,16 +72,23 @@ class FAISSRetriever:
     @staticmethod
     def _validate_content(content: Any) -> str:
         """
-        [KO] 문서 내용이 텍스트 형식이 되도록 검증 및 변환하는 헬퍼 메서드입니다.
+        [KO] 문서 내용이 스칼라(문자열 등)인지 검증 및 변환하는 헬퍼 메서드입니다.
         [EN] Helper method to validate and convert document content to a string.
         """
         if isinstance(content, str):
             return content
-        if content is None or isinstance(content, (list, dict)):
+        if content is None:
+            raise TypeError("Document content cannot be None.")
+        # [KO] 문자열/바이트 이외의 Sequence(리스트, 튜플 등)나 Mapping(딕셔너리 등) 같은 비스칼라 데이터 구조는 임베딩할 수 없으므로 명시적으로 차단합니다.
+        # [EN] Explicitly block non-scalar data structures like Sequence (excluding str/bytes) or Mapping (dicts) as they cannot be meaningfully embedded.
+        if isinstance(content, abc.Mapping) or (
+            isinstance(content, abc.Sequence)
+            and not isinstance(content, (str, bytes, bytearray))
+        ):
             raise TypeError(
-                f"Document content cannot be a structured or None type, got {type(content).__name__}"
+                f"Document content must be a scalar value, not a structured container type like {type(content).__name__}"
             )
-        # Enum, Path 등 __str__이 유효한 객체는 문자열로 변환 허용
+        # Enum, Path 등 __str__이 유효한 단일(scalar) 객체는 문자열로 변환 허용
         return str(content)
 
     def __init__(
@@ -322,8 +330,8 @@ if __name__ == "__main__":
 
     # 3. 임베딩 생성
     embedding_generator = EmbeddingGenerator()
-    # 헬퍼 메서드를 통해 안전하게 검증 및 변환
-    texts = [FAISSRetriever._validate_content(doc.get("content")) for doc in docs]
+    # 서브클래싱 등을 고려하여 정적 클래스명 대신 인스턴스의 클래스 메서드를 통해 헬퍼를 호출합니다.
+    texts = [type(retriever)._validate_content(doc.get("content")) for doc in docs]
 
     # ✅ 수정: result에서 embeddings 추출!
     result = embedding_generator.generate_embeddings(texts)


### PR DESCRIPTION
- **[확장성]**
  - 테스트 코드 내 헬퍼 메서드 호출을 하드코딩된 정적 클래스명 대신 `type()`을 활용한 동적 바인딩(Dynamic Binding)으로 변경하여 서브클래싱(Subclassing) 유연성 확보
- **[안정성]**
  - `_validate_content()` 헬퍼에서 단순 `list`/`dict` 차단을 넘어 `collections.abc`의 Sequence 및 Mapping 기반 검증을 도입하여 모든 비스칼라(Non-scalar) 컨테이너 타입 원천 차단
- **[가독성]**
  - TypeError 발생 시 '스칼라 값만 허용된다'는 명확한 메시지를 제공하여 문서 변환 정책의 의도를 코드 레벨에서 명시적으로 표현

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1700#pullrequestreview-4730050160)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

FAISS 검색을 위한 문서 콘텐츠 검증을 강화하고, 서브클래스에서 헬퍼 사용을 보다 유연하게 만들었습니다.

Bug Fixes:
- 문서 콘텐츠로 `None` 및 비스칼라 컨테이너 타입이 사용되지 않도록 방지하여, 스칼라 기반 임베딩만 허용합니다.

Enhancements:
- `collections.abc`를 사용해 콘텐츠 타입 검사를 강화하여, 시퀀스와 매핑 타입을 명시적으로 차단하면서 문자열로 유효하게 표현 가능한 스칼라 객체는 허용합니다.
- 기본 클래스를 하드코딩하는 대신, 검색기 인스턴스의 클래스를 통해 콘텐츠 검증 헬퍼를 호출하도록 변경하여 서브클래싱을 지원합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen document content validation for FAISS retrieval and make helper usage more flexible for subclasses.

Bug Fixes:
- Prevent None and non-scalar container types from being used as document content, enforcing scalar-only embeddings.

Enhancements:
- Tighten content type checks using collections.abc to explicitly block sequences and mappings while allowing scalar objects with valid string representations.
- Invoke the content validation helper via the retriever instance's class to support subclassing instead of hardcoding the base class.

</details>