### PR TITLE
✨ refactor [#12.3.20] - (53) 5차 개선 : `format_error_msg` 런타임 가드 추가 및 호출부 노이즈 제거

### DIFF
--- a/backend/metadata.py
+++ b/backend/metadata.py
@@ -115,7 +115,7 @@ class FileMetadata:
                     self.metadata = {}
             except json.JSONDecodeError as e:
                 logger.warning(
-                    f"메타데이터 파일 JSON 파싱 실패: {type(e).__name__}: {format_error_msg(e, mask_mode='auto')}",
+                    f"메타데이터 파일 JSON 파싱 실패: {type(e).__name__}: {format_error_msg(e)}",
                     extra={
                         "action": "load_metadata",
                         "storage_path": self.storage_path,
@@ -125,7 +125,7 @@ class FileMetadata:
                 self.metadata = {}
             except OSError as e:
                 logger.error(
-                    f"메타데이터 파일 읽기 실패: {type(e).__name__}: {format_error_msg(e, mask_mode='auto')}",
+                    f"메타데이터 파일 읽기 실패: {type(e).__name__}: {format_error_msg(e)}",
                     extra={
                         "action": "load_metadata",
                         "storage_path": self.storage_path,
@@ -153,7 +153,7 @@ class FileMetadata:
                 json.dump(self.metadata, f, ensure_ascii=False, indent=2)
         except OSError as e:
             logger.error(
-                f"메타데이터 파일 저장 실패: {type(e).__name__}: {format_error_msg(e, mask_mode='auto')}",
+                f"메타데이터 파일 저장 실패: {type(e).__name__}: {format_error_msg(e)}",
                 extra={
                     "action": "save_metadata",
                     "storage_path": self.storage_path,

--- a/backend/search_history.py
+++ b/backend/search_history.py
@@ -76,7 +76,7 @@ class SearchHistory:
                     self.history = json.load(f)
             except (OSError, ValueError, json.JSONDecodeError) as e:
                 logger.warning(
-                    f"히스토리 로드 실패: {type(e).__name__}: {format_error_msg(e, mask_mode='auto')}",
+                    f"히스토리 로드 실패: {type(e).__name__}: {format_error_msg(e)}",
                     extra={
                         "action": "load_history",
                         "path": self.storage_path,
@@ -108,7 +108,7 @@ class SearchHistory:
                 )
         except (OSError, TypeError, ValueError) as e:
             logger.warning(
-                f"히스토리 저장 실패: {type(e).__name__}: {format_error_msg(e, mask_mode='auto')}",
+                f"히스토리 저장 실패: {type(e).__name__}: {format_error_msg(e)}",
                 extra={
                     "action": "save_history",
                     "path": self.storage_path,

--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -191,6 +191,11 @@ def format_error_msg(
         The formatted, masked, and truncated error message string
     """
     err_msg = str(e)
+    if mask_mode not in ("auto", "force", "off"):
+        raise ValueError(
+            f"Invalid mask_mode: '{mask_mode}'. Expected 'auto', 'force', or 'off'."
+        )
+
     if mask_mode == "force" or (mask_mode == "auto" and isinstance(e, OSError)):
         err_msg = _SENSITIVE_PATH_RE.sub("[REDACTED_PATH]", err_msg)
 


### PR DESCRIPTION
- **[Fail Fast]**
  - 동적 타입 환경에서 유효하지 않은 `mask_mode` 값이 전달되어 마스킹이 조용히 무시되는(PII 유출) 문제를 방지하기 위해 ValueError 런타임 가드 추가
- `metadata.py` 및 `search_history.py` 등 호출부에서 불필요하게 명시되었던 기본값 인자(mask_mode='auto')를 제거하여 호출 컨텍스트의 노이즈 감소

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1742#pullrequestreview-4856660188)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

오류 메시지 마스킹 모드에 대한 런타임 검증을 추가하고 로깅 호출 위치를 단순화합니다.

버그 수정:
- 잘못된 `mask_mode` 값이 전달되었을 때 `ValueError`를 발생시켜, 오류 메시지 마스킹이 조용히 비활성화되는 것을 방지합니다.

개선 사항:
- `format_error_msg`의 기본 `mask_mode`에 의존하도록 하여, 메타데이터 및 검색 기록 로깅에서 중복된 `mask_mode` 지정 없이 더 깔끔하게 정리합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add runtime validation for error message masking mode and simplify logging call sites.

Bug Fixes:
- Prevent silent disabling of error message masking when an invalid mask_mode value is passed by raising a ValueError.

Enhancements:
- Clean up metadata and search history logging by relying on the default mask_mode in format_error_msg instead of redundantly specifying it.

</details>