### PR TITLE
✨ refactor [#12.3.20] - (54) 1차 개선 : 직렬화와 파일 I/O 예외 처리를 2단계로 분리

### DIFF
--- a/backend/metadata.py
+++ b/backend/metadata.py
@@ -148,25 +148,31 @@ class FileMetadata:
         [EN]
         Persists the current in-memory metadata to the JSON file.
         """
+        # [KO] 1단계: 직렬화 - 파일 I/O와 분리하여 예외 범위를 명확히 제한
+        # [EN] Step 1: Serialization — separated from file I/O to narrow the exception scope
         try:
-            with open(self.storage_path, "w", encoding="utf-8") as f:
-                json.dump(self.metadata, f, ensure_ascii=False, indent=2)
-        except OSError as e:
+            serialized = json.dumps(self.metadata, ensure_ascii=False, indent=2)
+        except (TypeError, ValueError) as e:
             logger.error(
-                f"메타데이터 파일 저장 실패: {type(e).__name__}: {format_error_msg(e)}",
+                f"메타데이터 직렬화 실패: {type(e).__name__}: {format_error_msg(e)}",
                 extra={
-                    "action": "save_metadata",
+                    "action": "save_metadata_serialize",
                     "storage_path": self.storage_path,
                     "error_type": type(e).__name__,
                 },
             )
-        except (TypeError, ValueError) as e:
-            # [KO] json.dump에서 직렬화 불가 타입(예: datetime, 커스텀 객체) 발생 시
-            # [EN] Raised when json.dump encounters a non-serializable type (e.g., datetime, custom objects)
+            return
+
+        # [KO] 2단계: 파일 I/O - 직렬화 성공 후에만 파일에 기록
+        # [EN] Step 2: File I/O — only writes to disk after successful serialization
+        try:
+            with open(self.storage_path, "w", encoding="utf-8") as f:
+                f.write(serialized)
+        except OSError as e:
             logger.error(
-                f"메타데이터 직렬화 실패: {type(e).__name__}: {format_error_msg(e)}",
+                f"메타데이터 파일 저장 실패: {type(e).__name__}: {format_error_msg(e)}",
                 extra={
-                    "action": "save_metadata",
+                    "action": "save_metadata_write",
                     "storage_path": self.storage_path,
                     "error_type": type(e).__name__,
                 },

--- a/backend/search_history.py
+++ b/backend/search_history.py
@@ -97,20 +97,36 @@ class SearchHistory:
         [EN]
         Saves the in-memory history data to a JSON file.
         """
+        # [KO] 1단계: 직렬화 - 파일 I/O와 분리하여 예외 범위를 명확히 제한
+        # [EN] Step 1: Serialization — separated from file I/O to narrow the exception scope
+        try:
+            serialized = json.dumps(
+                self.history,
+                ensure_ascii=False,
+                indent=2,
+                default=_custom_json_serializer,
+            )
+        except (TypeError, ValueError) as e:
+            logger.warning(
+                f"히스토리 직렬화 실패: {type(e).__name__}: {format_error_msg(e)}",
+                extra={
+                    "action": "save_history_serialize",
+                    "path": self.storage_path,
+                    "error_type": type(e).__name__,
+                },
+            )
+            return
+
+        # [KO] 2단계: 파일 I/O - 직렬화 성공 후에만 파일에 기록
+        # [EN] Step 2: File I/O — only writes to disk after successful serialization
         try:
             with open(self.storage_path, "w", encoding="utf-8") as f:
-                json.dump(
-                    self.history,
-                    f,
-                    ensure_ascii=False,
-                    indent=2,
-                    default=_custom_json_serializer,
-                )
-        except (OSError, TypeError, ValueError) as e:
+                f.write(serialized)
+        except OSError as e:
             logger.warning(
                 f"히스토리 저장 실패: {type(e).__name__}: {format_error_msg(e)}",
                 extra={
-                    "action": "save_history",
+                    "action": "save_history_write",
                     "path": self.storage_path,
                     "error_type": type(e).__name__,
                 },


### PR DESCRIPTION
- **[metadata.py]** -`_save_metadata`: `json.dumps()`를 먼저 실행하고 직렬화 성공 후에만 파일에 기록하는 2단계 구조로 변경
- **[search_history.py]**
  - `_save_history`: 동일한 구조적 문제를 일관되게 개선
- 직렬화 단계에서 `TypeError`/`ValueError` 발생 시 즉시 return하여 open("w")로 인한 기존 데이터 손실 방지
- action 키를 `save_*_serialize` / `save_*_write`로 세분화하여 구조화 로그의 진단 정밀도 향상

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1745#pullrequestreview-4876771534)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

메타데이터와 검색 기록을 영속화할 때 JSON 직렬화 단계와 파일 쓰기 단계를 분리하여 데이터 손실을 방지하고, 실패 상황에 대한 관찰 가능성을 개선합니다.

Bug Fixes:
- JSON 직렬화가 성공한 이후에만 파일을 쓰기 모드로 열도록 하여, 기존 메타데이터 및 히스토리 파일이 손상되는 것을 방지하고, 직렬화 오류 발생 시 파일을 변경하지 않고 처리합니다.

Enhancements:
- 메타데이터 및 히스토리 저장 과정에서 직렬화 단계와 쓰기 단계로 동작을 분리하여, 저장 작업에 대한 구조화된 로깅을 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Separate JSON serialization from file writing for metadata and search history persistence to prevent data loss and improve observability of failures.

Bug Fixes:
- Avoid corrupting existing metadata and history files by ensuring files are only opened for writing after successful JSON serialization and by handling serialization errors without touching the file.

Enhancements:
- Refine structured logging for save operations by splitting actions into serialization and write phases for both metadata and history storage.

</details>