### PR TITLE
✨ refactor [#12.3.20] - (53) 2차 개선 : 에러 헬퍼 공용 모듈 통합 및 안전성 강화

### DIFF
--- a/backend/metadata.py
+++ b/backend/metadata.py
@@ -19,34 +19,13 @@ upon upload, and persists it to a local JSON file.
 import json
 import logging
 import os
-import re
 import uuid
 from datetime import datetime
 from typing import Dict, List, Optional, TypedDict
 
+from backend.utils.common import format_error_msg  # type: ignore[import]
+
 logger = logging.getLogger(__name__)
-
-# 환경변수(배포 정마다 조정 가능) / Configurable via env var per deployment policy
-MAX_ERROR_LOG_LENGTH = int(os.getenv("FLOWNOTE_MAX_ERROR_LOG_LENGTH", "100"))
-
-# 파일 경로 패턴 (주요 PII 노출 원인) / Detects Unix/Windows absolute paths (primary PII risk)
-_SENSITIVE_PATH_RE = re.compile(r"(?:[A-Za-z]:[\\/]|/)(?:[\w.\-\\/]+)")
-
-
-def _format_error_msg(e: Exception) -> str:
-    """
-    [KO]
-    Exception 메시지의 파일 경로 패턴을 마스킹하고, 환경 변수로 설정된 최대 길이로 잘라내는 헬퍼.
-    주요 PII 위협: OSError에 포함된 파일 경로를 시작점으로 차단합니다.
-
-    [EN]
-    Masks file path patterns in the Exception message, then truncates to the
-    configured max length. Primary PII risk: file paths embedded in OSError.
-    """
-    err_msg = _SENSITIVE_PATH_RE.sub("[REDACTED_PATH]", str(e))
-    if len(err_msg) > MAX_ERROR_LOG_LENGTH:
-        return f"{err_msg[:MAX_ERROR_LOG_LENGTH]}..."
-    return err_msg
 
 
 class FileMetadataRecord(TypedDict):
@@ -136,7 +115,7 @@ class FileMetadata:
                     self.metadata = {}
             except json.JSONDecodeError as e:
                 logger.warning(
-                    f"메타데이터 파일 JSON 파싱 실패: {type(e).__name__}: {_format_error_msg(e)}",
+                    f"메타데이터 파일 JSON 파싱 실패: {type(e).__name__}: {format_error_msg(e)}",
                     extra={
                         "action": "load_metadata",
                         "storage_path": self.storage_path,
@@ -146,7 +125,7 @@ class FileMetadata:
                 self.metadata = {}
             except OSError as e:
                 logger.error(
-                    f"메타데이터 파일 읽기 실패: {type(e).__name__}: {_format_error_msg(e)}",
+                    f"메타데이터 파일 읽기 실패: {type(e).__name__}: {format_error_msg(e)}",
                     extra={
                         "action": "load_metadata",
                         "storage_path": self.storage_path,
@@ -174,7 +153,7 @@ class FileMetadata:
                 json.dump(self.metadata, f, ensure_ascii=False, indent=2)
         except OSError as e:
             logger.error(
-                f"메타데이터 파일 저장 실패: {type(e).__name__}: {_format_error_msg(e)}",
+                f"메타데이터 파일 저장 실패: {type(e).__name__}: {format_error_msg(e)}",
                 extra={
                     "action": "save_metadata",
                     "storage_path": self.storage_path,

--- a/backend/search_history.py
+++ b/backend/search_history.py
@@ -10,19 +10,14 @@
 import json
 import logging
 import os
-import re
 import uuid
 from collections import Counter
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional, TypedDict
 
+from backend.utils.common import format_error_msg  # type: ignore[import]
+
 logger = logging.getLogger(__name__)
-
-# 환경변수(배포 정마다 조정 가능) / Configurable via env var per deployment policy
-MAX_ERROR_LOG_LENGTH = int(os.getenv("FLOWNOTE_MAX_ERROR_LOG_LENGTH", "100"))
-
-# 파일 경로 패턴 (주요 PII 노출 원인) / Detects Unix/Windows absolute paths (primary PII risk)
-_SENSITIVE_PATH_RE = re.compile(r"(?:[A-Za-z]:[\\/]|/)(?:[\w.\-\\/]+)")
 
 
 def _custom_json_serializer(obj: Any) -> str:
@@ -30,22 +25,6 @@ def _custom_json_serializer(obj: Any) -> str:
     if isinstance(obj, (datetime, date)):
         return obj.isoformat()
     raise TypeError(f"Type {type(obj)} not serializable")
-
-
-def _format_error_msg(e: Exception) -> str:
-    """
-    [KO]
-    Exception 메시지의 파일 경로 패턴을 마스킹하고, 환경 변수로 설정된 최대 길이로 잘라내는 헬퍼.
-    주요 PII 위협: OSError에 포함된 파일 경로를 시작점으로 차단합니다.
-
-    [EN]
-    Masks file path patterns in the Exception message, then truncates to the
-    configured max length. Primary PII risk: file paths embedded in OSError.
-    """
-    err_msg = _SENSITIVE_PATH_RE.sub("[REDACTED_PATH]", str(e))
-    if len(err_msg) > MAX_ERROR_LOG_LENGTH:
-        return f"{err_msg[:MAX_ERROR_LOG_LENGTH]}..."
-    return err_msg
 
 
 class SearchStatistics(TypedDict):
@@ -97,7 +76,7 @@ class SearchHistory:
                     self.history = json.load(f)
             except (OSError, ValueError, json.JSONDecodeError) as e:
                 logger.warning(
-                    f"히스토리 로드 실패: {type(e).__name__}: {_format_error_msg(e)}",
+                    f"히스토리 로드 실패: {type(e).__name__}: {format_error_msg(e)}",
                     extra={
                         "action": "load_history",
                         "path": self.storage_path,
@@ -129,7 +108,7 @@ class SearchHistory:
                 )
         except (OSError, TypeError, ValueError) as e:
             logger.warning(
-                f"히스토리 저장 실패: {type(e).__name__}: {_format_error_msg(e)}",
+                f"히스토리 저장 실패: {type(e).__name__}: {format_error_msg(e)}",
                 extra={
                     "action": "save_history",
                     "path": self.storage_path,

--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -17,6 +17,7 @@ Handles common functionalities such as environment variable parsing, logging, an
 import hashlib
 import logging
 import os
+import re
 from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
@@ -33,6 +34,16 @@ logger = logging.getLogger(__name__)
 INVALID_PII_SENTINEL = "<INVALID_PII>"
 ANONYMOUS_USER_ID = "anonymous"
 MAX_QUERY_PREVIEW_LEN = 200
+
+# ―――――――――――――――――――――――――
+# 에러 로깅 유틸리티 (Error Logging Utilities)
+# ―――――――――――――――――――――――――
+
+_DEFAULT_MAX_ERROR_LOG_LENGTH = 100
+
+# Unix / Windows 절대 경로 패턴 — OSError 메시지의 주요 PII 노출 원인
+# Unix/Windows absolute path pattern — primary PII risk in OSError messages
+_SENSITIVE_PATH_RE = re.compile(r"(?:[A-Za-z]:[\\/]|/)(?:[\w.\-\\/]+)")
 
 
 def safe_parse_env_int(
@@ -139,6 +150,34 @@ def safe_parse_env_float(
             default,
         )
         return default
+
+
+# \ud658\uacbd\ubcc0\uc218\ub85c \uc870\uc815 \uac00\ub2a5; \uc798\ubabb\ub41c \uac12 \uc785\ub825 \uc2dc safe_parse_env_int\uc774 \uae30\ubcf8\uac12 \uc0ac\uc6a9 + warning \ub85c\uae45
+# Configurable via env var; safe_parse_env_int uses default + warning on invalid input
+MAX_ERROR_LOG_LENGTH: int = safe_parse_env_int(
+    "FLOWNOTE_MAX_ERROR_LOG_LENGTH", _DEFAULT_MAX_ERROR_LOG_LENGTH, min_val=1
+)
+
+
+def format_error_msg(e: Exception) -> str:
+    """
+    [KO]
+    Exception \uba54\uc2dc\uc9c0\uc5d0\uc11c \ud30c\uc77c \uacbd\ub85c\ub97c \ub9c8\uc2a4\ud0b9\ud558\uace0, \ud658\uacbd \ubcc0\uc218\ub85c \uc124\uc815\ub41c \ucd5c\ub300 \uae38\uc774\ub85c \uc798\ub77c\ub0b4\ub294 \uacf5\uc6a9 \ud5ec\ud37c.
+    - OSError: \ud30c\uc77c \uacbd\ub85c(PII \uc9c1\uc811 \ub178\ucd9c \uc704\ud611)\ub97c [REDACTED_PATH]\ub85c \uce58\ud658 \ud6c4 \uc5ed\uc0b0
+    - \uae30\ud0c0 \uc608\uc678: \uacbd\ub85c \ub9c8\uc2a4\ud0b9 \uc5c6\uc774 \ucd5c\ub300 \uae38\uc774\ub9cc \uc801\uc6a9
+
+    [EN]
+    Shared helper that masks file paths in Exception messages and truncates to the
+    configured max length.
+    - OSError: replaces file paths (primary PII exposure risk) with [REDACTED_PATH]
+    - Other exceptions: only truncation applied (no path masking)
+    """
+    err_msg = str(e)
+    if isinstance(e, OSError):
+        err_msg = _SENSITIVE_PATH_RE.sub("[REDACTED_PATH]", err_msg)
+    if len(err_msg) > MAX_ERROR_LOG_LENGTH:
+        return f"{err_msg[:MAX_ERROR_LOG_LENGTH]}..."
+    return err_msg
 
 
 def mask_pii_id(value: Optional[str], truncate_len: int = 12) -> str:


### PR DESCRIPTION
- `int()` 직접 변환 시 잘못된 환경변수 값으로 인한 임포트 실패 방지를 위해 `safe_parse_env_int()` 활용으로 교체 (ValueError 자동 처리 + 기본값 100 적용)
- `_SENSITIVE_PATH_RE` 마스킹을 `OSError`에만 조건부 적용하여 과도한 마스킹 방지 (json.JSONDecodeError 등에는 불필요한 경로 마스킹 없음)
- `metadata.py`와 `search_history.py`의 중복 코드(`_format_error_msg`, `_SENSITIVE_PATH_RE`, `MAX_ERROR_LOG_LENGTH`)를 `common.py`의 단일 소스로 통합

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1739#pullrequestreview-4851484565)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

오류 로그 유틸리티를 통합하고 강화하기 위해 경로 마스킹과 메시지 길이 축소(truncation) 로직을 공용 헬퍼로 중앙집중화하고, 오류 로그 길이 설정을 더 안전하게 만들었습니다.

Enhancements:
- 공용 유틸리티에 공유 오류 포매팅 헬퍼를 도입하여 `OSError`에 대해서만 민감한 파일 경로를 마스킹하고, 메시지를 설정 가능한 최대 길이로 잘라내도록 했습니다.
- 메타데이터 및 검색 히스토리 모듈의 오류 로깅을 중앙집중화된 오류 포매팅 헬퍼를 사용하도록 개선하여, 중복된 설정 및 정규식 로직을 제거했습니다.
- 환경 변수를 안전한 정수 파서로 파싱하고 합리적인 기본값과 최소값을 적용함으로써, 최대 오류 로그 길이 설정을 더 견고하게 만들었습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and harden error logging utilities by centralizing path-masking and truncation logic into a shared helper and making error log length configuration safer.

Enhancements:
- Introduce a shared error formatting helper in the common utilities that masks sensitive file paths only for OSError and truncates messages to a configurable maximum length.
- Refine error logging in metadata and search history modules to use the centralized error formatting helper, removing duplicated configuration and regex logic.
- Make the maximum error log length configuration more robust by parsing the environment variable via a safe integer parser with a sane default and minimum bound.

</details>