### PR TITLE
📝 docs [#12.3.20] - ㊼ `main.py` Docstring 이중 언어 표준화 적용

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -57,10 +57,17 @@ from backend.services.scheduler_service import shutdown_scheduler, start_schedul
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """
-    [KO] FastAPI 앱의 수명 주기(시작/종료)를 관리합니다. / [EN] Manages the FastAPI app lifespan (startup/shutdown).
+    [KO]
+    FastAPI 앱의 수명 주기(시작/종료)를 관리합니다.
 
     Args:
-        app: [KO] FastAPI 앱 인스턴스 / [EN] FastAPI app instance
+        app: FastAPI 앱 인스턴스
+
+    [EN]
+    Manages the FastAPI app lifespan (startup/shutdown).
+
+    Args:
+        app: FastAPI app instance
     """
     # Startup
     logger.info("Starting up: Initializing WebSocket Manager & Redis...")
@@ -130,6 +137,8 @@ app.add_middleware(
 # Exception Handlers (i18n support)
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+from typing import Any, Callable, cast
+
 from fastapi import Request  # type: ignore[import]
 from fastapi.exceptions import RequestValidationError  # type: ignore[import]
 from fastapi.responses import JSONResponse  # type: ignore[import]
@@ -142,8 +151,13 @@ from backend.services.chat_history_service import (  # type: ignore[import]
     RedisUnavailableError,
 )
 
-app.add_exception_handler(HTTPException, http_exception_handler)  # type: ignore[arg-type]
-app.add_exception_handler(RequestValidationError, validation_exception_handler)  # type: ignore[arg-type]
+app.add_exception_handler(
+    HTTPException, cast(Callable[[Request, Any], Any], http_exception_handler)
+)
+app.add_exception_handler(
+    RequestValidationError,
+    cast(Callable[[Request, Any], Any], validation_exception_handler),
+)
 
 
 @app.exception_handler(RedisUnavailableError)
@@ -151,17 +165,27 @@ async def redis_unavailable_handler(
     request: Request, exc: RedisUnavailableError
 ) -> JSONResponse:
     """
-    [KO] Redis 연결 불가 시 전역 503 응답을 반환합니다. / [EN] Returns a global 503 response when Redis is unavailable.
-
-    [KO] 개별 엔드포인트에서 에러를 처리하지 않아도 이 핸들러가 자동으로 503으로 변환합니다.
-    [EN] Automatically converts RedisUnavailableError to 503 without individual endpoint handling.
+    [KO]
+    Redis 연결 불가 시 전역 503 응답을 반환합니다.
+    개별 엔드포인트에서 에러를 처리하지 않아도 이 핸들러가 자동으로 503으로 변환합니다.
 
     Args:
-        request: [KO] FastAPI 요청 객체 / [EN] FastAPI request object
-        exc: [KO] Redis 예외 객체 / [EN] Redis exception object
+        request: FastAPI 요청 객체
+        exc: Redis 예외 객체
 
     Returns:
-        [KO] 503 상태 코드의 JSON 응답 / [EN] JSON response with 503 status code
+        503 상태 코드의 JSON 응답
+
+    [EN]
+    Returns a global 503 response when Redis is unavailable.
+    Automatically converts RedisUnavailableError to 503 without individual endpoint handling.
+
+    Args:
+        request: FastAPI request object
+        exc: Redis exception object
+
+    Returns:
+        JSON response with 503 status code
     """
     logger.warning(
         "Redis unavailable: %s",
@@ -229,10 +253,17 @@ logger.info("✅ chat_router 등록 완료 (RAG Streaming Chat)")
 @app.get("/health", response_model=HealthCheckResponse, tags=["System"])
 async def health():
     """
-    [KO] 서버 상태를 확인합니다. / [EN] Checks the server health status.
+    [KO]
+    서버 상태를 확인합니다.
 
     Returns:
-        [KO] 서버 상태 정보 (HealthCheckResponse) / [EN] Server health information (HealthCheckResponse)
+        서버 상태 정보 (HealthCheckResponse)
+
+    [EN]
+    Checks the server health status.
+
+    Returns:
+        Server health information (HealthCheckResponse)
     """
     return HealthCheckResponse(
         status="healthy",
@@ -244,10 +275,17 @@ async def health():
 @app.get("/", tags=["System"])
 async def root():
     """
-    [KO] API 루트 엔드포인트입니다. / [EN] API root endpoint.
+    [KO]
+    API 루트 엔드포인트입니다.
 
     Returns:
-        [KO] API 기본 정보 딕셔너리 / [EN] API basic information dictionary
+        API 기본 정보 딕셔너리
+
+    [EN]
+    API root endpoint.
+
+    Returns:
+        API basic information dictionary
     """
     return {
         "name": "FlowNote API",

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,27 +13,27 @@ from fastapi.middleware.cors import CORSMiddleware  # type: ignore[import]
 from pydantic import BaseModel  # type: ignore[import]
 
 from backend.api.endpoints.automation import (
-    router as automation_router,
-)  # type: ignore[import]
+    router as automation_router,  # type: ignore[import]
+)
 from backend.api.endpoints.chat import router as chat_router  # type: ignore[import]
 from backend.api.endpoints.graph import router as graph_router  # type: ignore[import]
 from backend.api.endpoints.search import router as search_router  # type: ignore[import]
 from backend.api.endpoints.sync import router as sync_router  # type: ignore[import]
 from backend.api.endpoints.websocket import (
-    router as websocket_router,
-)  # type: ignore[import]
+    router as websocket_router,  # type: ignore[import]
+)
 
 # 마이그레이션 모델 임포트
 from backend.models import FileMetadata, HealthCheckResponse  # type: ignore[import]
 from backend.routes.classifier_routes import (
-    router as classifier_router,
-)  # type: ignore[import]
+    router as classifier_router,  # type: ignore[import]
+)
 from backend.routes.conflict_routes import (
-    router as conflict_router,
-)  # type: ignore[import]
+    router as conflict_router,  # type: ignore[import]
+)
 from backend.routes.onboarding_routes import (
-    router as onboarding_router,
-)  # type: ignore[import]
+    router as onboarding_router,  # type: ignore[import]
+)
 from backend.services.websocket_manager import manager  # type: ignore[import]
 
 # 로깅 설정
