### PR TITLE
✨ refactor [#12.3.20] - (58) 6차 개선 : `_execute_scalar` 덕 타이핑 방어 및 기본값 센티넬 도입

### DIFF
--- a/backend/database/connection.py
+++ b/backend/database/connection.py
@@ -21,10 +21,9 @@ Design Principles:
 
 import logging
 import sqlite3
-from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple, TypeVar, cast
+from typing import Any, Dict, List, Literal, Optional, Tuple, TypeVar
 
 logger = logging.getLogger(__name__)
 
@@ -165,8 +164,8 @@ class DatabaseConnection:
         *,
         action: str,
         table: Optional[str] = None,
-        default: T = cast(T, 0),
-    ) -> T:
+        default: Any = _MISSING,
+    ) -> Any:
         """
         [KO] 단일 스칼라 값(예: COUNT, SUM, 단일 필드 조회)을 반환하는 쿼리의 전용 헬퍼입니다.
         _execute_query(fetch="one")를 래핑하여 튜플 인덱싱 없이 스칼라 값을 직접 반환합니다.
@@ -190,17 +189,19 @@ class DatabaseConnection:
             action=action,
             table=table,
             fetch="one",
-            default=(default,),
+            default=(default if default is not _MISSING else 0,),
         )
-        # 방어적 코드: 반환된 결과가 Sequence 타입인지 명시적으로 확인 (문자열 제외)
-        # / Defensive check: explicitly verify the result is a Sequence (excluding string) before indexing.
+
+        fallback_value = default if default is not _MISSING else 0
+        # 방어적 코드: collections.abc.Sequence 등록 여부와 무관하게 인덱싱이 가능한지(__getitem__) 덕 타이핑(Duck Typing) 검사
+        # / Defensive check: Duck typing check for indexability (__getitem__) regardless of collections.abc.Sequence registration.
         if (
-            isinstance(row, Sequence)
+            hasattr(row, "__getitem__")
             and not isinstance(row, (str, bytes))
             and len(row) > 0
         ):
-            return row[0] if row[0] is not None else default
-        return default
+            return row[0] if row[0] is not None else fallback_value
+        return fallback_value
 
     # ─────────────────────────────────────────────────────────────────────────
     # 스키마 초기화 (Schema)


### PR DESCRIPTION
- 방어적 검사 고도화
  - `_execute_scalar`에서 반환 결과(row)에 대한 인덱싱 가능 여부를 확인할 때, collections.abc.Sequence와 같은 특정 추상 타입에 의존하지 않고 hasattr(row, '__getitem__')을 사용하는 덕 타이핑(Duck Typing) 방식을 도입.
  - 이를 통해 sqlite3.Row 등 시퀀스로 등록되지 않은 인덱싱 가능한 커스텀 객체까지 안전하게 포용
- 타입 의미론 일치 및 센티넬 도입
  - default 매개변수의 기본값을 TypeVar T로 강제 캐스팅하던 방식에서 센티넬 객체(_MISSING)를 사용하여 런타임 값과 타입 힌트를 완전히 분리.
  - 호출자가 의도적으로 None이나 문자열 등을 기본값으로 전달할 때 발생할 수 있는 의미론적 충돌을 방지하고 유연성을 극대화

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1772#pullrequestreview-4945384866)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

스칼라 쿼리 헬퍼를 개선하여 인덱싱 가능 여부를 확인할 때 덕 타이핑을 사용하고, 런타임 기본값을 타입 힌트와 분리하기 위한 센티널 기반 기본값을 도입합니다.

Bug Fixes:
- `_execute_scalar`가 사용자 정의 데이터베이스 row 타입과 같이 인덱싱 가능하지만 `Sequence`가 아닌 row 객체를 안전하게 처리하도록 합니다.

Enhancements:
- `_execute_scalar`에서 row의 인덱싱 가능 여부를 판단할 때 `collections.abc.Sequence` 대신 `__getitem__` 기반의 덕 타이핑 체크를 채택합니다.
- 호출자가 명시적인 기본값을 전달할 때 의미 충돌을 방지하기 위해, `TypeVar` 기반의 기본 캐스팅을 센티널 기본값으로 교체합니다.
- 새로운 센티널 기본값 처리 방식에 맞춰 `_execute_scalar`의 타입 애너테이션을 `Any`를 받아서 `Any`를 반환하도록 완화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the scalar query helper to use duck typing for indexability checks and introduce a sentinel-based default value to decouple runtime defaults from type hints.

Bug Fixes:
- Ensure _execute_scalar safely handles indexable but non-Sequence row objects such as custom database row types.

Enhancements:
- Adopt a duck-typing (__getitem__) check instead of collections.abc.Sequence for determining row indexability in _execute_scalar.
- Replace TypeVar-based default casting with a sentinel default value to avoid semantic conflicts when callers pass explicit defaults.
- Relax _execute_scalar type annotations to accept and return Any, aligned with the new sentinel default handling.

</details>