### PR TITLE
⚡ perf [#12.3.20] - ㊲ 9차 개선 : FAISS pandas 지연 로딩(Lazy Load) 캐시 패턴 적용 및 검증 로직 정리

### DIFF
--- a/backend/faiss_search.py
+++ b/backend/faiss_search.py
@@ -17,9 +17,10 @@ logger = logging.getLogger(__name__)
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+import functools
 import numbers
 from collections import abc
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import faiss
 import numpy as np
@@ -27,14 +28,18 @@ import numpy as np
 from backend.embedding import EmbeddingGenerator
 from backend.utils import check_metadata_match
 
-# [KO] pandas는 선택적 의존성이므로 모듈 레벨에서 한 번만 임포트하여 호출마다 발생하는 import 비용을 방지합니다.
-# [EN] pandas is optional; import once at module level to avoid per-call import overhead.
-try:
-    import pandas as _pd
 
-    _PANDAS_ARRAY_TYPES: tuple = (_pd.DataFrame, _pd.Series)
-except ImportError:  # sourcery skip: use-contextlib-suppress
-    _PANDAS_ARRAY_TYPES = ()  # pandas 미설치 환경 / pandas not installed
+@functools.lru_cache(maxsize=None)
+def _get_pandas_array_types() -> Tuple[type, ...]:
+    """[KO] pandas DataFrame/Series 타입을 첫 호출 시점에 1회만 로드하고 이후 캐시합니다.
+    [EN] Lazily loads pandas DataFrame/Series types on first call and caches the result.
+    """
+    try:
+        import pandas as _pd  # noqa: PLC0415
+
+        return (_pd.DataFrame, _pd.Series)
+    except ImportError:  # sourcery skip: use-contextlib-suppress
+        return ()  # pandas 미설치 환경 / pandas not installed
 
 
 class FAISSRetriever:
@@ -97,19 +102,17 @@ class FAISSRetriever:
         # abc.Collection은 Mapping/Sequence/Set을 모두 포함하므로 하나로 충분합니다.
         # abc.Collection covers abc.Mapping, abc.Sequence, and abc.Set as subclasses.
         container_like = isinstance(content, abc.Collection) and not scalar_like
-        # [KO] numpy.ndarray 및 pandas 배열형 타입은 모듈 레벨 상수(_PANDAS_ARRAY_TYPES)로 캐시하여 호출마다 import 비용이 발생하지 않도록 합니다.
-        # [EN] np.ndarray and pandas array-like types are checked via the module-level constant _PANDAS_ARRAY_TYPES
-        #      to avoid per-call import overhead.
-        is_array_like = isinstance(content, np.ndarray) or (
-            bool(_PANDAS_ARRAY_TYPES) and isinstance(content, _PANDAS_ARRAY_TYPES)
-        )
+        # [KO] numpy.ndarray 및 pandas 배열형 타입은 첫 호출 시 _get_pandas_array_types()를 통해 지연 로드 및 캐시합니다.
+        # [EN] np.ndarray and pandas array-like types use _get_pandas_array_types() for lazy-loaded, cached checking.
+        is_array_like = isinstance(content, (np.ndarray, *_get_pandas_array_types()))
 
         if container_like or is_array_like:
-            # [KO] 에러 메시지는 실제 타입명을 동적으로 표시하여 검증 로직 변경 시에도 메시지가 자동으로 일치하도록 합니다.
-            # [EN] Use the actual type name dynamically so the message stays accurate as validation logic evolves.
+            # [KO] 실제 타입명을 동적으로 표시하고, 대표적인 차단 타입 예시를 비전체 힌트로 제공하여 디버깅을 돕습니다.
+            # [EN] Show the actual type dynamically; add a non-exhaustive hint of common blocked types for easier debugging.
             raise TypeError(
                 f"Document content must be a plain string or scalar value. "
-                f"Got unsupported type {type(content).__name__!r}."
+                f"Got unsupported type {type(content).__name__!r} "
+                f"(e.g. list, dict, ndarray, DataFrame, and Series are not supported)."
             )
 
         # Enum, Path 등 __str__이 유효한 단일(scalar) 객체는 문자열로 변환 허용

--- a/backend/faiss_search.py
+++ b/backend/faiss_search.py
@@ -30,16 +30,19 @@ from backend.utils import check_metadata_match
 
 
 @functools.lru_cache(maxsize=None)
-def _get_pandas_array_types() -> Tuple[type, ...]:
-    """[KO] pandas DataFrame/Series 타입을 첫 호출 시점에 1회만 로드하고 이후 캐시합니다.
-    [EN] Lazily loads pandas DataFrame/Series types on first call and caches the result.
+def _get_array_like_types() -> Tuple[type, ...]:
+    """[KO] numpy.ndarray 및 pandas DataFrame/Series 타입을 포함하는 완전한 투플을 첫 호출 시 1회만 생성하고 이후 재사용합니다.
+    [EN] Lazily builds and caches a full tuple of array-like types (numpy.ndarray + pandas types) on first call.
+         Reusing this cached tuple avoids per-call tuple allocation in _validate_content.
     """
+    pandas_types: Tuple[type, ...] = ()
     try:
         import pandas as _pd  # noqa: PLC0415
 
-        return (_pd.DataFrame, _pd.Series)
+        pandas_types = (_pd.DataFrame, _pd.Series)
     except ImportError:  # sourcery skip: use-contextlib-suppress
-        return ()  # pandas 미설치 환경 / pandas not installed
+        pass  # pandas 미설치 환경 / pandas not installed
+    return (np.ndarray, *pandas_types)
 
 
 class FAISSRetriever:
@@ -102,9 +105,9 @@ class FAISSRetriever:
         # abc.Collection은 Mapping/Sequence/Set을 모두 포함하므로 하나로 충분합니다.
         # abc.Collection covers abc.Mapping, abc.Sequence, and abc.Set as subclasses.
         container_like = isinstance(content, abc.Collection) and not scalar_like
-        # [KO] numpy.ndarray 및 pandas 배열형 타입은 첫 호출 시 _get_pandas_array_types()를 통해 지연 로드 및 캐시합니다.
-        # [EN] np.ndarray and pandas array-like types use _get_pandas_array_types() for lazy-loaded, cached checking.
-        is_array_like = isinstance(content, (np.ndarray, *_get_pandas_array_types()))
+        # [KO] numpy.ndarray 및 pandas 배열형 타입은 _get_array_like_types()를 통해 첫 호출 시 1회만 투플을 생성하고 이후 재사용합니다.
+        # [EN] _get_array_like_types() builds the full type tuple once and caches it, avoiding per-call allocation.
+        is_array_like = isinstance(content, _get_array_like_types())
 
         if container_like or is_array_like:
             # [KO] 실제 타입명을 동적으로 표시하고, 대표적인 차단 타입 예시를 비전체 힌트로 제공하여 디버깅을 돕습니다.


### PR DESCRIPTION
- **[성능]**
  - 모듈 레벨 즉시 `pandas import`를 `functools.lru_cache` 기반 `_get_pandas_array_types()` 헬퍼로 교체
  - 첫 호출 시점에만 1회 로드되는 지연 로딩(Lazy Load) + 캐시 패턴 구현
- **[간결성]**
  - `isinstance()` 호출 전의 불필요한 `bool()` 가드를 제거하여 코드 단순화
  - `isinstance`는 빈 튜플을 안전하게 처리
- **[디버깅]**
  - `TypeError` 메시지에 실제 타입명(동적)과 함께 대표적인 차단 타입 예시를 비전체 힌트로 추가하여 호출자 디버깅 편의 향상
- **[정적분석]**
  - 두 개의 `isinstance` 호출을 `tuple unpacking`으로 단일 호출로 병합
  - Sourcery 경고(merge-isinstance-calls) 완전 해소

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1706#pullrequestreview-4730152314)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

FAISS 콘텐츠 검증을 위해 pandas 배열 타입을 지연 로딩하고 캐시하는 감지 로직을 도입하고, 지원되지 않는 문서 콘텐츠에 대한 타입 검사와 오류 메시지를 강화합니다.

Enhancements:
- 모듈 수준에서 pandas를 바로 import하던 방식을, DataFrame/Series 타입을 지연 로딩 및 캐시하는 `lru_cache` 기반 헬퍼로 교체합니다.
- numpy와 pandas에 대한 `isinstance` 로직을 통합하고 중복되는 보호 로직을 제거하여 배열 유사 타입 검사 과정을 단순화합니다.
- 잘못된 문서 콘텐츠에 대해 동적 타입 이름과 대표적인 차단 타입 힌트를 포함하도록 `TypeError` 메시지를 풍부하게 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce lazy-loaded, cached detection of pandas array types for FAISS content validation and tighten type checking and error messaging for unsupported document content.

Enhancements:
- Replace module-level pandas import with an lru_cache-backed helper that lazily loads and caches DataFrame/Series types.
- Simplify array-like type checks by consolidating numpy and pandas isinstance logic and removing redundant guards.
- Enrich TypeError messages for invalid document content with dynamic type names and representative blocked type hints.

</details>