### PR TITLE
✨ refactor [#12.3.20] - (53) 3차 개선 : `__all__` 수출 명시로 type: ignore 제거 및 format_error_msg 계약 명확화

### DIFF
--- a/backend/metadata.py
+++ b/backend/metadata.py
@@ -23,7 +23,7 @@ import uuid
 from datetime import datetime
 from typing import Dict, List, Optional, TypedDict
 
-from backend.utils.common import format_error_msg  # type: ignore[import]
+from backend.utils.common import format_error_msg
 
 logger = logging.getLogger(__name__)
 

--- a/backend/search_history.py
+++ b/backend/search_history.py
@@ -15,7 +15,7 @@ from collections import Counter
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional, TypedDict
 
-from backend.utils.common import format_error_msg  # type: ignore[import]
+from backend.utils.common import format_error_msg
 
 logger = logging.getLogger(__name__)
 

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -1,1 +1,22 @@
-from .common import *
+"""
+[KO] FlowNote MVP - 코어 유틸리티 패키지
+[EN] FlowNote MVP - Core Utilities Package
+"""
+
+from .common import (
+    INVALID_PII_SENTINEL,
+    MAX_ERROR_LOG_LENGTH,
+    format_error_msg,
+    mask_pii_id,
+    safe_parse_env_float,
+    safe_parse_env_int,
+)
+
+__all__ = [
+    "format_error_msg",
+    "MAX_ERROR_LOG_LENGTH",
+    "safe_parse_env_int",
+    "safe_parse_env_float",
+    "mask_pii_id",
+    "INVALID_PII_SENTINEL",
+]

--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -159,21 +159,38 @@ MAX_ERROR_LOG_LENGTH: int = safe_parse_env_int(
 )
 
 
-def format_error_msg(e: Exception) -> str:
+def format_error_msg(e: Exception, mask_paths: Optional[bool] = None) -> str:
     """
     [KO]
-    Exception \uba54\uc2dc\uc9c0\uc5d0\uc11c \ud30c\uc77c \uacbd\ub85c\ub97c \ub9c8\uc2a4\ud0b9\ud558\uace0, \ud658\uacbd \ubcc0\uc218\ub85c \uc124\uc815\ub41c \ucd5c\ub300 \uae38\uc774\ub85c \uc798\ub77c\ub0b4\ub294 \uacf5\uc6a9 \ud5ec\ud37c.
-    - OSError: \ud30c\uc77c \uacbd\ub85c(PII \uc9c1\uc811 \ub178\ucd9c \uc704\ud611)\ub97c [REDACTED_PATH]\ub85c \uce58\ud658 \ud6c4 \uc5ed\uc0b0
-    - \uae30\ud0c0 \uc608\uc678: \uacbd\ub85c \ub9c8\uc2a4\ud0b9 \uc5c6\uc774 \ucd5c\ub300 \uae38\uc774\ub9cc \uc801\uc6a9
+    Exception 메시지에서 파일 경로를 마스킹하고, 환경 변수로 설정된 최대 길이로 잘라내는 공용 헬퍼.
+    - mask_paths=None (기본값): OSError 등 파일 경로가 포함되는 예외 타입인 경우 파일 경로를 [REDACTED_PATH]로 자동 치환 후 최대 길이 축약
+    - mask_paths=True: 예외 타입과 무관하게 파일 경로 마스킹 강제 적용
+    - mask_paths=False: 경로 마스킹을 수행하지 않고 최대 길이 축약만 적용
+
+    Args:
+        e: 처리할 예외 객체 (Exception)
+        mask_paths: 경로 마스킹 여부 (None일 경우 OSError 타입일 때 자동 마스킹)
+
+    Returns:
+        마스킹 및 축약 처리된 에러 메시지 문자열
 
     [EN]
     Shared helper that masks file paths in Exception messages and truncates to the
     configured max length.
-    - OSError: replaces file paths (primary PII exposure risk) with [REDACTED_PATH]
-    - Other exceptions: only truncation applied (no path masking)
+    - mask_paths=None (default): Automatically replaces file paths with [REDACTED_PATH] for file-related exceptions like OSError.
+    - mask_paths=True: Forces path masking regardless of exception type.
+    - mask_paths=False: Bypasses path masking and applies truncation only.
+
+    Args:
+        e: The exception instance to format
+        mask_paths: Whether to apply path masking (None auto-masks for OSError)
+
+    Returns:
+        The formatted, masked, and truncated error message string
     """
     err_msg = str(e)
-    if isinstance(e, OSError):
+    should_mask = mask_paths if mask_paths is not None else isinstance(e, OSError)
+    if should_mask:
         err_msg = _SENSITIVE_PATH_RE.sub("[REDACTED_PATH]", err_msg)
     if len(err_msg) > MAX_ERROR_LOG_LENGTH:
         return f"{err_msg[:MAX_ERROR_LOG_LENGTH]}..."


### PR DESCRIPTION
- `__init__.py`에 `__all__` 수출 리스트를 추가하여 `metadata.py` 및 `search_history.py` 의불필요한 `# type: ignore[import]` 주석 제거 및 `mypy` 타입 검사 정상화
- `format_error_msg`에 `optional mask_paths` 파라미터(기본값 None)를 추가하고 [KO]/[EN] Docstring을 보강하여 OSError 외 예외에 대한 경로 마스킹 제어 및 계약 명확화

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1740#pullrequestreview-4851555003)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.6 Flash (High)

## Summary by Sourcery

오류 메시지 포맷팅 동작을 명확히 하고, 더 깔끔한 import를 위해 핵심 유틸리티 심볼들을 export합니다.

버그 수정:
- `backend.utils`의 export를 정규화하여 `metadata`와 `search_history`에서 불필요한 `type: ignore` import 주석을 제거했습니다.

개선 사항:
- 선택적 `mask_paths` 플래그와 예외 타입 전반에 걸친 경로 마스킹 동작에 대한 문서화된 내용을 포함하도록 `format_error_msg`를 확장했습니다.
- 핵심 유틸리티 헬퍼의 공개 export를 제어하기 위해 `backend.utils`에 명시적인 `__all__`을 정의했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify error message formatting behavior and export core utility symbols for cleaner imports.

Bug Fixes:
- Remove unnecessary type: ignore import annotations in metadata and search_history by normalizing backend.utils exports.

Enhancements:
- Extend format_error_msg with an optional mask_paths flag and documented behavior for path masking across exception types.
- Define an explicit __all__ in backend.utils to control public exports of core utility helpers.

</details>