### PR TITLE
✨ refactor [#12.3.20] - (58) 4차 개선 : `_execute_scalar` 방어적 코드 추가 및 타입 일반화

### DIFF
--- a/backend/database/connection.py
+++ b/backend/database/connection.py
@@ -162,14 +162,14 @@ class DatabaseConnection:
         *,
         action: str,
         table: Optional[str] = None,
-        default: int = 0,
-    ) -> int:
+        default: Any = 0,
+    ) -> Any:
         """
-        [KO] COUNT·SUM처럼 단일 정수 값을 반환하는 쿼리의 전용 헬퍼입니다.
+        [KO] 단일 스칼라 값(예: COUNT, SUM, 단일 필드 조회)을 반환하는 쿼리의 전용 헬퍼입니다.
         _execute_query(fetch="one")를 래핑하여 튜플 인덱싱 없이 스칼라 값을 직접 반환합니다.
         SQL NULL(행 없을 때 SUM이 반환하는 값) 처리도 내부에서 일괄 처리합니다.
 
-        [EN] Dedicated helper for queries returning a single integer scalar (COUNT, SUM, etc.).
+        [EN] Dedicated helper for queries returning a single scalar value (COUNT, SUM, etc.).
         Wraps _execute_query(fetch="one") to return the value directly without tuple indexing.
         Also handles SQL NULL (returned by SUM when no rows exist) internally.
 
@@ -178,8 +178,8 @@ class DatabaseConnection:
             params:  쿼리 파라미터 (로그 미포함) / Query parameters (never logged).
             action:  로그 컨텍스트용 메서드명 / Method name for log context.
             table:   관련 테이블명 (선택) / Related table name (optional).
-            default: 예외 또는 NULL 결과 시 반환할 정수 기본값 (기본값: 0)
-                     / Integer fallback for exceptions or SQL NULL results (default: 0).
+            default: 예외 또는 NULL 결과 시 반환할 기본값 (기본값: 0)
+                     / Fallback value for exceptions or SQL NULL results (default: 0).
         """
         row = self._execute_query(
             query,
@@ -189,11 +189,11 @@ class DatabaseConnection:
             fetch="one",
             default=(default,),
         )
-        # row는 항상 튜플 — 실제 결과이거나 default 튜플
-        # row[0]이 None인 경우는 SUM()이 행 없을 때 NULL을 반환하는 경우
-        # / row is always a tuple — real result or default tuple.
-        # row[0] is None only when SUM() returns SQL NULL (no matching rows).
-        return row[0] if row[0] is not None else default
+        # 방어적 코드: 반환된 결과가 시퀀스(튜플/리스트 등)이고 요소가 존재하는지 확인
+        # / Defensive check: ensure the returned result is a sequence and has at least one element.
+        if row and len(row) > 0:
+            return row[0] if row[0] is not None else default
+        return default
 
     # ─────────────────────────────────────────────────────────────────────────
     # 스키마 초기화 (Schema)


### PR DESCRIPTION
- 방어적 검사 추가: `_execute_scalar`에서 row[0] 접근 전 반환 결과가 시퀀스인지(len(row) > 0) 먼저 확인하여 에러(IndexError 등) 사전 방지 및 안전성 강화
- 타입 일반화
  - `_execute_scalar`가 INTEGER(COUNT, SUM)뿐만 아니라 FLOAT 등 다른 비정수 스칼라 타입에도 안전하게 재사용될 수 있도록 default 파라미터와 반환 타입 힌트를 Any로 확장
  - 관련 문서 명확히 업데이트

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1770#pullrequestreview-4942873884)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

데이터베이스 스칼라 헬퍼를 일반화하여 정수 이외의 스칼라 값도 지원하도록 하고, 잘못된 쿼리 결과에 대해 더 견고하게 만들었습니다.

새로운 기능:
- `_execute_scalar`가 정수만이 아니라 임의의 스칼라 타입을 처리할 수 있도록 허용합니다.

버그 수정:
- 쿼리 결과가 비어 있거나 올바른 시퀀스가 아닐 때 발생하는 오류를 피하기 위해 `_execute_scalar`에 방어적 체크를 추가했습니다.

개선 사항:
- 더 폭넓은 재사용을 위해 `_execute_scalar`의 기본값과 반환 타입 힌트를 `Any`로 완화했습니다.
- 이중언어(docstring)를 정리하여 정수 개수 및 합계만이 아니라 일반적인 스칼라 값을 지원한다는 점을 명확히 기술했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Generalize the database scalar helper to support non-integer scalar values and harden it against invalid query results.

New Features:
- Allow _execute_scalar to handle arbitrary scalar types instead of only integers.

Bug Fixes:
- Add defensive checks in _execute_scalar to avoid errors when the query result is empty or not a proper sequence.

Enhancements:
- Relax _execute_scalar default value and return type hints to Any for broader reuse.
- Clarify bilingual docstrings to describe support for generic scalar values rather than only integer counts and sums.

</details>