### PR TITLE
✨ refactor [#12.3.20] - (54) 2차 개선 : 저장 결과 반환 및 로그 레벨 표준화

### DIFF
--- a/backend/metadata.py
+++ b/backend/metadata.py
@@ -21,7 +21,7 @@ import logging
 import os
 import uuid
 from datetime import datetime
-from typing import Dict, List, Optional, TypedDict
+from typing import Callable, Dict, List, Optional, TypedDict
 
 from backend.utils.common import format_error_msg
 
@@ -187,6 +187,47 @@ class FileMetadata:
 
         return True
 
+    def _apply_with_persistence(
+        self,
+        mutate: Callable[[], object],
+        rollback: Callable[[], object],
+        action: str,
+    ) -> bool:
+        """
+        [KO]
+        메모리 변경 → 저장 → 실패 시 롤백을 단일 헬퍼로 캡슐화합니다.
+        add_file, delete_file 등에서 반복되는 저장/롤백 패턴을 중앙화합니다.
+
+        Args:
+            mutate: 메모리 상태를 변경하는 함수
+            rollback: 저장 실패 시 메모리를 원복하는 함수
+            action: 로그 extra에 포함할 액션 식별자
+
+        Returns:
+            영속화 성공 시 True, 실패(롤백 완료) 시 False
+
+        [EN]
+        Encapsulates the mutate → persist → rollback-on-failure pattern into a single helper.
+        Centralizes the repeated save/rollback pattern used by add_file, delete_file, etc.
+
+        Args:
+            mutate: Function that applies the in-memory change
+            rollback: Function that reverts the in-memory change on save failure
+            action: Action identifier included in the log extra dict
+
+        Returns:
+            True if persisted successfully, False if rolled back due to failure.
+        """
+        mutate()
+        if self._save_metadata():
+            return True
+        rollback()
+        logger.error(
+            "메타데이터 저장 실패로 작업이 취소되었습니다.",
+            extra={"action": action, "error_type": "save_failure"},
+        )
+        return False
+
     def add_file(
         self,
         file_name: str,
@@ -194,11 +235,12 @@ class FileMetadata:
         chunk_count: int,
         embedding_dim: int,
         model: str = "text-embedding-3-small",
-    ) -> str:
+    ) -> Optional[str]:
         """
         [KO]
         새로운 파일의 메타데이터를 생성하고 저장소에 추가합니다.
         파일 ID는 타임스탬프와 UUID를 조합하여 고유성을 보장합니다.
+        영속화(디스크 저장)가 실패하면 메모리도 롤백되고 None을 반환합니다.
 
         Args:
             file_name: 업로드한 파일의 이름
@@ -208,11 +250,12 @@ class FileMetadata:
             model: 임베딩 생성에 사용된 모델 이름 (기본값: "text-embedding-3-small")
 
         Returns:
-            생성된 고유 파일 ID (예: "file_20251025_131227_d9977552")
+            저장 성공 시 고유 파일 ID (예: "file_20251025_131227_d9977552"), 실패 시 None
 
         [EN]
         Creates and adds metadata for a new file to the storage.
         The file ID is composed of a timestamp and UUID to ensure uniqueness.
+        Returns None if persistence fails; in-memory state is also rolled back.
 
         Args:
             file_name: Name of the uploaded file.
@@ -222,15 +265,12 @@ class FileMetadata:
             model: Name of the model used for embedding generation (default: "text-embedding-3-small").
 
         Returns:
-            The generated unique file ID (e.g., "file_20251025_131227_d9977552").
+            The unique file ID (e.g., "file_20251025_131227_d9977552") on success, or None on failure.
         """
-        # 파일 ID 생성 (타임스탬프 + UUID로 고유성 보장)
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        unique_id = uuid.uuid4().hex[:8]  # UUID의 앞 8자리
+        unique_id = uuid.uuid4().hex[:8]
         file_id = f"file_{timestamp}_{unique_id}"
