### PR TITLE
✨ refactor [#12.3.20] - (56) 5차 개선 : 에러 헬퍼 성능 최적화 및 툴 예외 표면 원복

### DIFF
--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -428,9 +428,7 @@ async def deep_web_search_tool(query: str, k: int = _DEFAULT_SEARCH_LIMIT) -> di
         )
         return {"context": final_context, "docs": serialized_docs}
 
-    except Exception as e:
-        if is_system_error(e):
-            raise
+    except (TimeoutError, ConnectionError, RuntimeError) as e:
         log_agent_error(
             logger,
             "[Tool] 웹 검색 중 오류 발생",
@@ -442,6 +440,8 @@ async def deep_web_search_tool(query: str, k: int = _DEFAULT_SEARCH_LIMIT) -> di
             "docs": [],
         }
     except Exception as e:
+        if is_system_error(e):
+            raise
         # [Last-Resort] Tavily 라이브러리 내부에서 발생하는 예상치 못한 예외 방어름
         log_agent_error(
             logger,

--- a/backend/agent/error_utils.py
+++ b/backend/agent/error_utils.py
@@ -56,11 +56,12 @@ _SECURITY_NOTICE: str = (
 )
 
 # log_agent_error()에서 허용하는 로그 레벨 집합
-_SUPPORTED_LOG_LEVELS: frozenset = frozenset(
-    {"error", "warning", "critical", "info", "debug"}
-)
-_DEFAULT_LOG_LEVEL: str = "error"
-_RESERVED_EXTRA_KEYS: frozenset = frozenset({"error_type", "error_msg", "security"})
+_SUPPORTED_LOG_LEVELS = frozenset({"error", "warning", "critical", "info", "debug"})
+_DEFAULT_LOG_LEVEL = "error"
+_RESERVED_EXTRA_KEYS = frozenset({"error_type", "error_msg", "security"})
+
+# 캐싱된 asyncio.CancelledError (반복 import 방지용)
+_CANCELLED_ERROR = None
 
 
 def _sanitize_pii(text: str) -> str:
@@ -113,9 +114,16 @@ def is_system_error(exc: BaseException) -> bool:
     [EN] Checks whether the exception is a system-level error that must be propagated
     and not swallowed by catch-all exception handlers.
     """
-    import asyncio
+    if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+        return True
 
-    return isinstance(exc, (KeyboardInterrupt, SystemExit, asyncio.CancelledError))
+    global _CANCELLED_ERROR
+    if _CANCELLED_ERROR is None:
+        import asyncio
+
+        _CANCELLED_ERROR = asyncio.CancelledError
+
+    return isinstance(exc, _CANCELLED_ERROR)
 
 
 def log_agent_error(


### PR DESCRIPTION
- **[backend/agent/error_utils.py]**
  - `is_system_error` 내부의 asyncio 반복 임포트 오버헤드를 제거하기 위해 모듈 레벨 `_CANCELLED_ERROR` 캐싱 도입
  - 동기 모듈에 대한 asyncio 하드 의존성은 방지하면서 성능 최적화 달성
- **[backend/agent/chat/tools.py]**
  - `deep_web_search_tool` 내부에서 과도하게 넓어졌던 `Exception` 예외 블록을 의도했던 좁은 예외(TimeoutError, ConnectionError, RuntimeError)로 원복하여 `Error Surface` 확장 방지
  - 예상치 못한 예외는 분리된 `Last-Resort` 핸들러로 안전하게 폴백되도록 수정

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1756#pullrequestreview-4903167168)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

에러 처리 성능을 최적화하고, 도구 예외 처리를 좁혀 과도한 예외 포착을 피하며 시스템 수준 오류를 보존합니다.

개선사항:
- 모듈 수준에서 `asyncio.CancelledError`를 캐시하여 시스템 오류 감지 시 반복적인 임포트를 방지합니다.
- `deep_web_search_tool` 에러 처리를 구체적인 비치명적 예외 타입을 사용하도록 개선하고, 예상치 못한 예외는 최후 수단 핸들러에 위임하며 시스템 오류는 다시 발생시키도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize error handling performance and narrow tool exception handling to avoid over-catching and preserve system-level errors.

Enhancements:
- Cache asyncio.CancelledError at module level to avoid repeated imports in system error detection.
- Refine deep_web_search_tool error handling to use specific non-fatal exception types and delegate unexpected exceptions to a last-resort handler while re-raising system errors.

</details>