### PR TITLE
✨ refactor [#12.3.20] - (56) 9차 개선 : 에러 타입 헬퍼의 반환 타입 좁히기 및 불필요한 cast 제거

### DIFF
--- a/backend/agent/error_utils.py
+++ b/backend/agent/error_utils.py
@@ -24,7 +24,7 @@ Design Principles:
 import logging
 import re
 from itertools import islice
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type
 
 if TYPE_CHECKING:
     import asyncio
@@ -67,7 +67,7 @@ _RESERVED_EXTRA_KEYS = frozenset({"error_type", "error_msg", "security"})
 _CANCELLED_ERROR: Optional[Type["asyncio.CancelledError"]] = None
 
 
-def _get_cancelled_error_type() -> Type[BaseException]:
+def _get_cancelled_error_type() -> "Type[asyncio.CancelledError]":
     """
     [KO] asyncio.CancelledError 타입을 지연(lazy) 로드하여 캐싱합니다.
     동기 모듈에서 불필요한 asyncio 의존성을 피하기 위해 사용됩니다.
@@ -76,7 +76,7 @@ def _get_cancelled_error_type() -> Type[BaseException]:
     if _CANCELLED_ERROR is None:
         import asyncio
 
-        _CANCELLED_ERROR = cast(Type[asyncio.CancelledError], asyncio.CancelledError)
+        _CANCELLED_ERROR = asyncio.CancelledError
     return _CANCELLED_ERROR
 
 


### PR DESCRIPTION
- **[backend/agent/error_utils.py]**
  - 이전 리뷰 피드백으로 추가되었던 불필요한 typing.cast 제거 및 의존성 정리
  - `_get_cancelled_error_type` 헬퍼의 반환 타입을 실제 반환값과 정확히 일치하는 `Type[asyncio.CancelledError]`로 좁혀서 타입 추론 최적화

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1760#pullrequestreview-4912824640)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

에러 헬퍼의 `asyncio.CancelledError` 타입 처리 방식을 더 엄격하게 하고 불필요한 타입 캐스트를 제거합니다.

Enhancements:
- `_get_cancelled_error_type`가 일반적인 `BaseException`이 아닌 구체적인 `asyncio.CancelledError` 타입을 반환하도록 개선합니다.
- `error_utils` 임포트를 단순화하고 `CancelledError` 캐싱을 위한 중복된 `typing.cast` 사용을 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten the error helper’s asyncio.CancelledError type handling and remove unnecessary typing casts.

Enhancements:
- Refine _get_cancelled_error_type to return the specific asyncio.CancelledError type instead of a generic BaseException.
- Simplify error_utils imports and eliminate redundant typing.cast usage for CancelledError caching.

</details>