### PR TITLE
✨ refactor [#12.3.20] - (60) 5차 개선 : 로깅 메타데이터 공용 헬퍼 범용성 강화 및 타입 유연화

### DIFF
--- a/backend/agent/error_utils.py
+++ b/backend/agent/error_utils.py
@@ -26,7 +26,7 @@ import logging
 import re
 from itertools import islice
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Type, Union
 
 if TYPE_CHECKING:
     import asyncio
@@ -154,6 +154,16 @@ def is_system_error(exc: BaseException) -> bool:
         return True
 
     return isinstance(exc, _get_cancelled_error_type())
+
+
+def build_meta(
+    base: Optional[Mapping[str, Any]] = None, **kwargs: Any
+) -> Dict[str, Any]:
+    """
+    [KO] 로그 메타데이터 일관성 유지를 위한 공통 헬퍼 함수
+    [EN] Common helper function for consistent log metadata construction
+    """
+    return dict(base or {}) | kwargs
 
 
 def log_agent_error(

--- a/backend/celery_app/tasks/archiving.py
+++ b/backend/celery_app/tasks/archiving.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import List, Optional, Set
 
-from backend.agent.error_utils import is_system_error, log_agent_error
+from backend.agent.error_utils import build_meta, is_system_error, log_agent_error
 from backend.celery_app.celery import app
 from backend.config import AppConfig, PathConfig
 from backend.models.automation import (
@@ -20,8 +20,6 @@ from backend.models.automation import (
     AutomationTaskType,
 )
 from backend.services.file_access_logger import FileAccessLogger
-
-from .utils import build_meta
 
 logger = logging.getLogger(__name__)
 

--- a/backend/celery_app/tasks/classification.py
+++ b/backend/celery_app/tasks/classification.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Optional
 
 from backend.agent.constants import UNKNOWN_FILE_ID
-from backend.agent.error_utils import is_system_error, log_agent_error
+from backend.agent.error_utils import build_meta, is_system_error, log_agent_error
 from backend.celery_app.celery import app
 
 # Sync & Config Imports
@@ -22,8 +22,6 @@ from backend.models.external_sync import (
 )
 from backend.services.classification_service import ClassificationService
 from backend.services.obsidian_sync import ObsidianSyncService
-
-from .utils import build_meta
 
 logger = logging.getLogger(__name__)
 

--- a/backend/celery_app/tasks/utils.py
+++ b/backend/celery_app/tasks/utils.py
@@ -1,6 +1,0 @@
-from typing import Any, Dict, Optional
-
-
-def build_meta(base: Optional[Dict[str, Any]] = None, **kwargs: Any) -> Dict[str, Any]:
-    """로그 메타데이터 일관성 유지를 위한 공통 헬퍼 함수"""
-    return (base or {}) | kwargs


### PR DESCRIPTION
- **[error_utils.py]**
  - `build_meta` 헬퍼를 `Celery` 태스크 전용에서 범용 에러 유틸리티 모듈로 승격시켜 중앙화
  - `build_meta` 파라미터 타입 변경: 다형성 지원 및 유연성 확보
    - "Postel's Law": Dict[str, Any] → Mapping[str, Any]로 추상화 수준 높임

- 사용하지 않는 **[celery_app/tasks/utils.py]** 삭제
  - **[classification.py]**, **[archiving.py]**, **[utils.py]** 의존성 제거 및 전역 `error_utils()` 임포트로 수정

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1786#pullrequestreview-4995984877)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Summary by Sourcery

Celery 태스크 전반에서 로깅 메타데이터 생성 로직을 중앙집중화하고 범용적으로 일반화합니다.

Enhancements:
- 공유 오류 유틸리티에서 로그 메타데이터 생성을 중앙집중화하고, 유연성을 높이기 위해 일반적인 매핑 입력을 허용합니다.
- 아카이빙 및 분류 태스크가 공통 메타데이터 헬퍼를 사용하도록 업데이트하고, 사용되지 않는 태스크 유틸리티 모듈을 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize and generalize logging metadata construction across Celery tasks.

Enhancements:
- Centralize log metadata construction in the shared error utilities and accept generic mapping inputs for greater flexibility.
- Update archiving and classification tasks to use the shared metadata helper and remove the obsolete task utility module.

</details>