### PR TITLE
✨ refactor [#12.3.20] - (58) 7차 개선 : `_execute_scalar` EAFP 패턴 적용 및 안전성 극대화

### DIFF
--- a/backend/database/connection.py
+++ b/backend/database/connection.py
@@ -21,6 +21,7 @@ Design Principles:
 
 import logging
 import sqlite3
+from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple, TypeVar
@@ -193,14 +194,16 @@ class DatabaseConnection:
         )
 
         fallback_value = default if default is not _MISSING else 0
-        # 방어적 코드: collections.abc.Sequence 등록 여부와 무관하게 인덱싱이 가능한지(__getitem__) 덕 타이핑(Duck Typing) 검사
-        # / Defensive check: Duck typing check for indexability (__getitem__) regardless of collections.abc.Sequence registration.
-        if (
-            hasattr(row, "__getitem__")
-            and not isinstance(row, (str, bytes))
-            and len(row) > 0
-        ):
-            return row[0] if row[0] is not None else fallback_value
+
+        # 방어적 코드: EAFP (허락보다 용서 구하기) 패턴 적용
+        # 명시적인 타입 검사나 불완전한 속성 검사(hasattr) 대신, 직접 접근을 시도하고 예외를 잡는 파이썬 표준 관례를 따름
+        # / Defensive check: EAFP (Easier to Ask for Forgiveness than Permission) pattern.
+        # Safely attempts to access index 0, catching any type/index/key mismatches (e.g. dicts, non-iterables, empty tuples).
+        if row is not None and not isinstance(row, (str, bytes)):
+            with suppress(IndexError, KeyError, TypeError):
+                val = row[0]
+                return val if val is not None else fallback_value
+
         return fallback_value
 
     # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
- 방어적 검사 최종 고도화
  - hasattr()를 활용한 불완전한 덕 타이핑 검사를 제거하고, 파이썬 표준 관례인 EAFP(허락보다 용서를 구하기 쉬움) 패턴을 전면 도입.
  - 일단 row[0] 접근을 시도한 뒤 발생하는 모든 예외(IndexError, KeyError, TypeError)를 묶어서 처리함으로써, dict 객체나 len()이 없는 특이한 커스텀 row 타입이 들어오더라도 런타임 에러 없이 완벽하게 방어하도록 수정
- IDE 권장 스타일(Sourcery) 적용
  - 빈 except pass 블록 대신 가독성이 뛰어나고 명시적인 contextlib.suppress() 컨텍스트 매니저를 도입하여 코드 품질 고도화
- 타입 의미론 정렬
  - 센티넬 값(_MISSING)과 fallback_value 간의 처리 로직을 명확히 함
  - 호출자가 비수치 스칼라를 요구할 때도 충돌 없이 동작하도록 안정성 향상

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1773#pullrequestreview-4945393916)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

`_execute_scalar`에서 EAFP 기반 방어적 처리를 적용하여 스칼라 값 접근을 안전하게 하고, 폴백 동작 의미를 명확히 합니다.

Enhancements:
- `row[0]`를 읽을 때 속성 기반 덕 타이핑 검사 대신 EAFP 스타일의 예외 억제를 사용하도록 변경합니다.
- 센티널 `_MISSING`와 `fallback_value`의 사용을 명확히 하고 표준화하여, 누락되었거나 `None`인 스칼라 결과를 더 강건하게 처리합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Apply EAFP-based defensive handling in `_execute_scalar` to safely access scalar values and clarify fallback semantics.

Enhancements:
- Replace attribute-based duck typing checks with EAFP-style exception suppression when reading `row[0]`.
- Clarify and standardize the use of sentinel `_MISSING` and `fallback_value` to handle missing or `None` scalar results more robustly.

</details>