### PR TITLE
✨ refactor [#12.3.20] - (54) `metadata.py` 코드 품질 개선

### DIFF
--- a/backend/metadata.py
+++ b/backend/metadata.py
@@ -160,6 +160,17 @@ class FileMetadata:
                     "error_type": type(e).__name__,
                 },
             )
+        except (TypeError, ValueError) as e:
+            # [KO] json.dump에서 직렬화 불가 타입(예: datetime, 커스텀 객체) 발생 시
+            # [EN] Raised when json.dump encounters a non-serializable type (e.g., datetime, custom objects)
+            logger.error(
+                f"메타데이터 직렬화 실패: {type(e).__name__}: {format_error_msg(e)}",
+                extra={
+                    "action": "save_metadata",
+                    "storage_path": self.storage_path,
+                    "error_type": type(e).__name__,
+                },
+            )
 
     def add_file(
         self,


### PR DESCRIPTION
- **[직렬화 예외 처리 추가]**
  - `_save_metadata`에서 `json.dump` 시 직렬화 불가 타입(datetime, 커스텀 객체 등)에 대해 `TypeError`/`ValueError`가 처리되지 않던 누락 이슈 수정
  - `OSError`와 동일한 구조화 로깅 패턴(extra= dict, action/storage_path/error_type 키)으로 일관성 유지
  - `format_error_msg`로 PII 보호 적용

🔗 Related: Issue [#1044]

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

메타데이터 저장 시 JSON 직렬화 오류를 처리하여 견고성과 로그 일관성을 개선합니다.

버그 수정:
- 메타데이터에 직렬화할 수 없는 타입이 포함되어 있을 때 `_save_metadata` 내 `json.dump`에서 발생하는 `TypeError` 및 `ValueError`를 처리하여, 처리되지 않은 예외가 발생하지 않도록 합니다.

개선 사항:
- JSON 직렬화 실패에 대한 오류 로깅을 기존의 구조화된 로깅 패턴과 일치하도록 정렬하고, PII(개인 식별 정보)에 안전한 오류 메시지 포맷팅을 적용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle JSON serialization errors in metadata saving to improve robustness and logging consistency.

Bug Fixes:
- Add handling for TypeError and ValueError raised during json.dump in _save_metadata to prevent unhandled exceptions when metadata contains non-serializable types.

Enhancements:
- Align error logging for JSON serialization failures with existing structured logging pattern and apply PII-safe error message formatting.

</details>