### PR TITLE
✨ refactor [#12.3.20] - (59) 2차 개선 : 분류 로그 `Sentinel` 일관성 및 데드 코드 버그 픽스

### DIFF
--- a/backend/services/classification_service.py
+++ b/backend/services/classification_service.py
@@ -122,7 +122,7 @@ class ClassificationService:
                     "action": "save_log",
                     "file_id": file_id or "unknown",
                     "user_id": user_id or "anonymous",
-                    "snapshot_id": para_result.get("snapshot_id", ""),
+                    "snapshot_id": para_result.get("snapshot_id") or "unknown_snapshot",
                 }
                 if isinstance(e, OSError):
                     log_agent_error(
@@ -141,7 +141,6 @@ class ClassificationService:
                         level="warning",
                     )
                 log_info = {"error": str(e), "logged": True}
-                log_info = {"error": str(e)}
 
             # Step 7: 응답 생성
             response = ClassifyResponse(


### PR DESCRIPTION
- 데드 코드 픽스: 예외 처리 블록 내에서 `log_info` 딕셔너리가 두 번 연속 할당되며 이전 값("logged": True 플래그)을 덮어씌우던 논리적 버그를 수정하여 의도된 메타데이터가 정상 전달되도록 복구
- `Sentinel` 정합성 확보
  - 로깅 메타데이터(meta)의 `snapshot_id` 폴백 값을 빈 문자열("")에서 명시적인 "unknown_snapshot"으로 변경.
  - 이를 통해 `file_id`("unknown"), `user_id`("anonymous")와의 정규화 포맷 일관성을 맞추고 다운스트림 로그 시스템에서의 가시성 개선

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1776#pullrequestreview-4948091774)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

분류 오류 로깅 메타데이터의 일관성을 개선하고, `logged` 플래그가 유지되지 않도록 하던 데드 코드 버그를 수정합니다.

Bug Fixes:
- 분류 오류 로그 메타데이터에서 `logged` 플래그가 올바르게 유지되도록, 이를 버리던 중복 재할당을 제거했습니다.

Enhancements:
- 다른 센티넬 값과의 일관성을 위해, 분류 오류 로그에서 `snapshot_id`의 폴백 값을 `unknown_snapshot`으로 표준화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve classification error logging metadata consistency and fix a dead-code bug preventing the logged flag from being preserved.

Bug Fixes:
- Restore proper preservation of the `logged` flag in classification error log metadata by removing a redundant reassignment that discarded it.

Enhancements:
- Standardize `snapshot_id` fallback in classification error logs to `unknown_snapshot` for consistency with other sentinel values.

</details>