### PR TITLE
✨ refactor [#12.3.20] - (57) 4차 개선 : 의존성 최적화 및 해시 식별자 문서화 강화

### DIFF
--- a/backend/agent/error_utils.py
+++ b/backend/agent/error_utils.py
@@ -85,10 +85,14 @@ def _get_cancelled_error_type() -> "Type[asyncio.CancelledError]":
 def get_safe_file_id(file_path: Union[str, Path]) -> str:
     """
     [KO] 파일의 경로를 기반으로 안전한 해시 식별자를 생성합니다.
-    경로를 정규화(resolve)하여 동일 파일에 대해 항상 같은 식별자를 반환합니다.
+    내부적으로 `Path.resolve()`를 사용하여 심볼릭 링크를 따라가고 상대 경로를
+    절대 경로로 정규화하므로, 동일한 파일에 대해 서로 다른 경로 입력이 주어지더라도
+    항상 단일하고 안정적인 식별자를 반환합니다.
     절대 경로 노출(PII)을 방지하면서도 로그 추적성을 유지할 때 사용합니다.
 
-    [EN] Generates a safe hashed identifier based on the file's resolved path.
+    [EN] Generates a safe hashed identifier based on the file's path.
+    Uses `Path.resolve()` to follow symlinks and normalize relative paths,
+    ensuring a single, stable identifier regardless of the input path format.
     Used to maintain log traceability without exposing absolute paths (PII).
     """
     path_obj = Path(file_path).resolve()

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -7,7 +7,6 @@
 """
 
 import asyncio
-import hashlib
 import logging
 import sys
 from dataclasses import dataclass
@@ -118,6 +117,8 @@ class FlowNoteCLI:
             # 보안: 내용 기반 해시값 사용 (분류 서비스용 고유 식별자)
 
             # 파일 내용 + 파일명 조합으로 고유성 확보
+            import hashlib
+
             content_preview = text[:100]  # 처음 100자만 해시에 사용
             hash_input = f"{path_obj.name}_{content_preview}".encode("utf-8")
             file_hash = hashlib.sha256(hash_input).hexdigest()[


### PR DESCRIPTION
- **[backend/cli.py]**
  - 불필요한 전역(top-level) `hashlib import`를 제거하여 네임스페이스 오염 방지
  - 파일 내용 해싱(content_preview)이 필요한 국소 블록(local scope)으로 `hashlib import` 위치 이동
- **[backend/agent/error_utils.py]**
  - `get_safe_file_id` 함수의 Docstring 업데이트
  - `Path.resolve()`가 심볼릭 링크 및 상대 경로를 정규화하여 식별자의 안정성(Stability)을 보장한다는 점을 명시

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1765#pullrequestreview-4919948534)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

파일 식별자 의미를 명확히 하고, CLI에서 해싱 관련 임포트 범위를 축소하여 전역 의존성을 줄입니다.

Enhancements:
- 콘텐츠 기반 파일 해시를 계산하는 로컬 블록에서만 `hashlib`를 사용하도록 제한하여, 불필요한 전역 임포트를 피합니다.

Documentation:
- `get_safe_file_id`의 도크스트링을 확장하여 경로 해석, 심볼릭 링크 처리, 식별자의 안정성 보장에 대해 문서화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify file identifier semantics and tighten CLI hashing import scope to reduce global dependencies.

Enhancements:
- Limit hashlib usage in the CLI to the local block that computes content-based file hashes, avoiding unnecessary global imports.

Documentation:
- Expand the get_safe_file_id docstring to document path resolution, symlink handling, and identifier stability guarantees.

</details>