### PR TITLE
📝 docs [#12.3.20] - ㊲ 7차 개선 : FAISS pandas 타입 감지 안전성 강화 및 에러 메시지 명확화

### DIFF
--- a/backend/faiss_search.py
+++ b/backend/faiss_search.py
@@ -82,22 +82,31 @@ class FAISSRetriever:
         #      NumPy/Pandas의 배열형 객체(ndarray, DataFrame, Series)는 임베딩 대상이 아니므로 명시적으로 차단합니다.
         #      단, str/bytes/bytearray와 같은 스칼라형 값과, 단순히 __iter__만 구현한 커스텀 타입은 차단 대상이 아닙니다.
         # [EN] Block container types (abc.Collection covers Mapping, Sequence, Set and their subclasses) and
-        #      specific NumPy/Pandas array-like objects (ndarray, DataFrame, Series) as they are not embeddable.
+        #      NumPy/Pandas array-like objects (ndarray, DataFrame, Series) as they are not embeddable.
         #      Scalar text types (str/bytes/bytearray) and custom types that merely implement __iter__ remain allowed.
         scalar_like = isinstance(content, (str, bytes, bytearray))
         # abc.Collection은 Mapping/Sequence/Set을 모두 포함하므로 하나로 충분합니다.
         # abc.Collection covers abc.Mapping, abc.Sequence, and abc.Set as subclasses.
         container_like = isinstance(content, abc.Collection) and not scalar_like
-        # 모듈명 대신 구체적인 배열형 타입만 명시적으로 차단하여 np.float32 같은 스칼라 유사 타입이 잘못 차단되는 것을 방지합니다.
-        # Use explicit type checks (not module name) to avoid blocking scalar-like types such as np.float32.
-        is_array_like = isinstance(content, np.ndarray) or type(content).__name__ in (
-            "DataFrame",
-            "Series",
-        )
+        # [KO] numpy.ndarray는 직접 isinstance로 확인하고, pandas는 선택적 의존성이므로 try/except로 안전하게 처리합니다.
+        #      type().__name__ 기반 감지는 동명의 비관련 클래스를 오탐하거나 서브클래스를 누락할 수 있으므로 사용하지 않습니다.
+        # [EN] Check np.ndarray directly; pandas is an optional dep so handle via try/except.
+        #      Avoid type().__name__ matching which can cause false positives or miss subclasses.
+        is_array_like = isinstance(content, np.ndarray)
+        try:
+            import pandas as pd  # noqa: PLC0415
+
+            is_array_like = is_array_like or isinstance(
+                content, (pd.DataFrame, pd.Series)
+            )
+        except ImportError:  # sourcery skip: use-contextlib-suppress
+            pass  # pandas가 설치되지 않은 환경에서는 검사를 건너뜁니다. / pandas not installed; skip check.
 
         if container_like or is_array_like:
             raise TypeError(
-                f"Document content must be a scalar value, not a structured container type like {type(content).__name__}"
+                f"Document content must be a plain string or scalar value, not a "
+                f"container or array-like type ({type(content).__name__}). "
+                f"Collection, ndarray, DataFrame, and Series are not supported."
             )
 
         # Enum, Path 등 __str__이 유효한 단일(scalar) 객체는 문자열로 변환 허용


### PR DESCRIPTION
- **[안정성]**
  - `type().__name__` 기반 pandas 감지 폐기
  - `try`/`except` `ImportError` 내 `isinstance`(pd.DataFrame, pd.Series) 방식으로 교체하여 동명 비관련 클래스 오탐 및 서브클래스 누락 방지
- **[가독성]**
  - `TypeError` 메시지를 '컨테이너 또는 배열형 타입' 거부 대상 목록 명시로 보완하여 `NumPy`/`Pandas` 객체도 거부 대상임을 직관적으로 안내
- **[호환성]**
  - `pandas`가 선택적 의존성인 환경(미설치)에서도 `ImportError` 없이 안전하게 동작하도록 처리
- **[정적분석]**
  - 이중 언어 주석 보존을 위해 Sourcery SIM105 경고를 sourcery skip 디렉티브로 명시적 억제

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1704#pullrequestreview-4730118771)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

NumPy/Pandas 타입과 관련된 FAISS 콘텐츠 검증을 강화하여 잘못된 판정(오탐)을 방지하고 오류 보고를 명확히 합니다.

버그 수정:
- DataFrame/Series 콘텐츠 타입을 감지할 때, Pandas가 아닌 클래스가 잘못 판별되거나 Pandas 서브클래스가 누락되는 문제를 방지합니다.
- ImportError를 피하여, pandas가 설치되지 않은 환경에서도 FAISS 콘텐츠 검증이 안전하게 작동하도록 합니다.

개선 사항:
- 지원되지 않는 컨테이너 및 배열형 타입(NumPy ndarray와 Pandas DataFrame/Series 포함)을 명시적으로 지적하도록 TypeError 메시지를 명확히 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen FAISS content validation around NumPy/Pandas types to avoid false positives and clarify error reporting.

Bug Fixes:
- Prevent misidentification of non-Pandas classes and omission of Pandas subclasses when detecting DataFrame/Series content types.
- Ensure FAISS content validation works safely in environments where pandas is not installed by avoiding ImportError.

Enhancements:
- Clarify TypeError messages to explicitly call out unsupported container and array-like types including NumPy ndarrays and Pandas DataFrame/Series.

</details>