### PR TITLE
✨ refactor [#12.3.20] - (55) 2차 개선 : 데이터 매니저 예외 처리 엣지 케이스 보강

### DIFF
--- a/backend/data_manager.py
+++ b/backend/data_manager.py
@@ -41,9 +41,9 @@ def _log_error(
     if level == "error":
         logger.error(formatted_msg, extra=log_extra, exc_info=exc_info)
     elif level == "warning":
-        logger.warning(formatted_msg, extra=log_extra)
+        logger.warning(formatted_msg, extra=log_extra, exc_info=exc_info)
     else:
-        logger.info(formatted_msg, extra=log_extra)
+        logger.info(formatted_msg, extra=log_extra, exc_info=exc_info)
 
 
 class DataManager:
@@ -292,7 +292,14 @@ class DataManager:
         try:
             with open(self.context_json, "r", encoding="utf-8") as f:
                 context_data = json.load(f)
-        except (OSError, json.JSONDecodeError):
+        except (OSError, json.JSONDecodeError) as e:
+            _log_error(
+                "read_user_context_warning",
+                "컨텍스트 파일 읽기 실패. 빈 상태로 초기화",
+                e,
+                level="warning",
+                user_id=user_id,
+            )
             # [KO] 파일이 없거나 손상된 경우 빈 딕셔너리로 초기화
             # [EN] Initialize as empty dict if file is missing or corrupted
             context_data = {}


### PR DESCRIPTION
- `_log_error` 공통 헬퍼에서 `warning` 및 `info` 레벨 로그에도 `exc_info` 인자를 전달하여, 호출자가 명시적으로 스택 트레이스를 요구할 경우 정상 동작하도록 논리적 결함 수정
- `save_user_context` 내 파일 읽기 실패 시 예외를 조용히 무시(Silent Swallow)하던 문제를 수정하고, 손상된 컨텍스트 파일 복구 시 `_log_error(level="warning")`를 기록하여 운영 환경의 가시성 확보

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1749#pullrequestreview-4891065542)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

사용자 컨텍스트를 읽거나 에러가 아닌 로그를 출력할 때 발생하는 엣지 케이스 실패 상황에 대해 데이터 매니저의 에러 로깅 및 처리 방식을 개선합니다.

버그 수정:
- 공통 `_log_error` 헬퍼를 통해 예외 정보를 요청한 경우, warning 및 info 로그에 예외 정보가 올바르게 포함되도록 합니다.
- `save_user_context`에서 파일 읽기 및 JSON 디코드 실패를 경고 로그로 남기고 사용자 컨텍스트를 빈 상태로 재설정함으로써, 이러한 실패를 조용히 무시하지 않도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve error logging and handling in the data manager for edge-case failures when reading user context and emitting non-error logs.

Bug Fixes:
- Ensure warning and info logs correctly include exception information when requested via the common _log_error helper.
- Stop silently swallowing file read and JSON decode failures in save_user_context by logging a warning and resetting the user context to an empty state.

</details>