### PR TITLE
✨ refactor [#12.3.20] - (59) 6차 개선 : `Sentinel` 사용법 예시 코드 인라인 문서화

### DIFF
--- a/backend/agent/constants.py
+++ b/backend/agent/constants.py
@@ -24,5 +24,10 @@ UNKNOWN_FILE_ID: Final[str] = "unknown"
 
 # [주의]: UNKNOWN_SNAPSHOT_ID는 스냅샷 데이터 자체가 "누락"되었음을 나타내는 센티넬입니다.
 # 업스트림 로직에서 의도적으로 전달한 "빈 문자열('')"과는 엄격히 구분되어 처리되어야 합니다.
-# (예: dict.get()을 사용하여 빈 문자열이 센티넬 값으로 덮어씌워지지 않도록 유의)
+#
+# [올바른 사용법]: dict.get() 으로 키 자체가 없을 때만 폴백 (빈 문자열은 그대로 보존)
+#   snapshot_id = data.get("snapshot_id", UNKNOWN_SNAPSHOT_ID)
+#
+# [잘못된 사용법]: or 연산자 사용 시 빈 문자열('')도 센티넬로 덮어씌워짐
+#   snapshot_id = data.get("snapshot_id") or UNKNOWN_SNAPSHOT_ID  # <- 회귀 위험
 UNKNOWN_SNAPSHOT_ID: Final[str] = "unknown_snapshot"


### PR DESCRIPTION
- UNKNOWN_SNAPSHOT_ID 주석에 올바른 사용법(dict.get(key, SENTINEL))과 잘못된 사용법(or 연산자 방식) 예시를 나란히 추가하여, 향후 독자가 빈 문자열 보존 엣지케이스 동작을 즉시 직관적으로 파악할 수 있도록 개선
- Wrapper/Helper 모듈 생성 제안은 기존 중복 상수(common.py:ANONYMOUS_USER_ID) 및 작업 범위 초과를 이유로 이번 PR에서 미반영 결정 → 별도 기술 부채 티켓으로 추적 예정

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1780#pullrequestreview-4957544769)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Enhancements:
- 올바른 및 잘못된 `UNKNOWN_SNAPSHOT_ID` 사용 사례를 문서 내에 직접 설명하여, 명시적으로 제공된 빈 문자열은 그대로 유지되어야 하며 키가 누락된 경우에만 센티널 폴백을 사용한다는 점을 명확히 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Document correct and incorrect `UNKNOWN_SNAPSHOT_ID` usage inline, clarifying that explicitly provided empty strings must be preserved while only missing keys use the sentinel fallback.

</details>