### PR TITLE
✨ refactor [#12.3.20] - (60) 4차 개선 : 로깅 메타데이터 공용 유틸리티 분리 및 타입 강화

### DIFF
--- a/backend/celery_app/tasks/archiving.py
+++ b/backend/celery_app/tasks/archiving.py
@@ -21,6 +21,8 @@ from backend.models.automation import (
 )
 from backend.services.file_access_logger import FileAccessLogger
 
+from .utils import build_meta
+
 logger = logging.getLogger(__name__)
 
 # 로그 디렉토리 설정
@@ -48,18 +50,13 @@ class ArchivingStats:
     errors: int = 0
 
 
-def _build_meta(base: Optional[dict] = None, **kwargs) -> dict:
-    """로그 메타데이터 일관성 유지를 위한 헬퍼 함수"""
-    return (base or {}) | kwargs
-
-
 def _save_automation_log(log: AutomationLog):
     """AutomationLog를 JSONL 파일에 저장"""
     try:
         with open(AUTO_LOG_FILE, "a", encoding="utf-8") as f:
             f.write(log.model_dump_json() + "\n")
     except OSError as e:
-        meta = _build_meta(
+        meta = build_meta(
             {"action": "save_automation_log"},
             auto_log_file=str(AUTO_LOG_FILE),
             log_id=getattr(log, "id", getattr(log, "log_id", None)),
@@ -74,7 +71,7 @@ def _save_automation_log(log: AutomationLog):
     except Exception as e:
         if is_system_error(e):
             raise
-        meta = _build_meta(
+        meta = build_meta(
             {"action": "save_automation_log"},
             auto_log_file=str(AUTO_LOG_FILE),
             log_id=getattr(log, "id", getattr(log, "log_id", None)),
@@ -95,7 +92,7 @@ def _save_archiving_records(records: List[ArchivingRecord]):
             for record in records:
                 f.write(record.model_dump_json() + "\n")
     except OSError as e:
-        meta = _build_meta(
+        meta = build_meta(
             {"action": "save_archiving_records"},
             count=len(records),
             archive_log_file=str(ARCHIVE_LOG_FILE),
@@ -110,7 +107,7 @@ def _save_archiving_records(records: List[ArchivingRecord]):
     except Exception as e:
         if is_system_error(e):
             raise
-        meta = _build_meta(
+        meta = build_meta(
             {"action": "save_archiving_records"},
             count=len(records),
             archive_log_file=str(ARCHIVE_LOG_FILE),
@@ -277,7 +274,7 @@ def _archive_single_file(path_obj: Path, log_id: str) -> ArchivingResult:
         return ArchivingResult(record=record, is_archived=True)
 
     except OSError as e:
-        meta = _build_meta(
+        meta = build_meta(
             {"action": "archive_single_file"}, source_path=str(path_obj), log_id=log_id
         )
         log_agent_error(
@@ -288,7 +285,7 @@ def _archive_single_file(path_obj: Path, log_id: str) -> ArchivingResult:
         )
         return ArchivingResult(is_error=True)
     except Exception as e:
-        meta = _build_meta(
+        meta = build_meta(
             {"action": "archive_single_file"}, source_path=str(path_obj), log_id=log_id
         )
         if is_system_error(e):

--- a/backend/celery_app/tasks/classification.py
+++ b/backend/celery_app/tasks/classification.py
@@ -23,6 +23,8 @@ from backend.models.external_sync import (
 from backend.services.classification_service import ClassificationService
 from backend.services.obsidian_sync import ObsidianSyncService
 
+from .utils import build_meta
+
 logger = logging.getLogger(__name__)
 
 # Constants
@@ -42,11 +44,6 @@ LOCAL_OBSIDIAN_USER: str = "obsidian_local_agent"
 # Initialized lazily to avoid resource creation if not needed
 _executor: Optional[ThreadPoolExecutor] = None
 _executor_lock = threading.Lock()  # Lock for thread-safe initialization
-
-
-def _build_meta(base: Optional[dict] = None, **kwargs) -> dict:
-    """로그 메타데이터 구성을 위한 헬퍼 함수"""
-    return (base or {}) | kwargs
 
 
 def _safe_path(path_str: str) -> str:
@@ -141,7 +138,7 @@ def _safe_obsidian_move(
             logger.info(f"Moved file to: {new_path}")
         return new_path
     except OSError as e:
-        meta = _build_meta(
+        meta = build_meta(
             {"action": "obsidian_move"},
             file_id=file_id if file_id is not None else UNKNOWN_FILE_ID,
             category=category,
@@ -155,7 +152,7 @@ def _safe_obsidian_move(
         )
         return None
     except Exception as e:
-        meta = _build_meta(
+        meta = build_meta(
             {"action": "obsidian_move"},
             file_id=file_id if file_id is not None else UNKNOWN_FILE_ID,
             category=category,
@@ -175,7 +172,7 @@ def _safe_obsidian_move(
 
 def _handle_classify_error(task_self, e: Exception, file_path: str) -> None:
     file_id = str(Path(file_path).absolute())
-    meta = _build_meta(
+    meta = build_meta(
         {"action": "classify_file"},
         file_id=file_id if file_id is not None else UNKNOWN_FILE_ID,
     )

--- a/backend/celery_app/tasks/utils.py
+++ b/backend/celery_app/tasks/utils.py
@@ -1,0 +1,6 @@
+from typing import Any, Dict, Optional
+
+
+def build_meta(base: Optional[Dict[str, Any]] = None, **kwargs: Any) -> Dict[str, Any]:
+    """로그 메타데이터 일관성 유지를 위한 공통 헬퍼 함수"""
+    return (base or {}) | kwargs


### PR DESCRIPTION
- **[classification.py]** & **[archiving.py]**
  - 중복 정의되어 있던 `_build_meta` 헬퍼 함수를 제거
  - DRY 원칙 준수
- **[utils.py]**
  - 태스크 간 공통으로 사용하는 유틸리티 모듈 신규 생성 및 `build_meta` 중앙화
  - 방어적 프로그래밍: `build_meta`의 시그니처에 엄격한 타입 힌팅(Optional[Dict[str, Any]])을 적용하여 메타데이터 구조 명확화 및 향후 개발 간 휴먼 에러 방지

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1785#pullrequestreview-4985168353)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Celery 태스크 전반에서 로깅 메타데이터 생성 로직을 중앙화하고 강화했습니다.

개선 사항:
- 공용 태스크 유틸리티에서 로깅 메타데이터 생성 로직을 중앙화하고, 더 강력한 타입 정의를 추가했습니다.
- 분류(classification) 태스크와 아카이빙(archiving) 태스크에 중복되어 있던 메타데이터 헬퍼 구현을 제거했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize and strengthen logging metadata construction across Celery tasks.

Enhancements:
- Centralize logging metadata construction in a shared task utility with stronger type definitions.
- Remove duplicated metadata helper implementations from classification and archiving tasks.

</details>