### PR TITLE
✨ refactor [#12.3.20] - (61) 1차 개선 : `reclassification.py` 버그 및 로깅 PII 취약점 해결

### DIFF
--- a/backend/celery_app/tasks/reclassification.py
+++ b/backend/celery_app/tasks/reclassification.py
@@ -88,7 +88,7 @@ def _read_file_content(path_obj: Path) -> Tuple[Optional[str], bool]:
     try:
         content = path_obj.read_text(encoding="utf-8", errors="ignore")
     except OSError as exc:
-        meta = build_meta({"action": "read_file_content"}, file_path=str(path_obj))
+        meta = build_meta({"action": "read_file_content"}, file_path=path_obj.name)
         log_agent_error(logger, f"Failed to read file {path_obj.name}", exc, meta)
         return None, True
 
@@ -147,7 +147,7 @@ async def _reclassify_file(
             old_category=old_category,
             new_category=new_category,
             confidence_score=result.get("confidence", 0.0),
-            reason=result.get("reason", ""),
+            reason=result.get("reasoning", ""),
             processed_at=datetime.now(),
         )
 
@@ -157,7 +157,7 @@ async def _reclassify_file(
         if is_system_error(exc):
             raise
         meta = build_meta(
-            {"action": "reclassify_file"}, file_path=file_path, log_id=log_id
+            {"action": "reclassify_file"}, file_path=Path(file_path).name, log_id=log_id
         )
         log_agent_error(
             logger, f"Error classifying file {Path(file_path).name}", exc, meta
@@ -206,6 +206,21 @@ async def _classify_files_async(
     return records, stats
 
 
+def _finalize_log(
+    log: AutomationLog,
+    start_time: datetime,
+    status: AutomationStatus,
+    details: Optional[dict] = None,
+) -> None:
+    """AutomationLog의 완료/스킵 상태를 일관성 있게 설정하고 저장하는 헬퍼"""
+    log.status = status
+    if details is not None:
+        log.details = details
+    log.completed_at = datetime.now()
+    log.duration_seconds = (log.completed_at - start_time).total_seconds()
+    _save_automation_log(log)
+
+
 def _execute_reclassification(task_id: str, task_name: str, days: int):
     """재분류 로직 공통 실행 함수"""
     start_time = datetime.now()
@@ -229,11 +244,12 @@ def _execute_reclassification(task_id: str, task_name: str, days: int):
         )
 
         if not target_files:
-            log.status = AutomationStatus.SKIPPED
-            log.details = {"message": "No files found to reclassify."}
-            log.completed_at = datetime.now()
-            log.duration_seconds = (log.completed_at - start_time).total_seconds()
-            _save_automation_log(log)
+            _finalize_log(
+                log,
+                start_time,
+                AutomationStatus.SKIPPED,
+                {"message": "No files found to reclassify."},
+            )
             return "Skipped (No files)"
 
         records, stats = asyncio.run(_classify_files_async(target_files, log_id))
@@ -242,12 +258,8 @@ def _execute_reclassification(task_id: str, task_name: str, days: int):
         log.files_updated = stats.updated
         log.errors_count = stats.errors
 
-        log.status = AutomationStatus.COMPLETED
-        log.completed_at = datetime.now()
-        log.duration_seconds = (log.completed_at - start_time).total_seconds()
-
         _save_reclassification_records(records)
-        _save_automation_log(log)
+        _finalize_log(log, start_time, AutomationStatus.COMPLETED)
 
         return f"Success: {stats.processed} processed, {stats.updated} updated."
 


### PR DESCRIPTION
- **[Fix]**
  - 재분류 레코드 생성 시, 분류기(Classifier)의 실제 출력 키인 "reasoning"을 정상적으로 읽어오도록 수정하여 데이터 유실 버그 해결 (reason → reasoning)
- **[Security]**
  - 예외 발생 시 에러 메타데이터(`log_agent_error`)에 전체 파일 경로가 아닌 파일명(basename)만 남기도록 수정하여 PII 노출 취약점 해결
  - 자체 추가 검증: `_reclassify_file` 함수 내부의 동일한 PII 노출 취약점 선제적 대응
- **[Refactor]**
  - `AutomationLog` 완료/스킵 처리 로직을 `_finalize_log()` 헬퍼로 추출하여 코드 중복 제거 및 Sourcery 경고 해소

🔗 Related:
- Issue [#1044]
- @ai-bot-review (https://github.com/jjaayy2222/flownote-mvp/pull/1788#pullrequestreview-5000427524)

Co-authored-by: Claude Sonnet 4.6 (Thinking), Gemini 3.1 Pro

## Sourcery 요약

재분류 사유 처리를 수정하고 오류 메타데이터에서 민감한 파일 경로를 보호하는 한편, 자동화 로그 완료 처리를 간소화했습니다.

버그 수정:
- 재분류 레코드 생성 시 분류기의 `reasoning` 출력을 읽어 사유 데이터가 손실되지 않도록 했습니다.
- 오류 로그의 파일 경로 메타데이터를 파일 이름으로 제한하여 파일 읽기 및 재분류 실패 시 PII가 노출되지 않도록 했습니다.

개선 사항:
- 자동화 로그의 완료 및 건너뛰기 처리를 중앙화하여 중복을 줄이고 상태, 시간 기록 및 영속성 업데이트의 일관성을 보장했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix reclassification reason handling and protect sensitive file paths in error metadata while simplifying automation-log finalization.

Bug Fixes:
- Read the classifier's `reasoning` output when creating reclassification records to prevent reason data loss.
- Restrict file-path metadata in error logs to filenames, preventing PII exposure during file-reading and reclassification failures.

Enhancements:
- Centralize automation-log completion and skip handling to reduce duplication and ensure consistent status, timing, and persistence updates.

</details>