### PR TITLE
📝 docs [#12.3.20] - ㊲ 5차 개선 : FAISS 모듈 컨테이너 검증 고도화 및 오탐(False Positive) 방지

### DIFF
--- a/backend/faiss_search.py
+++ b/backend/faiss_search.py
@@ -78,14 +78,31 @@ class FAISSRetriever:
             return content
         if content is None:
             raise TypeError("Document content cannot be None.")
-        # [KO] 문자열/바이트 이외의 Iterable(리스트, 딕셔너리, NumPy 배열, Pandas DataFrame 등) 객체는 임베딩할 수 없으므로 명시적으로 차단합니다.
-        # [EN] Explicitly block non-scalar Iterable structures (e.g. lists, dicts, np.ndarray, pandas DataFrames).
-        if isinstance(content, abc.Iterable) and not isinstance(
-            content, (str, bytes, bytearray)
-        ):
+        # [KO] 전형적인 컨테이너(Collection/Mapping/Sequence/Set) 및 NumPy/Pandas 객체는 문서 내용으로 사용할 수 없으므로 차단합니다.
+        #      단, 문자열/바이트와 같은 스칼라형 값은 허용합니다. __iter__만 구현한 커스텀 스칼라형 타입(예: 일부 Path 객체)은 차단 대상이 아닙니다.
+        # [EN] Block typical container-like structures (Collection/Mapping/Sequence/Set) and NumPy/Pandas objects as document content.
+        #      Scalar text-like values (str/bytes/bytearray) remain allowed; custom scalar-like types that merely implement __iter__
+        #      are not rejected solely for being Iterable.
+        scalar_like = isinstance(content, (str, bytes, bytearray))
+        container_like = isinstance(
+            content,
+            (
+                abc.Mapping,
+                abc.Sequence,
+                abc.Set,
+                abc.Collection,
+            ),
+        )
+        module_name = getattr(type(content), "__module__", "")
+        is_numpy_or_pandas = module_name.startswith("numpy") or module_name.startswith(
+            "pandas"
+        )
+
+        if (container_like or is_numpy_or_pandas) and not scalar_like:
             raise TypeError(
                 f"Document content must be a scalar value, not a structured container type like {type(content).__name__}"
             )
+
         # Enum, Path 등 __str__이 유효한 단일(scalar) 객체는 문자열로 변환 허용
         return str(content)
 


### PR DESCRIPTION
- **[안정성]**
  - `Iterable` 기반의 광범위한 차단 로직을 정교화
  - 단순 `__iter__` 구현체(커스텀 스칼라, Path 등)가 구조화된 컨테이너로 오인되어 차단되는 버그 리스크(False Positive) 원천 제거
- **[정밀도]**
  - `abc.Collection`/`Mapping`/`Sequence`/`Set` 기반의 엄격한 컬렉션 검증과 `__module__` 네임스페이스 기반의 `NumPy`/`Pandas` 객체 탐지를 결합
  - 유효한 스칼라는 보호하되 임베딩 불가 컨테이너만 핀셋 차단하도록 견고함 향상

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1702#pullrequestreview-4730080060)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

FAISS 문서 콘텐츠 유효성 검사를 개선하여 스칼라 값과 컨테이너 유사 구조 및 데이터프레임을 더 정확하게 구분합니다.

Bug Fixes:
- 사용자 정의 스칼라 유사 iterable(예: `Path` 인스턴스)가 임베딩 불가능한 컨테이너로 잘못 판정되어 거부되는 오탐을 방지합니다.

Enhancements:
- 표준 컬렉션 타입과 NumPy/Pandas 객체를 대상으로 콘텐츠 차단 로직을 강화하면서, 텍스트 유사 스칼라 값은 명시적으로 허용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine FAISS document content validation to more precisely distinguish scalar values from container-like structures and dataframes.

Bug Fixes:
- Prevent false positives where custom scalar-like iterables (e.g. Path instances) were incorrectly rejected as non-embeddable containers.

Enhancements:
- Strengthen content blocking logic by targeting standard collection types and NumPy/Pandas objects while explicitly allowing text-like scalars.

</details>