### PR TITLE
✨ refactor [#12.3.20] - (58) 3차 개선 : `_execute_scalar` 헬퍼 도입 및 `get_weekly_trend` 가독성 개선

### DIFF
--- a/backend/database/connection.py
+++ b/backend/database/connection.py
@@ -155,6 +155,46 @@ class DatabaseConnection:
             )
             return False
 
+    def _execute_scalar(
+        self,
+        query: str,
+        params: Tuple[Any, ...] = (),
+        *,
+        action: str,
+        table: Optional[str] = None,
+        default: int = 0,
+    ) -> int:
+        """
+        [KO] COUNT·SUM처럼 단일 정수 값을 반환하는 쿼리의 전용 헬퍼입니다.
+        _execute_query(fetch="one")를 래핑하여 튜플 인덱싱 없이 스칼라 값을 직접 반환합니다.
+        SQL NULL(행 없을 때 SUM이 반환하는 값) 처리도 내부에서 일괄 처리합니다.
+
+        [EN] Dedicated helper for queries returning a single integer scalar (COUNT, SUM, etc.).
+        Wraps _execute_query(fetch="one") to return the value directly without tuple indexing.
+        Also handles SQL NULL (returned by SUM when no rows exist) internally.
+
+        Args:
+            query:   실행할 스칼라 SELECT 쿼리 / Scalar SELECT query to execute.
+            params:  쿼리 파라미터 (로그 미포함) / Query parameters (never logged).
+            action:  로그 컨텍스트용 메서드명 / Method name for log context.
+            table:   관련 테이블명 (선택) / Related table name (optional).
+            default: 예외 또는 NULL 결과 시 반환할 정수 기본값 (기본값: 0)
+                     / Integer fallback for exceptions or SQL NULL results (default: 0).
+        """
+        row = self._execute_query(
+            query,
+            params,
+            action=action,
+            table=table,
+            fetch="one",
+            default=(default,),
+        )
+        # row는 항상 튜플 — 실제 결과이거나 default 튜플
+        # row[0]이 None인 경우는 SUM()이 행 없을 때 NULL을 반환하는 경우
+        # / row is always a tuple — real result or default tuple.
+        # row[0] is None only when SUM() returns SQL NULL (no matching rows).
+        return row[0] if row[0] is not None else default
+
     # ─────────────────────────────────────────────────────────────────────────
     # 스키마 초기화 (Schema)
     # ─────────────────────────────────────────────────────────────────────────
@@ -232,24 +272,17 @@ class DatabaseConnection:
         [KO] 파일 통계를 수집하여 반환합니다.
         [EN] Collects and returns file statistics.
         """
-        total_files_row = self._execute_query(
-            "SELECT COUNT(*) FROM files",
-            action="get_statistics.total_files",
-            table="files",
-            fetch="one",
-            default=(0,),
-        )
-        total_searches_row = self._execute_query(
-            "SELECT SUM(search_count) FROM search_analytics",
-            action="get_statistics.total_searches",
-            table="search_analytics",
-            fetch="one",
-            default=(0,),
-        )
-
         return {
-            "total_files": total_files_row[0],
-            "total_searches": total_searches_row[0] or 0,
+            "total_files": self._execute_scalar(
+                "SELECT COUNT(*) FROM files",
+                action="get_statistics.total_files",
+                table="files",
+            ),
+            "total_searches": self._execute_scalar(
+                "SELECT SUM(search_count) FROM search_analytics",
+                action="get_statistics.total_searches",
+                table="search_analytics",
+            ),
             "by_type": self._group_by_extension(),
             "by_category": self._group_by_para(),
             "top_keywords": self.get_top_keywords(10),
@@ -303,15 +336,12 @@ class DatabaseConnection:
         [KO] 특정 PARA 카테고리의 파일 수를 반환합니다.
         [EN] Returns file count for a specific PARA category.
         """
