### PR TITLE
📝 docs [#12.3.20] - ㊽ `utils` 디렉토리 Docstring 이중 언어 표준화 적용

### DIFF
--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -39,23 +39,29 @@ def safe_parse_env_int(
     env_var_name: str, default: int, min_val: Optional[int] = None
 ) -> int:
     """
+    [KO]
     환경 변수를 정수형(int)으로 안전하게 파싱합니다.
     실패 시 로그를 남기고 기본값을 반환합니다.
 
+    Args:
+        env_var_name: 파싱할 환경 변수의 이름
+        default: 파싱 실패 시 반환할 기본값
+        min_val: 허용되는 최소값 (지정 시 이보다 작으면 기본값 반환)
+
+    Returns:
+        파싱된 정수값 또는 기본값
+
+    [EN]
     Safely parses an environment variable into an integer.
     Logs a warning and returns the default value upon failure.
 
     Args:
-        env_var_name (str): 파싱할 환경 변수의 이름.
-            The name of the environment variable to parse.
-        default (int): 파싱 실패 시 반환할 기본값.
-            The default value to return if parsing fails.
-        min_val (Optional[int]): 허용되는 최소값 (지정 시 이보다 작으면 기본값 반환).
-            The minimum allowed value (returns default if parsed value is smaller).
+        env_var_name: The name of the environment variable to parse
+        default: The default value to return if parsing fails
+        min_val: The minimum allowed value (returns default if parsed value is smaller)
 
     Returns:
-        int: 파싱된 정수값 또는 기본값.
-            The parsed integer or the default value.
+        The parsed integer or the default value
     """
     val = os.getenv(env_var_name)
     if val is None:
@@ -86,23 +92,29 @@ def safe_parse_env_float(
     env_var_name: str, default: float, min_val: Optional[float] = None
 ) -> float:
     """
+    [KO]
     환경 변수를 실수형(float)으로 안전하게 파싱합니다.
     실패 시 로그를 남기고 기본값을 반환합니다.
 
+    Args:
+        env_var_name: 파싱할 환경 변수의 이름
+        default: 파싱 실패 시 반환할 기본값
+        min_val: 허용되는 최소값 (지정 시 이보다 작으면 기본값 반환)
+
+    Returns:
+        파싱된 실수값 또는 기본값
+
+    [EN]
     Safely parses an environment variable into a float.
     Logs a warning and returns the default value upon failure.
 
     Args:
-        env_var_name (str): 파싱할 환경 변수의 이름.
-            The name of the environment variable to parse.
-        default (float): 파싱 실패 시 반환할 기본값.
-            The default value to return if parsing fails.
-        min_val (Optional[float]): 허용되는 최소값 (지정 시 이보다 작으면 기본값 반환).
-            The minimum allowed value (returns default if parsed value is smaller).
+        env_var_name: The name of the environment variable to parse
+        default: The default value to return if parsing fails
+        min_val: The minimum allowed value (returns default if parsed value is smaller)
 
     Returns:
-        float: 파싱된 실수값 또는 기본값.
-            The parsed float or the default value.
+        The parsed float or the default value
     """
     val = os.getenv(env_var_name)
     if val is None:
@@ -131,25 +143,31 @@ def safe_parse_env_float(
 
 def mask_pii_id(value: Optional[str], truncate_len: int = 12) -> str:
     """
-    민감 문자열(user_id, session_id 등)을 SHA-256으로 해시화하는 중앙 유틸리티.
+    [KO]
+    민감 문자열(user_id, session_id 등)을 SHA-256으로 해시화하는 중앙 유틸리티입니다.
     로그에 개인정보(PII)가 노출되지 않도록 안전하게 마스킹합니다.
 
+    Args:
+        value: 마스킹할 원본 문자열
+        truncate_len: 반환할 해시 문자열의 최대 길이 (기본값 12)
+            - 0이면 전체 해시 문자열 반환
+            - 음수 전달 시 0으로 정규화(안전 폴백)하여 전체 반환
+
+    Returns:
+        안전하게 마스킹된 해시 문자열 또는 INVALID_PII_SENTINEL
+
+    [EN]
     Central utility to hash sensitive strings (e.g., user_id, session_id) using SHA-256.
     Safely masks Personally Identifiable Information (PII) to prevent log exposure.
 
     Args:
-        value (Optional[str]): 마스킹할 원본 문자열.
-            The original string to mask.
-        truncate_len (int): 반환할 해시 문자열의 최대 길이 (기본값 12).
-            - 0이면 전체 해시 문자열 반환.
-            - 음수 전달 시 0으로 정규화(안전 폴백)하여 전체 반환.
-            Maximum length of the returned hash string (default 12).
-            - If 0, returns the full hash string.
-            - If negative, normalizes to 0 (safe fallback) and returns full.
+        value: The original string to mask
+        truncate_len: Maximum length of the returned hash string (default 12)
+            - If 0, returns the full hash string
+            - If negative, normalizes to 0 (safe fallback) and returns full
 
     Returns:
-        str: 안전하게 마스킹된 해시 문자열 또는 INVALID_PII_SENTINEL.
-            Safely masked hash string or INVALID_PII_SENTINEL.
+        Safely masked hash string or INVALID_PII_SENTINEL
     """
     if not value or not isinstance(value, str):
         return INVALID_PII_SENTINEL
@@ -163,23 +181,25 @@ def mask_pii_id(value: Optional[str], truncate_len: int = 12) -> str:
 
 def get_chat_log_extra(request_or_body: Any) -> Dict[str, Any]:
     """
+    [KO]
     채팅 엔드포인트에서 공통으로 사용하는 안전한 로깅 딕셔너리를 생성합니다.
-
-    입력 객체의 형태를 검사하여 (dict 또는 BaseModel 등)
-    안전하게 필드를 추출하고 민감 정보를 마스킹 처리합니다.
-
-    Creates a safe logging dictionary commonly used across chat endpoints.
-
-    Inspects the input object type (dict or BaseModel) to safely extract
-    fields and mask sensitive information.
+    입력 객체의 형태를 검사하여 (dict 또는 BaseModel 등) 안전하게 필드를 추출하고 민감 정보를 마스킹 처리합니다.
 
     Args:
-        request_or_body (Any): 파싱할 요청 객체 또는 딕셔너리.
-            The request object or dictionary to parse.
+        request_or_body: 파싱할 요청 객체 또는 딕셔너리
 
     Returns:
-        Dict[str, Any]: 마스킹된 사용자 ID와 축약된 쿼리 문자열이 포함된 딕셔너리.
-            A dictionary containing the masked user ID and truncated query string.
+        마스킹된 사용자 ID와 축약된 쿼리 문자열이 포함된 딕셔너리
+
+    [EN]
+    Creates a safe logging dictionary commonly used across chat endpoints.
+    Inspects the input object type (dict or BaseModel) to safely extract fields and mask sensitive information.
+
+    Args:
+        request_or_body: The request object or dictionary to parse
+
+    Returns:
+        A dictionary containing the masked user ID and truncated query string
     """
     if isinstance(request_or_body, Mapping):
         raw_user_id = request_or_body.get("user_id")
@@ -208,25 +228,29 @@ def check_metadata_match(
     doc_metadata: Optional[Dict[str, Any]], metadata_filter: Optional[Dict[str, Any]]
 ) -> bool:
     """
+    [KO]
     문서의 메타데이터가 지정된 필터 조건에 부합하는지 확인합니다.
-
     OR 시맨틱을 적용하여 문서의 값 중 하나라도 필터 후보군에 포함되는지 검사합니다.
     빈 리스트 필터([])는 유효한 매칭 후보가 없는 것으로 간주하여 즉시 False를 반환합니다.
 
-    Checks if the document's metadata matches the specified filter conditions.
+    Args:
+        doc_metadata: 문서에서 추출한 메타데이터 딕셔너리
+        metadata_filter: 적용할 필터 조건
 
+    Returns:
+        모든 필터 조건을 만족하면 True, 하나라도 불일치하면 False
+
+    [EN]
+    Checks if the document's metadata matches the specified filter conditions.
     Applies OR semantics to check if any document value is included in the filter candidates.
     An empty list filter ([]) is considered to have no valid matching candidates, returning False immediately.
 
     Args:
-        doc_metadata (Optional[Dict[str, Any]]): 문서에서 추출한 메타데이터 딕셔너리.
-            The metadata dictionary extracted from the document.
-        metadata_filter (Optional[Dict[str, Any]]): 적용할 필터 조건.
-            The filter conditions to apply.
+        doc_metadata: The metadata dictionary extracted from the document
+        metadata_filter: The filter conditions to apply
 
     Returns:
-        bool: 모든 필터 조건을 만족하면 True, 하나라도 불일치하면 False.
-            True if all conditions are met, False if any condition fails.
+        True if all conditions are met, False if any condition fails
     """
     if not metadata_filter:
         return True
@@ -259,25 +283,27 @@ def check_metadata_match(
 
 def count_tokens(text: str, model: str = "gpt-4") -> int:
     """
+    [KO]
     주어진 텍스트와 모델에 대한 토큰 수를 계산합니다.
-
-    tiktoken을 사용하여 정확한 토큰 수를 산출하며,
-    실패 시 단순 문자 길이 기반 휴리스틱(문자수 // 4)으로 대체합니다.
-
-    Calculates the number of tokens for a given text and model.
-
-    Uses tiktoken for accurate calculation, falling back to a simple
-    character length heuristic (char length // 4) on failure.
+    tiktoken을 사용하여 정확한 토큰 수를 산출하며, 실패 시 단순 문자 길이 기반 휴리스틱(문자수 // 4)으로 대체합니다.
 
     Args:
-        text (str): 토큰 수를 계산할 텍스트.
-            The text to count tokens for.
-        model (str): 기준이 되는 모델명 (기본값: "gpt-4").
-            The reference model name (default: "gpt-4").
+        text: 토큰 수를 계산할 텍스트
+        model: 기준이 되는 모델명 (기본값: "gpt-4")
 
     Returns:
-        int: 계산된 토큰 수.
-            The calculated number of tokens.
+        계산된 토큰 수
+
+    [EN]
+    Calculates the number of tokens for a given text and model.
+    Uses tiktoken for accurate calculation, falling back to a simple character length heuristic (char length // 4) on failure.
+
+    Args:
+        text: The text to count tokens for
+        model: The reference model name (default: "gpt-4")
+
+    Returns:
+        The calculated number of tokens
     """
     try:
         encoding = tiktoken.encoding_for_model(model)
@@ -289,42 +315,56 @@ def count_tokens(text: str, model: str = "gpt-4") -> int:
 
 def read_file_content(file_path: str) -> str:
     """
+    [KO]
     지정된 경로의 파일 내용을 읽어 문자열로 반환합니다.
 
+    Args:
+        file_path: 읽어올 파일의 경로
+
+    Returns:
+        파일의 텍스트 내용
+
+    Raises:
+        RuntimeError: 파일 읽기에 실패했을 때 발생
+
+    [EN]
     Reads the contents of a file at the specified path and returns it as a string.
 
     Args:
-        file_path (str): 읽어올 파일의 경로.
-            The path of the file to read.
+        file_path: The path of the file to read
 
     Returns:
-        str: 파일의 텍스트 내용.
-            The text content of the file.
+        The text content of the file
 
     Raises:
-        Exception: 파일 읽기에 실패했을 때 발생.
-            Raised when reading the file fails.
+        RuntimeError: Raised when reading the file fails
     """
     try:
         with open(file_path, "r", encoding="utf-8") as f:
             return f.read()
-    except Exception as e:
-        raise Exception(f"파일 읽기 실패: {str(e)}")
+    except OSError as e:
+        raise RuntimeError(f"파일 읽기 실패: {str(e)}") from e
 
 
 def format_file_size(size_bytes: int) -> str:
     """
+    [KO]
     바이트 단위의 파일 크기를 사람이 읽기 쉬운 형식(B, KB, MB, GB, TB)으로 변환합니다.
 
+    Args:
+        size_bytes: 변환할 파일 크기(바이트)
+
+    Returns:
+        변환된 문자열 포맷
+
+    [EN]
     Converts a file size in bytes to a human-readable format (B, KB, MB, GB, TB).
 
     Args:
-        size_bytes (int): 변환할 파일 크기(바이트).
-            The file size in bytes to convert.
+        size_bytes: The file size in bytes to convert
 
     Returns:
-        str: 변환된 문자열 포맷.
-            The formatted file size string.
+        The formatted file size string
     """
     # [Validation] 음수 용량 예외 방어
     current_size: float = max(0.0, float(size_bytes))
@@ -337,40 +377,54 @@ def format_file_size(size_bytes: int) -> str:
 
 def estimate_cost(tokens: int, cost_per_token: float) -> float:
     """
+    [KO]
     총 토큰 수와 토큰당 단가를 기반으로 예상 비용(USD)을 추정합니다.
 
+    Args:
+        tokens: 사용된 전체 토큰 수
+        cost_per_token: 1 토큰당 비용
+
+    Returns:
+        추정된 총 비용
+
+    [EN]
     Estimates the expected cost (in USD) based on total tokens and cost per token.
 
     Args:
-        tokens (int): 사용된 전체 토큰 수.
-            The total number of tokens used.
-        cost_per_token (float): 1 토큰당 비용.
-            The cost per single token.
+        tokens: The total number of tokens used
+        cost_per_token: The cost per single token
 
     Returns:
-        float: 추정된 총 비용.
-            The estimated total cost.
+        The estimated total cost
     """
     return tokens * cost_per_token
 
 
 def load_pdf(file) -> str:
     """
+    [KO]
     Streamlit 인터페이스를 통해 업로드된 PDF 파일에서 텍스트를 추출합니다.
 
+    Args:
+        file: Streamlit의 UploadedFile 객체
+
+    Returns:
+        PDF에서 추출된 전체 텍스트
+
+    Raises:
+        RuntimeError: PDF 파싱이나 텍스트 추출에 실패했을 때 발생
+
+    [EN]
     Extracts text from a PDF file uploaded via the Streamlit interface.
 
     Args:
-        file: Streamlit의 UploadedFile 객체.
-            The UploadedFile object from Streamlit.
+        file: The UploadedFile object from Streamlit
 
     Returns:
-        str: PDF에서 추출된 전체 텍스트.
-            The complete text extracted from the PDF.
+        The complete text extracted from the PDF
 
     Raises:
-        Exception: PDF 파싱이나 텍스트 추출에 실패했을 때 발생.
-            Raised when PDF parsing or text extraction fails.
+        RuntimeError: Raised when PDF parsing or text extraction fails
     """
     try:
         import pypdf  # type: ignore[import]
@@ -387,27 +441,28 @@ def load_pdf(file) -> str:
         return "\n".join(pages_text).strip()
 
     except Exception as e:
-        raise Exception(f"PDF 읽기 실패: {str(e)}")
+        raise RuntimeError(f"PDF 읽기 실패: {str(e)}") from e
 
 
 def save_to_markdown(text: str, filepath: str, title: str = "Untitled"):
     """
+    [KO]
     추출된 텍스트를 지정된 경로에 마크다운(.md) 파일로 저장합니다.
-
     디렉터리가 존재하지 않으면 자동으로 생성하고, 문서 상단에 메타데이터를 추가합니다.
 
-    Saves the extracted text to a Markdown (.md) file at the specified path.
+    Args:
+        text: 저장할 본문 텍스트
+        filepath: 생성할 마크다운 파일의 절대 또는 상대 경로
+        title: 문서 상단 헤더에 들어갈 제목 (기본값: "Untitled")
 
-    Automatically creates parent directories if they do not exist, and prepends
-    metadata to the top of the document.
+    [EN]
+    Saves the extracted text to a Markdown (.md) file at the specified path.
+    Automatically creates parent directories if they do not exist, and prepends metadata to the top of the document.
 
     Args:
-        text (str): 저장할 본문 텍스트.
-            The body text to save.
-        filepath (str): 생성할 마크다운 파일의 절대 또는 상대 경로.
-            The absolute or relative path for the generated markdown file.
-        title (str): 문서 상단 헤더에 들어갈 제목 (기본값: "Untitled").
-            The title to insert at the top header of the document (default: "Untitled").
+        text: The body text to save
+        filepath: The absolute or relative path for the generated markdown file
+        title: The title to insert at the top header of the document (default: "Untitled")
     """
     # 디렉토리 생성
     Path(filepath).parent.mkdir(parents=True, exist_ok=True)

--- a/backend/utils/observability.py
+++ b/backend/utils/observability.py
@@ -23,10 +23,13 @@ from backend.config import AlertConfig
 
 class ObsEvent(str, Enum):
     """
-    Standard event names for the observability system (표준 관측성 이벤트 이름).
+    [KO]
+    표준 관측성 이벤트 이름입니다.
+    모니터링 대시보드(ELK 등)와 알림 규칙 엔진에서 사용할 수 있도록 중앙화된 이벤트 식별자를 제공합니다.
 
-    [KO] 모니터링 대시보드(ELK 등)와 알림 규칙 엔진에서 사용할 수 있도록 중앙화된 이벤트 식별자를 제공합니다.
-    [EN] Provides centralized event identifiers for monitoring dashboards (e.g., ELK) and alert rule engines.
+    [EN]
+    Standard event names for the observability system.
+    Provides centralized event identifiers for monitoring dashboards (e.g., ELK) and alert rule engines.
     """
 
     FINETUNE_RESERVED_REDIS_KEY_VIOLATION = "reserved_redis_keys_in_extra_fields"
@@ -34,10 +37,13 @@ class ObsEvent(str, Enum):
 
 class ObsMetaTag(str, Enum):
     """
-    Metadata flags for the observability system (관측성 메타데이터 태그).
+    [KO]
+    관측성 메타데이터 태그입니다.
+    `meta_` 네임스페이스를 사용하여 시스템 제어용 데이터를 비즈니스 데이터와 분리합니다.
 
-    [KO] `meta_` 네임스페이스를 사용하여 시스템 제어용 데이터를 비즈니스 데이터와 분리합니다.
-    [EN] Uses the `meta_` namespace to separate system control data from business data.
+    [EN]
+    Metadata flags for the observability system.
+    Uses the `meta_` namespace to separate system control data from business data.
     """
 
     INTENTIONAL_WARNING = "meta_intentional_warning"
@@ -45,24 +51,38 @@ class ObsMetaTag(str, Enum):
 
 class DiscordAlertHandler(logging.Handler):
     """
-    Discord Webhook Alert Handler (Discord 알림 전송 핸들러).
+    [KO]
+    Discord 웹훅 알림 전송 핸들러입니다.
+    `[OBS]` 태그가 포함되거나 ERROR 레벨 이상인 로그를 감지하여 비동기로 전송합니다.
 
-    [KO] `[OBS]` 태그가 포함되거나 ERROR 레벨 이상인 로그를 감지하여 비동기로 전송합니다.
-    [EN] Detects logs with the `[OBS]` tag or at ERROR level and above, sending them asynchronously.
+    알림 제한 규칙 (Throttling Semantics):
+    - Key: 로그 레벨 및 포맷팅되지 않은 원본 메시지 기준
+    - Window: `throttle_seconds` (기본값: AlertConfig.DEFAULT_THROTTLE_SECONDS)
+    - Behavior: 동일한 시간 창(Window) 내의 중복 알림을 억제하여 스팸을 방지합니다.
 
-    Throttling Semantics (알림 제한 규칙):
-    - Key: `f"{record.levelno}:{record.getMessage()}"` (Per log level and unformatted content).
-    - Window: `throttle_seconds` (Default: AlertConfig.DEFAULT_THROTTLE_SECONDS).
+    [EN]
+    Discord Webhook Alert Handler.
+    Detects logs with the `[OBS]` tag or at ERROR level and above, sending them asynchronously.
+
+    Throttling Semantics:
+    - Key: Per log level and unformatted content
+    - Window: `throttle_seconds` (Default: AlertConfig.DEFAULT_THROTTLE_SECONDS)
     - Behavior: Suppresses duplicate alerts within the same time window to prevent spam.
     """
 
     def __init__(self, webhook_url: Optional[str] = None):
         """
-        [KO] 핸들러 및 Throttling 제어 상태를 초기화합니다.
-        [EN] Initializes the handler and its throttling control state.
+        [KO]
+        핸들러 및 Throttling 제어 상태를 초기화합니다.
 
         Args:
-            webhook_url: Discord webhook URL. (Default: AlertConfig.DISCORD_WEBHOOK_URL)
+            webhook_url: Discord 웹훅 URL (기본값: AlertConfig.DISCORD_WEBHOOK_URL)
+
+        [EN]
+        Initializes the handler and its throttling control state.
+
+        Args:
+            webhook_url: Discord webhook URL (Default: AlertConfig.DISCORD_WEBHOOK_URL)
         """
         super().__init__()
         self.webhook_url = webhook_url or AlertConfig.DISCORD_WEBHOOK_URL
@@ -77,8 +97,11 @@ class DiscordAlertHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord):
         """
-        [KO] 로그 레코드를 평가하여 Throttling 규칙 통과 시 Discord 알림을 트리거합니다.
-        [EN] Evaluates the log record and triggers a Discord alert if it passes throttling rules.
+        [KO]
+        로그 레코드를 평가하여 Throttling 규칙 통과 시 Discord 알림을 트리거합니다.
+
+        [EN]
+        Evaluates the log record and triggers a Discord alert if it passes throttling rules.
         """
         # 1. 대상 필터링: [OBS] 태그 체크 또는 ERROR 레벨 이상
         message = self.format(record)
@@ -119,8 +142,11 @@ class DiscordAlertHandler(logging.Handler):
 
     def _send_discord_alert(self, formatted_message: str, record: logging.LogRecord):
         """
-        [KO] HTTP 통신을 통해 구성된 Embed 데이터를 Discord 웹훅으로 전송합니다.
-        [EN] Sends the constructed Embed data to the Discord webhook via HTTP request.
+        [KO]
+        HTTP 통신을 통해 구성된 Embed 데이터를 Discord 웹훅으로 전송합니다.
+
+        [EN]
+        Sends the constructed Embed data to the Discord webhook via HTTP request.
         """
         if not self.webhook_url:
             return
@@ -178,8 +204,11 @@ class DiscordAlertHandler(logging.Handler):
 
     def close(self):
         """
-        [KO] 로깅 시스템 종료 시 ThreadPool 자원을 회수하며(Shutdown Hook), 부모 핸들러의 close()를 호출합니다.
-        [EN] Reclaims ThreadPool resources on system shutdown and calls the parent handler's close().
+        [KO]
+        로깅 시스템 종료 시 ThreadPool 자원을 회수하며(Shutdown Hook), 부모 핸들러의 close()를 호출합니다.
+
+        [EN]
+        Reclaims ThreadPool resources on system shutdown and calls the parent handler's close().
         """
         if hasattr(self, "_executor"):
             # 최대한 생성된 알림 전송 태스크가 완료되도록 대기 (Best-effort delivery)


### PR DESCRIPTION
- **[이중 언어 표준화 적용]**
  - `backend/utils/common.py` 내 11개의 코어 헬퍼 함수에 대해 이중 언어(KO/EN) 포맷 적용.
  - `backend/utils/observability.py` 내 로깅 및 모니터링 훅에 대해 이중 언어(KO/EN) 포맷 적용.
  - 직전 코드 리뷰(가독성 개선) 사항을 선제적으로 반영하여, `[KO]`와 `[EN]` 블록을 상하로 완전히 분리하는 최신 레이아웃 도입.
  - 함수의 파라미터 타입과 중복되는 불필요한 Args 타입 힌트를 제거하여 문서의 간결함 확보.

- **[코드 품질 개선]**
  - 예외 처리 시 범용적인 `Exception` 대신 구체적인 `RuntimeError`를 사용하고, `from e` 구문을 통해 원본 예외(Stack Trace)를 명시적으로 체이닝하도록 수정.

🔗 Related: Issue [#1044]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

코어 유틸리티 및 관측(Observability) 모듈의 한·영(KO/EN) 도크스트링 형식을 표준화하고, 파일 및 PDF 작업에 대한 예외 처리를 강화합니다.

Enhancements:
- 파일 및 PDF 유틸리티에서 예외 처리를 개선하여, 일반적인 예외 대신 명시적인 예외 체이닝이 포함된 `RuntimeError`를 발생시키도록 변경.
- 관측 관련 enum과 알림(알럿) 핸들러 동작 설명을 명확히 정리하여, 스로틀링(throttling) 동작과 종료(shutdown) 처리 방식을 분명히 하되, 런타임 동작 자체는 변경하지 않음.

Documentation:
- 공통 유틸리티 헬퍼와 관측 컴포넌트에 일관된 한·영(KO/EN) 도크스트링 레이아웃을 적용하고, 인자 및 반환 타입 설명을 단순화하여 가독성을 향상.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize bilingual (KO/EN) docstrings in core utility and observability modules and tighten exception handling for file and PDF operations.

Enhancements:
- Refine exception handling in file and PDF utilities to raise RuntimeError with explicit exception chaining instead of generic exceptions.
- Clarify observability enums and alert handler behavior descriptions, including throttling semantics and shutdown handling, without changing runtime behavior.

Documentation:
- Apply consistent bilingual KO/EN docstring layout to common utility helpers and observability components, simplifying argument and return type descriptions for better readability.

</details>