### PR TITLE
✨ refactor [#12.3.20] - (53) 6차 개선 : `format_error_msg`의 모드 관리를 단일 진실공급원(SSOT)으로 통합

### DIFF
--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -21,7 +21,10 @@ import re
 from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, Literal, Optional, get_args
+
+MaskMode = Literal["auto", "force", "off"]
+VALID_MASK_MODES = get_args(MaskMode)
 
 import tiktoken  # type: ignore[import]
 
@@ -152,16 +155,14 @@ def safe_parse_env_float(
         return default
 
 
-# \ud658\uacbd\ubcc0\uc218\ub85c \uc870\uc815 \uac00\ub2a5; \uc798\ubabb\ub41c \uac12 \uc785\ub825 \uc2dc safe_parse_env_int\uc774 \uae30\ubcf8\uac12 \uc0ac\uc6a9 + warning \ub85c\uae45
+# 환경변수로 조정 가능; 잘못된 값 입력 시 safe_parse_env_int이 기본값 사용 + warning 로깅
 # Configurable via env var; safe_parse_env_int uses default + warning on invalid input
 MAX_ERROR_LOG_LENGTH: int = safe_parse_env_int(
     "FLOWNOTE_MAX_ERROR_LOG_LENGTH", _DEFAULT_MAX_ERROR_LOG_LENGTH, min_val=1
 )
 
 
-def format_error_msg(
-    e: Exception, mask_mode: Literal["auto", "force", "off"] = "auto"
-) -> str:
+def format_error_msg(e: Exception, mask_mode: MaskMode = "auto") -> str:
     """
     [KO]
     Exception 메시지에서 파일 경로를 마스킹하고, 환경 변수로 설정된 최대 길이로 잘라내는 공용 헬퍼.
@@ -191,9 +192,10 @@ def format_error_msg(
         The formatted, masked, and truncated error message string
     """
     err_msg = str(e)
-    if mask_mode not in ("auto", "force", "off"):
+    if mask_mode not in VALID_MASK_MODES:
+        valid_modes_str = ", ".join(f"'{m}'" for m in VALID_MASK_MODES)
         raise ValueError(
-            f"Invalid mask_mode: '{mask_mode}'. Expected 'auto', 'force', or 'off'."
+            f"Invalid mask_mode: '{mask_mode}'. Expected one of: {valid_modes_str}."
         )
 
     if mask_mode == "force" or (mask_mode == "auto" and isinstance(e, OSError)):


### PR DESCRIPTION
- `typing.get_args`를 사용하여 `Literal` 타입으로부터 `VALID_MASK_MODES` 상수를 동적으로 추출하여, 타입 힌트와 런타임 가드 간의 매직 스트링 중복(DRY 위반)을 근본적으로 제거
- `ValueError` 발생 시 하드코딩된 문자열 대신 `VALID_MASK_MODES`를 기반으로 동적 에러 메시지를 생성하도록 개선하여 유지보수성 극대화
- 전체 코드베이스 검토 결과, 의도치 않은 `ValueError`를 유발할 수 있는 잘못된 호출부가 없음을 안전하게 확인 완료

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1743#pullrequestreview-4856755580)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

에러 마스킹 모드 정의를 단일 소스로 통합하고, `format_error_msg`에 대한 검증 메시지를 개선합니다.

Enhancements:
- 유효한 에러 마스크 모드를 중앙에서 관리하기 위해 `typing.get_args`를 통해 도출된 `MaskMode` Literal 별칭과 `VALID_MASK_MODES` 상수를 도입합니다.
- `format_error_msg`가 공통 `MaskMode` 타입을 사용하도록 업데이트하고, 유지보수를 쉽게 하기 위해 `VALID_MASK_MODES`로부터 `ValueError` 메시지를 동적으로 생성하도록 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify error masking mode definitions into a single source of truth and improve validation messaging for format_error_msg.

Enhancements:
- Introduce a MaskMode Literal alias and VALID_MASK_MODES constant derived via typing.get_args to centralize valid error mask modes.
- Update format_error_msg to use the shared MaskMode type and generate its ValueError message dynamically from VALID_MASK_MODES for easier maintenance.

</details>