### PR TITLE
📝 docs [#12.3.20] - ㊽ 1차 개선 : `load_pdf` 예외 처리 구체화

### DIFF
--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -412,7 +412,8 @@ def load_pdf(file) -> str:
         PDF에서 추출된 전체 텍스트
 
     Raises:
-        RuntimeError: PDF 파싱이나 텍스트 추출에 실패했을 때 발생
+        RuntimeError: pypdf 라이브러리가 설치되지 않았을 때, PDF 파싱 오류(PyPdfError),
+            입력값 오류(ValueError), 또는 I/O 오류(OSError) 발생 시
 
     [EN]
     Extracts text from a PDF file uploaded via the Streamlit interface.
@@ -424,11 +425,16 @@ def load_pdf(file) -> str:
         The complete text extracted from the PDF
 
     Raises:
-        RuntimeError: Raised when PDF parsing or text extraction fails
+        RuntimeError: Raised when pypdf is not installed, on PDF parsing error (PyPdfError),
+            invalid input (ValueError), or I/O error (OSError)
     """
     try:
         import pypdf  # type: ignore[import]
+        import pypdf.errors  # type: ignore[import]
+    except ImportError as e:
+        raise RuntimeError("pypdf 라이브러리가 설치되어 있지 않습니다.") from e
 
+    try:
         # PDF 리더 생성
         pdf_reader = pypdf.PdfReader(file)
 
@@ -440,7 +446,11 @@ def load_pdf(file) -> str:
 
         return "\n".join(pages_text).strip()
 
-    except Exception as e:
+    except pypdf.errors.PyPdfError as e:
+        # PDF 파싱 오류 (pypdf 내부 예외 계층 base)
+        raise RuntimeError(f"PDF 파싱 실패: {str(e)}") from e
+    except (ValueError, OSError) as e:
+        # 잘못된 입력값 또는 I/O 오류
         raise RuntimeError(f"PDF 읽기 실패: {str(e)}") from e
 
 


### PR DESCRIPTION
- Sourcery 리뷰 반영: `load_pdf` 함수의 광범위한 `except Exception` 구문을 3가지 구체적 예외로 분리.
  - `ImportError`: pypdf 미설치 시 → 별도 try 블록으로 분리하여 스코프 문제 해결
  - `pypdf.errors.PyPdfError`: pypdf 내부 파싱 오류 (PDF 구조 이상, 암호화 파일 등)
  - `(ValueError, OSError)`: 잘못된 입력값 또는 I/O 오류
- `read_file_content`와 동급의 예외 구체성 달성 (일관성 확보).
- 각 except 절에서 `from e` 체이닝으로 원본 스택 트레이스 보존.
- Docstring Raises 항목에 새로운 예외 경로 3가지 모두 명시.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1724#pullrequestreview-4812073118)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

구체적인 예외 타입을 사용하도록 PDF 로딩 오류 처리를 개선하고, 새로운 실패 양상을 문서에 반영합니다.

Enhancements:
- `load_pdf`의 오류 처리를 광범위한 포괄적인 예외 처리에서 `ImportError`, `PyPdfError`, `ValueError`, `OSError`를 명시적으로 처리하도록 범위를 좁히면서, 기존 스택 트레이스를 유지합니다.

Documentation:
- 이제 `RuntimeError`로 매핑되는 개별 오류 시나리오를 문서화하기 위해 `load_pdf`의 docstring 내 `Raises` 섹션을 확장합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine PDF loading error handling to use specific exception types and update documentation to reflect the new failure modes.

Enhancements:
- Narrow load_pdf error handling from a broad catch-all to explicit handling of ImportError, PyPdfError, ValueError, and OSError while preserving original stack traces.

Documentation:
- Expand load_pdf docstring Raises section to document the distinct error scenarios that now map to RuntimeError.

</details>