### PR TITLE
📝 docs [#12.3.20] - ㊾ `pdf_helper.py` 모듈 Docstring 표준화 및 예외 구체화

### DIFF
--- a/backend/modules/pdf_helper.py
+++ b/backend/modules/pdf_helper.py
@@ -3,60 +3,93 @@
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 """
-FlowNote MVP - PDF 처리 모듈
+[KO] FlowNote MVP - PDF 처리 모듈
+[EN] FlowNote MVP - PDF Helper Module
+
+[KO] 업로드된 PDF 파일에서 텍스트를 추출하거나 유효성을 검증하는 헬퍼 모듈입니다.
+[EN] Helper module for extracting text or validating uploaded PDF files.
 """
 
-
-import pypdf
+from pypdf import PdfReader
+from pypdf.errors import PyPdfError
 
 
 def extract_text_from_pdf(file) -> str:
     """
-    PDF 파일에서 텍스트 추출 (Streamlit UploadedFile 또는 파일 경로)
+    [KO]
+    PDF 파일에서 텍스트를 추출합니다.
 
     Args:
         file: Streamlit UploadedFile 객체 또는 파일 경로
 
     Returns:
-        str: 추출된 텍스트
+        추출된 전체 텍스트
+
+    Raises:
+        RuntimeError: PDF 읽기 실패 시 발생
+            (예외 유형 포함: ``PDF 읽기 실패: ExcType: 메시지`` 형식으로 디버깅 지원)
+
+    [EN]
+    Extracts text from a PDF file.
+
+    Args:
+        file: Streamlit UploadedFile object or file path
+
+    Returns:
+        The complete text extracted from the PDF
+
+    Raises:
+        RuntimeError: Raised when PDF reading fails.
+            Format: ``PDF 읽기 실패: ExcType: message``
+            (note: the ``PDF 읽기 실패`` prefix is Korean-localized)
     """
     try:
         # UploadedFile인 경우
         if hasattr(file, "read"):
-            pdf_reader = pypdf.PdfReader(file)
+            pdf_reader = PdfReader(file)
         else:
             # 파일 경로인 경우
-            pdf_reader = pypdf.PdfReader(str(file))
+            pdf_reader = PdfReader(str(file))
 
         text = ""
         for page_num, page in enumerate(pdf_reader.pages):
             try:
-                page_text = page.extract_text()
-                if page_text:
+                if page_text := page.extract_text():
                     text += page_text + "\n"
-            except Exception as e:
-                print(f"⚠️ Page {page_num+1} extraction failed: {e}")
+            except (PyPdfError, ValueError, OSError) as e:
+                print(f"⚠️ Page {page_num+1} extraction failed: {type(e).__name__}: {e}")
                 continue
 
         return text.strip()
 
-    except Exception as e:
-        raise Exception(f"PDF 읽기 실패: {str(e)}")
+    except (PyPdfError, ValueError, OSError) as e:
+        # PDF 파싱 오류(PyPdfError), 잘못된 입력값(ValueError), 또는 I/O 오류(OSError)
+        raise RuntimeError(f"PDF 읽기 실패: {type(e).__name__}: {e}") from e
 
 
 def is_valid_pdf(file) -> bool:
     """
-    PDF 파일이 유효한지 확인
+    [KO]
+    PDF 파일이 유효한지 확인합니다.
 
     Args:
-        file: PDF 파일 객체
+        file: PDF 파일 객체 (Streamlit UploadedFile 또는 파일 경로)
 
     Returns:
-        bool: 유효하면 True
+        최소 1페이지 이상 존재하고 파싱 가능한 경우 True, 그렇지 않으면 False
+
+    [EN]
+    Validates if a PDF file is readable.
+
+    Args:
+        file: PDF file object (Streamlit UploadedFile or file path)
+
+    Returns:
+        True if the PDF has at least 1 page and can be parsed, False otherwise
     """
     try:
-        pdf_reader = pypdf.PdfReader(file)
+        pdf_reader = PdfReader(file)
         # 최소 1페이지 이상 있는지 확인
         return len(pdf_reader.pages) > 0
-    except Exception:
+    except (PyPdfError, ValueError, OSError):
         return False


### PR DESCRIPTION
- `pdf_helper.py`의 모듈 및 함수 레벨 Docstring에 `[KO]/[EN]` 이중 언어 표준화 적용
- `extract_text_from_pdf`, `is_valid_pdf` 함수의 포괄적인 `except Exception`을 `except (PyPdfError, ValueError, OSError)`로 구체화하여 안정성 확보
- `import pypdf`를 `from pypdf import PdfReader, errors` 스타일로 최적화
- walrus 연산자(`:=`)를 도입하여 향후 발생할 수 있는 잠재적 Sourcery 린트 리뷰 선제적 대응

🔗 Related: Issue [#1044]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

PDF 헬퍼 모듈의 docstring을 표준화하고, 텍스트 추출 및 검증을 위한 PDF 오류 처리를 강화합니다.

Enhancements:
- PDF 관련 예외 처리를 구체적인 `PyPdfError`, `ValueError`, `OSError` 타입으로 정교하게 다듬고, 더 명확한 메시지와 함께 `RuntimeError`를 발생시키도록 개선합니다.
- `pypdf` 임포트를 최적화하여 `PdfReader`를 직접 사용하고, 페이지 텍스트 추출 로직을 더 간결하게 하기 위해 바다코끼리 연산자(walrus operator)를 도입합니다.

Documentation:
- PDF 헬퍼 유틸리티에 한국어/영어 이중 언어 모듈 및 함수 수준 docstring을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize PDF helper module docstrings and harden PDF error handling for text extraction and validation.

Enhancements:
- Refine PDF-related exception handling to use specific PyPdfError, ValueError, and OSError types and raise RuntimeError with clearer messages.
- Optimize pypdf imports to use PdfReader directly and introduce a walrus operator for more concise page text extraction logic.

Documentation:
- Add bilingual Korean/English module- and function-level docstrings to the PDF helper utilities.

</details>