### PR TITLE
✨ refactor [#12.3.20] - (56) 6차 개선 : 시스템 에러 헬퍼 타입 명시 및 예외 포착 범위 최적화

### DIFF
--- a/backend/agent/chat/tools.py
+++ b/backend/agent/chat/tools.py
@@ -428,7 +428,7 @@ async def deep_web_search_tool(query: str, k: int = _DEFAULT_SEARCH_LIMIT) -> di
         )
         return {"context": final_context, "docs": serialized_docs}
 
-    except (TimeoutError, ConnectionError, RuntimeError) as e:
+    except (TimeoutError, ConnectionError) as e:
         log_agent_error(
             logger,
             "[Tool] 웹 검색 중 오류 발생",

--- a/backend/agent/error_utils.py
+++ b/backend/agent/error_utils.py
@@ -24,7 +24,7 @@ Design Principles:
 import logging
 import re
 from itertools import islice
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Type
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 모듈 상수 (하드코딩 완전 배제)
@@ -61,7 +61,20 @@ _DEFAULT_LOG_LEVEL = "error"
 _RESERVED_EXTRA_KEYS = frozenset({"error_type", "error_msg", "security"})
 
 # 캐싱된 asyncio.CancelledError (반복 import 방지용)
-_CANCELLED_ERROR = None
+_CANCELLED_ERROR: Optional[Type[BaseException]] = None
+
+
+def _get_cancelled_error_type() -> Type[BaseException]:
+    """
+    [KO] asyncio.CancelledError 타입을 지연(lazy) 로드하여 캐싱합니다.
+    동기 모듈에서 불필요한 asyncio 의존성을 피하기 위해 사용됩니다.
+    """
+    global _CANCELLED_ERROR
+    if _CANCELLED_ERROR is None:
+        import asyncio
+
+        _CANCELLED_ERROR = asyncio.CancelledError
+    return _CANCELLED_ERROR
 
 
 def _sanitize_pii(text: str) -> str:
@@ -117,13 +130,7 @@ def is_system_error(exc: BaseException) -> bool:
     if isinstance(exc, (KeyboardInterrupt, SystemExit)):
         return True
 
-    global _CANCELLED_ERROR
-    if _CANCELLED_ERROR is None:
-        import asyncio
-
-        _CANCELLED_ERROR = asyncio.CancelledError
-
-    return isinstance(exc, _CANCELLED_ERROR)
+    return isinstance(exc, _get_cancelled_error_type())
 
 
 def log_agent_error(


### PR DESCRIPTION
- **[backend/agent/error_utils.py]**
  - `_CANCELLED_ERROR`에 `Optional`[Type[BaseException]] 정적 타입 어노테이션 추가
  - `_get_cancelled_error_type()` 지연 초기화 헬퍼 함수를 도입하여 `is_system_error` 내부 로직 단순화
- **[backend/agent/chat/tools.py]**
  - `deep_web_search_tool`에서 `RuntimeError`를 제외하여 예외 포착 범위를 (TimeoutError, ConnectionError)로 축소
  - 예측하지 못한 RuntimeError가 단순 통신 장애로 마스킹되는 것을 방지

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1757#pullrequestreview-4903192801)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

정적 타이핑을 사용해 `asyncio.CancelledError` 타입을 지연 캐싱하고, 예기치 않은 런타임 오류가 가려지지 않도록 딥 웹 검색 실패에 대한 예외 범위를 좁혀 시스템 오류 처리 방식을 개선합니다.

버그 수정:
- 딥 웹 검색 오류 처리를 타임아웃 및 연결 오류로 제한하여, 예기치 않은 런타임 실패가 더 이상 일시적인 통신 문제로 처리되지 않도록 합니다.

개선 사항:
- `asyncio.CancelledError` 타입을 캐싱하기 위한 지연 로딩 헬퍼를 도입하고 시스템 오류 검사 로직을 단순화합니다.
- 캐시된 `CancelledError` 참조에 대해 명시적인 옵셔널 타입 애너테이션을 추가하여 타입 안정성을 향상합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine system error handling by lazily caching the asyncio.CancelledError type with static typing and narrowing the exception scope for deep web search failures to avoid masking unexpected runtime errors.

Bug Fixes:
- Restrict deep web search error handling to timeout and connection errors so unexpected runtime failures are no longer treated as transient communication issues.

Enhancements:
- Introduce a lazily-loaded helper for caching the asyncio.CancelledError type and simplify system error checks.
- Add explicit optional type annotation for the cached CancelledError reference to improve type safety.

</details>