### PR TITLE
✨ refactor [#12.3.20] - (56) 2차 개선 : BaseException 방어 로직 세분화 및 안전한 에러 로깅 헬퍼 개선

### DIFF
--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -376,7 +376,7 @@ async def _run_search_agent(
         planner_error_message = (
             "파싱 오류로 인해 Planner 실행에 실패했습니다. 기본 응답을 시도합니다."
         )
-    except BaseException as e:
+    except Exception as e:
         # [Last-Resort] 위에서 명시적으로 설정한 예외 이외의 예상치 못한 런타임 오류 방어름
         # (LangChain 프로바이더 전용 예외 등)
         # 에이전트가 크래시되지 않고 우아하게 성능 저하(Graceful Degradation)하도록 보장
@@ -723,7 +723,7 @@ async def responder_node(state: AgentState) -> Dict[str, Any]:
             "죄송합니다, AI 모델의 응답을 처리하는 중 오류가 발생했습니다. "
             "잠시 후 다시 시도해 주시기 바랍니다."
         )
-    except BaseException as e:
+    except Exception as e:
         # [Last-Resort] 에이전트가 완전히 크래시되는 대신 폴백 메시지를 반환하여 Graceful Degradation 보장
         log_agent_error(
             logger,

--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -338,7 +338,7 @@ async def search_documents_tool(query: str, k: int = _DEFAULT_SEARCH_LIMIT) -> d
             "context": "문서 검색 중 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
             "docs": [],
         }
-    except BaseException as e:
+    except Exception as e:
         # [Last-Resort] 위에서 명시하지 않은 예상치 못한 런타임 오류 방어름
         # (HybridSearchService 내부에서 발생하는 서드파티 예외 등)
         log_agent_error(
@@ -438,7 +438,7 @@ async def deep_web_search_tool(query: str, k: int = _DEFAULT_SEARCH_LIMIT) -> di
             "context": "웹 검색 중 일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
             "docs": [],
         }
-    except BaseException as e:
+    except Exception as e:
         # [Last-Resort] Tavily 라이브러리 내부에서 발생하는 예상치 못한 예외 방어름
         log_agent_error(
             logger,

--- a/backend/agent/error_utils.py
+++ b/backend/agent/error_utils.py
@@ -56,7 +56,11 @@ _SECURITY_NOTICE: str = (
 )
 
 # log_agent_error()에서 허용하는 로그 레벨 집합
-_SUPPORTED_LOG_LEVELS: frozenset = frozenset({"error", "warning", "critical"})
+_SUPPORTED_LOG_LEVELS: frozenset = frozenset(
+    {"error", "warning", "critical", "info", "debug"}
+)
+_DEFAULT_LOG_LEVEL: str = "error"
+_RESERVED_EXTRA_KEYS: frozenset = frozenset({"error_type", "error_msg", "security"})
 
 
 def _sanitize_pii(text: str) -> str:
@@ -70,9 +74,7 @@ def _sanitize_pii(text: str) -> str:
     return sanitized
 
 
-def sanitize_error_msg(
-    exc: BaseException, max_chars: int = _MAX_ERROR_MSG_CHARS
-) -> str:
+def sanitize_error_msg(exc: Exception, max_chars: int = _MAX_ERROR_MSG_CHARS) -> str:
     """
     [KO] 예외 객체의 문자열 표현을 PII 마스킹 처리 후 최대 길이로 잘라 반환합니다.
 
@@ -92,13 +94,24 @@ def sanitize_error_msg(
     return "".join(islice(sanitized, max_chars))
 
 
+def get_safe_error_summary(exc: Exception) -> str:
+    """
+    [KO] 예외의 PII 정제 및 자르기 로직을 래핑하는 헬퍼 함수입니다.
+    이 함수를 통해 log_agent_error가 로깅에만 집중하도록 유지합니다.
+
+    [EN] Helper function wrapping PII sanitization and truncation logic.
+    Keeps log_agent_error focused solely on logging.
+    """
+    return sanitize_error_msg(exc)
+
+
 def log_agent_error(
     logger_instance: logging.Logger,
     context_label: str,
-    exc: BaseException,
+    exc: Exception,
     extra_metadata: Optional[Dict[str, Any]] = None,
     *,
-    level: str = "error",
+    level: str = _DEFAULT_LOG_LEVEL,
 ) -> None:
     """
     [KO] 에이전트 경계 레이어에서 발생한 예외를 PII-안전하게 구조화된 포맷으로 로깅합니다.
@@ -121,26 +134,33 @@ def log_agent_error(
         extra_metadata: 추가적인 비민감 메타데이터 딕셔너리.
                         (예: {"action": "graph_traversal", "tool": "search_documents_tool"})
                         / Additional non-sensitive metadata dict to include in the log.
-        level:          로그 레벨 문자열. "error" | "warning" | "critical" (기본값: "error").
-                        / Log level string. Must be one of the supported levels.
-
-    Raises:
-        ValueError: level 파라미터가 지원되지 않는 값인 경우.
-                    / If `level` is not in the set of supported log levels.
+        level:          로그 레벨 문자열. "error" | "warning" | "critical" 등 (기본값: "error").
+                        지원되지 않는 경우 기본값("error")으로 롤백됩니다.
+                        / Log level string. Falls back to default if unsupported.
     """
     if level not in _SUPPORTED_LOG_LEVELS:
-        raise ValueError(
-            f"Unsupported log level '{level}'. Must be one of: {sorted(_SUPPORTED_LOG_LEVELS)}"
+        logger_instance.warning(
+            f"Unsupported log level '{level}' for log_agent_error. Falling back to '{_DEFAULT_LOG_LEVEL}'."
         )
+        level = _DEFAULT_LOG_LEVEL
 
-    # 보안 키를 기본으로 구성하고, 호출부의 extra_metadata는 앞에 붙여 보안 키가 덮어써지지 않게 함
     extra: Dict[str, Any] = {
         "error_type": type(exc).__name__,
-        "error_msg": sanitize_error_msg(exc),
+        "error_msg": get_safe_error_summary(exc),
         "security": _SECURITY_NOTICE,
     }
+
     if extra_metadata:
-        extra = {**extra_metadata, **extra}
+        if overlap := _RESERVED_EXTRA_KEYS & extra_metadata.keys():
+            logger_instance.warning(
+                f"[log_agent_error] extra_metadata contains reserved keys which will be ignored: {overlap}"
+            )
+            safe_extra = {
+                k: v for k, v in extra_metadata.items() if k not in _RESERVED_EXTRA_KEYS
+            }
+            extra |= safe_extra
+        else:
+            extra |= extra_metadata
 
     log_fn = getattr(logger_instance, level)
     log_fn(context_label, extra=extra)

--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -394,7 +394,7 @@ class GraphHybridRouter:
                 extra_metadata={"action": "graph_traversal"},
             )
             return graph_enriched
-        except BaseException as e:
+        except Exception as e:
             # [Last-Resort] 그래프 라이브러리 내부에서 발생하는 예상치 못한 시스템 예외 방어름
             log_agent_error(
                 logger,


### PR DESCRIPTION
- 전역 예외 처리 범위 축소 (BaseException → Exception)
  - [backend/agent/chat/nodes.py] (Planner, Responder)
  - [backend/agent/chat/tools.py] (search_documents_tool, deep_web_search_tool)
  - [backend/agent/graph_router.py]
  - `asyncio.CancelledError` 등 시스템 신호 및 비동기 취소 예외가 삼켜지지 않도록 범위 축소
- **[backend/agent/error_utils.py]
  - `log_agent_error` 헬퍼 안전성 및 책임 분리 개선
  - 지원되지 않는 로그 레벨 수신 시 ValueError 대신 default('error')로 안전 롤백 적용 (Non-throwing 보장)
  - PII 정제와 문자열 자르기 책임을 get_safe_error_summary 헬퍼로 분리
  - `extra_metadata` 전달 시 예약된 키(error_type, error_msg, security)와 충돌할 경우 오버라이딩을 방지하고 명시적 경고(warning) 로깅 후 무시 처리
  - [Lint] Sourcery 권고사항(Walrus 연산자 및 Dict Union `|=` 연산자 적용) 반영하여 코드 간결화

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1753#pullrequestreview-4903083002)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

에이전트 오류 처리 방식을 강화하고 구조화된 로깅의 안전성과 유연성을 개선합니다.

New Features:
- 에이전트 오류 로깅에 `info` 및 `debug` 레벨 지원을 추가합니다.
- PII 안전한 오류 요약을 캡슐화하기 위한 `get_safe_error_summary` 헬퍼를 도입합니다.

Bug Fixes:
- `BaseException` 대신 `Exception`을 포착하도록 catch 블록을 좁혀, 시스템 수준 및 취소 예외가 의도치 않게 삼켜지는 문제를 방지합니다.
- `log_agent_error`에서 지원되지 않는 로그 레벨이 사용될 경우 오류를 발생시키지 않고 안전한 기본값으로 폴백되도록 보장합니다.
- 예약된 로깅 메타데이터 키가 `extra_metadata`에 의해 덮어쓰이지 않도록 보호하고, 충돌이 발생하면 경고를 출력합니다.

Enhancements:
- 에이전트 오류 로깅을 다듬어 PII 정제 및 잘림(truncation) 책임을 중앙화합니다.
- 예약 키 필터링과 최신 딕셔너리 연산을 사용해 오류 로깅 메타데이터 병합을 단순화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten agent error handling and improve structured logging safety and flexibility.

New Features:
- Add support for info and debug levels to agent error logging.
- Introduce get_safe_error_summary helper to encapsulate PII-safe error summarization.

Bug Fixes:
- Prevent system-level and cancellation exceptions from being unintentionally swallowed by narrowing catch blocks from BaseException to Exception.
- Ensure unsupported log levels in log_agent_error fall back to a safe default without raising errors.
- Protect reserved logging metadata keys from being overridden by extra_metadata and emit warnings when conflicts occur.

Enhancements:
- Refine agent error logging to centralize PII sanitization and truncation responsibilities.
- Simplify error logging metadata merging using reserved-key filtering and modern dict operations.

</details>