### PR TITLE
🛠️ fix [#12.3.20] - ㊳ 1차 개선 : Docstring 오탈자 수정 및 타입 힌트 고도화

### DIFF
--- a/backend/bm25_search.py
+++ b/backend/bm25_search.py
@@ -23,7 +23,17 @@ import logging
 import pickle
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    TypedDict,
+    Union,
+)
 
 from rank_bm25 import BM25Okapi
 
@@ -73,7 +83,7 @@ def _format_samples(samples: List[str], total_count: int, max_visible: int) -> s
 
     Args:
         samples: [KO] 포맷팅할 샘플 문자열 리스트 / [EN] List of sample strings to format
-        total_count: [KO] 실제 전체 샘플 충 개수 / [EN] Total number of samples
+        total_count: [KO] 전체 샘플 총 개수 / [EN] Total number of samples
         max_visible: [KO] 로그에 표시할 최대 샘플 수 / [EN] Maximum number of samples to display
 
     Returns:
@@ -101,7 +111,7 @@ class BM25Retriever:
 
     def __init__(
         self,
-        tokenizer: Optional[Callable[[str], List[str]]] = None,
+        tokenizer: Optional[Callable[[str], Iterable[str]]] = None,
         coerce_all_strings: bool = False,
     ):
         """
@@ -110,12 +120,12 @@ class BM25Retriever:
 
         Args:
             tokenizer: [KO] 사용자 지정 토크나이저. 반환되는 이터러블/제너레이터는 즉시 `list()`로 소비됩니다. / [EN] Custom tokenizer. Returned iterables/generators are immediately consumed with `list()`.
-            coerce_all_strings: [KO] `dict`나 `list` 등 비문자열 객체가 content로 들어왔을 때, 조용히 건너뜨지 않고 무조건 `str()`로 강제 변환할지 여부. / [EN] Whether to forcibly cast non-string content to `str()` instead of silently skipping it.
+            coerce_all_strings: [KO] `dict`나 `list` 등 비문자열 객체가 content로 들어왔을 때, 조용히 건너뛰지 않고 무조건 `str()`로 강제 변환할지 여부. / [EN] Whether to forcibly cast non-string content to `str()` instead of silently skipping it.
         """
         self.bm25: Optional[BM25Okapi] = None
         self.documents: List[Dict[str, Any]] = []
         self.coerce_all_strings = coerce_all_strings
-        self.tokenizer: Callable[[str], List[str]]
+        self.tokenizer: Callable[[str], Iterable[str]]
 
         # 외부 토크나이저 주입 처리 방어
         if tokenizer is not None and callable(tokenizer):
@@ -129,7 +139,7 @@ class BM25Retriever:
 
     def _default_tokenize(self, text: str) -> List[str]:
         """
-        [KO] 간단한 떠어쓰기 기반 토크나이징 기본 구현입니다.
+        [KO] 간단한 띄어쓰기 기반 토크나이징 기본 구현입니다.
         [EN] Simple whitespace-based tokenization (default implementation).
         """
         # _safe_tokenize에서 이미 str 타입 여부 및 빈 문자열을 검증하므로 바로 처리
@@ -202,7 +212,7 @@ class BM25Retriever:
         [EN] Filters valid documents for index construction and collects statistics.
 
         Returns:
-            Tuple[List[Dict], List[List[str]], FilterStats]:
+            Tuple[List[Dict[str, Any]], List[List[str]], FilterStats]:
                 [KO] (유효 문서 리스트, 토큰화된 코퍼스, 필터링 통계) 튜플 /
                 [EN] Tuple of (valid document list, tokenized corpus, filter statistics)
         """
@@ -335,7 +345,7 @@ class BM25Retriever:
 
         Args:
             documents: [KO] 문서 dict 리스트 (content, metadata 포함) / [EN] List of document dicts (including content, metadata)
-            rebuild: [KO] 문서 추가 후 즐시 인덱스를 재빌드할지 여부 / [EN] Whether to immediately rebuild the index after adding documents
+            rebuild: [KO] 문서 추가 후 즉시 인덱스를 재빌드할지 여부 / [EN] Whether to immediately rebuild the index after adding documents
 
         Returns:
             AddDocumentsStats:
@@ -409,7 +419,7 @@ class BM25Retriever:
             metadata_filter: [KO] 메타데이터 필터 조건 (예: {"category": "Projects"}) / [EN] Metadata filter condition dictionary (e.g. {"category": "Projects"})
 
         Returns:
-            List[Dict]: [KO] 검색 결과 리스트 (content, metadata, score 포함) / [EN] List of search results (including content, metadata, score)
+            List[Dict[str, Any]]: [KO] 검색 결과 리스트 (content, metadata, score 포함) / [EN] List of search results (including content, metadata, score)
         """
         if not isinstance(query, str):
             logger.warning(
@@ -468,7 +478,7 @@ class BM25Retriever:
 
     def clear(self):
         """
-        [KO] FAISS 인덱스와 저장된 문서를 모두 초기화합니다.
+        [KO] BM25 인덱스와 저장된 문서를 모두 초기화합니다.
         [EN] Clears the BM25 index and all stored documents.
         """
         self.bm25 = None


### PR DESCRIPTION
- [Docs]
  - `_format_samples`, `_default_tokenize`, `add_documents` 내 한글 오탈자
  - (충→총, 떠어쓰기→띄어쓰기, 즐시→즉시, 건너뜨지→건너뛰지) 일괄 수정
  - clear() 메서드 내 잘못된 엔진 참조 : FAISS 인덱스 → BM25 인덱스 정정
- [Type]
  - `tokenizer` 타입 힌트를 `Callable[[str]`, `List[str]]`에서 `Iterable[str]`로 확장하여 외부 제너레이터 호환성 명시
  - `_filter_documents_for_index` 및 `search`의 반환 타입 명세를 `Dict[str, Any]`로 구체화하여 정적 분석 정합성 확보

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1708#pullrequestreview-4732521454)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

더 나은 정적 분석과 보다 명확한 동작을 위해 BM25 리트리버의 타입 지정과 문서를 정제합니다.

버그 수정:
- `clear()` 메서드의 도크스트링에서 FAISS 대신 BM25 인덱스를 참조하도록 수정했습니다.

개선 사항:
- 토크나이저 타입 힌트를 문자열의 이터러블(iterable)을 모두 허용하도록 확장하여 외부 제너레이터와의 호환성을 개선했습니다.
- 문서 필터링과 검색 결과의 반환 타입 힌트를 `Dict[str, Any]`로 엄격하게 지정하여 정적 분석의 정확성을 높였습니다.

문서:
- BM25 리트리버 헬퍼 전반에 걸쳐 여러 한국어 도크스트링 오타를 수정하고, 파라미터 및 반환 값 설명을 더 명확하게 다듬었습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine BM25 retriever typing and documentation for better static analysis and clearer behavior.

Bug Fixes:
- Correct the clear() method docstring to reference the BM25 index instead of FAISS.

Enhancements:
- Broaden the tokenizer type hint to accept any iterable of strings, improving compatibility with external generators.
- Tighten return type hints for document filtering and search results to use Dict[str, Any] for more precise static analysis.

Documentation:
- Fix multiple Korean docstring typos and clarify parameter and return descriptions across BM25 retriever helpers.

</details>