### PR TITLE
✨ refactor [#12.3.20] - (53) 1차 개선 : PII 경로 마스킹 및 로그 길이 환경변수 설정

### DIFF
--- a/backend/metadata.py
+++ b/backend/metadata.py
@@ -19,18 +19,31 @@ upon upload, and persists it to a local JSON file.
 import json
 import logging
 import os
+import re
 import uuid
 from datetime import datetime
 from typing import Dict, List, Optional, TypedDict
 
 logger = logging.getLogger(__name__)
 
-MAX_ERROR_LOG_LENGTH = 100
+# 환경변수(배포 정마다 조정 가능) / Configurable via env var per deployment policy
+MAX_ERROR_LOG_LENGTH = int(os.getenv("FLOWNOTE_MAX_ERROR_LOG_LENGTH", "100"))
+
+# 파일 경로 패턴 (주요 PII 노출 원인) / Detects Unix/Windows absolute paths (primary PII risk)
+_SENSITIVE_PATH_RE = re.compile(r"(?:[A-Za-z]:[\\/]|/)(?:[\w.\-\\/]+)")
 
 
 def _format_error_msg(e: Exception) -> str:
-    """Exception 메시지 축약 헬퍼 함수"""
-    err_msg = str(e)
+    """
+    [KO]
+    Exception 메시지의 파일 경로 패턴을 마스킹하고, 환경 변수로 설정된 최대 길이로 잘라내는 헬퍼.
+    주요 PII 위협: OSError에 포함된 파일 경로를 시작점으로 차단합니다.
+
+    [EN]
+    Masks file path patterns in the Exception message, then truncates to the
+    configured max length. Primary PII risk: file paths embedded in OSError.
+    """
+    err_msg = _SENSITIVE_PATH_RE.sub("[REDACTED_PATH]", str(e))
     if len(err_msg) > MAX_ERROR_LOG_LENGTH:
         return f"{err_msg[:MAX_ERROR_LOG_LENGTH]}..."
     return err_msg

--- a/backend/search_history.py
+++ b/backend/search_history.py
@@ -10,6 +10,7 @@
 import json
 import logging
 import os
+import re
 import uuid
 from collections import Counter
 from datetime import date, datetime
@@ -17,7 +18,11 @@ from typing import Any, Dict, List, Optional, TypedDict
 
 logger = logging.getLogger(__name__)
 
-MAX_ERROR_LOG_LENGTH = 100
+# 환경변수(배포 정마다 조정 가능) / Configurable via env var per deployment policy
+MAX_ERROR_LOG_LENGTH = int(os.getenv("FLOWNOTE_MAX_ERROR_LOG_LENGTH", "100"))
+
+# 파일 경로 패턴 (주요 PII 노출 원인) / Detects Unix/Windows absolute paths (primary PII risk)
+_SENSITIVE_PATH_RE = re.compile(r"(?:[A-Za-z]:[\\/]|/)(?:[\w.\-\\/]+)")
 
 
 def _custom_json_serializer(obj: Any) -> str:
@@ -28,13 +33,19 @@ def _custom_json_serializer(obj: Any) -> str:
 
 
 def _format_error_msg(e: Exception) -> str:
-    """Exception 메시지 축약 헬퍼 함수"""
-    err_msg = str(e)
-    return (
-        f"{err_msg[:MAX_ERROR_LOG_LENGTH]}..."
-        if len(err_msg) > MAX_ERROR_LOG_LENGTH
-        else err_msg
-    )
+    """
+    [KO]
+    Exception 메시지의 파일 경로 패턴을 마스킹하고, 환경 변수로 설정된 최대 길이로 잘라내는 헬퍼.
+    주요 PII 위협: OSError에 포함된 파일 경로를 시작점으로 차단합니다.
+
+    [EN]
+    Masks file path patterns in the Exception message, then truncates to the
+    configured max length. Primary PII risk: file paths embedded in OSError.
+    """
+    err_msg = _SENSITIVE_PATH_RE.sub("[REDACTED_PATH]", str(e))
+    if len(err_msg) > MAX_ERROR_LOG_LENGTH:
+        return f"{err_msg[:MAX_ERROR_LOG_LENGTH]}..."
+    return err_msg
 
 
 class SearchStatistics(TypedDict):


### PR DESCRIPTION
- OSError 메시지에 포함될 수 있는 절대 파일 경로(Unix/Windows 패턴)를 [REDACTED_PATH]로 치환하는 `_SENSITIVE_PATH_RE` 정규식 기반 마스킹 로직 추가
- 하드코딩된 `MAX_ERROR_LOG_LENGTH = 100`을 `FLOWNOTE_MAX_ERROR_LOG_LENGTH` 환경변수로 설정 가능하도록 변경하여 배포 환경별 유연한 조정 지원
- `metadata.py` 와 `search_history.py` 에 동일하게 적용하여 코드베이스 일관성 유지

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1738#pullrequestreview-4851413489)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

오류 로그를 개선하여 PII 노출을 줄이고, 모듈 전반에서 로그 잘림 길이를 설정 가능하도록 합니다.

새로운 기능:
- `FLOWNOTE_MAX_ERROR_LOG_LENGTH` 환경 변수를 통해 최대 오류 로그 메시지 길이를 설정할 수 있도록 합니다.

개선 사항:
- 로그에서 PII 유출을 줄이기 위해 예외 메시지에 포함된 절대 파일 경로를 마스킹하고, 비식별화된 플레이스홀더로 대체합니다.
- 통합된 오류 메시지 포매팅 로직을 `metadata` 모듈과 `search_history` 모듈에 모두 일관되게 적용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve error logging to reduce PII exposure and make log truncation length configurable across modules.

New Features:
- Allow configuring maximum error log message length via FLOWNOTE_MAX_ERROR_LOG_LENGTH environment variable.

Enhancements:
- Mask absolute file paths in exception messages with a redacted placeholder to mitigate PII leakage in logs.
- Apply the unified error message formatting logic consistently in both metadata and search_history modules.

</details>