### PR TITLE
✨ refactor [#12.3.20] - (57) 2차 개선 : CLI 로깅 식별자 고도화 및 메타데이터 키 통일

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -82,14 +82,21 @@ class FlowNoteCLI:
             [KO] 분류 결과 객체(ClassifyResponse), 실패 시 None / [EN] Classification result object (ClassifyResponse), or None on failure
         """
         try:
+            import hashlib
+
             path_obj = Path(file_path)
+
+            # 절대 경로 노출을 막으면서도 추적 가능하도록 경로 기반의 해시 식별자 생성
+            path_hash = hashlib.sha256(file_path.encode("utf-8")).hexdigest()[:12]
+            log_file_id = f"{path_obj.name}_{path_hash}"
+
             if not path_obj.exists():
-                logger.warning(f"File not found: {path_obj.name}")
+                logger.warning(f"File not found: {log_file_id}")
                 print(f"❌ 파일을 찾을 수 없습니다: {path_obj.name}")
                 return None
 
             if not path_obj.is_file():
-                logger.warning(f"Not a file: {path_obj.name}")
+                logger.warning(f"Not a file: {log_file_id}")
                 print(f"❌ 유효한 파일이 아닙니다: {path_obj.name}")
                 return None
 
@@ -98,22 +105,19 @@ class FlowNoteCLI:
                 with open(file_path, "r", encoding="utf-8") as f:
                     text = f.read()
             except UnicodeDecodeError as e:
-                log_agent_error(
-                    logger, "파일 인코딩 오류", e, {"file_name": path_obj.name}
-                )
+                log_agent_error(logger, "파일 인코딩 오류", e, {"file_id": log_file_id})
                 print(
                     f"❌ 지원하지 않는 인코딩이거나 텍스트 파일이 아닙니다: {path_obj.name}"
                 )
                 return None
             except OSError as e:
                 log_agent_error(
-                    logger, "파일 읽기 시스템 오류", e, {"file_name": path_obj.name}
+                    logger, "파일 읽기 시스템 오류", e, {"file_id": log_file_id}
                 )
                 print(f"❌ 파일을 읽는 중 시스템 오류가 발생했습니다: {path_obj.name}")
                 return None
 
-            # 보안: 절대 경로 노출 방지를 위해 해시값 사용 (SHA256)
-            import hashlib
+            # 보안: 내용 기반 해시값 사용 (분류 서비스용 고유 식별자)
 
             # 파일 내용 + 파일명 조합으로 고유성 확보
             content_preview = text[:100]  # 처음 100자만 해시에 사용


### PR DESCRIPTION
- **[backend/cli.py]**
  - 파일 입출력 에러 로깅 시 절대 경로 대신 경로 기반의 해시 식별자(log_file_id)를 생성하여 PII 유출 없이 로그 추적성 확보
  - `log_agent_error`에 전달하는 메타데이터 키를 시스템 관례에 맞게 `file_name`에서 `file_id`로 변경하여 일관성 향상

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1763#pullrequestreview-4919861584)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

PII 노출을 방지하면서 추적 가능성을 향상시키기 위해 CLI 파일 분류 로깅 식별자와 메타데이터의 일관성을 개선합니다.

개선 사항:
- 절대 경로 노출을 막기 위해 CLI 경고 로그에서 원시 파일 이름 대신 경로로부터 생성된 해시된 파일 식별자를 사용합니다.
- `log_agent_error`를 통해 파일 I/O 및 인코딩 문제를 보고할 때 메타데이터 필드를 `file_name`에서 `file_id`로 변경하여 오류 로깅 메타데이터를 표준화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve CLI file classification logging identifiers and metadata consistency to enhance traceability while avoiding PII exposure.

Enhancements:
- Replace raw file names in CLI warning logs with a hashed file identifier derived from the path to prevent absolute path exposure.
- Standardize error logging metadata by switching from `file_name` to `file_id` when reporting file I/O and encoding issues via `log_agent_error`.

</details>