### PR TITLE
📝 docs [#12.3.20] - ㊶ 텍스트 분할 모듈(chunking.py) 명세 표준화

### DIFF
--- a/backend/chunking.py
+++ b/backend/chunking.py
@@ -34,10 +34,10 @@ class TextChunker:
         [EN] Initialization: Injects a splitter or uses the default RecursiveCharacterTextSplitter.
 
         Args:
-            splitter (Optional[TextSplitter]): 의존성 주입을 위한 TextSplitter 객체 / TextSplitter object for dependency injection
-            chunk_size (int): 청크 크기 (기본 스플리터 사용 시) / Chunk size (when using default splitter)
-            chunk_overlap (int): 청크 중첩 크기 (기본 스플리터 사용 시) / Chunk overlap size (when using default splitter)
-            **splitter_kwargs: 기본 스플리터에 전달할 추가 옵션 / Additional options to pass to the default splitter
+            splitter: [KO] 의존성 주입을 위한 TextSplitter 객체 / [EN] TextSplitter object for dependency injection
+            chunk_size: [KO] 청크 크기 (기본 스플리터 사용 시) / [EN] Chunk size (when using default splitter)
+            chunk_overlap: [KO] 청크 중첩 크기 (기본 스플리터 사용 시) / [EN] Chunk overlap size (when using default splitter)
+            **splitter_kwargs: [KO] 기본 스플리터에 전달할 추가 옵션 / [EN] Additional options to pass to the default splitter
         """
         if splitter is None:
             # 중복 키워드 인자 충돌 방지 (방어적 코딩)
@@ -65,7 +65,7 @@ class TextChunker:
         [EN] Returns the logging context (ID and type) of the splitter.
 
         Returns:
-            Dict[str, Any]: 로깅 컨텍스트 딕셔너리 / Logging context dictionary
+            Dict[str, Any]: [KO] 로깅 컨텍스트 딕셔너리 / [EN] Logging context dictionary
         """
         return {
             "splitter_id": id(self._splitter),
@@ -80,11 +80,11 @@ class TextChunker:
         [EN] Safely coerces and returns a specific attribute of the splitter as an integer.
 
         Args:
-            attr_name (str): 가져올 속성 이름 / The name of the attribute to fetch
-            is_private (bool): 해당 속성이 비공개(private)인지 여부 / Whether the attribute is private
+            attr_name: [KO] 가져올 속성 이름 / [EN] The name of the attribute to fetch
+            is_private: [KO] 해당 속성이 비공개(private)인지 여부 / [EN] Whether the attribute is private
 
         Returns:
-            Optional[int]: 변환된 정수값 또는 None / The coerced integer value or None
+            Optional[int]: [KO] 변환된 정수값 또는 None / [EN] The coerced integer value or None
         """
         if not hasattr(self._splitter, attr_name):
             return None
@@ -109,9 +109,9 @@ class TextChunker:
              To prevent log bloat from long string values, the value is truncated based on `MAX_INVALID_VALUE_REPR_LEN` (default 100 chars).
 
         Args:
-            val (Any): 유효하지 않은 속성 값 / The invalid attribute value
-            attr_name (str): 속성 이름 / The attribute name
-            is_private (bool): 비공개(private) 속성 여부 / Whether the attribute is private
+            val: [KO] 유효하지 않은 속성 값 / [EN] The invalid attribute value
+            attr_name: [KO] 속성 이름 / [EN] The attribute name
+            is_private: [KO] 비공개(private) 속성 여부 / [EN] Whether the attribute is private
         """
         val_repr = repr(val)
         max_len = self.MAX_INVALID_VALUE_REPR_LEN
@@ -139,8 +139,8 @@ class TextChunker:
              Uses a tuple of `(splitter_id, splitter_type, attr_name, private_attr)` as a deduplication key to suppress repeated logging for the same attribute on the same instance.
 
         Args:
-            attr_name (str): 찾지 못한 공개 속성 이름 / The public attribute name that was not found
-            private_attr (str): 찾지 못한 비공개 속성 이름 / The private attribute name that was not found
+            attr_name: [KO] 찾지 못한 공개 속성 이름 / [EN] The public attribute name that was not found
+            private_attr: [KO] 찾지 못한 비공개 속성 이름 / [EN] The private attribute name that was not found
         """
         context = self._get_splitter_context()
         missing_attr_key = (
@@ -171,6 +171,13 @@ class TextChunker:
         """
         [KO] 스플리터에서 동적으로 속성을 읽어옵니다. (Public 및 명시적 Fallback 속성 지원)
         [EN] Dynamically reads an attribute from the splitter. (Supports Public and explicit Fallback attributes)
+
+        Args:
+            attr_name: [KO] 가져올 속성 이름 / [EN] The attribute name to fetch
+            fallback_attr: [KO] 대체하여 가져올 속성 이름 (비공개 속성 등) / [EN] Fallback attribute name to fetch (private attribute, etc.)
+
+        Returns:
+            Optional[int]: [KO] 조회된 정수값 또는 None / [EN] The retrieved integer value or None
         """
         # 1. Public 속성 시도
         val = self._coerce_splitter_int_attr(attr_name, is_private=False)
@@ -192,6 +199,9 @@ class TextChunker:
         """
         [KO] 현재 스플리터에 설정된 chunk_size 동적 반환 (런타임 변경 반영)
         [EN] Dynamically returns the chunk_size set on the current splitter (reflects runtime changes)
+
+        Returns:
+            Optional[int]: [KO] 현재 청크 크기 또는 None / [EN] Current chunk size or None
         """
         return self._get_splitter_attr("chunk_size")
 
@@ -200,6 +210,9 @@ class TextChunker:
         """
         [KO] 현재 스플리터에 설정된 chunk_overlap 동적 반환 (런타임 변경 반영)
         [EN] Dynamically returns the chunk_overlap set on the current splitter (reflects runtime changes)
+
+        Returns:
+            Optional[int]: [KO] 현재 청크 중첩 크기 또는 None / [EN] Current chunk overlap size or None
         """
         return self._get_splitter_attr("chunk_overlap")
 
@@ -209,11 +222,13 @@ class TextChunker:
         [EN] Splits text into chunks.
 
         Args:
-            text (str): 분할할 텍스트 / The text to split
+            text: [KO] 분할할 텍스트 / [EN] The text to split
+
         Returns:
-            List[str]: 분할된 문자열 청크 리스트 / List of string chunks
+            List[str]: [KO] 분할된 문자열 청크 리스트 / [EN] List of string chunks
+
         Raises:
-            TypeError: text가 str 타입이 아닌 경우 / If text is not a string type
+            TypeError: [KO] text가 str 타입이 아닌 경우 / [EN] If text is not a string type
         """
         if not isinstance(text, str):
             logger.error(
@@ -234,12 +249,14 @@ class TextChunker:
         [EN] Generates text chunks along with metadata.
 
         Args:
-            text (str): 분할할 원본 텍스트 / The original text to split
-            metadata (Optional[Dict[str, Any]]): 각 청크에 포함할 메타데이터 / Metadata to include in each chunk
+            text: [KO] 분할할 원본 텍스트 / [EN] The original text to split
+            metadata: [KO] 각 청크에 포함할 메타데이터 / [EN] Metadata to include in each chunk
+
         Returns:
-            List[Dict[str, Any]]: 텍스트와 메타데이터가 결합된 청크 리스트 / List of chunks combined with text and metadata
+            List[Dict[str, Any]]: [KO] 텍스트와 메타데이터가 결합된 청크 리스트 / [EN] List of chunks combined with text and metadata
+
         Raises:
-            TypeError: metadata가 딕셔너리 타입이 아닌 경우 / If metadata is not a dictionary type
+            TypeError: [KO] metadata가 딕셔너리 타입이 아닌 경우 / [EN] If metadata is not a dictionary type
         """
         if metadata is not None and not isinstance(metadata, dict):
             logger.error(

--- a/backend/hybrid_search.py
+++ b/backend/hybrid_search.py
@@ -4,7 +4,7 @@
 
 """
 [KO] FlowNote MVP - 하이브리드 검색 및 RRF 병합 모듈
-[EN] FlowNote MVP - Hybrid Search and RRF Merging Module
+[EN] FlowNote MVP - Hybrid Search and RRF Merging module
 """
 
 import hashlib
@@ -43,12 +43,14 @@ class Retriever(Protocol):
         the score field is recommended for interface consistency.
 
         Args:
-            query: [KO] 검색 질의 / [EN] Search query string
-            k: [KO] 반환할 최대 결과 수 / [EN] Maximum number of results to return
-            metadata_filter: [KO] 메타데이터 필터 조건 (예: {"category": "Projects"}) / [EN] Metadata filter conditions (e.g., {"category": "Projects"})
+            query (str): [KO] 검색 질의 / [EN] Search query string
+            k (int): [KO] 반환할 최대 결과 수 / [EN] Maximum number of results to return
+            metadata_filter (Optional[Dict[str, Any]]): [KO] 메타데이터 필터 조건 (예: {"category": "Projects"})
+                / [EN] Metadata filter conditions (e.g., {"category": "Projects"})
 
         Returns:
-            List[Dict[str, Any]]: [KO] 검색 결과 딕셔너리의 리스트 (content, metadata, score 포함) / [EN] List of search result dictionaries (including content, metadata, score)
+            List[Dict[str, Any]]: [KO] 검색 결과 딕셔너리의 리스트 (content, metadata, score 포함)
+                / [EN] List of search result dictionaries (including content, metadata, score)
         """
         ...
 
@@ -79,9 +81,14 @@ class HybridSearcher:
         [EN] Initialization: Injects FAISS/BM25 retrievers and configures the RRF penalty constant.
 
         Args:
-            faiss_retriever: [KO] `search()` 메서드를 가진 Dense 벡터 리트리버 / [EN] Dense vector retriever with a `search()` method
-            bm25_retriever: [KO] `search()` 메서드를 가진 Sparse 키워드 리트리버 / [EN] Sparse keyword retriever with a `search()` method
-            rrf_k: [KO] RRF 페널티 상수 (기본값: 60, 반드시 양수여야 함). 값이 클수록 고순위 문서 간의 점수 차이가 완만해집니다. / [EN] RRF penalty constant (default: 60, must be positive). Larger values smooth out score differences between top-ranked documents.
+            faiss_retriever (Retriever): [KO] `search()` 메서드를 가진 Dense 벡터 리트리버
+                / [EN] Dense vector retriever with a `search()` method
+            bm25_retriever (Retriever): [KO] `search()` 메서드를 가진 Sparse 키워드 리트리버
+                / [EN] Sparse keyword retriever with a `search()` method
+            rrf_k (int): [KO] RRF 페널티 상수 (기본값: 60, 반드시 양수여야 함).
+                값이 클수록 고순위 문서 간의 점수 차이가 완만해집니다.
+                / [EN] RRF penalty constant (default: 60, must be positive).
+                Larger values smooth out score differences between top-ranked documents.
 
         Raises:
             ValueError: [KO] rrf_k가 0 이하인 경우 / [EN] If rrf_k is not positive
@@ -102,10 +109,12 @@ class HybridSearcher:
         [EN] Used to prevent duplicate aggregation when the same document is returned by both FAISS and BM25.
 
         Args:
-            doc: [KO] 리트리버가 반환한 단일 검색 결과 딕셔너리 / [EN] A single search result dictionary returned by a retriever
+            doc (Dict[str, Any]): [KO] 리트리버가 반환한 단일 검색 결과 딕셔너리
+                / [EN] A single search result dictionary returned by a retriever
 
         Returns:
-            str: [KO] 문서의 고유 식별자 (metadata["id"] 또는 SHA-256 해시) / [EN] Unique identifier for the document (metadata["id"] or SHA-256 hash)
+            str: [KO] 문서의 고유 식별자 (metadata["id"] 또는 SHA-256 해시)
+                / [EN] Unique identifier for the document (metadata["id"] or SHA-256 hash)
         """
         metadata = doc.get("metadata")
         if isinstance(metadata, dict) and "id" in metadata:
@@ -147,19 +156,32 @@ class HybridSearcher:
            [EN] Sort in descending order by final RRF score and return the top-k results.
 
         Args:
-            query: [KO] 검색 질의 / [EN] Search query string
-            k: [KO] 최종 반환할 문서 수 (0 이상) / [EN] Number of final results to return (non-negative)
-            faiss_k: [KO] FAISS에서 가져올 후보 수 (기본값: k × filter_expansion_factor, 필터 시만 적용) / [EN] Number of candidates to fetch from FAISS (default: k × filter_expansion_factor, only when filtering)
-            bm25_k: [KO] BM25에서 가져올 후보 수 (기본값: k × filter_expansion_factor, 필터 시만 적용) / [EN] Number of candidates to fetch from BM25 (default: k × filter_expansion_factor, only when filtering)
-            alpha: [KO] [0, 1] 범위의 Dense/Sparse 가중치. 1.0에 가까울수록 FAISS 비중이 커짐. / [EN] Dense/Sparse weight in [0, 1]. Values closer to 1.0 increase FAISS influence.
-            metadata_filter: [KO] 메타데이터 필터 조건 (예: {"category": "Projects"}) / [EN] Metadata filter conditions (e.g., {"category": "Projects"})
-            filter_expansion_factor: [KO] 후보군 확장 계수 (기본값: 2). metadata_filter가 제공되고 faiss_k/bm25_k가 None인 경우에만 적용됩니다. / [EN] Candidate expansion factor (default: 2). Applied only when metadata_filter is provided and faiss_k/bm25_k are None.
+            query (str): [KO] 검색 질의 / [EN] Search query string
+            k (int): [KO] 최종 반환할 문서 수 (0 이상) / [EN] Number of final results to return (non-negative)
+            faiss_k (Optional[int]): [KO] FAISS에서 가져올 후보 수 (기본값: k × filter_expansion_factor, 필터 시만 적용)
+                / [EN] Number of candidates to fetch from FAISS (default: k × filter_expansion_factor, only when filtering)
+            bm25_k (Optional[int]): [KO] BM25에서 가져올 후보 수 (기본값: k × filter_expansion_factor, 필터 시만 적용)
+                / [EN] Number of candidates to fetch from BM25 (default: k × filter_expansion_factor, only when filtering)
+            alpha (float): [KO] [0, 1] 범위의 Dense/Sparse 가중치. 1.0에 가까울수록 FAISS 비중이 커짐.
+                / [EN] Dense/Sparse weight in [0, 1]. Values closer to 1.0 increase FAISS influence.
+            metadata_filter (Optional[Dict[str, Any]]): [KO] 메타데이터 필터 조건 (예: {"category": "Projects"})
+                / [EN] Metadata filter conditions (e.g., {"category": "Projects"})
+            filter_expansion_factor (int): [KO] 후보군 확장 계수 (기본값: 2).
+                metadata_filter가 제공되고 faiss_k/bm25_k가 None인 경우에만 적용됩니다.
+                / [EN] Candidate expansion factor (default: 2).
+                Applied only when metadata_filter is provided and faiss_k/bm25_k are None.
 
         Returns:
-            List[Dict[str, Any]]: [KO] RRF 점수 기준 내림차순으로 정렬된 검색 결과 리스트 (각 항목은 content, metadata, id, score 포함) / [EN] List of search results sorted by RRF score in descending order (each item includes content, metadata, id, score)
+            List[Dict[str, Any]]: [KO] RRF 점수 기준 내림차순으로 정렬된 검색 결과 리스트
+                (각 항목은 content, metadata, id, score 포함)
+                / [EN] List of search results sorted by RRF score in descending order
+                (each item includes content, metadata, id, score)
 
         Raises:
-            ValueError: [KO] alpha가 [0, 1] 범위를 벗어나거나, k/faiss_k/bm25_k가 음수이거나, filter_expansion_factor가 1 미만인 경우 / [EN] If alpha is out of [0, 1] range, k/faiss_k/bm25_k is negative, or filter_expansion_factor is less than 1
+            ValueError: [KO] alpha가 [0, 1] 범위를 벗어나거나, k/faiss_k/bm25_k가 음수이거나,
+                filter_expansion_factor가 1 미만인 경우
+                / [EN] If alpha is out of [0, 1] range, k/faiss_k/bm25_k is negative,
+                or filter_expansion_factor is less than 1
         """
         # [KO] 파라미터 유효 범위 검증
         # [EN] Validate parameter value ranges


### PR DESCRIPTION
- **[문서화 고도화] 중복 타입 제거 및 이중 언어 표준화**
  - `TextChunker` 클래스의 모든 메서드(`__init__`, `_get_splitter_context`, `_coerce_splitter_int_attr`, `_log_invalid_int_attr`, `_log_missing_splitter_attr`, `chunk_text`, `chunk_with_metadata`) 내 Args 섹션에서 이미 함수 시그니처에 존재하는 타입 표시를 제거하여 단순화.
  - `Returns`, `Raises` 명세 영역에 일관된 `[KO]`/`[EN]` 다국어 구분자 적용.

- **[문서화 누락 보강] 내부 메서드 및 프로퍼티 문서 추가**
  - `_get_splitter_attr` 내부 헬퍼 메서드에 대한 Args/Returns 섹션 신설.
  - `chunk_size`, `chunk_overlap` dynamic property의 Returns 섹션을 상세히 보강.

🔗 Related: Issue [#1044]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

런타임 동작을 변경하지 않고 하이브리드 검색 및 텍스트 청킹 모듈의 이중 언어(docstring)를 표준화하고 확장합니다.

향상 사항:
- 하이브리드 검색 API에 대해 매개변수, 반환 값, 오류에 대한 문서를 명확히 하고, 명시적인 타입 정보와 다중 줄 한‧영 병기 설명을 추가합니다.
- 텍스트 청킹 모듈에서 지금까지 문서화되지 않았던 헬퍼 메서드와 동적 프로퍼티에 대해, 그 동작 방식과 반환 값을 상세히 문서화합니다.
- 청킹 인터페이스의 docstring을 프로젝트 전반에 적용되는 한글/영문 문서화 규칙과 일치하도록 정렬합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize and expand bilingual docstrings for hybrid search and text chunking modules without changing runtime behavior.

Enhancements:
- Clarify parameter, return, and error documentation for hybrid search APIs, including explicit typing and multiline bilingual descriptions.
- Document previously undocumented helper methods and dynamic properties in the text chunking module, detailing their behavior and return values.
- Align chunking interface docstrings with the project-wide Korean/English documentation conventions.

</details>