### PR TITLE
📝 docs [#12.3.20] - ㊿ `export.py` Args 레이아웃 업그레이드

### DIFF
--- a/backend/export.py
+++ b/backend/export.py
@@ -32,16 +32,27 @@ class MarkdownExporter:
         self, query: str, results: List[SearchResult], include_metadata: bool = True
     ) -> str:
         """
-        [KO] 검색 결과 리스트를 마크다운 형식의 문자열로 변환합니다.
-        [EN] Converts a list of search results into a Markdown formatted string.
+        [KO]
+        검색 결과 리스트를 마크다운 형식의 문자열로 변환합니다.
 
         Args:
-            query: 사용자가 입력한 원본 검색 쿼리 / The original search query entered by the user
-            results: 검색 엔진으로부터 반환된 TypedDict 기반 결과 리스트 / List of result dictionaries matching the SearchResult TypedDict
-            include_metadata: 문서 출처, 청크 번호 등 메타데이터 포함 여부 (기본값 True) / Whether to include metadata such as source and chunk index (default True)
+            query: 사용자가 입력한 원본 검색 쿼리
+            results: 검색 엔진으로부터 반환된 TypedDict 기반 결과 리스트
+            include_metadata: 문서 출처, 청크 번호 등 메타데이터 포함 여부 (기본값 True)
 
         Returns:
-            포맷팅이 완료된 마크다운 문자열 / The fully formatted Markdown string
+            포맷팅이 완료된 마크다운 문자열
+
+        [EN]
+        Converts a list of search results into a Markdown formatted string.
+
+        Args:
+            query: The original search query entered by the user
+            results: List of result dictionaries matching the SearchResult TypedDict
+            include_metadata: Whether to include metadata such as source and chunk index (default True)
+
+        Returns:
+            The fully formatted Markdown string
         """
 
         # 시간


### PR DESCRIPTION
- `export.py` 내 `export_search_results()` 함수의 Docstring 레이아웃 표준화
- 기존 인라인 슬래시(`/`) 혼용 방식에서 `[KO]`와 `[EN]` 섹션 분리 방식으로 변경하여 코드베이스 전반의 Docstring 스타일 일관성 확보

🔗 Related: Issue [#1044]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Documentation:
- `export_search_results`의 도큐스트링을 업데이트하여 설명, 파라미터, 반환 값에 대해 [KO]와 [EN] 섹션을 각각 구분해서 사용하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update export_search_results docstring to use distinct [KO] and [EN] sections for description, parameters, and return value.

</details>