@@ -56,6 +56,12 @@ from backend.services.scheduler_service import shutdown_scheduler, start_schedul
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    """
+    [KO] FastAPI 앱의 수명 주기(시작/종료)를 관리합니다. / [EN] Manages the FastAPI app lifespan (startup/shutdown).
+
+    Args:
+        app: [KO] FastAPI 앱 인스턴스 / [EN] FastAPI app instance
+    """
     # Startup
     logger.info("Starting up: Initializing WebSocket Manager & Redis...")
     await manager.initialize()
@@ -76,23 +82,23 @@ app = FastAPI(
     title="FlowNote API",
     description="""
     ## FlowNote MVP - AI 기반 PARA 분류 및 충돌 해결 API
-    
+
     ### 주요 기능
     * **온보딩**: 사용자 생성 및 관심 영역 추천
     * **분류**: PARA 방법론 기반 텍스트 자동 분류
     * **충돌 해결**: AI 기반 분류 충돌 감지 및 해결
-    
+
     ### 엔드포인트
     * `/classifier` - 파일 및 텍스트 분류
     * `/onboarding` - 사용자 온보딩
     * `/conflict` - 충돌 해결
     * `/search/hybrid` - FAISS+BM25 하이브리드 RAG 검색 (PARA 카테고리 필터 지원)
     * `/health` - 서버 상태 확인
-    
+
     ### 테스트 커버리지
     * 전체 커버리지: 51%
     * 핵심 서비스: 70%+
-    
+
     ### CI/CD
     * GitHub Actions 자동 테스트
     * Codecov 커버리지 리포팅
@@ -132,22 +138,30 @@ from backend.api.exceptions import (  # type: ignore[import]
     http_exception_handler,
     validation_exception_handler,
 )
-from backend.services.chat_history_service import (
+from backend.services.chat_history_service import (  # type: ignore[import]
     RedisUnavailableError,
-)  # type: ignore[import]
+)
 
-app.add_exception_handler(HTTPException, http_exception_handler)
-app.add_exception_handler(RequestValidationError, validation_exception_handler)
+app.add_exception_handler(HTTPException, http_exception_handler)  # type: ignore[arg-type]
+app.add_exception_handler(RequestValidationError, validation_exception_handler)  # type: ignore[arg-type]
 
 
 @app.exception_handler(RedisUnavailableError)
 async def redis_unavailable_handler(
     request: Request, exc: RedisUnavailableError
 ) -> JSONResponse:
-    """Redis 연결 불가 시 전역 503 응답 반환.
+    """
+    [KO] Redis 연결 불가 시 전역 503 응답을 반환합니다. / [EN] Returns a global 503 response when Redis is unavailable.
 
-    chat_history_service의 모든 엔드포인트에서 각자 RedisUnavailableError를
-    처리하지 않아도 이 핸들러가 자동으로 503으로 변환한다.
+    [KO] 개별 엔드포인트에서 에러를 처리하지 않아도 이 핸들러가 자동으로 503으로 변환합니다.
+    [EN] Automatically converts RedisUnavailableError to 503 without individual endpoint handling.
+
+    Args:
+        request: [KO] FastAPI 요청 객체 / [EN] FastAPI request object
+        exc: [KO] Redis 예외 객체 / [EN] Redis exception object
+
+    Returns:
+        [KO] 503 상태 코드의 JSON 응답 / [EN] JSON response with 503 status code
     """
     logger.warning(
         "Redis unavailable: %s",
@@ -215,10 +229,10 @@ logger.info("✅ chat_router 등록 완료 (RAG Streaming Chat)")
 @app.get("/health", response_model=HealthCheckResponse, tags=["System"])
 async def health():
     """
-    서버 상태 확인
+    [KO] 서버 상태를 확인합니다. / [EN] Checks the server health status.
 
     Returns:
-        HealthCheckResponse: 서버 상태 정보
+        [KO] 서버 상태 정보 (HealthCheckResponse) / [EN] Server health information (HealthCheckResponse)
     """
     return HealthCheckResponse(
         status="healthy",
@@ -230,10 +244,10 @@ async def health():
 @app.get("/", tags=["System"])
 async def root():
     """
-    루트 엔드포인트
+    [KO] API 루트 엔드포인트입니다. / [EN] API root endpoint.
 
     Returns:
-        dict: API 정보
+        [KO] API 기본 정보 딕셔너리 / [EN] API basic information dictionary
     """
     return {
         "name": "FlowNote API",


### PR DESCRIPTION
- **[이중 언어 표준화 적용]**
  - FastAPI 메인 진입점인 `backend/main.py` 내 주요 엔드포인트 및 핸들러에 이중 언어(KO/EN) 포맷 적용.
  - `lifespan` 수명 주기 관리자, `redis_unavailable_handler` 예외 처리기, `health`, `root` 기본 라우터에 대한 설명 및 Args/Returns 구조 표준화.
  - 향후 리뷰 개선 요청을 방지하기 위해 구체적인 반환 객체(HealthCheckResponse 등)를 사전에 명시.

- **[코드 품질 개선]**
  - Starlette 전역 예외 처리기 등록 시 발생하는 타입 불일치(Pyright strict typing) 린트 에러를 `# type: ignore[arg-type]` 주석으로 깔끔하게 해결.

🔗 Related: Issue [#1044]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

FastAPI 메인 엔트리포인트에서 문서화와 에러 처리 메타데이터를 표준화합니다.

버그 수정:
- 전역 Starlette 예외 처리기 등록 시 발생하는 엄격한 타입 불일치를, 대상 지정을 통한 `type: ignore` 주석으로 무시하도록 했습니다.

개선 사항:
- 메인 애플리케이션 모듈에서 라우터 임포트 형식을 정리했습니다.

문서화:
- FastAPI lifespan 매니저, Redis 비가용성 핸들러, health 및 root 엔드포인트에 대해 한·영( KO/EN ) 이중 언어 docstring 을 추가하고, 표준화된 Args/Returns 설명과 명시적인 response model 을 포함했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize documentation and error handling metadata in the FastAPI main entrypoint.

Bug Fixes:
- Silence strict typing mismatches for global Starlette exception handler registrations using targeted type ignore annotations.

Enhancements:
- Clean up router import formatting in the main application module.

Documentation:
- Add bilingual (KO/EN) docstrings for the FastAPI lifespan manager, Redis unavailability handler, health, and root endpoints, including standardized Args/Returns descriptions and explicit response models.

</details>