-
-        # 메타데이터 생성
-        self.metadata[file_id] = {
+        record: FileMetadataRecord = {
             "file_name": file_name,
             "file_size": file_size,
             "file_size_mb": round(file_size / (1024 * 1024), 2),
@@ -241,17 +281,12 @@ class FileMetadata:
             "created_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         }
 
-        # [KO] 저장 - 실패 시 메모리에서도 롤백하여 일관성 유지
-        # [EN] Save — roll back from memory on failure to maintain consistency
-        if not self._save_metadata():
-            del self.metadata[file_id]
-            logger.error(
-                "메타데이터 저장 실패로 파일 추가가 취소되었습니다.",
-                extra={"action": "add_file_rollback", "error_type": "save_failure"},
-            )
-            return file_id
-
-        return file_id
+        persisted = self._apply_with_persistence(
+            mutate=lambda: self.metadata.update({file_id: record}),
+            rollback=lambda: self.metadata.pop(file_id, None),
+            action="add_file_rollback",
+        )
+        return file_id if persisted else None
 
     def get_file(self, file_id: str) -> Optional[FileMetadataRecord]:
         """
@@ -295,38 +330,32 @@ class FileMetadata:
         """
         [KO]
         특정 파일 ID에 해당하는 메타데이터를 삭제합니다.
+        영속화 실패 시 메모리에서도 롤백되고 False를 반환합니다.
 
         Args:
             file_id: 삭제할 파일의 고유 ID
 
         Returns:
-            삭제 성공 시 True, 파일 ID가 존재하지 않으면 False
+            삭제 및 영속화 성공 시 True, 파일 ID가 없거나 저장 실패 시 False
 
         [EN]
         Deletes the metadata corresponding to a specific file ID.
+        Rolls back in-memory state on persistence failure and returns False.
 
         Args:
             file_id: The unique ID of the file to delete.
 
         Returns:
-            True if deletion was successful, False if the file ID was not found.
+            True if deletion and persistence succeeded, False if file ID not found or save failed.
         """
-        if file_id in self.metadata:
-            record = self.metadata.pop(file_id)
-            # [KO] 저장 실패 시 삭제된 레코드를 메모리에 복원하여 일관성 유지
-            # [EN] Restore the deleted record on save failure to maintain consistency
-            if not self._save_metadata():
-                self.metadata[file_id] = record
-                logger.error(
-                    "메타데이터 저장 실패로 파일 삭제가 취소되었습니다.",
-                    extra={
-                        "action": "delete_file_rollback",
-                        "error_type": "save_failure",
-                    },
-                )
-                return False
-            return True
-        return False
+        if file_id not in self.metadata:
+            return False
+        record = self.metadata[file_id]
+        return self._apply_with_persistence(
+            mutate=lambda: self.metadata.pop(file_id, None),
+            rollback=lambda: self.metadata.update({file_id: record}),
+            action="delete_file_rollback",
+        )
 
     def get_statistics(self) -> MetadataStatistics:
         """
@@ -400,7 +429,7 @@ if __name__ == "__main__":
     print("\n2. 파일 조회 테스트")
     print("-" * 50)
 
-    file_info = metadata.get_file(file_id1)
+    file_info = metadata.get_file(file_id1) if file_id1 else None
     print("📄 첫 번째 파일:")
     if file_info is not None:
         print(f"   - 파일명: {file_info['file_name']}")
@@ -408,7 +437,7 @@ if __name__ == "__main__":
         print(f"   - 청크 수: {file_info['chunk_count']}")
         print(f"   - 모델: {file_info['embedding_model']}")
 
-    file_info2 = metadata.get_file(file_id2)
+    file_info2 = metadata.get_file(file_id2) if file_id2 else None
     print("\n📄 두 번째 파일:")
     if file_info2 is not None:
         print(f"   - 파일명: {file_info2['file_name']}")

--- a/backend/metadata.py
+++ b/backend/metadata.py
@@ -140,13 +140,19 @@ class FileMetadata:
                 os.makedirs(storage_dir, exist_ok=True)
             self.metadata = {}
 
-    def _save_metadata(self) -> None:
+    def _save_metadata(self) -> bool:
         """
         [KO]
         현재 메모리에 있는 메타데이터를 JSON 파일에 영속화합니다.
 
+        Returns:
+            저장 성공 시 True, 직렬화 또는 I/O 실패 시 False
+
         [EN]
         Persists the current in-memory metadata to the JSON file.
+
+        Returns:
+            True if saved successfully, False on serialization or I/O failure.
         """
         # [KO] 1단계: 직렬화 - 파일 I/O와 분리하여 예외 범위를 명확히 제한
         # [EN] Step 1: Serialization — separated from file I/O to narrow the exception scope
@@ -161,7 +167,7 @@ class FileMetadata:
                     "error_type": type(e).__name__,
                 },
             )
