### PR TITLE
✨ refactor [#12.3.20] - (58) 5차 개선 : `_execute_scalar` 더 엄격한 방어적 검사 및 TypeVar 적용

### DIFF
--- a/backend/database/connection.py
+++ b/backend/database/connection.py
@@ -21,9 +21,10 @@ Design Principles:
 
 import logging
 import sqlite3
+from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple, TypeVar, cast
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,8 @@ _FetchMode = Literal["all", "one", "none"]
 # default 파라미터의 '미지정' 여부를 구분하는 센티넬
 # (None을 유효한 기본값으로 허용하기 위해 별도 객체 사용)
 _MISSING: object = object()
+
+T = TypeVar("T")
 
 
 class DatabaseConnection:
@@ -162,8 +165,8 @@ class DatabaseConnection:
         *,
         action: str,
         table: Optional[str] = None,
-        default: Any = 0,
-    ) -> Any:
+        default: T = cast(T, 0),
+    ) -> T:
         """
         [KO] 단일 스칼라 값(예: COUNT, SUM, 단일 필드 조회)을 반환하는 쿼리의 전용 헬퍼입니다.
         _execute_query(fetch="one")를 래핑하여 튜플 인덱싱 없이 스칼라 값을 직접 반환합니다.
@@ -189,9 +192,13 @@ class DatabaseConnection:
             fetch="one",
             default=(default,),
         )
-        # 방어적 코드: 반환된 결과가 시퀀스(튜플/리스트 등)이고 요소가 존재하는지 확인
-        # / Defensive check: ensure the returned result is a sequence and has at least one element.
-        if row and len(row) > 0:
+        # 방어적 코드: 반환된 결과가 Sequence 타입인지 명시적으로 확인 (문자열 제외)
+        # / Defensive check: explicitly verify the result is a Sequence (excluding string) before indexing.
+        if (
+            isinstance(row, Sequence)
+            and not isinstance(row, (str, bytes))
+            and len(row) > 0
+        ):
             return row[0] if row[0] is not None else default
         return default
 
@@ -277,11 +284,13 @@ class DatabaseConnection:
                 "SELECT COUNT(*) FROM files",
                 action="get_statistics.total_files",
                 table="files",
+                default=0,
             ),
             "total_searches": self._execute_scalar(
                 "SELECT SUM(search_count) FROM search_analytics",
                 action="get_statistics.total_searches",
                 table="search_analytics",
+                default=0,
             ),
             "by_type": self._group_by_extension(),
             "by_category": self._group_by_para(),
@@ -341,6 +350,7 @@ class DatabaseConnection:
             (category,),
             action="count_by_para",
             table="metadata",
+            default=0,
         )
 
     def get_keyword_categories(self) -> Dict[str, int]:
@@ -363,6 +373,7 @@ class DatabaseConnection:
             (f"%{tag}%",),
             action="count_by_keyword_tag",
             table="metadata",
+            default=0,
         )
 
     def get_top_keywords(self, top_n: int = 10) -> List[str]:
@@ -400,6 +411,7 @@ class DatabaseConnection:
             "SELECT SUM(search_count) FROM search_analytics",
             action="get_total_searches",
             table="search_analytics",
+            default=0,
         )
 
     def get_activity_heatmap(self) -> List[Dict[str, Any]]:


### PR DESCRIPTION
- 방어적 검사 고도화
  - `_execute_scalar` 내에서 단순히 Truthy를 검사하는 것을 넘어 `isinstance`(row, Sequence)를 사용하여 인덱싱 가능한 자료형인지 엄격하게 검증.
  - 문자열/바이트 등 잘못된 시퀀스 처리 방지 로직 포함 (불필요한 중첩 if문 병합)
- 강한 타입 안전성 확보
  - Any 타입 대신 바운드된 타입 변수(TypeVar("T"))와 cast를 사용
  - 호출자가 지정한 default 값의 타입에 따라 반환 타입(T)이 런타임에 동적으로 바인딩되도록 개선
- IDE 타입 추론 해결
  - `count_by_para`, `get_total_searches` 등 `_execute_scalar`를 호출하는 5곳의 쿼리 메서드에서 `default=0`을 명시적으로 전달
  - 정적 분석 도구가 TypeVar 추론을 완벽히 수행할 수 있도록 수정

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1771#pullrequestreview-4942890533)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

스칼라 쿼리 헬퍼의 타이핑과 방어적인 결과 처리 방식을 강화하고, 호출부를 새로운 타입 지정 기본 동작에 맞게 정렬했습니다.

개선 사항:
- `_execute_scalar`의 방어적 검사를 강화하여, 인덱싱 전에 결과가 문자열이 아닌 시퀀스인지 검증하고 첫 번째 요소 또는 기본값을 반환하도록 했습니다.
- 스칼라 쿼리 결과에 대한 타입 안전성과 IDE/정적 분석의 추론을 개선하기 위해 `_execute_scalar`에 제네릭 타입 변수와 타입이 지정된 기본값을 도입했습니다.
- 새로운 제네릭 타이핑에 맞추고 일관된 숫자 기본값을 보장하기 위해 스칼라 쿼리 호출부(통계 및 카운트 헬퍼)에서 `default=0`을 명시적으로 전달하도록 수정했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen scalar query helper typing and defensive result handling, and align callers with the new typed default behavior.

Enhancements:
- Tighten `_execute_scalar`’s defensive checks by validating results as non-string sequences before indexing and returning the first element or a default.
- Introduce a generic type variable and typed default for `_execute_scalar` to improve type safety and IDE/static-analysis inference for scalar query results.
- Update scalar query call sites (statistics and count helpers) to pass an explicit `default=0` to match the new generic typing and ensure consistent numeric fallbacks.

</details>