### PR TITLE
📝 docs [#12.3.20] - ㊲ 4차 개선 : FAISS 모듈 비스칼라 차단 강화 및 인스턴스 헬퍼 적용

### DIFF
--- a/backend/faiss_search.py
+++ b/backend/faiss_search.py
@@ -69,8 +69,7 @@ class FAISSRetriever:
 
         return normalized
 
-    @staticmethod
-    def _validate_content(content: Any) -> str:
+    def _validate_content(self, content: Any) -> str:
         """
         [KO] 문서 내용이 스칼라(문자열 등)인지 검증 및 변환하는 헬퍼 메서드입니다.
         [EN] Helper method to validate and convert document content to a string.
@@ -79,11 +78,10 @@ class FAISSRetriever:
             return content
         if content is None:
             raise TypeError("Document content cannot be None.")
-        # [KO] 문자열/바이트 이외의 Sequence(리스트, 튜플 등)나 Mapping(딕셔너리 등) 같은 비스칼라 데이터 구조는 임베딩할 수 없으므로 명시적으로 차단합니다.
-        # [EN] Explicitly block non-scalar data structures like Sequence (excluding str/bytes) or Mapping (dicts) as they cannot be meaningfully embedded.
-        if isinstance(content, abc.Mapping) or (
-            isinstance(content, abc.Sequence)
-            and not isinstance(content, (str, bytes, bytearray))
+        # [KO] 문자열/바이트 이외의 Iterable(리스트, 딕셔너리, NumPy 배열, Pandas DataFrame 등) 객체는 임베딩할 수 없으므로 명시적으로 차단합니다.
+        # [EN] Explicitly block non-scalar Iterable structures (e.g. lists, dicts, np.ndarray, pandas DataFrames).
+        if isinstance(content, abc.Iterable) and not isinstance(
+            content, (str, bytes, bytearray)
         ):
             raise TypeError(
                 f"Document content must be a scalar value, not a structured container type like {type(content).__name__}"
@@ -330,8 +328,8 @@ if __name__ == "__main__":
 
     # 3. 임베딩 생성
     embedding_generator = EmbeddingGenerator()
-    # 서브클래싱 등을 고려하여 정적 클래스명 대신 인스턴스의 클래스 메서드를 통해 헬퍼를 호출합니다.
-    texts = [type(retriever)._validate_content(doc.get("content")) for doc in docs]
+    # 서브클래싱 및 인스턴스별 동작 오버라이딩을 지원하기 위해 인스턴스 메서드로 호출합니다.
+    texts = [retriever._validate_content(doc.get("content")) for doc in docs]
 
     # ✅ 수정: result에서 embeddings 추출!
     result = embedding_generator.generate_embeddings(texts)


### PR DESCRIPTION
- **[확장성]**
  - 문서 검증 헬퍼(_validate_content)를 인스턴스 메서드로 전환
  - 향후 인스턴스별 유효성 검사 정책 오버라이딩 및 설정 주입이 가능하도록 유연성 확보
- **[안정성]**
  - 비스칼라 구조(Non-scalar) 차단 범위를 `collections.abc.Iterable` 기반으로 격상
  - 기본 자료형(list, dict)뿐만 아니라 `np.ndarray`, `Pandas DataFrame` 등 임베딩이 불가능한 모든 복합 데이터 타입의 진입을 원천 차단(Fail-Fast)

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1701#pullrequestreview-4730063622)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

개별 검색기 인스턴스마다 도우미를 재정의할 수 있도록 하고, 비스칼라 입력 차단 범위를 모든 반복 가능한 컨테이너 유형으로 확장하여 FAISS 문서 내용 검증을 개선합니다.

Bug Fixes:
- 임베딩 전에 모든 비스칼라 반복 가능한 문서 내용을 조기에 실패하도록 검증을 강화했습니다.

Enhancements:
- 서브클래스별 검증 동작을 지원하기 위해 문서 내용 검증 도우미를 인스턴스 메서드로 변환했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve FAISS document content validation by making the helper overridable per retriever instance and broadening non-scalar input blocking to all iterable container types.

Bug Fixes:
- Strengthen validation to fail fast on all non-scalar iterable document contents before embedding.

Enhancements:
- Convert the document content validation helper to an instance method to support subclass-specific validation behavior.

</details>