-        row = self._execute_query(
+        return self._execute_scalar(
             "SELECT COUNT(*) FROM metadata WHERE para_category = ?",
             (category,),
             action="count_by_para",
             table="metadata",
-            fetch="one",
-            default=(0,),
         )
-        return row[0]
 
     def get_keyword_categories(self) -> Dict[str, int]:
         """
@@ -328,15 +358,12 @@ class DatabaseConnection:
         [KO] 특정 키워드 태그를 포함하는 파일 수를 반환합니다.
         [EN] Returns count of files containing the specified keyword tag.
         """
-        row = self._execute_query(
+        return self._execute_scalar(
             "SELECT COUNT(*) FROM metadata WHERE keyword_tags LIKE ?",
             (f"%{tag}%",),
             action="count_by_keyword_tag",
             table="metadata",
-            fetch="one",
-            default=(0,),
         )
-        return row[0]
 
     def get_top_keywords(self, top_n: int = 10) -> List[str]:
         """
@@ -369,14 +396,11 @@ class DatabaseConnection:
         [KO] 총 검색 횟수를 반환합니다.
         [EN] Returns total search count.
         """
-        row = self._execute_query(
+        return self._execute_scalar(
             "SELECT SUM(search_count) FROM search_analytics",
             action="get_total_searches",
             table="search_analytics",
-            fetch="one",
-            default=(0,),
         )
-        return row[0] or 0
 
     def get_activity_heatmap(self) -> List[Dict[str, Any]]:
         """
@@ -431,9 +455,10 @@ class DatabaseConnection:
             table="files",
             fetch="all",
         )
-        return [{"name": r[0], "value": r[1]} for r in rows][
-            ::-1
-        ]  # 과거 → 현재 순으로 정렬
+        # DB에서 최신순(DESC)으로 받은 결과를 과거→현재 순으로 뒤집어 반환
+        # / Reverse DESC results from DB to return in chronological (ASC) order
+        data = [{"name": r[0], "value": r[1]} for r in rows]
+        return list(reversed(data))
 
     # ─────────────────────────────────────────────────────────────────────────
     # 연결 관리 (Connection Lifecycle)


### PR DESCRIPTION
- `_execute_scalar` 내부 헬퍼 도입: COUNT·SUM 등 단일 정수 반환 쿼리의 튜플 인덱싱 패턴 캡슐화
  - SQL NULL(행 없을 때 SUM 반환값) 처리를 헬퍼 내부에서 일괄 처리
  - `get_statistics`, `count_by_para`, `count_by_keyword_tag`, `get_total_searches`에 적용
- `get_weekly_trend`
  - [::-1] 슬라이싱 → list(reversed(data)) 변경으로 역순 정렬 의도 명확화

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1769#pullrequestreview-4942853715)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

단일 정수 `SELECT`를 위한 스칼라 쿼리 헬퍼를 도입하고, 이에 맞춰 통계 및 트렌드 조회 API를 단순화합니다.

New Features:
- 정수를 반환하고 SQL `NULL` 처리를 중앙집중화하는 `COUNT`/`SUM` 스타일 쿼리용 전용 `_execute_scalar` 헬퍼를 추가합니다.

Enhancements:
- 통계 관련 메서드들이 수동 튜플 인덱싱 대신 스칼라 헬퍼를 사용하도록 리팩터링합니다.
- 준비된 데이터 리스트를 역순으로 정렬해 시간순으로 출력되도록 함으로써 `get_weekly_trend` 결과의 정렬 방식을 명확히 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a scalar query helper for single-integer SELECTs and simplify statistics and trend retrieval APIs accordingly.

New Features:
- Add a dedicated _execute_scalar helper for COUNT/SUM-style queries that returns an integer and centralizes SQL NULL handling.

Enhancements:
- Refactor statistics-related methods to use the scalar helper instead of manual tuple indexing.
- Clarify get_weekly_trend result ordering by reversing the prepared data list for chronological output.

</details>