### PR TITLE
📝 docs [#12.3.20] - ㊽ 2차 개선 : `load_pdf` import 정리 및 에러 메시지 통일

### DIFF
--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -412,8 +412,8 @@ def load_pdf(file) -> str:
         PDF에서 추출된 전체 텍스트
 
     Raises:
-        RuntimeError: pypdf 라이브러리가 설치되지 않았을 때, PDF 파싱 오류(PyPdfError),
-            입력값 오류(ValueError), 또는 I/O 오류(OSError) 발생 시
+        RuntimeError: pypdf 라이브러리가 설치되지 않았을 때, 또는 PDF 읽기 실패 시
+            (예외 유형 포함: ``PDF 읽기 실패: ExcType: 메시지`` 형식으로 디버깅 지원)
 
     [EN]
     Extracts text from a PDF file uploaded via the Streamlit interface.
@@ -425,18 +425,18 @@ def load_pdf(file) -> str:
         The complete text extracted from the PDF
 
     Raises:
-        RuntimeError: Raised when pypdf is not installed, on PDF parsing error (PyPdfError),
-            invalid input (ValueError), or I/O error (OSError)
+        RuntimeError: Raised when pypdf is not installed, or when PDF reading fails.
+            Message format: ``PDF 읽기 실패: ExcType: message`` for debuggability.
     """
     try:
-        import pypdf  # type: ignore[import]
-        import pypdf.errors  # type: ignore[import]
+        from pypdf import PdfReader  # type: ignore[import]
+        from pypdf.errors import PyPdfError  # type: ignore[import]
     except ImportError as e:
         raise RuntimeError("pypdf 라이브러리가 설치되어 있지 않습니다.") from e
 
     try:
         # PDF 리더 생성
-        pdf_reader = pypdf.PdfReader(file)
+        pdf_reader = PdfReader(file)
 
         # 모든 페이지의 텍스트 추출 (리스트 컴프리헨션 및 join 사용으로 성능 최적화)
         pages_text = []
@@ -446,12 +446,12 @@ def load_pdf(file) -> str:
 
         return "\n".join(pages_text).strip()
 
-    except pypdf.errors.PyPdfError as e:
+    except PyPdfError as e:
         # PDF 파싱 오류 (pypdf 내부 예외 계층 base)
-        raise RuntimeError(f"PDF 파싱 실패: {str(e)}") from e
+        raise RuntimeError(f"PDF 읽기 실패: {type(e).__name__}: {e}") from e
     except (ValueError, OSError) as e:
         # 잘못된 입력값 또는 I/O 오류
-        raise RuntimeError(f"PDF 읽기 실패: {str(e)}") from e
+        raise RuntimeError(f"PDF 읽기 실패: {type(e).__name__}: {e}") from e
 
 
 def save_to_markdown(text: str, filepath: str, title: str = "Untitled"):


### PR DESCRIPTION
- Sourcery 2차 리뷰 반영: 두 줄의 분리된 임포트를 단일 `from-style` 임포트로 통합.
  - 변경 전: `import pypdf` + `import pypdf.errors` (2줄)
  - 변경 후: `from pypdf import PdfReader` + `from pypdf.errors import PyPdfError` (명시적 참조)
- 에러 메시지 불일치 해소: 모든 except 경로를 `"PDF 읽기 실패: {type(e).__name__}: {e}"` 형식으로 통일.
  - 예외 유형 이름을 메시지에 포함시켜 디버깅 시 즉시 원인 식별 가능.
  - 기존 테스트의 `assert "PDF 읽기 실패"` 검증과 완전 호환 유지.
- Docstring Raises 항목도 새 메시지 형식을 명시하도록 업데이트.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1725#pullrequestreview-4812167654)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

PDF 로딩 오류 처리를 표준화하고 `load_pdf` 유틸리티의 임포트를 업데이트합니다.

Enhancements:
- `load_pdf`에서 `pypdf`의 `PdfReader`와 `PyPdfError`를 명시적으로 임포트하여 사용하도록 개선합니다.
- 모든 PDF 읽기 실패에 대해 `RuntimeError` 메시지를 통일하여, 예외 타입을 포함하도록 함으로써 디버깅을 쉽게 합니다.

Documentation:
- `load_pdf`의 독스트링을 업데이트하여 예외 타입을 포함하는 새로운 일관된 PDF 오류 메시지 형식을 설명합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize PDF loading error handling and update imports in the load_pdf utility.

Enhancements:
- Refine load_pdf to use explicit PdfReader and PyPdfError imports from pypdf.
- Unify RuntimeError messages for all PDF reading failures to include the exception type for easier debugging.

Documentation:
- Update load_pdf docstring to describe the new, consistent PDF error message format including exception type.

</details>