### PR TITLE
📝 docs [#12.3.20] - ㊸ 1차 개선 : Returns 반환 구조 설명 보강

### DIFF
--- a/backend/search_history.py
+++ b/backend/search_history.py
@@ -115,7 +115,8 @@ class SearchHistory:
             search_id: [KO] 조회할 검색 고유 ID / [EN] Unique search ID to retrieve
 
         Returns:
-            [KO] 검색 히스토리 딕셔너리 (존재하지 않으면 None) / [EN] Search history dictionary (None if not found)
+            [KO] 해당 ID의 검색 기록 딕셔너리(키: query, results_count, top_results, search_time, created_at), 없으면 None
+            / [EN] Search record dict (keys: query, results_count, top_results, search_time, created_at), or None if not found
         """
         return self.history.get(search_id)
 
@@ -128,7 +129,8 @@ class SearchHistory:
             limit: [KO] 반환할 최대 결과 수 / [EN] Maximum number of results to return
 
         Returns:
-            [KO] 최신순으로 정렬된 검색 기록 리스트 / [EN] List of search records sorted by newest first
+            [KO] 최신순 정렬된 검색 기록 리스트. 각 항목은 id, query, results_count, top_results, search_time, created_at 키를 포함
+            / [EN] List of search records sorted newest-first; each item contains id, query, results_count, top_results, search_time, created_at
         """
         # 시간순 정렬 (최신순)
         sorted_history = sorted(
@@ -144,7 +146,7 @@ class SearchHistory:
         [EN] Retrieves all saved search records.
 
         Returns:
-            [KO] 전체 검색 히스토리를 담은 딕셔너리 / [EN] Dictionary containing the entire search history
+            [KO] search_id를 키, 검색 기록 딕셔너리를 값으로 하는 전체 히스토리 / [EN] Full history dict keyed by search_id, with each value being a search record dict
         """
         return self.history
 


### PR DESCRIPTION
- **[문서화 보강] Dict 반환 구조 키 목록 명시**
  - `get_search()`: 반환 딕셔너리 키(query, results_count, top_results, search_time, created_at) 및 None 조건 명시.
  - `get_recent_searches()`: 각 항목의 구성 키(id 포함) 명시.
  - `get_all_searches()`: search_id를 키, 검색 기록 딕셔너리를 값으로 하는 구조 명시.
  - `get_statistics()`: 파일 상단 SearchStatistics TypedDict에 이미 명세되어 있어 변경 없음.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1715#pullrequestreview-4779197125)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

검색 기록 반환 값의 구조를 각 조회 메서드별로 명확히 문서화합니다.

Documentation:
- `get_search`가 반환하는 딕셔너리에서 기대되는 키들을 명시하고, `None`이 반환되는 조건을 설명합니다.
- `get_recent_searches`가 반환하는 리스트에서 각 항목의 키 구조와 `id` 필드를 문서화합니다.
- `get_all_searches`가 `search_id`를 키로 하고 검색 기록 딕셔너리를 값으로 갖는 딕셔너리를 반환한다는 점을 명확히 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the documented structure of search history return values across retrieval methods.

Documentation:
- Specify the expected keys in the dictionary returned by get_search, including conditions under which None is returned.
- Document the per-item key structure for lists returned by get_recent_searches, including the id field.
- Clarify that get_all_searches returns a dictionary keyed by search_id with search record dictionaries as values.

</details>