### PR TITLE
📝 docs [#12.3.20] - ㊻ CLI 모듈(cli.py) 명세 이중 언어 표준화 및 타입 린트 오류 해결

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -1,12 +1,16 @@
 """
-CLI Interface for MCP Integration
-- Demonstrates how MCP can call services directly without HTTP
+[KO] FlowNote CLI - MCP 통합 인터페이스
+[EN] FlowNote CLI - MCP Integration Interface
+
+[KO] MCP가 HTTP 없이 서비스를 직접 호출하는 방법을 시연하는 모듈입니다.
+[EN] Demonstrates how MCP can call services directly without HTTP.
 """
 
 import asyncio
 import logging
 import sys
 from pathlib import Path
+from typing import Optional
 
 # Service imports
 from backend.services.classification_service import ClassificationService
@@ -14,18 +18,26 @@ from backend.services.onboarding_service import OnboardingService
 
 
 class FlowNoteCLI:
-    """FlowNote CLI - MCP 통합 시뮬레이션"""
+    """
+    [KO] FlowNote CLI - MCP 통합 시뮬레이션
+    [EN] FlowNote CLI - MCP Integration Simulation
+    """
 
     def __init__(self):
         self.classification_service = ClassificationService()
         self.onboarding_service = OnboardingService()
 
-    async def classify_file(self, file_path: str, user_id: str = None):
-        """파일 분류 (MCP가 이렇게 호출할 것)
+    async def classify_file(self, file_path: str, user_id: Optional[str] = None):
+        """
+        [KO] 단일 파일 분류를 실행합니다 (MCP 직접 호출용).
+        [EN] Executes single file classification (for direct MCP calls).
 
         Args:
-            file_path: 로컬 파일 경로
-            user_id: 사용자 ID (선택)
+            file_path: [KO] 로컬 파일 경로 / [EN] Local file path
+            user_id: [KO] 사용자 ID (선택) / [EN] User ID (optional)
+
+        Returns:
+            [KO] 분류 결과 객체, 실패 시 None / [EN] Classification result object, or None on failure
         """
         try:
             path_obj = Path(file_path)
@@ -80,10 +92,10 @@ class FlowNoteCLI:
             print(f"🔍 분류 시작: {path_obj.name} (User: {user_id or 'Anonymous'})")
             result = await self.classification_service.classify(
                 text=text,
-                user_id=user_id,
+                user_id=user_id or "anonymous",
                 file_id=safe_file_id,
-                occupation=user_context.get("occupation"),
-                areas=user_context.get("areas"),
+                occupation=user_context.get("occupation") or "",
+                areas=user_context.get("areas") or [],
             )
 
             print(f"✅ 분류 완료: {result.category}")
@@ -96,10 +108,17 @@ class FlowNoteCLI:
             print(f"❌ 분류 실패: {e}")
             return None
 
-    async def batch_classify(self, directory: str, user_id: str = None):
-        """디렉토리 내 모든 파일 분류
+    async def batch_classify(self, directory: str, user_id: Optional[str] = None):
+        """
+        [KO] 지정한 디렉토리 내의 모든 텍스트/마크다운 파일을 분류합니다. (MCP 워크스페이스 전체 분류용)
+        [EN] Classifies all text/markdown files in a specified directory. (For MCP workspace-wide classification)
 
-        MCP가 워크스페이스 전체를 분류할 때 사용
+        Args:
+            directory: [KO] 분석할 디렉토리 경로 / [EN] Directory path to analyze
+            user_id: [KO] 사용자 ID (선택) / [EN] User ID (optional)
+
+        Returns:
+            [KO] 각 파일의 분류 결과 딕셔너리 리스트 (file, category, confidence 포함) / [EN] List of classification result dictionaries for each file
         """
         dir_path = Path(directory)
 
@@ -134,7 +153,10 @@ class FlowNoteCLI:
 
 
 async def main():
-    """CLI 실행 예제"""
+    """
+    [KO] CLI 실행 진입점 예제
+    [EN] CLI execution entry point example
+    """
     cli = FlowNoteCLI()
 
     if len(sys.argv) < 2:


### PR DESCRIPTION
- **[문서화 고도화] CLI 진입점 독스트링 이중 언어 포맷 적용**
  - 모듈 최상단 헤더 및 `FlowNoteCLI` 클래스의 기본 설명을 `[KO]/[EN]` 멀티라인 포맷으로 통일.
  - `classify_file` 및 `batch_classify` 메서드, `main` 함수의 메인 설명, Args, Returns 섹션에 프로젝트 표준 인라인 슬래시(` / `) 포맷 적용.
  - 불필요한 인자/반환값 타입 명시를 제거하여 가독성 개선.

- **[코드 품질 개선] 엄격한 타입 힌팅 오류(IDE Lint) 해결**
  - `user_id` 파라미터가 `None`을 허용하도록 `Optional[str]`로 명시적 선언.
  - `ClassificationService.classify()` 호출 시, `user_id`, `occupation`, `areas`에 `None` 값이 들어가지 않도록 안전한 기본값(fallback) 적용하여 타입 안정성 강화.

🔗 Related: Issue [#1044]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

FlowNote CLI 엔트리포인트에 대한 이중 언어(한·영) 문서를 표준화하고, 분류 호출의 타입 안정성을 강화합니다.

버그 수정:
- CLI 메서드에서 `user_id` 파라미터를 `Optional[str]`로 선언하여 엄격한 타입 검사 및 린트 문제를 해결합니다.

개선 사항:
- 프로젝트의 표준화된 형식을 사용하여 CLI 모듈 헤더, `FlowNoteCLI` 클래스 및 그 공개 메서드에 한국어/영어 이중 언어 도크스트링을 추가합니다.
- 실행 시 안정성을 높이기 위해 분류 호출에서 `user_id`, `occupation`, `areas`가 누락된 경우 널이 아닌 대체값을 제공하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize bilingual documentation for the FlowNote CLI entrypoint and tighten type safety for classification calls.

Bug Fixes:
- Declare user_id parameters as Optional[str] in CLI methods to resolve strict typing and linting issues.

Enhancements:
- Add Korean/English bilingual docstrings to the CLI module header, FlowNoteCLI class, and its public methods using the project’s standardized format.
- Ensure classification calls provide non-null fallbacks for user_id, occupation, and areas when missing to improve runtime robustness.

</details>