### PR TITLE
📝 docs & fix [#12.3.20] - ㊴ 1차 개선 : `exceptions.py` 타입 별칭 주석 IDE 호환성 개선

### DIFF
--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -72,11 +72,9 @@ class ConfigurationError(FlowNoteError):
     """
 
 
+# [KO] 임베딩 에러의 세부 원인을 분류하는 타입입니다.
+# [EN] Type representing the detailed cause of an embedding error.
 EmbeddingErrorType = Literal["timeout", "connection", "rate_limit", "api_error"]
-"""
-[KO] 임베딩 에러의 세부 원인을 분류하는 타입입니다.
-[EN] Type representing the detailed cause of an embedding error.
-"""
 
 
 class EmbeddingError(FlowNoteError):


### PR DESCRIPTION
- **[Docs]** `EmbeddingErrorType` 선언부의 삼중 따옴표(docstring)를 파이썬 표준에 맞게 앞쪽 라인 주석(#)으로 변환
- **[DX]** IDE 탐색기 및 정적 분석 도구에서 타입 별칭 힌트를 정상적으로 노출하도록 사용성 고도화

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1710#pullrequestreview-4744695689)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Documentation:
- `EmbeddingErrorType` 설명을 Python 문서 작성 관례를 따르고 IDE에서의 가시성을 향상시키기 위해 삼중 따옴표로 된 도크스트링에서 한 줄 주석으로 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update EmbeddingErrorType description from a triple-quoted docstring to line comments to follow Python documentation conventions and improve IDE visibility.

</details>