### PR TITLE
✨ refactor [#12.3.20] - (59) 4차 개선 : `Sentinel` 상수 전역 모듈화 및 회귀 방지 문서화

### DIFF
--- a/backend/agent/constants.py
+++ b/backend/agent/constants.py
@@ -12,3 +12,10 @@ from typing import Final
 # 2. backend.agent.utils.search_similar_docs: 빈 키워드 폴백 로직 내 반환
 # ※ 향후 "검색 결과 없음"의 표현 형식이 바뀔 경우, 파편화 방지를 위해 반드시 이 상수만을 수정해야 합니다.
 EMPTY_RETRIEVED_CONTEXT: Final[str] = ""
+
+# 공용 센티넬 상수 (메타데이터 로깅 및 데이터 정합성 유지)
+# 백엔드 전반에서 추적용 메타데이터(meta payload)를 생성할 때, 식별자가 누락되었음을
+# 일관되게 표현하기 위해 사용됩니다.
+UNKNOWN_USER_ID: Final[str] = "anonymous"
+UNKNOWN_FILE_ID: Final[str] = "unknown"
+UNKNOWN_SNAPSHOT_ID: Final[str] = "unknown_snapshot"

--- a/backend/services/classification_service.py
+++ b/backend/services/classification_service.py
@@ -17,6 +17,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, List, Optional
 
+from backend.agent.constants import (
+    UNKNOWN_FILE_ID,
+    UNKNOWN_SNAPSHOT_ID,
+    UNKNOWN_USER_ID,
+)
 from backend.agent.error_utils import is_system_error, log_agent_error
 from backend.classifier.hybrid_classifier import HybridClassifier
 from backend.classifier.keyword import KeywordClassifier
@@ -31,11 +36,6 @@ from backend.services.conflict_service import ConflictService
 # from backend.classifier.keyword_classifier import KeywordClassifier
 
 logger = logging.getLogger(__name__)
-
-# 공용 센티넬 상수 (메타데이터 로깅 및 데이터 정합성 유지)
-UNKNOWN_USER_ID = "anonymous"
-UNKNOWN_FILE_ID = "unknown"
-UNKNOWN_SNAPSHOT_ID = "unknown_snapshot"
 
 
 class ClassificationService:
@@ -127,6 +127,8 @@ class ClassificationService:
                     "action": "save_log",
                     "file_id": file_id or UNKNOWN_FILE_ID,
                     "user_id": user_id or UNKNOWN_USER_ID,
+                    # [설명]: 이전 방식(or 연산자)은 빈 문자열("")을 "unknown_snapshot"으로 덮어씌웠지만,
+                    # 이제 dict.get(key, default)를 사용하여 업스트림에서 의도적으로 전달한 빈 문자열("") 데이터를 그대로 보존합니다.
                     "snapshot_id": para_result.get("snapshot_id", UNKNOWN_SNAPSHOT_ID),
                 }
                 if isinstance(e, OSError):


### PR DESCRIPTION
- 아키텍처 모듈화
  - [classification_service.py]에 종속되어 있던 `UNKNOWN_*` 센티넬 상수들을 단일 진실 공급원인 [backend/agent/constants.py]로 이동
  - 백엔드 전반의 로깅 및 메타데이터 추적 로직에서 일관성 있게 재사용할 수 있도록 아키텍처 개선
- 회귀(Regression) 방지 주석 추가
  - `snapshot_id`의 빈 문자열 보존 로직(dict.get)에 인라인 주석을 명시
  - 향후 다른 개발자가 과거의 or 연산자 방식으로 되돌리는 실수를 원천 차단

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1778#pullrequestreview-4957482308)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

메타데이터 센티널 값들을 중앙 집중화하고, 스냅샷 ID 처리 로직을 회귀로부터 보호합니다.

버그 수정:
- 필드가 존재하지 않을 때는 알 수 없는 스냅샷용 센티널을 계속 적용하면서도, 의도적으로 비어 있는 스냅샷 ID가 전달된 경우에는 이를 그대로 유지합니다.

개선 사항:
- 백엔드 전역에서 일관되게 재사용할 수 있도록, 알 수 없는 사용자·파일·스냅샷용 센티널 상수들을 공유 에이전트 상수 모듈로 중앙 집중화했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize metadata sentinel values and protect snapshot ID handling from regression.

Bug Fixes:
- Preserve intentionally supplied empty snapshot IDs while continuing to apply the unknown snapshot sentinel when the field is absent.

Enhancements:
- Centralize unknown user, file, and snapshot sentinel constants in the shared agent constants module for consistent backend-wide reuse.

</details>