### PR TITLE
✨ refactor [#12.3.20] - (53) 4차 개선 : `format_error_msg`의 삼중 상태(Boolean) 인자를 명시적 `Literal`로 교체

### DIFF
--- a/backend/metadata.py
+++ b/backend/metadata.py
@@ -115,7 +115,7 @@ class FileMetadata:
                     self.metadata = {}
             except json.JSONDecodeError as e:
                 logger.warning(
-                    f"메타데이터 파일 JSON 파싱 실패: {type(e).__name__}: {format_error_msg(e)}",
+                    f"메타데이터 파일 JSON 파싱 실패: {type(e).__name__}: {format_error_msg(e, mask_mode='auto')}",
                     extra={
                         "action": "load_metadata",
                         "storage_path": self.storage_path,
@@ -125,7 +125,7 @@ class FileMetadata:
                 self.metadata = {}
             except OSError as e:
                 logger.error(
-                    f"메타데이터 파일 읽기 실패: {type(e).__name__}: {format_error_msg(e)}",
+                    f"메타데이터 파일 읽기 실패: {type(e).__name__}: {format_error_msg(e, mask_mode='auto')}",
                     extra={
                         "action": "load_metadata",
                         "storage_path": self.storage_path,
@@ -153,7 +153,7 @@ class FileMetadata:
                 json.dump(self.metadata, f, ensure_ascii=False, indent=2)
         except OSError as e:
             logger.error(
-                f"메타데이터 파일 저장 실패: {type(e).__name__}: {format_error_msg(e)}",
+                f"메타데이터 파일 저장 실패: {type(e).__name__}: {format_error_msg(e, mask_mode='auto')}",
                 extra={
                     "action": "save_metadata",
                     "storage_path": self.storage_path,

--- a/backend/search_history.py
+++ b/backend/search_history.py
@@ -76,7 +76,7 @@ class SearchHistory:
                     self.history = json.load(f)
             except (OSError, ValueError, json.JSONDecodeError) as e:
                 logger.warning(
-                    f"히스토리 로드 실패: {type(e).__name__}: {format_error_msg(e)}",
+                    f"히스토리 로드 실패: {type(e).__name__}: {format_error_msg(e, mask_mode='auto')}",
                     extra={
                         "action": "load_history",
                         "path": self.storage_path,
@@ -108,7 +108,7 @@ class SearchHistory:
                 )
         except (OSError, TypeError, ValueError) as e:
             logger.warning(
-                f"히스토리 저장 실패: {type(e).__name__}: {format_error_msg(e)}",
+                f"히스토리 저장 실패: {type(e).__name__}: {format_error_msg(e, mask_mode='auto')}",
                 extra={
                     "action": "save_history",
                     "path": self.storage_path,

--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -21,7 +21,7 @@ import re
 from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 import tiktoken  # type: ignore[import]
 
@@ -159,17 +159,19 @@ MAX_ERROR_LOG_LENGTH: int = safe_parse_env_int(
 )
 
 
-def format_error_msg(e: Exception, mask_paths: Optional[bool] = None) -> str:
+def format_error_msg(
+    e: Exception, mask_mode: Literal["auto", "force", "off"] = "auto"
+) -> str:
     """
     [KO]
     Exception 메시지에서 파일 경로를 마스킹하고, 환경 변수로 설정된 최대 길이로 잘라내는 공용 헬퍼.
-    - mask_paths=None (기본값): OSError 등 파일 경로가 포함되는 예외 타입인 경우 파일 경로를 [REDACTED_PATH]로 자동 치환 후 최대 길이 축약
-    - mask_paths=True: 예외 타입과 무관하게 파일 경로 마스킹 강제 적용
-    - mask_paths=False: 경로 마스킹을 수행하지 않고 최대 길이 축약만 적용
+    - mask_mode='auto' (기본값): OSError 등 파일 경로가 포함되는 예외 타입인 경우 파일 경로를 [REDACTED_PATH]로 자동 치환 후 최대 길이 축약
+    - mask_mode='force': 예외 타입과 무관하게 파일 경로 마스킹 강제 적용
+    - mask_mode='off': 경로 마스킹을 수행하지 않고 최대 길이 축약만 적용
 
     Args:
         e: 처리할 예외 객체 (Exception)
-        mask_paths: 경로 마스킹 여부 (None일 경우 OSError 타입일 때 자동 마스킹)
+        mask_mode: 마스킹 모드 제어 ('auto', 'force', 'off')
 
     Returns:
         마스킹 및 축약 처리된 에러 메시지 문자열
@@ -177,21 +179,21 @@ def format_error_msg(e: Exception, mask_paths: Optional[bool] = None) -> str:
     [EN]
     Shared helper that masks file paths in Exception messages and truncates to the
     configured max length.
-    - mask_paths=None (default): Automatically replaces file paths with [REDACTED_PATH] for file-related exceptions like OSError.
-    - mask_paths=True: Forces path masking regardless of exception type.
-    - mask_paths=False: Bypasses path masking and applies truncation only.
+    - mask_mode='auto' (default): Automatically replaces file paths with [REDACTED_PATH] for file-related exceptions like OSError.
+    - mask_mode='force': Forces path masking regardless of exception type.
+    - mask_mode='off': Bypasses path masking and applies truncation only.
 
     Args:
         e: The exception instance to format
-        mask_paths: Whether to apply path masking (None auto-masks for OSError)
+        mask_mode: The masking mode to apply ('auto', 'force', 'off')
 
     Returns:
         The formatted, masked, and truncated error message string
     """
     err_msg = str(e)
-    should_mask = mask_paths if mask_paths is not None else isinstance(e, OSError)
-    if should_mask:
+    if mask_mode == "force" or (mask_mode == "auto" and isinstance(e, OSError)):
         err_msg = _SENSITIVE_PATH_RE.sub("[REDACTED_PATH]", err_msg)
+
     if len(err_msg) > MAX_ERROR_LOG_LENGTH:
         return f"{err_msg[:MAX_ERROR_LOG_LENGTH]}..."
     return err_msg


### PR DESCRIPTION
- `format_error_msg`의 `mask_paths` 파라미터를 모호한 `Optional`[bool]에서 명시적인 `Literal`['auto', 'force', 'off'] 기반의 `mask_mode`로 교체하여 `Boolean Blindness`(불리언 맹점) 문제 해결
- `metadata.py` 및 `search_history.py`의 호출부에서 `format_error_msg`(e, mask_mode='auto')를 명시적으로 넘기도록 수정하여 호출 컨텍스트와 계약을 자가 문서화(Self-Documenting)
- `Python 3.11 f-string` 구문 분석 오류를 방지하기 위해 호출부 문자열에 작은따옴표('auto') 적용

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1741#pullrequestreview-4856381970)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

명시적인 마스킹 모드를 도입하고 호출 측에서 이를 일관되게 사용하도록 업데이트하여 오류 메시지 포맷을 명확히 합니다.

Enhancements:
- 오류 경로 마스킹 동작을 더 명확히 하기 위해 `format_error_msg`에서 모호한 `Optional[bool]` 마스킹 플래그를 명시적인 `Literal` 기반 `mask_mode`로 교체
- 오류 메시지를 포맷할 때 메타데이터와 `search_history` 로깅 호출이 명시적인 `mask_mode` 값을 전달하도록 업데이트

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify error message formatting by introducing an explicit masking mode and updating callers to use it consistently.

Enhancements:
- Replace ambiguous Optional[bool] masking flag in format_error_msg with explicit Literal-based mask_mode for clearer error path masking behavior
- Update metadata and search_history logging calls to pass an explicit mask_mode value when formatting error messages

</details>