### PR TITLE
📝 docs [#12.3.20] - ㊽ 3차 개선 : `load_pdf` except 블록 통합 및 EN docstring 수정

### DIFF
--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -426,7 +426,8 @@ def load_pdf(file) -> str:
 
     Raises:
         RuntimeError: Raised when pypdf is not installed, or when PDF reading fails.
-            Message format: ``PDF 읽기 실패: ExcType: message`` for debuggability.
+            Format: ``PDF 읽기 실패: ExcType: message``
+            (note: the ``PDF 읽기 실패`` prefix is Korean-localized)
     """
     try:
         from pypdf import PdfReader  # type: ignore[import]
@@ -446,11 +447,8 @@ def load_pdf(file) -> str:
 
         return "\n".join(pages_text).strip()
 
-    except PyPdfError as e:
-        # PDF 파싱 오류 (pypdf 내부 예외 계층 base)
-        raise RuntimeError(f"PDF 읽기 실패: {type(e).__name__}: {e}") from e
-    except (ValueError, OSError) as e:
-        # 잘못된 입력값 또는 I/O 오류
+    except (PyPdfError, ValueError, OSError) as e:
+        # PDF 파싱 오류(PyPdfError), 잘못된 입력값(ValueError), 또는 I/O 오류(OSError)
         raise RuntimeError(f"PDF 읽기 실패: {type(e).__name__}: {e}") from e
 
 


### PR DESCRIPTION
- 3차 리뷰 반영: 동일한 로직을 가진 두 개의 except 블록을 단일 블록으로 통합.
  - 변경 전: `except PyPdfError` + `except (ValueError, OSError)` (2개 블록)
  - 변경 후: `except (PyPdfError, ValueError, OSError)` (1개 블록)
  - 에러 메시지 형식 변경 시 한 곳만 수정하면 됨 (Single Source of Truth).
- `[EN]` Docstring Raises에서 한국어 prefix(`PDF 읽기 실패`)가 노출되던 문제 수정.
  - 영문 예시 형식을 유지하되 `(note: ... prefix is Korean-localized)`로 의도 명시.
- Individual 코멘트(헬퍼 함수 제안): 블록 통합으로 중복이 원천 해소되어 헬퍼 불필요.

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1726#pullrequestreview-4812224397)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

PDF 로딩 오류 처리를 단일 예외 블록으로 통합하고, `load_pdf` docstring에서 지역화된 오류 메시지 형식(포맷)을 명확히 합니다.

Enhancements:
- `load_pdf`에서 `PyPdfError`, `ValueError`, `OSError` 처리를 단일 `RuntimeError` 발생 블록으로 통합하여 PDF 읽기 실패 로직을 중앙집중식으로 관리합니다.

Documentation:
- 기존 형식(description of format)을 유지하면서, 영어 `load_pdf` docstring을 업데이트하여 한국어로 지역화된 오류 메시지 접두사(prefix)가 어떻게 표현되는지 명시적으로 설명합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Consolidate PDF loading error handling into a single exception block and clarify the localized error message format in the load_pdf docstring.

Enhancements:
- Unify PyPdfError, ValueError, and OSError handling in load_pdf into a single RuntimeError-raising block to centralize PDF read failure logic.

Documentation:
- Update the English load_pdf docstring to describe the Korean-localized error message prefix explicitly while preserving the existing format description.

</details>