### PR TITLE
✨ refactor [#12.3.20] - (56) 7차 개선 : 시스템 에러 헬퍼의 타입 정합성 최적화

### DIFF
--- a/backend/agent/error_utils.py
+++ b/backend/agent/error_utils.py
@@ -24,7 +24,10 @@ Design Principles:
 import logging
 import re
 from itertools import islice
-from typing import Any, Dict, Optional, Type
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type, cast
+
+if TYPE_CHECKING:
+    import asyncio
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 모듈 상수 (하드코딩 완전 배제)
@@ -61,7 +64,7 @@ _DEFAULT_LOG_LEVEL = "error"
 _RESERVED_EXTRA_KEYS = frozenset({"error_type", "error_msg", "security"})
 
 # 캐싱된 asyncio.CancelledError (반복 import 방지용)
-_CANCELLED_ERROR: Optional[Type[BaseException]] = None
+_CANCELLED_ERROR: "Optional[Type[asyncio.CancelledError]]" = None
 
 
 def _get_cancelled_error_type() -> Type[BaseException]:
@@ -73,7 +76,7 @@ def _get_cancelled_error_type() -> Type[BaseException]:
     if _CANCELLED_ERROR is None:
         import asyncio
 
-        _CANCELLED_ERROR = asyncio.CancelledError
+        _CANCELLED_ERROR = cast("Type[asyncio.CancelledError]", asyncio.CancelledError)
     return _CANCELLED_ERROR
 
 


### PR DESCRIPTION
- **[backend/agent/error_utils.py]**
  - `_get_cancelled_error_type` 헬퍼의 반환 타입을 Type[BaseException]으로 명시하여 호출부 호환성 보장
  - 헬퍼 내부 캐싱 로직에 `typing.cast`('Type[asyncio.CancelledError]', ...)를 적용하여 구체적인 타입 좁히기(Type Narrowing) 달성 및 자기 설명적 코드 개선

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1758#pullrequestreview-4912779623)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

캐시된 `asyncio.CancelledError` 헬퍼와 관련된 타입 안정성과 명확성을 개선합니다.

향상 사항:
- 캐시된 `asyncio.CancelledError` 참조를 더 구체적인 `Optional[Type[asyncio.CancelledError]]` 타입을 사용하도록 정교하게 다듬습니다.
- 런타임 동작에 영향을 주지 않으면서 `CancelledError` 타입을 구체화하고 검증하기 위해 `typing.cast`와 `TYPE_CHECKING` 전용 `asyncio` 임포트를 적용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve type safety and clarity around the cached asyncio.CancelledError helper.

Enhancements:
- Refine the cached asyncio.CancelledError reference to use a more specific Optional[Type[asyncio.CancelledError]] type.
- Apply typing.cast and TYPE_CHECKING-only asyncio imports to narrow and validate the CancelledError type without impacting runtime behavior.

</details>