-            return
+            return False
 
         # [KO] 2단계: 파일 I/O - 직렬화 성공 후에만 파일에 기록
         # [EN] Step 2: File I/O — only writes to disk after successful serialization
@@ -177,6 +183,9 @@ class FileMetadata:
                     "error_type": type(e).__name__,
                 },
             )
+            return False
+
+        return True
 
     def add_file(
         self,
@@ -232,8 +241,15 @@ class FileMetadata:
             "created_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         }
 
-        # 저장
-        self._save_metadata()
+        # [KO] 저장 - 실패 시 메모리에서도 롤백하여 일관성 유지
+        # [EN] Save — roll back from memory on failure to maintain consistency
+        if not self._save_metadata():
+            del self.metadata[file_id]
+            logger.error(
+                "메타데이터 저장 실패로 파일 추가가 취소되었습니다.",
+                extra={"action": "add_file_rollback", "error_type": "save_failure"},
+            )
+            return file_id
 
         return file_id
 
@@ -296,8 +312,19 @@ class FileMetadata:
             True if deletion was successful, False if the file ID was not found.
         """
         if file_id in self.metadata:
-            del self.metadata[file_id]
-            self._save_metadata()
+            record = self.metadata.pop(file_id)
+            # [KO] 저장 실패 시 삭제된 레코드를 메모리에 복원하여 일관성 유지
+            # [EN] Restore the deleted record on save failure to maintain consistency
+            if not self._save_metadata():
+                self.metadata[file_id] = record
+                logger.error(
+                    "메타데이터 저장 실패로 파일 삭제가 취소되었습니다.",
+                    extra={
+                        "action": "delete_file_rollback",
+                        "error_type": "save_failure",
+                    },
+                )
+                return False
             return True
         return False
 

--- a/backend/search_history.py
+++ b/backend/search_history.py
@@ -13,7 +13,7 @@ import os
 import uuid
 from collections import Counter
 from datetime import date, datetime
-from typing import Any, Dict, List, Optional, TypedDict
+from typing import Any, Callable, Dict, List, Optional, TypedDict
 
 from backend.utils.common import format_error_msg
 
@@ -141,12 +141,57 @@ class SearchHistory:
 
         return True
 
+    def _apply_and_persist(
+        self,
+        mutate: Callable[[], object],
+        rollback: Callable[[], object],
+        rollback_msg: str,
+        action: str,
+    ) -> bool:
+        """
+        [KO]
+        메모리 변경 → 저장 → 실패 시 롤백을 단일 헬퍼로 코드화합니다.
+        add_search, delete_search, clear_all 등에서 반복되는 저장/롤백 패턴을 중앙화합니다.
+
+        Args:
+            mutate: 메모리 상태를 변경하는 함수
+            rollback: 저장 실패 시 메모리를 원복하는 함수
+            rollback_msg: 롤백 시 로그에 남길 메시지
+            action: 로그 extra에 포함할 액션 식별자
+
+        Returns:
+            영속화 성공 시 True, 실패(롤백 완료) 시 False
+
+        [EN]
+        Encapsulates the mutate → persist → rollback-on-failure pattern into a single helper.
+        Centralizes the repeated save/rollback pattern used by add_search, delete_search, clear_all, etc.
+
+        Args:
+            mutate: Function that applies the in-memory change
+            rollback: Function that reverts the in-memory change on save failure
+            rollback_msg: Log message to emit on rollback
+            action: Action identifier included in the log extra dict
+
+        Returns:
+            True if persisted successfully, False if rolled back due to failure.
+        """
+        mutate()
+        if self._save_history():
+            return True
+        rollback()
+        logger.error(
+            rollback_msg,
+            extra={"action": action, "error_type": "save_failure"},
+        )
+        return False
+
     def add_search(
         self, query: str, results_count: int, top_results: Optional[List[str]] = None
-    ) -> str:
+    ) -> Optional[str]:
         """
         [KO]
         새로운 검색 기록을 추가하고 저장합니다.
+        영속화(디스크 저장)가 실패하면 메모리도 롤백되고 None을 반환합니다.
 
         Args:
             query: 검색에 사용된 쿼리 문자열
@@ -154,10 +199,11 @@ class SearchHistory:
             top_results: 상위 검색 결과 미리보기 텍스트 리스트
 
         Returns:
-            새로 생성된 검색 고유 ID
+            저장 성공 시 새로 생성된 검색 고유 ID, 실패 시 None
 
         [EN]
         Adds and saves a new search record.
+        Returns None if persistence fails; in-memory state is also rolled back.
 
         Args:
             query: Query string used for the search
@@ -165,15 +211,12 @@ class SearchHistory:
             top_results: List of preview texts for top search results
 
         Returns:
-            Newly generated unique search ID
+            Newly generated unique search ID on success, or None on failure.
         """
-        # 검색 ID 생성
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         unique_id = uuid.uuid4().hex[:8]
         search_id = f"search_{timestamp}_{unique_id}"
-
-        # 히스토리 생성
-        self.history[search_id] = {
+        record = {
             "query": query,
             "results_count": results_count,
             "top_results": top_results[:3] if top_results else [],
@@ -181,16 +224,13 @@ class SearchHistory:
             "created_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         }
 
-        # [KO] 저장 - 실패 시 메모리에서도 롤백하여 일관성 유지
-        # [EN] Save — roll back from memory on failure to maintain consistency
-        if not self._save_history():
-            del self.history[search_id]
-            logger.error(
-                "히스토리 저장 실패로 검색 기록 추가가 취소되었습니다.",
-                extra={"action": "add_search_rollback", "error_type": "save_failure"},
-            )
-
-        return search_id
+        persisted = self._apply_and_persist(
+            mutate=lambda: self.history.update({search_id: record}),
+            rollback=lambda: self.history.pop(search_id, None),
+            rollback_msg="히스토리 저장 실패로 검색 기록 추가가 취소되었습니다.",
+            action="add_search_rollback",
+        )
+        return search_id if persisted else None
 
     def get_search(self, search_id: str) -> Optional[Dict]:
         """
@@ -262,57 +302,57 @@ class SearchHistory:
         """
         [KO]
         특정 검색 ID의 기록을 삭제합니다.
+        영속화 실패 시 메모리에서도 롤백되고 False를 반환합니다.
 
         Args:
             search_id: 삭제할 검색 고유 ID
 
         Returns:
-            삭제 성공 시 True, 실패 시(ID 없음) False
+            삭제 및 영속화 성공 시 True, 실패 시(없는 ID 또는 저장 실패) False
 
         [EN]
         Deletes the record for a specific search ID.
+        Rolls back in-memory state on persistence failure and returns False.
 
         Args:
             search_id: Unique search ID to delete
 
         Returns:
-            True if successfully deleted, False otherwise (ID not found)
+            True if deletion and persistence succeeded, False otherwise
         """
-        if search_id in self.history:
-            record = self.history.pop(search_id)
-            # [KO] 저장 실패 시 삭제된 레코드를 메모리에 복원하여 일관성 유지
-            # [EN] Restore the deleted record on save failure to maintain consistency
-            if not self._save_history():
-                self.history[search_id] = record
-                logger.error(
-                    "히스토리 저장 실패로 검색 기록 삭제가 취소되었습니다.",
-                    extra={
-                        "action": "delete_search_rollback",
-                        "error_type": "save_failure",
-                    },
-                )
-                return False
-            return True
-        return False
+        if search_id not in self.history:
+            return False
+        record = self.history[search_id]
+        return self._apply_and_persist(
+            mutate=lambda: self.history.pop(search_id, None),
+            rollback=lambda: self.history.update({search_id: record}),
+            rollback_msg="히스토리 저장 실패로 검색 기록 삭제가 취소되었습니다.",
+            action="delete_search_rollback",
+        )
 
-    def clear_all(self):
+    def clear_all(self) -> bool:
         """
         [KO]
         모든 검색 기록을 영구적으로 삭제합니다.
+        영속화 실패 시 이전 히스토리를 복원하고 False를 반환합니다.
+
+        Returns:
+            성공 시 True, 영속화 실패(이전 상태 복원) 시 False
 
         [EN]
         Permanently clears all search records.
+        Restores previous history on persistence failure and returns False.
+
+        Returns:
+            True if cleared and persisted successfully, False if rollback occurred.
         """
         prev_history = self.history
-        self.history = {}
-        # [KO] 저장 실패 시 이전 히스토리를 메모리에 복원하여 일관성 유지
-        # [EN] Restore previous history on save failure to maintain consistency
-        if not self._save_history():
-            self.history = prev_history
-            logger.error(
-                "히스토리 저장 실패로 전체 삭제가 취소되었습니다.",
-                extra={"action": "clear_all_rollback", "error_type": "save_failure"},
-            )
+        return self._apply_and_persist(
+            mutate=lambda: setattr(self, "history", {}),
+            rollback=lambda: setattr(self, "history", prev_history),
+            rollback_msg="히스토리 저장 실패로 전체 삭제가 취소되었습니다.",
+            action="clear_all_rollback",
+        )
 
     def get_statistics(self) -> SearchStatistics:
         """

--- a/backend/search_history.py
+++ b/backend/search_history.py
@@ -89,13 +89,19 @@ class SearchHistory:
             os.makedirs(os.path.dirname(self.storage_path), exist_ok=True)
             self.history = {}
 
-    def _save_history(self):
+    def _save_history(self) -> bool:
         """
         [KO]
         메모리의 히스토리 데이터를 JSON 파일에 저장합니다.
 
+        Returns:
+            저장 성공 시 True, 직렬화 또는 I/O 실패 시 False
+
         [EN]
         Saves the in-memory history data to a JSON file.
+
+        Returns:
+            True if saved successfully, False on serialization or I/O failure.
         """
         # [KO] 1단계: 직렬화 - 파일 I/O와 분리하여 예외 범위를 명확히 제한
         # [EN] Step 1: Serialization — separated from file I/O to narrow the exception scope
@@ -107,7 +113,7 @@ class SearchHistory:
                 default=_custom_json_serializer,
             )
         except (TypeError, ValueError) as e:
-            logger.warning(
+            logger.error(
                 f"히스토리 직렬화 실패: {type(e).__name__}: {format_error_msg(e)}",
                 extra={
                     "action": "save_history_serialize",
@@ -115,7 +121,7 @@ class SearchHistory:
                     "error_type": type(e).__name__,
                 },
             )
-            return
+            return False
 
         # [KO] 2단계: 파일 I/O - 직렬화 성공 후에만 파일에 기록
         # [EN] Step 2: File I/O — only writes to disk after successful serialization
@@ -123,7 +129,7 @@ class SearchHistory:
             with open(self.storage_path, "w", encoding="utf-8") as f:
                 f.write(serialized)
         except OSError as e:
-            logger.warning(
+            logger.error(
                 f"히스토리 저장 실패: {type(e).__name__}: {format_error_msg(e)}",
                 extra={
                     "action": "save_history_write",
@@ -131,6 +137,9 @@ class SearchHistory:
                     "error_type": type(e).__name__,
                 },
             )
+            return False
+
+        return True
 
     def add_search(
         self, query: str, results_count: int, top_results: Optional[List[str]] = None
@@ -172,8 +181,14 @@ class SearchHistory:
             "created_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         }
 
-        # 저장
-        self._save_history()
+        # [KO] 저장 - 실패 시 메모리에서도 롤백하여 일관성 유지
+        # [EN] Save — roll back from memory on failure to maintain consistency
+        if not self._save_history():
+            del self.history[search_id]
+            logger.error(
+                "히스토리 저장 실패로 검색 기록 추가가 취소되었습니다.",
+                extra={"action": "add_search_rollback", "error_type": "save_failure"},
+            )
 
         return search_id
 
@@ -264,8 +279,19 @@ class SearchHistory:
             True if successfully deleted, False otherwise (ID not found)
         """
         if search_id in self.history:
-            del self.history[search_id]
-            self._save_history()
+            record = self.history.pop(search_id)
+            # [KO] 저장 실패 시 삭제된 레코드를 메모리에 복원하여 일관성 유지
+            # [EN] Restore the deleted record on save failure to maintain consistency
+            if not self._save_history():
+                self.history[search_id] = record
+                logger.error(
+                    "히스토리 저장 실패로 검색 기록 삭제가 취소되었습니다.",
+                    extra={
+                        "action": "delete_search_rollback",
+                        "error_type": "save_failure",
+                    },
+                )
+                return False
             return True
         return False
 
@@ -277,8 +303,16 @@ class SearchHistory:
         [EN]
         Permanently clears all search records.
         """
+        prev_history = self.history
         self.history = {}
-        self._save_history()
+        # [KO] 저장 실패 시 이전 히스토리를 메모리에 복원하여 일관성 유지
+        # [EN] Restore previous history on save failure to maintain consistency
+        if not self._save_history():
+            self.history = prev_history
+            logger.error(
+                "히스토리 저장 실패로 전체 삭제가 취소되었습니다.",
+                extra={"action": "clear_all_rollback", "error_type": "save_failure"},
+            )
 
     def get_statistics(self) -> SearchStatistics:
         """


### PR DESCRIPTION
- `_save_metadata` / `_save_history`의 반환 타입을 None에서 bool로 변경하여 호출자가 저장 성공 여부를 명시적으로 확인할 수 있도록 개선
- `add_file`/`delete_file`/`add_search`/`delete_search`/`clear_all`에 저장 실패 시 메모리 롤백 로직 추가하여 메모리-파일 데이터 불일치 원천 차단
- `search_history.py`의 직렬화·I/O 실패 로그 레벨을 `logger.warning` → `logger.error`로 통일하여 모니터링 경보 누락 방지

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1746#pullrequestreview-4876813669)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

메타데이터 및 검색 기록 저장에 성공/실패 여부를 명시적으로 표시하고, 저장 실패 시 메모리 내 데이터가 디스크 상태와 일치하도록 유지합니다.

New Features:
- 메타데이터 및 검색 기록 저장 작업에서 boolean 상태 값을 반환하여 호출자가 영속성(persistence) 실패를 감지할 수 있도록 합니다.
- 추가/삭제/초기화 작업에 롤백 로직을 도입하여 저장 실패 시 메타데이터나 검색 기록이 일관성 없는 상태로 남지 않도록 합니다.

Bug Fixes:
- 직렬화 또는 I/O 오류가 발생했을 때, 저장 실패 시 변경 내용을 되돌려(invert/rollback) 메모리 내 검색 기록/메타데이터와 JSON 파일에 저장된 데이터 간의 불일치를 방지합니다.

Enhancements:
- 검색 기록에서 직렬화 및 I/O 실패 로그를 오류 수준(error level)으로 표준화하여 모니터링 및 알림을 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add explicit success/failure signaling to metadata and search history persistence and ensure in-memory data stays consistent with disk on save failures.

New Features:
- Return boolean status from metadata and search history save operations to allow callers to detect persistence failures.
- Introduce rollback logic for add/delete/clear operations so failed saves do not leave metadata or search history in an inconsistent state.

Bug Fixes:
- Prevent divergence between in-memory search history/metadata and their persisted JSON files when serialization or I/O errors occur by reverting changes on save failure.

Enhancements:
- Standardize serialization and I/O failure logs in search history to use error level for better monitoring and alerting.

</details>