### PR TITLE
📝 docs [#12.3.20] - ㊲ 6차 개선 : FAISS 컨테이너 검증 중복 제거 및 NumPy/Pandas 타입 체크 정밀화

### DIFF
--- a/backend/faiss_search.py
+++ b/backend/faiss_search.py
@@ -78,27 +78,24 @@ class FAISSRetriever:
             return content
         if content is None:
             raise TypeError("Document content cannot be None.")
-        # [KO] 전형적인 컨테이너(Collection/Mapping/Sequence/Set) 및 NumPy/Pandas 객체는 문서 내용으로 사용할 수 없으므로 차단합니다.
-        #      단, 문자열/바이트와 같은 스칼라형 값은 허용합니다. __iter__만 구현한 커스텀 스칼라형 타입(예: 일부 Path 객체)은 차단 대상이 아닙니다.
-        # [EN] Block typical container-like structures (Collection/Mapping/Sequence/Set) and NumPy/Pandas objects as document content.
-        #      Scalar text-like values (str/bytes/bytearray) remain allowed; custom scalar-like types that merely implement __iter__
-        #      are not rejected solely for being Iterable.
+        # [KO] 전형적인 컨테이너 타입(abc.Collection의 서브클래스인 Mapping, Sequence, Set 등을 모두 포함) 및
+        #      NumPy/Pandas의 배열형 객체(ndarray, DataFrame, Series)는 임베딩 대상이 아니므로 명시적으로 차단합니다.
+        #      단, str/bytes/bytearray와 같은 스칼라형 값과, 단순히 __iter__만 구현한 커스텀 타입은 차단 대상이 아닙니다.
+        # [EN] Block container types (abc.Collection covers Mapping, Sequence, Set and their subclasses) and
+        #      specific NumPy/Pandas array-like objects (ndarray, DataFrame, Series) as they are not embeddable.
+        #      Scalar text types (str/bytes/bytearray) and custom types that merely implement __iter__ remain allowed.
         scalar_like = isinstance(content, (str, bytes, bytearray))
-        container_like = isinstance(
-            content,
-            (
-                abc.Mapping,
-                abc.Sequence,
-                abc.Set,
-                abc.Collection,
-            ),
-        )
-        module_name = getattr(type(content), "__module__", "")
-        is_numpy_or_pandas = module_name.startswith("numpy") or module_name.startswith(
-            "pandas"
+        # abc.Collection은 Mapping/Sequence/Set을 모두 포함하므로 하나로 충분합니다.
+        # abc.Collection covers abc.Mapping, abc.Sequence, and abc.Set as subclasses.
+        container_like = isinstance(content, abc.Collection) and not scalar_like
+        # 모듈명 대신 구체적인 배열형 타입만 명시적으로 차단하여 np.float32 같은 스칼라 유사 타입이 잘못 차단되는 것을 방지합니다.
+        # Use explicit type checks (not module name) to avoid blocking scalar-like types such as np.float32.
+        is_array_like = isinstance(content, np.ndarray) or type(content).__name__ in (
+            "DataFrame",
+            "Series",
         )
 
-        if (container_like or is_numpy_or_pandas) and not scalar_like:
+        if container_like or is_array_like:
             raise TypeError(
                 f"Document content must be a scalar value, not a structured container type like {type(content).__name__}"
             )


### PR DESCRIPTION
- **[가독성]**
  - `abc.Collection`이 `Mapping`/`Sequence`/`Set`을 상속 포함하므로 중복 나열을 제거하고 Collection 단일 체크로 통합
  - 관계 근거를 주석으로 명시
- **[정밀도]**
  - 모듈명 `prefix` 기반의 광범위한 `NumPy`/`Pandas` 차단 폐기
  - 실제 배열형 객체(`np.ndarray`, `DataFrame`, `Series`)만 타입 기반으로 명시적 차단하여 `np.float32` 등 스칼라 유사 타입의 오탐(False Positive) 방지

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1703#pullrequestreview-4730096538)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

FAISS 문서 콘텐츠 검증을 정교하게 다듬어 컨테이너 감지를 단순화하고 NumPy/Pandas 타입 차단을 더 정밀하게 합니다.

버그 수정:
- 스칼라 형태의 NumPy 값(예: `np.float32`)이 임베딩 불가능한 콘텐츠로 잘못 판정되어 거부되는 문제를 방지합니다.

개선 사항:
- 컨테이너 체크를 `abc.Collection` 기반으로 통합하고, 알려진 배열형 NumPy/Pandas 객체를 명시적으로 차단하여 검증의 명확성과 견고성을 향상합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine FAISS document content validation to simplify container detection and make NumPy/Pandas type blocking more precise.

Bug Fixes:
- Prevent scalar-like NumPy values (e.g. np.float32) from being incorrectly rejected as non-embeddable content.

Enhancements:
- Unify container checks under abc.Collection and explicitly block known array-like NumPy/Pandas objects to improve validation clarity and robustness.

</details>