### PR TITLE
📝 docs [#12.3.20] - ㊷ 임베딩 모듈(embedding.py) 명세 표준화

### DIFF
--- a/backend/embedding.py
+++ b/backend/embedding.py
@@ -74,11 +74,10 @@ def _get_error_mapping(exc: Exception) -> Tuple[str, EmbeddingErrorType]:
     [EN] Returns the most appropriate error message prefix and type for a given exception instance.
 
     Args:
-        exc (Exception): [KO] 발생한 예외 객체 / [EN] The exception object that was raised
+        exc: [KO] 발생한 예외 객체 / [EN] The exception object that was raised
 
     Returns:
-        Tuple[str, EmbeddingErrorType]: [KO] 메시지 접두어와 에러 타입을 포함하는 튜플
-                                        / [EN] A tuple containing the message prefix and error type
+        [KO] 메시지 접두어와 에러 타입을 포함하는 튜플 / [EN] A tuple containing the message prefix and error type
     """
     return next(
         (v for k, v in ERROR_MAP.items() if isinstance(exc, k)),
@@ -98,8 +97,7 @@ class EmbeddingGenerator:
         [EN] Sets the embedding model to use and initializes the API client.
 
         Args:
-            model_name (str): [KO] 사용할 임베딩 모델의 이름 (기본값: EMBEDDING_MODEL)
-                              / [EN] Name of the embedding model to use (default: EMBEDDING_MODEL)
+            model_name: [KO] 사용할 임베딩 모델의 이름 (기본값: EMBEDDING_MODEL) / [EN] Name of the embedding model to use (default: EMBEDDING_MODEL)
         """
         _verify_invariants()
         self.model_name = model_name
@@ -115,16 +113,13 @@ class EmbeddingGenerator:
         [EN] Generates embedding vectors for a list of texts and returns cost and token metrics.
 
         Args:
-            texts (List[str]): [KO] 임베딩으로 변환할 텍스트 청크 리스트
-                               / [EN] List of text chunks to convert into embeddings.
+            texts: [KO] 임베딩으로 변환할 텍스트 청크 리스트 / [EN] List of text chunks to convert into embeddings.
 
         Returns:
-            EmbeddingResult: [KO] 임베딩 벡터 리스트, 총 사용 토큰 수, 예상 비용을 포함한 딕셔너리
-                            / [EN] Dictionary containing embedding vectors, total token count, and estimated cost.
+            [KO] 임베딩 벡터 리스트, 총 사용 토큰 수, 예상 비용을 포함한 딕셔너리 / [EN] Dictionary containing embedding vectors, total token count, and estimated cost.
 
         Raises:
-            EmbeddingError: [KO] 외부 임베딩 모델 API 호출에 실패한 경우 (HTTP 502 매핑 대상)
-                            / [EN] If the external embedding model API call fails (mapped to HTTP 502).
+            EmbeddingError: [KO] 외부 임베딩 모델 API 호출에 실패한 경우 (HTTP 502 매핑 대상) / [EN] If the external embedding model API call fails (mapped to HTTP 502).
         """
         if not texts:
             return {"embeddings": [], "tokens": 0, "cost": 0.0}


### PR DESCRIPTION
- **[문서화 고도화] 중복 타입 제거 및 이중 언어 표준화**
  - `EmbeddingGenerator` 클래스의 메서드(`__init__`, `generate_embeddings`) 및 헬퍼 함수(`_get_error_mapping`) 내 Args 섹션에서 이미 함수 시그니처에 존재하는 타입 표시를 제거하여 단순화.
  - `Returns`, `Raises` 명세 영역에 일관된 `[KO]`/`[EN]` 인라인 다국어 구분자 적용.

🔗 Related: Issue [#1044]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

임베딩 모듈의 이중 언어 문서를 표준화합니다.

개선 사항:
- Args 섹션에서 중복되는 타입 주석을 제거하여 임베딩 헬퍼 및 생성기 메서드의 독스트링을 단순화합니다.
- 임베딩 관련 독스트링의 Returns 및 Raises 섹션을 일관된 인라인 [KO]/[EN] 이중 언어 형식으로 정렬합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize bilingual documentation for the embedding module.

Enhancements:
- Simplify docstrings in embedding helper and generator methods by removing redundant type annotations from Args sections.
- Align Returns and Raises sections in embedding-related docstrings with a consistent inline [KO]/[EN] bilingual format.

</details>