### PR TITLE
✨ refactor [#12.3.20] - (56) 8차 개선 : 시스템 에러 헬퍼의 정적 타입 힌트 고도화

### DIFF
--- a/backend/agent/error_utils.py
+++ b/backend/agent/error_utils.py
@@ -64,7 +64,7 @@ _DEFAULT_LOG_LEVEL = "error"
 _RESERVED_EXTRA_KEYS = frozenset({"error_type", "error_msg", "security"})
 
 # 캐싱된 asyncio.CancelledError (반복 import 방지용)
-_CANCELLED_ERROR: "Optional[Type[asyncio.CancelledError]]" = None
+_CANCELLED_ERROR: Optional[Type["asyncio.CancelledError"]] = None
 
 
 def _get_cancelled_error_type() -> Type[BaseException]:
@@ -76,7 +76,7 @@ def _get_cancelled_error_type() -> Type[BaseException]:
     if _CANCELLED_ERROR is None:
         import asyncio
 
-        _CANCELLED_ERROR = cast("Type[asyncio.CancelledError]", asyncio.CancelledError)
+        _CANCELLED_ERROR = cast(Type[asyncio.CancelledError], asyncio.CancelledError)
     return _CANCELLED_ERROR
 
 


### PR DESCRIPTION
- **[backend/agent/error_utils.py]**
  - `_CANCELLED_ERROR의` 타입 힌트를 `"Optional[...]"` 형태의 전체 문자열에서 `Optional`[Type["asyncio.CancelledError"]] 포워드 레퍼런스로 변경하여 타입 체커의 오해(Optional[str] 취급) 방지
  - `_get_cancelled_error_type` 내부의 `typing.cast()` 호출 시, 문자열 리터럴 대신 실제 런타임 타입 객체(Type[asyncio.CancelledError])를 전달하여 타입 안정성 극대화

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1759#pullrequestreview-4912801708)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

타입 검사기가 잘못 해석하지 않도록, 캐시된 `asyncio.CancelledError` 헬퍼에 대한 정적 타이핑을 개선합니다.

개선 사항:
- 캐시된 `asyncio.CancelledError` 참조에 대한 타입 힌트를, 구체적인 예외 타입에 대한 `Optional` 선행 참조를 사용하도록 정교하게 다듬습니다.
- 문자열 리터럴이 아닌, 실제 런타임의 `CancelledError` 타입에 대해 동작하도록 취소된 오류 타입 헬퍼 내의 `cast`를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve static typing for cached asyncio.CancelledError helper to avoid misinterpretation by type checkers.

Enhancements:
- Refine the type hint for the cached asyncio.CancelledError reference to use an Optional forward reference to the concrete exception type.
- Update the cast in the cancelled error type helper to operate on the actual runtime CancelledError type instead of a string literal.

</details>