### PR TITLE
📝 docs [#12.3.20] - ㊴ `exceptions.py` Docstring 이중 언어(KO/EN) 표준화 완료

### DIFF
--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -1,7 +1,8 @@
 # backend/exceptions.py
 
 """
-FlowNote MVP - Custom Exception Hierarchy (커스텀 예외 클래스 계층 구조).
+[KO] FlowNote MVP - 커스텀 예외 클래스 계층 구조
+[EN] FlowNote MVP - Custom Exception Hierarchy
 
 [KO] 백엔드 전역에서 사용되는 커스텀 예외 클래스를 정의합니다.
      호출자(API 라우터 등)는 각 예외 타입에 따라 아래에 명시된 HTTP 상태 코드를 결정론적으로 매핑해야 합니다.
@@ -72,6 +73,10 @@ class ConfigurationError(FlowNoteError):
 
 
 EmbeddingErrorType = Literal["timeout", "connection", "rate_limit", "api_error"]
+"""
+[KO] 임베딩 에러의 세부 원인을 분류하는 타입입니다.
+[EN] Type representing the detailed cause of an embedding error.
+"""
 
 
 class EmbeddingError(FlowNoteError):
@@ -94,6 +99,14 @@ class EmbeddingError(FlowNoteError):
     """
 
     def __init__(self, message: str = "", error_type: EmbeddingErrorType = "api_error"):
+        """
+        [KO] EmbeddingError 인스턴스를 초기화합니다.
+        [EN] Initializes an EmbeddingError instance.
+
+        Args:
+            message: [KO] 예외 메시지 / [EN] Exception message
+            error_type: [KO] 오류 세부 유형 분류 / [EN] Detailed categorization of the error
+        """
         super().__init__(message)
         self.error_type = error_type
 


### PR DESCRIPTION
- 모듈 docstring을 [KO]/[EN] 이중 언어 Google 스타일로 일관되게 정비
- EmbeddingErrorType Literal 타입에 이중 언어 설명을 추가하여 용도 명확화
- EmbeddingError.__init__() 내 누락된 Args 명세를 이중 언어로 보강하여 IDE 편의성 및 통일성 증대

🔗 Related: Issue [#1044]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

백엔드에서 임베딩 관련 예외에 대한 KO/EN 이중 언어 문서를 표준화합니다.

Documentation:
- `exceptions.py`의 모듈 수준 도크스트링을 일관된 KO/EN Google 스타일 형식으로 업데이트합니다.
- `EmbeddingErrorType` 리터럴에 해당 목적을 설명하는 KO/EN 설명을 추가합니다.
- 도구 및 IDE에서의 파라미터와 사용 방법을 명확히 하기 위해 `EmbeddingError`에 KO/EN `__init__` 도크스트링을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize bilingual (KO/EN) documentation for embedding-related exceptions in the backend.

Documentation:
- Update module-level docstring in exceptions.py to consistent KO/EN Google-style format.
- Document EmbeddingErrorType literal with KO/EN description of its purpose.
- Add KO/EN __init__ docstring to EmbeddingError to clarify parameters and usage for tooling and IDEs.

</details>