### PR TITLE
✨ refactor [#12.3.20] - (56) 4차 개선 : 시스템 예외 처리 헬퍼 도입 및 불필요한 의존성 제거

### DIFF
--- a/backend/agent/chat/nodes.py
+++ b/backend/agent/chat/nodes.py
@@ -1,6 +1,5 @@
 # backend/agent/chat/nodes.py
 
-import asyncio
 import logging
 import numbers
 import re
@@ -22,6 +21,7 @@ from backend.agent.chat.tools import (  # type: ignore[import, import-untyped, r
     search_documents_tool,
 )
 from backend.agent.error_utils import (  # type: ignore[import, import-untyped, reportMissingImports]
+    is_system_error,
     log_agent_error,
 )
 from backend.api.models.shared import (  # type: ignore[import, import-untyped, reportMissingImports]
@@ -377,9 +377,9 @@ async def _run_search_agent(
         planner_error_message = (
             "파싱 오류로 인해 Planner 실행에 실패했습니다. 기본 응답을 시도합니다."
         )
-    except (asyncio.CancelledError, KeyboardInterrupt, SystemExit):
-        raise
     except Exception as e:
+        if is_system_error(e):
+            raise
         # [Last-Resort] 위에서 명시적으로 설정한 예외 이외의 예상치 못한 런타임 오류 방어름
         # (LangChain 프로바이더 전용 예외 등)
         # 에이전트가 크래시되지 않고 우아하게 성능 저하(Graceful Degradation)하도록 보장
@@ -726,9 +726,9 @@ async def responder_node(state: AgentState) -> Dict[str, Any]:
             "죄송합니다, AI 모델의 응답을 처리하는 중 오류가 발생했습니다. "
             "잠시 후 다시 시도해 주시기 바랍니다."
         )
-    except (asyncio.CancelledError, KeyboardInterrupt, SystemExit):
-        raise
     except Exception as e:
+        if is_system_error(e):
+            raise
         # [Last-Resort] 에이전트가 완전히 크래시되는 대신 폴백 메시지를 반환하여 Graceful Degradation 보장
         log_agent_error(
             logger,

--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -15,6 +15,7 @@ from langchain_core.tools import (  # type: ignore[import, import-untyped, repor
 from tavily import TavilyClient
 
 from backend.agent.error_utils import (  # type: ignore[import, import-untyped, reportMissingImports]
+    is_system_error,
     log_agent_error,
 )
 from backend.services.hybrid_search_service import (  # type: ignore[import, import-untyped, reportMissingImports]
@@ -427,7 +428,9 @@ async def deep_web_search_tool(query: str, k: int = _DEFAULT_SEARCH_LIMIT) -> di
         )
         return {"context": final_context, "docs": serialized_docs}
 
-    except (TimeoutError, ConnectionError, RuntimeError) as e:
+    except Exception as e:
+        if is_system_error(e):
+            raise
         log_agent_error(
             logger,
             "[Tool] 웹 검색 중 오류 발생",

--- a/backend/agent/error_utils.py
+++ b/backend/agent/error_utils.py
@@ -105,6 +105,19 @@ def get_safe_error_summary(exc: Exception) -> str:
     return sanitize_error_msg(exc)
 
 
+def is_system_error(exc: BaseException) -> bool:
+    """
+    [KO] 시스템 레벨의 예외(비동기 취소, 키보드 인터럽트, 프로그램 종료 등)인지 확인합니다.
+    이러한 예외는 포괄적(catch-all) 에러 핸들러에서 삼키지 않고 즉시 재발생(raise)시켜야 합니다.
+
+    [EN] Checks whether the exception is a system-level error that must be propagated
+    and not swallowed by catch-all exception handlers.
+    """
+    import asyncio
+
+    return isinstance(exc, (KeyboardInterrupt, SystemExit, asyncio.CancelledError))
+
+
 def log_agent_error(
     logger_instance: logging.Logger,
     context_label: str,

--- a/backend/agent/graph_router.py
+++ b/backend/agent/graph_router.py
@@ -16,11 +16,11 @@ Phase 4-2: GraphRAG 하이브리드 라우터
   - stateless_load 컨텍스트 매니저를 사용하여 조회 후 인메모리 데이터를 즉시 정리.
 """
 
-import asyncio
 import logging
 from typing import Any, Dict, List, Optional, Union
 
 from backend.agent.error_utils import (  # type: ignore[import, import-untyped, reportMissingImports]
+    is_system_error,
     log_agent_error,
 )
 from backend.core.config.graph import (
@@ -395,9 +395,9 @@ class GraphHybridRouter:
                 extra_metadata={"action": "graph_traversal"},
             )
             return graph_enriched
-        except (asyncio.CancelledError, KeyboardInterrupt, SystemExit):
-            raise
         except Exception as e:
+            if is_system_error(e):
+                raise
             # [Last-Resort] 그래프 라이브러리 내부에서 발생하는 예상치 못한 시스템 예외 방어름
             log_agent_error(
                 logger,


### PR DESCRIPTION
- 시스템 예외(비동기 취소, 종료 등) 전파 로직을 중앙 집중화
  - [backend/agent/error_utils.py]: `is_system_error` 헬퍼 함수 추가
  - [backend/agent/chat/nodes.py], [tools.py], [graph_router.py]의 중복된 except 블록을 `is_system_error`를 사용하도록 리팩터링
- 동기 모듈의 불필요한 `asyncio` 의존성(import asyncio) 완전 제거
  - [graph_router.py] 등에서 `CancelledError` 캐치를 위해 존재하던 `import` 제거
  - 헬퍼 함수 내부에서만 평가되도록 구조 개선

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1755#pullrequestreview-4903145871)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

시스템 수준 예외 처리를 중앙 집중화하고, 동기식 모듈에서 불필요한 `asyncio` 의존성을 제거했습니다.

새 기능:
- 시스템 수준 예외를 식별하고 반드시 전파되어야 하는지를 판단하는 `is_system_error` 헬퍼를 도입했습니다.

개선 사항:
- 에이전트 채팅 노드, 도구, 그래프 라우터에서 개별적인 포괄적 예외 처리 블록 대신 공용 시스템 오류 헬퍼를 사용하도록 리팩터링했습니다.
- 공용 헬퍼에 시스템 오류 감지를 위임함으로써 딥 웹 검색 도구의 예외 처리를 단순화했습니다.
- `CancelledError` 처리를 헬퍼 내부로 한정하여 동기식 모듈에서 직접적인 `asyncio` import를 제거했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize system-level exception handling and remove unnecessary asyncio dependencies from synchronous modules.

New Features:
- Introduce an is_system_error helper to identify system-level exceptions that must be propagated.

Enhancements:
- Refactor agent chat nodes, tools, and graph router to use the shared system error helper instead of local catch-all blocks.
- Simplify exception handling in deep web search tool by delegating system error detection to the shared helper.
- Eliminate direct asyncio imports from synchronous modules by containing CancelledError handling inside the helper.

</details>