### PR TITLE
✨ refactor [#12.3.20] - (56) 3차 개선 : 취소/종료 시스템 예외 명시적 전파 및 docstring 현행화

### DIFF
--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -1,5 +1,6 @@
 # backend/agent/chat/nodes.py
 
+import asyncio
 import logging
 import numbers
 import re
@@ -376,6 +377,8 @@ async def _run_search_agent(
         planner_error_message = (
             "파싱 오류로 인해 Planner 실행에 실패했습니다. 기본 응답을 시도합니다."
         )
+    except (asyncio.CancelledError, KeyboardInterrupt, SystemExit):
+        raise
     except Exception as e:
         # [Last-Resort] 위에서 명시적으로 설정한 예외 이외의 예상치 못한 런타임 오류 방어름
         # (LangChain 프로바이더 전용 예외 등)
@@ -723,6 +726,8 @@ async def responder_node(state: AgentState) -> Dict[str, Any]:
             "죄송합니다, AI 모델의 응답을 처리하는 중 오류가 발생했습니다. "
             "잠시 후 다시 시도해 주시기 바랍니다."
         )
+    except (asyncio.CancelledError, KeyboardInterrupt, SystemExit):
+        raise
     except Exception as e:
         # [Last-Resort] 에이전트가 완전히 크래시되는 대신 폴백 메시지를 반환하여 Graceful Degradation 보장
         log_agent_error(

--- a/backend/agent/error_utils.py
+++ b/backend/agent/error_utils.py
@@ -134,7 +134,7 @@ def log_agent_error(
         extra_metadata: 추가적인 비민감 메타데이터 딕셔너리.
                         (예: {"action": "graph_traversal", "tool": "search_documents_tool"})
                         / Additional non-sensitive metadata dict to include in the log.
-        level:          로그 레벨 문자열. "error" | "warning" | "critical" 등 (기본값: "error").
+        level:          로그 레벨 문자열. "error" | "warning" | "critical" | "info" | "debug" 등 (기본값: "error").
                         지원되지 않는 경우 기본값("error")으로 롤백됩니다.
                         / Log level string. Falls back to default if unsupported.
     """

--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -16,6 +16,7 @@ Phase 4-2: GraphRAG 하이브리드 라우터
   - stateless_load 컨텍스트 매니저를 사용하여 조회 후 인메모리 데이터를 즉시 정리.
 """
 
+import asyncio
 import logging
 from typing import Any, Dict, List, Optional, Union
 
@@ -394,6 +395,8 @@ class GraphHybridRouter:
                 extra_metadata={"action": "graph_traversal"},
             )
             return graph_enriched
+        except (asyncio.CancelledError, KeyboardInterrupt, SystemExit):
+            raise
         except Exception as e:
             # [Last-Resort] 그래프 라이브러리 내부에서 발생하는 예상치 못한 시스템 예외 방어름
             log_agent_error(


### PR DESCRIPTION
- **[비동기 취소 및 시스템 시그널 전파 강제]**
  - `asyncio.CancelledError`, `KeyboardInterrupt`, `SystemExit` 명시적 raise
  - [backend/agent/chat/nodes.py]
  - [backend/agent/chat/tools.py]
  - [backend/agent/graph_router.py]
  - 광범위한 Exception 핸들러가 시스템/비동기 중단 시그널을 삼키는 부작용 원천 차단
- **[backend/agent/error_utils.py]**
  - `log_agent_error()`의 지원 로그 레벨을 코드(info, debug 추가)와 동일하게 docstring 현행화

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1754#pullrequestreview-4903118529)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

광범위한 예외 처리기에서 취소 및 시스템 종료 신호를 포착하지 않고 전파하도록 변경하고, 지원되는 로그 레벨에 맞게 오류 로깅 관련 문서를 정렬했습니다.

Bug Fixes:
- 채팅 노드와 그래프 라우팅 로직에서 일반적인 예외 처리기가 더 이상 asyncio 취소 및 시스템 수준 인터럽트를 삼키지 않도록 했습니다.

Enhancements:
- 구현과 일치하도록 `log_agent_error`가 info 및 debug 레벨을 지원한다는 내용을 docstring에 명확히 했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Propagate cancellation and system termination signals instead of catching them in broad exception handlers, and align error logging documentation with supported log levels.

Bug Fixes:
- Ensure asyncio cancellation and system-level interrupts are no longer swallowed by generic exception handlers in chat nodes and graph routing logic.

Enhancements:
- Clarify that log_agent_error supports info and debug levels in its docstring to match the implementation.

</details>