### PR TITLE
📝 docs [#12.3.20] - ㊻ 1차 개선 : CLI 모듈 리뷰 반영 및 타입 명확화

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -37,7 +37,7 @@ class FlowNoteCLI:
             user_id: [KO] 사용자 ID (선택) / [EN] User ID (optional)
 
         Returns:
-            [KO] 분류 결과 객체, 실패 시 None / [EN] Classification result object, or None on failure
+            [KO] 분류 결과 객체(ClassifyResponse), 실패 시 None / [EN] Classification result object (ClassifyResponse), or None on failure
         """
         try:
             path_obj = Path(file_path)
@@ -92,10 +92,10 @@ class FlowNoteCLI:
             print(f"🔍 분류 시작: {path_obj.name} (User: {user_id or 'Anonymous'})")
             result = await self.classification_service.classify(
                 text=text,
-                user_id=user_id or "anonymous",
+                user_id=user_id,
                 file_id=safe_file_id,
-                occupation=user_context.get("occupation") or "",
-                areas=user_context.get("areas") or [],
+                occupation=user_context.get("occupation"),
+                areas=user_context.get("areas"),
             )
 
             print(f"✅ 분류 완료: {result.category}")
@@ -118,7 +118,7 @@ class FlowNoteCLI:
             user_id: [KO] 사용자 ID (선택) / [EN] User ID (optional)
 
         Returns:
-            [KO] 각 파일의 분류 결과 딕셔너리 리스트 (file, category, confidence 포함) / [EN] List of classification result dictionaries for each file
+            [KO] 각 파일의 분류 결과 딕셔너리 리스트 (키: file, category, confidence) / [EN] List of classification result dicts (keys: file, category, confidence)
         """
         dir_path = Path(directory)
 

--- a/backend/services/classification_service.py
+++ b/backend/services/classification_service.py
@@ -14,7 +14,7 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from backend.classifier.hybrid_classifier import HybridClassifier
 from backend.classifier.keyword import KeywordClassifier
@@ -53,11 +53,11 @@ class ClassificationService:
     async def classify(
         self,
         text: str,
-        user_id: str = None,
-        file_id: str = None,
-        occupation: str = None,
-        areas: list = None,
-        interests: list = None,
+        user_id: Optional[str] = None,
+        file_id: Optional[str] = None,
+        occupation: Optional[str] = None,
+        areas: Optional[List[str]] = None,
+        interests: Optional[List[str]] = None,
     ) -> ClassifyResponse:
         """
         통합 분류 메서드 (Main Entry Point)
@@ -279,7 +279,7 @@ class ClassificationService:
             with open(json_path, "w", encoding="utf-8") as f:
                 json.dump(json_data, f, ensure_ascii=False, indent=2)
 
-            logger.info(f"✅ 로그 저장: CSV + JSON")
+            logger.info("✅ 로그 저장: CSV + JSON")
 
             return {
                 "csv_saved": True,


### PR DESCRIPTION
- **[리뷰 반영 1] 타입 안정성 및 의도 보존 (Type Safety)**
  - `cli.py`에서 `ClassificationService.classify` 호출 시 임의의 기본값(`"anonymous"`, `""`, `[]`)을 강제 주입하던 로직을 원상 복구하여, 값의 부재(`None`)를 서비스 레이어로 명확히 전달하도록 수정.
  - `backend/services/classification_service.py`의 `classify` 메서드 파라미터를 `Optional[str]` 및 `Optional[List[str]]`로 업데이트하여 `None` 입력을 공식적으로 지원하고 린트 오류의 근본 원인을 해결.

- **[리뷰 반영 2] 독스트링 반환 타입 구체화**
  - `cli.py`의 `classify_file` Returns 설명에 실제 반환 객체인 `(ClassifyResponse)` 명시.
  - `batch_classify` Returns 설명에 반환되는 딕셔너리의 구체적인 키 구조(`file`, `category`, `confidence`)를 명시하여 모호성 제거.

- **[코드 품질 개선] 불필요한 f-string 제거**
  - `backend/services/classification_service.py` 내부 로깅 중 변수 삽입이 없는 무의미한 f-string 포맷팅 제거 (Sourcery Lint 해결).

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1719#pullrequestreview-4797747637)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

CLI 분류 인터페이스와 선택적 사용자 컨텍스트 필드의 타입 처리 방식을 명확히 합니다.

Bug Fixes:
- 선택적 사용자 컨텍스트 필드가 분류 서비스로 전달될 때, 암묵적인 기본값이 아니라 `None`으로 전달되도록 수정했습니다.

Enhancements:
- 사용자 메타데이터와 컨텍스트 리스트를 구체적인 리스트 요소 타입을 가진 `Optional`로 표시하여 분류 서비스의 타입 힌트를 더 엄격하게 했습니다.
- `classify_file` 및 `batch_classify` CLI 함수의 docstring에 반환 타입과 결과 키 구조를 명시적으로 기술하여 더 명확히 했습니다.
- 불필요한 f-string을 제거해 분류 서비스의 로깅을 단순화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify CLI classification interfaces and type handling for optional user context fields.

Bug Fixes:
- Ensure optional user context fields are passed as None instead of implicit default values to the classification service.

Enhancements:
- Tighten classification service type hints by marking user metadata and context lists as Optional with concrete list element types.
- Clarify CLI classify_file and batch_classify docstrings with explicit return type and result key structure.
- Simplify logging in classification service by removing an unnecessary f-string.

</details>